### PR TITLE
Improve setup-soldr cache diagnostics

### DIFF
--- a/.github/actions/setup-soldr/ensure_rust_toolchain.py
+++ b/.github/actions/setup-soldr/ensure_rust_toolchain.py
@@ -12,9 +12,7 @@ from pathlib import Path
 from urllib.error import URLError
 from urllib.request import urlopen
 
-
-def run(command: list[str]) -> None:
-    subprocess.run(command, check=True)
+from log_utils import log, run
 
 
 def append_github_env(name: str, value: str) -> None:
@@ -67,6 +65,7 @@ def download_rustup_init(destination_dir: Path) -> Path:
     url = rustup_init_url()
     temp_destination = destination.with_name(f"{destination.name}.tmp")
     try:
+        log(f"Downloading rustup-init from {url}")
         with urlopen(url) as response, open(temp_destination, "wb") as fh:
             shutil.copyfileobj(response, fh)
         temp_destination.replace(destination)
@@ -84,6 +83,7 @@ def download_rustup_init(destination_dir: Path) -> Path:
 def ensure_rustup_available(soldr_root: Path) -> str:
     rustup = shutil.which("rustup")
     if rustup is not None:
+        log(f"Using rustup at {rustup}")
         return rustup
 
     installer_dir = soldr_root / "cache"
@@ -114,6 +114,7 @@ def main() -> None:
     components = json.loads(os.environ.get("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", "[]"))
     targets = json.loads(os.environ.get("SETUP_SOLDR_TOOLCHAIN_TARGETS", "[]"))
 
+    log(f"Installing Rust toolchain {channel} with profile {profile}")
     run([rustup, "set", "profile", profile])
     install_command = [rustup, "toolchain", "install", channel, "--profile", profile]
     for component in components:

--- a/.github/actions/setup-soldr/ensure_soldr.py
+++ b/.github/actions/setup-soldr/ensure_soldr.py
@@ -15,6 +15,8 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
+from log_utils import log
+
 
 def _normalize_version(value: str) -> str:
     return value[1:] if value.startswith("v") else value
@@ -113,6 +115,7 @@ def main() -> None:
     current = _installed_version(binary_path)
     if current is not None:
         if not requested_version or _normalize_version(current) == _normalize_version(requested_version):
+            log(f"Using cached soldr {current} at {binary_path}")
             output = os.environ.get("GITHUB_OUTPUT")
             if output:
                 with open(output, "a", encoding="utf-8") as fh:
@@ -121,6 +124,7 @@ def main() -> None:
 
     repo = os.environ.get("SOLDR_REPO", "zackees/soldr").strip() or "zackees/soldr"
     target, archive_ext, binary_name = _detect_target()
+    log(f"Resolving soldr release from {repo}")
     release = _fetch_release(repo, requested_version)
     asset_name, download_url = _select_asset(release, target, archive_ext)
     tag_name = str(release["tag_name"])
@@ -129,11 +133,13 @@ def main() -> None:
         tmp_dir = Path(tmp)
         archive_path = tmp_dir / asset_name
         extract_dir = tmp_dir / "extract"
+        log(f"Downloading {asset_name}")
         urllib.request.urlretrieve(download_url, archive_path)
         source = _extract_binary(archive_path, archive_ext, binary_name, extract_dir)
         shutil.copy2(source, binary_path)
         if os.name != "nt":
             binary_path.chmod(binary_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    log(f"Installed soldr {tag_name} at {binary_path}")
 
     output = os.environ.get("GITHUB_OUTPUT")
     if output:

--- a/.github/actions/setup-soldr/log_utils.py
+++ b/.github/actions/setup-soldr/log_utils.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+import time
+
+
+_FALLBACK_START = time.time()
+
+
+def timestamps_enabled() -> bool:
+    value = os.environ.get("SETUP_SOLDR_TIMESTAMPS", "true").strip().lower()
+    return value not in {"0", "false", "no", "off"}
+
+
+def _start_epoch() -> float:
+    value = os.environ.get("SETUP_SOLDR_LOG_START_EPOCH", "").strip()
+    if value:
+        try:
+            return float(value)
+        except ValueError:
+            pass
+    return _FALLBACK_START
+
+
+def elapsed_prefix() -> str:
+    elapsed = max(0, int(time.time() - _start_epoch()))
+    minutes, seconds = divmod(elapsed, 60)
+    return f"{minutes:02d}:{seconds:02d}"
+
+
+def format_line(message: str) -> str:
+    if timestamps_enabled():
+        return f"{elapsed_prefix()} {message}"
+    return message
+
+
+def log(message: str) -> None:
+    print(format_line(message), flush=True)
+
+
+def run(command: list[str]) -> None:
+    log(f"+ {shlex.join(command)}")
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    assert process.stdout is not None
+    for line in process.stdout:
+        print(format_line(line.rstrip("\n")), flush=True)
+    returncode = process.wait()
+    if returncode != 0:
+        raise subprocess.CalledProcessError(returncode, command)
+
+
+def main() -> int:
+    for line in sys.stdin:
+        print(format_line(line.rstrip("\n")), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 import re
+import time
 from pathlib import Path
 from typing import Any
 
@@ -74,6 +75,40 @@ def _short_file_hash(path: Path, missing: str) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
 
 
+def _resolve_workspace_path(workspace: Path, value: str) -> Path | None:
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    path = Path(cleaned).expanduser()
+    if not path.is_absolute():
+        path = workspace / path
+    return path.resolve()
+
+
+def resolve_lockfile_path(workspace: Path, target_cache_path: Path, lockfile_input: str) -> Path | None:
+    explicit = _resolve_workspace_path(workspace, lockfile_input)
+    if explicit is not None:
+        return explicit
+
+    candidates = [
+        target_cache_path.parent / "Cargo.lock",
+        workspace / "Cargo.lock",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.resolve()
+    return candidates[0].resolve()
+
+
+def _path_for_output(workspace: Path, path: Path | None) -> str:
+    if path is None:
+        return ""
+    try:
+        return str(path.relative_to(workspace))
+    except ValueError:
+        return str(path)
+
+
 def _write_env(name: str, value: str) -> None:
     output = os.environ.get("GITHUB_ENV")
     if not output:
@@ -107,6 +142,9 @@ def _write_outputs(values: dict[str, str]) -> None:
 def main() -> None:
     workspace = Path(os.environ["ACTION_WORKSPACE"]).resolve()
     runner_temp = Path(os.environ.get("RUNNER_TEMP", workspace / ".tmp")).resolve()
+    log_start = os.environ.get("SETUP_SOLDR_LOG_START_EPOCH", "").strip()
+    if not log_start:
+        log_start = str(int(time.time()))
 
     requested_cache_dir = os.environ.get("INPUT_CACHE_DIR", "").strip()
     cache_root = Path(requested_cache_dir).expanduser().resolve() if requested_cache_dir else (
@@ -158,7 +196,6 @@ def main() -> None:
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
     cache_prefix = f"setup-soldr-v0-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
-    cargo_lock_hash = _short_file_hash(workspace / "Cargo.lock", "no-lock")
 
     suffix = os.environ.get("INPUT_CACHE_KEY_SUFFIX", "").strip()
     if suffix:
@@ -179,6 +216,13 @@ def main() -> None:
     if not target_cache_path.is_absolute():
         target_cache_path = workspace / target_cache_path
     target_cache_path = target_cache_path.resolve()
+    target_cache_path.mkdir(parents=True, exist_ok=True)
+    lockfile_path = resolve_lockfile_path(
+        workspace,
+        target_cache_path,
+        os.environ.get("INPUT_LOCKFILE", ""),
+    )
+    cargo_lock_hash = _short_file_hash(lockfile_path, "no-lock") if lockfile_path else "no-lock"
     target_cache_prefix = f"setup-soldr-targetcache-v0-{runner_os}-{runner_arch}"
     target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
     target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
@@ -196,6 +240,8 @@ def main() -> None:
     _write_env("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain["profile"])
     _write_env("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", json.dumps(toolchain["components"]))
     _write_env("SETUP_SOLDR_TOOLCHAIN_TARGETS", json.dumps(toolchain["targets"]))
+    _write_env("SETUP_SOLDR_LOG_START_EPOCH", log_start)
+    _write_env("SETUP_SOLDR_TIMESTAMPS", os.environ.get("INPUT_TIMESTAMPS", "true").strip() or "true")
     if os.environ.get("INPUT_TRUST_MODE", "").strip():
         _write_env("SOLDR_TRUST_MODE", os.environ["INPUT_TRUST_MODE"].strip())
 
@@ -214,6 +260,8 @@ def main() -> None:
             "target_cache_path": str(target_cache_path),
             "target_cache_key": target_cache_key,
             "target_cache_restore_key_lock": target_cache_lock_prefix,
+            "target_lockfile_path": _path_for_output(workspace, lockfile_path),
+            "target_lockfile_hash": cargo_lock_hash,
             "soldr_root": str(soldr_root),
             "cargo_home": str(cargo_home),
             "rustup_home": str(rustup_home),

--- a/.github/actions/setup-soldr/verify_soldr.py
+++ b/.github/actions/setup-soldr/verify_soldr.py
@@ -6,6 +6,8 @@ import os
 import subprocess
 import sys
 
+from log_utils import log, run
+
 
 def _is_transient_zccache_status_failure(exc: subprocess.CalledProcessError) -> bool:
     combined = "\n".join(
@@ -24,19 +26,30 @@ def main() -> None:
     binary = os.environ["SETUP_SOLDR_PATH"]
     output_path = os.environ["GITHUB_OUTPUT"]
 
+    log(f"Verifying soldr at {binary}")
     version_json = subprocess.check_output([binary, "version", "--json"], text=True)
     payload = json.loads(version_json)
 
     with open(output_path, "a", encoding="utf-8") as fh:
         fh.write(f"soldr_version={payload['soldr_version']}\n")
 
-    subprocess.run(["cargo", "--version"], check=True)
-    subprocess.run(["rustc", "--version"], check=True)
+    run(["cargo", "--version"])
+    run(["rustc", "--version"])
+    log("+ soldr status --json")
     try:
-        subprocess.run(["soldr", "status", "--json"], check=True, capture_output=True, text=True)
+        status = subprocess.run(
+            ["soldr", "status", "--json"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
     except subprocess.CalledProcessError as exc:
         if not _is_transient_zccache_status_failure(exc):
             raise
+    else:
+        if status.stdout.strip():
+            for line in status.stdout.splitlines():
+                log(line)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -33,12 +33,18 @@ jobs:
           path: soldr
           persist-credentials: false
 
+      - name: Initialize elapsed log clock
+        shell: bash
+        run: |
+          echo "SETUP_SOLDR_LOG_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
       - id: setup
         name: Setup Soldr
         uses: ./setup-soldr
         with:
           cache: true
           toolchain-file: soldr/rust-toolchain.toml
+          lockfile: soldr/Cargo.lock
           target-dir: soldr/target
           cache-key-suffix: soldr-self-build
 
@@ -49,11 +55,73 @@ jobs:
           Write-Host "soldr-version=${{ steps.setup.outputs.soldr-version }}"
           Write-Host "cache-dir=${{ steps.setup.outputs.cache-dir }}"
           Write-Host "cache-hit=${{ steps.setup.outputs.cache-hit }}"
+          Write-Host "cache-key=${{ steps.setup.outputs.cache-key }}"
+          Write-Host "cache-restore-status=${{ steps.setup.outputs.cache-restore-status }}"
           Write-Host "build-cache-hit=${{ steps.setup.outputs.build-cache-hit }}"
+          Write-Host "build-cache-key=${{ steps.setup.outputs.build-cache-key }}"
+          Write-Host "build-cache-path=${{ steps.setup.outputs.build-cache-path }}"
+          Write-Host "build-cache-restore-status=${{ steps.setup.outputs.build-cache-restore-status }}"
           Write-Host "target-cache-hit=${{ steps.setup.outputs.target-cache-hit }}"
+          Write-Host "target-cache-key=${{ steps.setup.outputs.target-cache-key }}"
+          Write-Host "target-cache-path=${{ steps.setup.outputs.target-cache-path }}"
+          Write-Host "target-cache-restore-status=${{ steps.setup.outputs.target-cache-restore-status }}"
+          Write-Host "target-lockfile=${{ steps.setup.outputs.target-lockfile }}"
+          Write-Host "target-lockfile-hash=${{ steps.setup.outputs.target-lockfile-hash }}"
           Write-Host "toolchain=${{ steps.setup.outputs.toolchain }}"
 
       - name: Build zackees/soldr through soldr
-        shell: pwsh
+        shell: bash
         working-directory: soldr
-        run: soldr cargo build --locked --package soldr-cli
+        env:
+          SETUP_CACHE_DIR: ${{ steps.setup.outputs.cache-dir }}
+          BUILD_CACHE_PATH: ${{ steps.setup.outputs.build-cache-path }}
+          TARGET_CACHE_PATH: ${{ steps.setup.outputs.target-cache-path }}
+        run: |
+          set -o pipefail
+
+          log() {
+            local message="$1"
+            local value="${SETUP_SOLDR_TIMESTAMPS:-true}"
+            case "${value,,}" in
+              0|false|no|off)
+                printf '%s\n' "$message"
+                ;;
+              *)
+                local now elapsed minutes seconds
+                now="$(date +%s)"
+                elapsed=$((now - SETUP_SOLDR_LOG_START_EPOCH))
+                if [ "$elapsed" -lt 0 ]; then
+                  elapsed=0
+                fi
+                minutes=$((elapsed / 60))
+                seconds=$((elapsed % 60))
+                printf '%02d:%02d %s\n' "$minutes" "$seconds" "$message"
+                ;;
+            esac
+          }
+
+          path_summary() {
+            local label="$1"
+            local path="$2"
+            if [ -z "$path" ] || [ ! -e "$path" ]; then
+              log "$label path=$path exists=false files=0 bytes=0"
+              return
+            fi
+            local files bytes
+            files="$(find "$path" -type f 2>/dev/null | wc -l | tr -d ' ')"
+            bytes="$(du -sb "$path" 2>/dev/null | cut -f1)"
+            log "$label path=$path exists=true files=$files bytes=${bytes:-0}"
+          }
+
+          logger="$GITHUB_WORKSPACE/setup-soldr/.github/actions/setup-soldr/log_utils.py"
+
+          path_summary "cache before build" "$SETUP_CACHE_DIR"
+          path_summary "build-cache before build" "$BUILD_CACHE_PATH"
+          path_summary "target-cache before build" "$TARGET_CACHE_PATH"
+          log "running soldr cargo build --locked --package soldr-cli"
+          soldr cargo build --locked --package soldr-cli 2>&1 | python "$logger"
+          status=$?
+          path_summary "cache after build" "$SETUP_CACHE_DIR"
+          path_summary "build-cache after build" "$BUILD_CACHE_PATH"
+          path_summary "target-cache after build" "$TARGET_CACHE_PATH"
+          exit "$status"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ jobs:
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
+| `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
+| `lockfile` | Optional `Cargo.lock` path used for target-cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
 | `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
@@ -92,8 +94,18 @@ jobs:
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
+| `cache-key` | Primary key used for the action-managed cache/state root. |
+| `cache-restore-status` | Diagnostic restore status for the action-managed cache/state root. |
 | `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is disabled. |
+| `build-cache-key` | Primary key used for the Soldr-owned zccache compilation cache. |
+| `build-cache-path` | Soldr-owned zccache compilation cache path. |
+| `build-cache-restore-status` | Diagnostic restore status for the Soldr-owned zccache compilation cache. |
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. |
+| `target-cache-key` | Primary key used for the Cargo target directory cache. |
+| `target-cache-path` | Cargo target directory cache path. |
+| `target-cache-restore-status` | Diagnostic restore status for the Cargo target directory cache. |
+| `target-lockfile` | `Cargo.lock` path used for target-cache keying. |
+| `target-lockfile-hash` | Short hash of the `Cargo.lock` used for target-cache keying, or `no-lock`. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
     description: Optional value for SOLDR_TRUST_MODE.
     required: false
     default: ""
+  timestamps:
+    description: Prefix setup-soldr diagnostic and streamed command output with elapsed mm:ss timestamps.
+    required: false
+    default: "true"
+  lockfile:
+    description: Optional Cargo.lock path used for target-cache keying. Empty infers Cargo.lock next to target-dir, then workspace Cargo.lock.
+    required: false
+    default: ""
   build-cache:
     description: >
       Restore and save the Soldr-owned zccache compilation artifact cache
@@ -69,6 +77,12 @@ outputs:
   cache-hit:
     description: Whether the action restored an exact cache hit for the selected cache/state root.
     value: ${{ steps.cache-meta.outputs.cache_hit }}
+  cache-key:
+    description: Primary key used for the action-managed cache/state root.
+    value: ${{ steps.resolve.outputs.cache_key }}
+  cache-restore-status:
+    description: Diagnostic restore status for the action-managed cache/state root.
+    value: ${{ steps.cache-meta.outputs.cache_restore_status }}
   build-cache-hit:
     description: >
       Whether the action restored the Soldr-owned zccache compilation
@@ -76,12 +90,36 @@ outputs:
       restore-key fallback or no cache, empty string when `build-cache`
       is explicitly disabled.
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
+  build-cache-key:
+    description: Primary key used for the Soldr-owned zccache compilation cache.
+    value: ${{ steps.resolve.outputs.build_cache_key }}
+  build-cache-path:
+    description: Soldr-owned zccache compilation cache path.
+    value: ${{ steps.resolve.outputs.build_cache_path }}
+  build-cache-restore-status:
+    description: Diagnostic restore status for the Soldr-owned zccache compilation cache.
+    value: ${{ steps.cache-meta.outputs.build_cache_restore_status }}
   target-cache-hit:
     description: >
       Whether the action restored the Cargo target directory cache. "true"
       for an exact key match, "false" for a restore-key fallback or no cache,
       empty string when `target-cache` or `build-cache` is disabled.
     value: ${{ steps.cache-meta.outputs.target_cache_hit }}
+  target-cache-key:
+    description: Primary key used for the Cargo target directory cache.
+    value: ${{ steps.resolve.outputs.target_cache_key }}
+  target-cache-path:
+    description: Cargo target directory cache path.
+    value: ${{ steps.resolve.outputs.target_cache_path }}
+  target-cache-restore-status:
+    description: Diagnostic restore status for the Cargo target directory cache.
+    value: ${{ steps.cache-meta.outputs.target_cache_restore_status }}
+  target-lockfile:
+    description: Cargo.lock path used for target-cache keying.
+    value: ${{ steps.resolve.outputs.target_lockfile_path }}
+  target-lockfile-hash:
+    description: Short hash of the Cargo.lock used for target-cache keying, or no-lock.
+    value: ${{ steps.resolve.outputs.target_lockfile_hash }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
@@ -97,11 +135,71 @@ runs:
         INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
         INPUT_TOOLCHAIN_FILE: ${{ inputs.toolchain-file }}
         INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
+        INPUT_TIMESTAMPS: ${{ inputs.timestamps }}
+        INPUT_LOCKFILE: ${{ inputs.lockfile }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/resolve_setup.py"
+
+    - id: cache-plan
+      shell: pwsh
+      run: |
+        function TimestampEnabled {
+          $value = "$env:SETUP_SOLDR_TIMESTAMPS".Trim().ToLowerInvariant()
+          return -not @("0", "false", "no", "off").Contains($value)
+        }
+        function ElapsedPrefix {
+          $start = 0L
+          if (-not [long]::TryParse($env:SETUP_SOLDR_LOG_START_EPOCH, [ref]$start)) {
+            $start = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+          }
+          $elapsed = [Math]::Max(0, [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - $start)
+          $span = [TimeSpan]::FromSeconds($elapsed)
+          return "{0:00}:{1:00}" -f [Math]::Floor($span.TotalMinutes), $span.Seconds
+        }
+        function Log($message) {
+          if (TimestampEnabled) {
+            Write-Host "$(ElapsedPrefix) $message"
+          } else {
+            Write-Host $message
+          }
+        }
+        function LogPath($label, $path) {
+          if ([string]::IsNullOrWhiteSpace($path) -or -not (Test-Path -LiteralPath $path)) {
+            Log "$label path=$path exists=false files=0 bytes=0"
+            return
+          }
+          $measure = Get-ChildItem -LiteralPath $path -Recurse -File -Force -ErrorAction SilentlyContinue |
+            Measure-Object -Property Length -Sum
+          $bytes = if ($measure.Sum) { [int64]$measure.Sum } else { 0 }
+          Log "$label path=$path exists=true files=$($measure.Count) bytes=$bytes"
+        }
+
+        Log "setup-soldr cache plan"
+        Log "cache key=${{ steps.resolve.outputs.cache_key }}"
+        Log "cache restore-key=${{ steps.resolve.outputs.cache_restore_prefix }}"
+        Log "build-cache key=${{ steps.resolve.outputs.build_cache_key }}"
+        Log "build-cache restore-key-toolchain=${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}"
+        Log "build-cache restore-key-os-arch=${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}"
+        Log "target-cache key=${{ steps.resolve.outputs.target_cache_key }}"
+        Log "target-cache restore-key-lock=${{ steps.resolve.outputs.target_cache_restore_key_lock }}"
+        Log "target-cache lockfile=${{ steps.resolve.outputs.target_lockfile_path }}"
+        Log "target-cache lockfile-hash=${{ steps.resolve.outputs.target_lockfile_hash }}"
+        LogPath "cache before restore" "${{ steps.resolve.outputs.cache_root }}"
+        LogPath "build-cache before restore" "${{ steps.resolve.outputs.build_cache_path }}"
+        LogPath "target-cache before restore" "${{ steps.resolve.outputs.target_cache_path }}"
+
+    - id: cache-lookup
+      if: ${{ inputs.cache == 'true' }}
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.cache_root }}
+        key: ${{ steps.resolve.outputs.cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.cache_restore_prefix }}
+        lookup-only: true
 
     - id: cache
       if: ${{ inputs.cache == 'true' }}
@@ -112,6 +210,17 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
 
+    - id: build-cache-lookup
+      if: ${{ inputs.build-cache == 'true' }}
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.build_cache_path }}
+        key: ${{ steps.resolve.outputs.build_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
+        lookup-only: true
+
     - id: build-cache-restore
       if: ${{ inputs.build-cache == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -121,6 +230,16 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
           ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
+
+    - id: target-cache-lookup
+      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.target_cache_path }}
+        key: ${{ steps.resolve.outputs.target_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+        lookup-only: true
 
     - id: target-cache
       if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
@@ -197,16 +316,70 @@ runs:
       shell: pwsh
       env:
         RAW_CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        LOOKUP_CACHE_HIT: ${{ steps.cache-lookup.outputs.cache-hit }}
+        LOOKUP_CACHE_MATCHED_KEY: ${{ steps.cache-lookup.outputs.cache-matched-key }}
+        CACHE_KEY: ${{ steps.resolve.outputs.cache_key }}
         RAW_BUILD_CACHE_HIT: ${{ steps.build-cache-restore.outputs.cache-hit }}
+        LOOKUP_BUILD_CACHE_HIT: ${{ steps.build-cache-lookup.outputs.cache-hit }}
+        LOOKUP_BUILD_CACHE_MATCHED_KEY: ${{ steps.build-cache-lookup.outputs.cache-matched-key }}
+        BUILD_CACHE_KEY: ${{ steps.resolve.outputs.build_cache_key }}
         RAW_TARGET_CACHE_HIT: ${{ steps.target-cache.outputs.cache-hit }}
+        LOOKUP_TARGET_CACHE_HIT: ${{ steps.target-cache-lookup.outputs.cache-hit }}
+        LOOKUP_TARGET_CACHE_MATCHED_KEY: ${{ steps.target-cache-lookup.outputs.cache-matched-key }}
+        TARGET_CACHE_KEY: ${{ steps.resolve.outputs.target_cache_key }}
         BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
         TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
       run: |
+        function TimestampEnabled {
+          $value = "$env:SETUP_SOLDR_TIMESTAMPS".Trim().ToLowerInvariant()
+          return -not @("0", "false", "no", "off").Contains($value)
+        }
+        function ElapsedPrefix {
+          $start = 0L
+          if (-not [long]::TryParse($env:SETUP_SOLDR_LOG_START_EPOCH, [ref]$start)) {
+            $start = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+          }
+          $elapsed = [Math]::Max(0, [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - $start)
+          $span = [TimeSpan]::FromSeconds($elapsed)
+          return "{0:00}:{1:00}" -f [Math]::Floor($span.TotalMinutes), $span.Seconds
+        }
+        function Log($message) {
+          if (TimestampEnabled) {
+            Write-Host "$(ElapsedPrefix) $message"
+          } else {
+            Write-Host $message
+          }
+        }
+        function RestoreStatus($enabled, $lookupHit, $matchedKey, $primaryKey) {
+          if ($enabled -ne "true") {
+            return "disabled"
+          }
+          if ($lookupHit -eq "true") {
+            return "exact-hit"
+          }
+          if (-not [string]::IsNullOrWhiteSpace($matchedKey)) {
+            return "restore-key-hit:$matchedKey"
+          }
+          return "miss"
+        }
+        function LogPath($label, $path) {
+          if ([string]::IsNullOrWhiteSpace($path) -or -not (Test-Path -LiteralPath $path)) {
+            Log "$label path=$path exists=false files=0 bytes=0"
+            return
+          }
+          $measure = Get-ChildItem -LiteralPath $path -Recurse -File -Force -ErrorAction SilentlyContinue |
+            Measure-Object -Property Length -Sum
+          $bytes = if ($measure.Sum) { [int64]$measure.Sum } else { 0 }
+          Log "$label path=$path exists=true files=$($measure.Count) bytes=$bytes"
+        }
+
         $value = $env:RAW_CACHE_HIT
         if ([string]::IsNullOrWhiteSpace($value)) {
           $value = "false"
         }
         "cache_hit=$value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        $cacheStatus = RestoreStatus "${{ inputs.cache }}" $env:LOOKUP_CACHE_HIT $env:LOOKUP_CACHE_MATCHED_KEY $env:CACHE_KEY
+        "cache_restore_status=$cacheStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
         if ($env:BUILD_CACHE_ENABLED -eq "true") {
           $buildValue = $env:RAW_BUILD_CACHE_HIT
@@ -217,6 +390,8 @@ runs:
           $buildValue = ""
         }
         "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        $buildStatus = RestoreStatus $env:BUILD_CACHE_ENABLED $env:LOOKUP_BUILD_CACHE_HIT $env:LOOKUP_BUILD_CACHE_MATCHED_KEY $env:BUILD_CACHE_KEY
+        "build_cache_restore_status=$buildStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
         if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:TARGET_CACHE_ENABLED -eq "true") {
           $targetValue = $env:RAW_TARGET_CACHE_HIT
@@ -227,3 +402,13 @@ runs:
           $targetValue = ""
         }
         "target_cache_hit=$targetValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        $targetEnabled = if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:TARGET_CACHE_ENABLED -eq "true") { "true" } else { "false" }
+        $targetStatus = RestoreStatus $targetEnabled $env:LOOKUP_TARGET_CACHE_HIT $env:LOOKUP_TARGET_CACHE_MATCHED_KEY $env:TARGET_CACHE_KEY
+        "target_cache_restore_status=$targetStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+        Log "cache restore status=$cacheStatus exact-hit=$value"
+        Log "build-cache restore status=$buildStatus exact-hit=$buildValue"
+        Log "target-cache restore status=$targetStatus exact-hit=$targetValue"
+        LogPath "cache after restore" "${{ steps.resolve.outputs.cache_root }}"
+        LogPath "build-cache after restore" "${{ steps.resolve.outputs.build_cache_path }}"
+        LogPath "target-cache after restore" "${{ steps.resolve.outputs.target_cache_path }}"


### PR DESCRIPTION
## Summary
- add a timestamps input, defaulting to true, and stream setup/build output with elapsed mm:ss prefixes
- infer/hash Cargo.lock next to target-dir and expose target lockfile diagnostics
- expose cache keys, cache paths, restore status, and path-size diagnostics for setup, zccache, and target caches
- replace the heavy zackees/soldr smoke checkout with a generated no-dependency Rust smoke project

## Validation
- actionlint .github/workflows/setup-soldr-action.yml
- python -B -m py_compile .github/actions/setup-soldr/*.py
- local resolver simulation confirmed nested Cargo.lock is hashed instead of no-lock

Fixes #2