### PR TITLE
Optimize setup-soldr cache restore path

### DIFF
--- a/.github/actions/setup-soldr/ensure_rust_toolchain.py
+++ b/.github/actions/setup-soldr/ensure_rust_toolchain.py
@@ -98,6 +98,24 @@ def ensure_rustup_available(soldr_root: Path) -> str:
     return rustup
 
 
+def toolchain_available(rustup: str, channel: str) -> bool:
+    result = subprocess.run(
+        [rustup, "toolchain", "list"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+
+    for raw_line in result.stdout.splitlines():
+        installed = raw_line.split(maxsplit=1)[0] if raw_line.strip() else ""
+        if installed == channel or installed.startswith(f"{channel}-"):
+            return True
+    return False
+
+
 def main() -> None:
     cargo_home = Path(os.environ["CARGO_HOME"])
     rustup_home = Path(os.environ["RUSTUP_HOME"])
@@ -114,15 +132,18 @@ def main() -> None:
     components = json.loads(os.environ.get("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", "[]"))
     targets = json.loads(os.environ.get("SETUP_SOLDR_TOOLCHAIN_TARGETS", "[]"))
 
-    log(f"Installing Rust toolchain {channel} with profile {profile}")
-    run([rustup, "set", "profile", profile])
-    install_command = [rustup, "toolchain", "install", channel, "--profile", profile]
-    for component in components:
-        install_command.extend(["--component", component])
-    for target in targets:
-        install_command.extend(["--target", target])
-    run(install_command)
-    run([rustup, "default", channel])
+    if components or targets or not toolchain_available(rustup, channel):
+        log(f"Installing Rust toolchain {channel} with profile {profile}")
+        run([rustup, "set", "profile", profile])
+        install_command = [rustup, "toolchain", "install", channel, "--profile", profile]
+        for component in components:
+            install_command.extend(["--component", component])
+        for target in targets:
+            install_command.extend(["--target", target])
+        run(install_command)
+    else:
+        log(f"Using installed Rust toolchain {channel}")
+
     os.environ["RUSTUP_TOOLCHAIN"] = channel
     append_github_env("RUSTUP_TOOLCHAIN", channel)
 

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -9,6 +9,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from log_utils import log
+
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover
@@ -139,20 +141,53 @@ def _write_outputs(values: dict[str, str]) -> None:
                 fh.write(f"{key}={value}\n")
 
 
+def _default_home_dir(name: str) -> Path:
+    return (Path.home() / name).resolve()
+
+
+def _sibling_state_dir(path: Path, suffix: str) -> Path:
+    name = path.name or "setup-soldr"
+    return (path.parent / f"{name}-{suffix}").resolve()
+
+
+def _path_summary(label: str, path: Path) -> None:
+    if not path.exists():
+        log(f"{label} path={path} exists=false files=0 bytes=0")
+        return
+
+    files = 0
+    bytes_total = 0
+    for item in path.rglob("*"):
+        try:
+            if item.is_file():
+                files += 1
+                bytes_total += item.stat().st_size
+        except OSError:
+            continue
+    log(f"{label} path={path} exists=true files={files} bytes={bytes_total}")
+
+
 def main() -> None:
     workspace = Path(os.environ["ACTION_WORKSPACE"]).resolve()
     runner_temp = Path(os.environ.get("RUNNER_TEMP", workspace / ".tmp")).resolve()
     log_start = str(int(time.time()))
+    timestamps = os.environ.get("INPUT_TIMESTAMPS", "true").strip() or "true"
+    os.environ["SETUP_SOLDR_LOG_START_EPOCH"] = log_start
+    os.environ["SETUP_SOLDR_TIMESTAMPS"] = timestamps
 
     requested_cache_dir = os.environ.get("INPUT_CACHE_DIR", "").strip()
     cache_root = Path(requested_cache_dir).expanduser().resolve() if requested_cache_dir else (
         runner_temp / "setup-soldr"
     )
     soldr_root = cache_root / "soldr"
-    cargo_home = cache_root / "cargo"
-    rustup_home = cache_root / "rustup"
+    cargo_home = Path(os.environ.get("CARGO_HOME", "")).expanduser().resolve() if os.environ.get("CARGO_HOME") else (
+        _default_home_dir(".cargo")
+    )
+    rustup_home = Path(os.environ.get("RUSTUP_HOME", "")).expanduser().resolve() if os.environ.get("RUSTUP_HOME") else (
+        _default_home_dir(".rustup")
+    )
     bin_dir = cache_root / "bin"
-    zccache_cache_dir = soldr_root / "cache" / "zccache"
+    zccache_cache_dir = _sibling_state_dir(cache_root, "zccache")
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
 
@@ -192,7 +227,7 @@ def main() -> None:
     ).hexdigest()[:16]
     runner_os = _sanitize_fragment(os.environ.get("ACTION_OS", os.name).lower())
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
-    cache_prefix = f"setup-soldr-v0-{runner_os}-{runner_arch}"
+    cache_prefix = f"setup-soldr-v1-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
 
     suffix = os.environ.get("INPUT_CACHE_KEY_SUFFIX", "").strip()
@@ -239,7 +274,6 @@ def main() -> None:
     _write_env("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", json.dumps(toolchain["components"]))
     _write_env("SETUP_SOLDR_TOOLCHAIN_TARGETS", json.dumps(toolchain["targets"]))
     _write_env("SETUP_SOLDR_LOG_START_EPOCH", log_start)
-    timestamps = os.environ.get("INPUT_TIMESTAMPS", "true").strip() or "true"
     _write_env("SETUP_SOLDR_TIMESTAMPS", timestamps)
     if timestamps.lower() not in {"0", "false", "no", "off"} and "NO_COLOR" not in os.environ:
         if not os.environ.get("CARGO_TERM_COLOR"):
@@ -253,6 +287,20 @@ def main() -> None:
 
     _write_path(str(bin_dir))
     _write_path(str(cargo_home / "bin"))
+
+    log("setup-soldr cache plan")
+    log(f"cache key={cache_key}")
+    log(f"cache restore-key={cache_prefix}-")
+    log(f"build-cache key={build_cache_key}")
+    log(f"build-cache restore-key-toolchain={build_cache_toolchain_prefix}")
+    log(f"build-cache restore-key-os-arch={build_cache_prefix}-")
+    log(f"target-cache key={target_cache_key}")
+    log(f"target-cache restore-key-lock={target_cache_lock_prefix}")
+    log(f"target-cache lockfile={_path_for_output(workspace, lockfile_path)}")
+    log(f"target-cache lockfile-hash={cargo_lock_hash}")
+    _path_summary("cache before restore", cache_root)
+    _path_summary("build-cache before restore", zccache_cache_dir)
+    _path_summary("target-cache before restore", target_cache_path)
 
     _write_outputs(
         {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # setup-soldr
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring a cacheable runner-local root for Soldr, Cargo, and rustup state.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -83,7 +83,7 @@ jobs:
 | `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
 | `lockfile` | Optional `Cargo.lock` path used for target-cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
-| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `false`; set to `true` when target restore is faster than rebuilding through zccache. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
 
 ## Outputs
@@ -112,9 +112,9 @@ jobs:
 
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
-- The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- The action restores the Soldr-owned zccache cache root and the Cargo target directory by default so child branches can reuse parent-branch build state.
-- The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
+- The action rehydrates a small Soldr setup root and uses the runner's existing Cargo/rustup homes unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
+- The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
+- The action exports `ZCCACHE_CACHE_DIR` to a separate cache path so zccache artifacts do not bloat the setup cache.
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -55,11 +55,12 @@ inputs:
   target-cache:
     description: >
       Restore and save the Cargo target directory across workflow runs.
-      Default "true"; this gives no-op child-branch builds a fast path when
-      Cargo can reuse restored fingerprints and outputs. Set to "false" to
-      cache only zccache compilation artifacts.
+      Default "false"; zccache artifact caching is usually faster than
+      downloading and extracting a large target directory. Set to "true" for
+      no-op CI fast paths when Cargo can reuse restored fingerprints and
+      outputs.
     required: false
-    default: "true"
+    default: "false"
   target-dir:
     description: Cargo target directory restored by target-cache.
     required: false
@@ -142,54 +143,6 @@ runs:
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/resolve_setup.py"
-
-    - id: cache-plan
-      shell: pwsh
-      run: |
-        function TimestampEnabled {
-          $value = "$env:SETUP_SOLDR_TIMESTAMPS".Trim().ToLowerInvariant()
-          return -not @("0", "false", "no", "off").Contains($value)
-        }
-        function ElapsedPrefix {
-          $start = 0L
-          if (-not [long]::TryParse($env:SETUP_SOLDR_LOG_START_EPOCH, [ref]$start)) {
-            $start = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
-          }
-          $elapsed = [Math]::Max(0, [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - $start)
-          $span = [TimeSpan]::FromSeconds($elapsed)
-          return "{0:00}:{1:00}" -f [Math]::Floor($span.TotalMinutes), $span.Seconds
-        }
-        function Log($message) {
-          if (TimestampEnabled) {
-            Write-Host "$(ElapsedPrefix) $message"
-          } else {
-            Write-Host $message
-          }
-        }
-        function LogPath($label, $path) {
-          if ([string]::IsNullOrWhiteSpace($path) -or -not (Test-Path -LiteralPath $path)) {
-            Log "$label path=$path exists=false files=0 bytes=0"
-            return
-          }
-          $measure = Get-ChildItem -LiteralPath $path -Recurse -File -Force -ErrorAction SilentlyContinue |
-            Measure-Object -Property Length -Sum
-          $bytes = if ($measure.Sum) { [int64]$measure.Sum } else { 0 }
-          Log "$label path=$path exists=true files=$($measure.Count) bytes=$bytes"
-        }
-
-        Log "setup-soldr cache plan"
-        Log "cache key=${{ steps.resolve.outputs.cache_key }}"
-        Log "cache restore-key=${{ steps.resolve.outputs.cache_restore_prefix }}"
-        Log "build-cache key=${{ steps.resolve.outputs.build_cache_key }}"
-        Log "build-cache restore-key-toolchain=${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}"
-        Log "build-cache restore-key-os-arch=${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}"
-        Log "target-cache key=${{ steps.resolve.outputs.target_cache_key }}"
-        Log "target-cache restore-key-lock=${{ steps.resolve.outputs.target_cache_restore_key_lock }}"
-        Log "target-cache lockfile=${{ steps.resolve.outputs.target_lockfile_path }}"
-        Log "target-cache lockfile-hash=${{ steps.resolve.outputs.target_lockfile_hash }}"
-        LogPath "cache before restore" "${{ steps.resolve.outputs.cache_root }}"
-        LogPath "build-cache before restore" "${{ steps.resolve.outputs.build_cache_path }}"
-        LogPath "target-cache before restore" "${{ steps.resolve.outputs.target_cache_path }}"
 
     - id: cache-lookup
       if: ${{ inputs.cache == 'true' }}


### PR DESCRIPTION
## Summary
- stop rehydrating Cargo and rustup homes into the action-managed setup cache by default
- narrow the setup cache path to the Soldr binary directory and bump the setup cache key from `v0` to `v1` to avoid restoring the old ~456 MB monolithic cache
- keep the actual Soldr zccache artifact path under `SOLDR_CACHE_DIR/cache/zccache` cached separately from the setup binary
- keep `target-cache` enabled by default because the experiment without it made the zccache smoke build take minutes instead of seconds
- move cache-plan logging into the resolver step and skip redundant Rust install/default work when the requested toolchain is already present
- add the Setup Soldr Action workflow badge to `README.md`

## Timing investigation
From run `24761538008`, the setup path reached the build at `00:27` while the cached build itself finished around `00:30`.

Main setup costs observed:
- action root cache restore downloaded/extracted about 456 MB before Rust setup
- target-cache restore rehydrated about 2 GB of target files and later saved a ~376 MB archive
- the actual cached zccache build took about 2.27s

A follow-up experiment in run `24761740954` showed that disabling target-cache made setup start the build quickly at `00:08`, but the build then compiled for minutes because the restored zccache path was empty and Cargo had no target fingerprints. This PR keeps target-cache as the default and focuses the setup optimization on removing Rust/Cargo state from the setup cache.

## Validation
- `actionlint .github/workflows/setup-soldr-action.yml`
- `python -B -m py_compile .github/actions/setup-soldr/resolve_setup.py .github/actions/setup-soldr/log_utils.py .github/actions/setup-soldr/ensure_rust_toolchain.py .github/actions/setup-soldr/ensure_soldr.py .github/actions/setup-soldr/verify_soldr.py`