### PR TITLE
Restore managed zccache setup cache

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -182,7 +182,7 @@ def main() -> None:
         _default_home_dir(".rustup")
     )
     bin_dir = cache_root / "bin"
-    setup_cache_path = bin_dir
+    setup_cache_path = cache_root
     zccache_cache_dir = soldr_root / "cache" / "zccache"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
@@ -223,7 +223,7 @@ def main() -> None:
     ).hexdigest()[:16]
     runner_os = _sanitize_fragment(os.environ.get("ACTION_OS", os.name).lower())
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
-    cache_prefix = f"setup-soldr-v1-{runner_os}-{runner_arch}"
+    cache_prefix = f"setup-soldr-v2-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
 
     suffix = os.environ.get("INPUT_CACHE_KEY_SUFFIX", "").strip()

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ jobs:
 
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
-- The action rehydrates a small Soldr setup root and uses the runner's existing Cargo/rustup homes unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
+- The action rehydrates the Soldr setup root and uses the runner's existing Cargo/rustup homes unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
 - The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
-- The action caches the Soldr binary separately from `SOLDR_CACHE_DIR/cache/zccache`, keeping setup restore small while preserving zccache artifacts.
+- The setup cache intentionally keeps Soldr-managed state so the managed zccache binary does not need to be rebuilt on every run.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- cache the full setup root again so soldr's managed zccache binary/state survives across runs
- keep Cargo and rustup homes outside that setup root, preserving the main optimization from PR #7
- bump the setup cache namespace to `v2` so runs do not restore the broken `v1` cache that only contained the Soldr binary directory
- update README notes to document why Soldr-managed state remains in the setup cache

## Investigation
After PR #8, setup reached the build around `00:17`, but `soldr cargo build` then spent minutes compiling release-profile managed zccache before the actual project build. The log showed `binary_path: null` before the build and several `Finished release profile` entries during `soldr cargo build`.

The action had narrowed the setup cache to `bin/`, which preserved the `soldr` binary but dropped the managed zccache binary under `SOLDR_CACHE_DIR`. This PR restores that setup state without bringing back cached Cargo/rustup homes.

## Validation
- `actionlint .github/workflows/setup-soldr-action.yml`
- `python -B -m py_compile .github/actions/setup-soldr/resolve_setup.py .github/actions/setup-soldr/log_utils.py .github/actions/setup-soldr/ensure_rust_toolchain.py .github/actions/setup-soldr/ensure_soldr.py .github/actions/setup-soldr/verify_soldr.py`