### PR TITLE
Preserve colors with timestamped logs

### DIFF
--- a/.github/actions/setup-soldr/log_utils.py
+++ b/.github/actions/setup-soldr/log_utils.py
@@ -15,6 +15,15 @@ def timestamps_enabled() -> bool:
     return value not in {"0", "false", "no", "off"}
 
 
+def color_force_environment(base: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(os.environ if base is None else base)
+    if timestamps_enabled() and "NO_COLOR" not in env:
+        env.setdefault("CARGO_TERM_COLOR", "always")
+        env.setdefault("CLICOLOR_FORCE", "1")
+        env.setdefault("FORCE_COLOR", "1")
+    return env
+
+
 def _start_epoch() -> float:
     value = os.environ.get("SETUP_SOLDR_LOG_START_EPOCH", "").strip()
     if value:
@@ -48,6 +57,7 @@ def run(command: list[str]) -> None:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        env=color_force_environment(),
     )
     assert process.stdout is not None
     for line in process.stdout:
@@ -58,8 +68,9 @@ def run(command: list[str]) -> None:
 
 
 def main() -> int:
-    for line in sys.stdin:
-        print(format_line(line.rstrip("\n")), flush=True)
+    for line in sys.stdin.buffer:
+        message = line.rstrip(b"\r\n").decode("utf-8", errors="replace")
+        print(format_line(message), flush=True)
     return 0
 
 

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -142,9 +142,7 @@ def _write_outputs(values: dict[str, str]) -> None:
 def main() -> None:
     workspace = Path(os.environ["ACTION_WORKSPACE"]).resolve()
     runner_temp = Path(os.environ.get("RUNNER_TEMP", workspace / ".tmp")).resolve()
-    log_start = os.environ.get("SETUP_SOLDR_LOG_START_EPOCH", "").strip()
-    if not log_start:
-        log_start = str(int(time.time()))
+    log_start = str(int(time.time()))
 
     requested_cache_dir = os.environ.get("INPUT_CACHE_DIR", "").strip()
     cache_root = Path(requested_cache_dir).expanduser().resolve() if requested_cache_dir else (

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -241,7 +241,15 @@ def main() -> None:
     _write_env("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", json.dumps(toolchain["components"]))
     _write_env("SETUP_SOLDR_TOOLCHAIN_TARGETS", json.dumps(toolchain["targets"]))
     _write_env("SETUP_SOLDR_LOG_START_EPOCH", log_start)
-    _write_env("SETUP_SOLDR_TIMESTAMPS", os.environ.get("INPUT_TIMESTAMPS", "true").strip() or "true")
+    timestamps = os.environ.get("INPUT_TIMESTAMPS", "true").strip() or "true"
+    _write_env("SETUP_SOLDR_TIMESTAMPS", timestamps)
+    if timestamps.lower() not in {"0", "false", "no", "off"} and "NO_COLOR" not in os.environ:
+        if not os.environ.get("CARGO_TERM_COLOR"):
+            _write_env("CARGO_TERM_COLOR", "always")
+        if not os.environ.get("CLICOLOR_FORCE"):
+            _write_env("CLICOLOR_FORCE", "1")
+        if not os.environ.get("FORCE_COLOR"):
+            _write_env("FORCE_COLOR", "1")
     if os.environ.get("INPUT_TRUST_MODE", "").strip():
         _write_env("SOLDR_TRUST_MODE", os.environ["INPUT_TRUST_MODE"].strip())
 

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -33,11 +33,6 @@ jobs:
           path: zccache
           persist-credentials: false
 
-      - name: Initialize elapsed log clock
-        shell: bash
-        run: |
-          echo "SETUP_SOLDR_LOG_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
-
       - id: setup
         name: Setup Soldr
         uses: ./setup-soldr


### PR DESCRIPTION
## Summary
- force Rust/Cargo-compatible color env vars only when timestamps are enabled and NO_COLOR is absent
- preserve ANSI escape sequences while prefixing streamed log lines
- keep timestamps:false from forcing color

## Validation
- actionlint .github/workflows/setup-soldr-action.yml
- python -B -m py_compile .github/actions/setup-soldr/*.py
- local ANSI stream test shows timestamp prefix plus ANSI escapes survive
- local resolver simulation confirms color env exports with timestamps=true and not with timestamps=false

Fixes #5