### PR TITLE
Add workflow badge and correct cache paths

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -145,11 +145,6 @@ def _default_home_dir(name: str) -> Path:
     return (Path.home() / name).resolve()
 
 
-def _sibling_state_dir(path: Path, suffix: str) -> Path:
-    name = path.name or "setup-soldr"
-    return (path.parent / f"{name}-{suffix}").resolve()
-
-
 def _path_summary(label: str, path: Path) -> None:
     if not path.exists():
         log(f"{label} path={path} exists=false files=0 bytes=0")
@@ -187,7 +182,8 @@ def main() -> None:
         _default_home_dir(".rustup")
     )
     bin_dir = cache_root / "bin"
-    zccache_cache_dir = _sibling_state_dir(cache_root, "zccache")
+    setup_cache_path = bin_dir
+    zccache_cache_dir = soldr_root / "cache" / "zccache"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
 
@@ -298,13 +294,14 @@ def main() -> None:
     log(f"target-cache restore-key-lock={target_cache_lock_prefix}")
     log(f"target-cache lockfile={_path_for_output(workspace, lockfile_path)}")
     log(f"target-cache lockfile-hash={cargo_lock_hash}")
-    _path_summary("cache before restore", cache_root)
+    _path_summary("cache before restore", setup_cache_path)
     _path_summary("build-cache before restore", zccache_cache_dir)
     _path_summary("target-cache before restore", target_cache_path)
 
     _write_outputs(
         {
             "cache_root": str(cache_root),
+            "setup_cache_path": str(setup_cache_path),
             "cache_key": cache_key,
             "cache_restore_prefix": f"{cache_prefix}-",
             "build_cache_key": build_cache_key,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # setup-soldr
 
+[![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
+
 Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
@@ -83,7 +85,7 @@ jobs:
 | `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
 | `lockfile` | Optional `Cargo.lock` path used for target-cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
-| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `false`; set to `true` when target restore is faster than rebuilding through zccache. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `true`; set to `false` to cache only zccache compilation artifacts. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
 
 ## Outputs
@@ -114,7 +116,7 @@ jobs:
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates a small Soldr setup root and uses the runner's existing Cargo/rustup homes unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
 - The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
-- The action exports `ZCCACHE_CACHE_DIR` to a separate cache path so zccache artifacts do not bloat the setup cache.
+- The action caches the Soldr binary separately from `SOLDR_CACHE_DIR/cache/zccache`, keeping setup restore small while preserving zccache artifacts.
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -55,12 +55,11 @@ inputs:
   target-cache:
     description: >
       Restore and save the Cargo target directory across workflow runs.
-      Default "false"; zccache artifact caching is usually faster than
-      downloading and extracting a large target directory. Set to "true" for
-      no-op CI fast paths when Cargo can reuse restored fingerprints and
-      outputs.
+      Default "true"; this gives no-op child-branch builds a fast path when
+      Cargo can reuse restored fingerprints and outputs. Set to "false" to
+      cache only zccache compilation artifacts.
     required: false
-    default: "false"
+    default: "true"
   target-dir:
     description: Cargo target directory restored by target-cache.
     required: false
@@ -148,7 +147,7 @@ runs:
       if: ${{ inputs.cache == 'true' }}
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.cache_root }}
+        path: ${{ steps.resolve.outputs.setup_cache_path }}
         key: ${{ steps.resolve.outputs.cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
@@ -158,7 +157,7 @@ runs:
       if: ${{ inputs.cache == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.cache_root }}
+        path: ${{ steps.resolve.outputs.setup_cache_path }}
         key: ${{ steps.resolve.outputs.cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
@@ -362,6 +361,6 @@ runs:
         Log "cache restore status=$cacheStatus exact-hit=$value"
         Log "build-cache restore status=$buildStatus exact-hit=$buildValue"
         Log "target-cache restore status=$targetStatus exact-hit=$targetValue"
-        LogPath "cache after restore" "${{ steps.resolve.outputs.cache_root }}"
+        LogPath "cache after restore" "${{ steps.resolve.outputs.setup_cache_path }}"
         LogPath "build-cache after restore" "${{ steps.resolve.outputs.build_cache_path }}"
         LogPath "target-cache after restore" "${{ steps.resolve.outputs.target_cache_path }}"


### PR DESCRIPTION
## Summary
- add the Setup Soldr Action workflow badge to `README.md`
- keep setup cache restore small by caching only the Soldr binary directory for the action setup cache
- restore the actual soldr zccache path under `SOLDR_CACHE_DIR/cache/zccache` so build-cache points at the path soldr currently uses
- restore `target-cache` default to `true`; the no-target-cache experiment built zccache for minutes instead of seconds

## Investigation
PR #7 proved that removing Cargo/rustup from the setup cache works: setup reached the build at `00:08`. It also proved target-cache cannot be default-off yet: with target-cache disabled and an empty zccache path, the zccache build compiled for minutes.

This PR keeps the good part of the optimization while correcting the cache path/defaults.

## Validation
- `actionlint .github/workflows/setup-soldr-action.yml`
- `python -B -m py_compile .github/actions/setup-soldr/resolve_setup.py .github/actions/setup-soldr/log_utils.py .github/actions/setup-soldr/ensure_rust_toolchain.py .github/actions/setup-soldr/ensure_soldr.py .github/actions/setup-soldr/verify_soldr.py`