### PR TITLE
Allow scoped target cache paths

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -87,6 +87,33 @@ def _resolve_workspace_path(workspace: Path, value: str) -> Path | None:
     return path.resolve()
 
 
+def _path_or_pattern_for_output(workspace: Path, value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        return ""
+
+    negate = cleaned.startswith("!")
+    if negate:
+        cleaned = cleaned[1:].strip()
+
+    path = Path(cleaned).expanduser()
+    if not path.is_absolute():
+        path = workspace / path
+    rendered = str(path)
+    return f"!{rendered}" if negate else rendered
+
+
+def resolve_target_cache_paths(workspace: Path, target_cache_path: Path, target_cache_paths_input: str) -> str:
+    values = [
+        _path_or_pattern_for_output(workspace, line)
+        for line in target_cache_paths_input.splitlines()
+        if line.strip()
+    ]
+    if not values:
+        return str(target_cache_path)
+    return "\n".join(values)
+
+
 def resolve_lockfile_path(workspace: Path, target_cache_path: Path, lockfile_input: str) -> Path | None:
     explicit = _resolve_workspace_path(workspace, lockfile_input)
     if explicit is not None:
@@ -252,8 +279,19 @@ def main() -> None:
         os.environ.get("INPUT_LOCKFILE", ""),
     )
     cargo_lock_hash = _short_file_hash(lockfile_path, "no-lock") if lockfile_path else "no-lock"
-    target_cache_prefix = f"setup-soldr-targetcache-v0-{runner_os}-{runner_arch}"
-    target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+    target_cache_paths = resolve_target_cache_paths(
+        workspace,
+        target_cache_path,
+        os.environ.get("INPUT_TARGET_CACHE_PATHS", ""),
+    )
+    target_paths_customized = target_cache_paths != str(target_cache_path)
+    if target_paths_customized:
+        target_paths_hash = hashlib.sha256(target_cache_paths.encode("utf-8")).hexdigest()[:16]
+        target_cache_prefix = f"setup-soldr-targetcache-v1-{runner_os}-{runner_arch}"
+        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-{target_paths_hash}-"
+    else:
+        target_cache_prefix = f"setup-soldr-targetcache-v0-{runner_os}-{runner_arch}"
+        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
     target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
 
     if suffix:
@@ -292,6 +330,7 @@ def main() -> None:
     log(f"build-cache restore-key-os-arch={build_cache_prefix}-")
     log(f"target-cache key={target_cache_key}")
     log(f"target-cache restore-key-lock={target_cache_lock_prefix}")
+    log(f"target-cache paths={target_cache_paths}")
     log(f"target-cache lockfile={_path_for_output(workspace, lockfile_path)}")
     log(f"target-cache lockfile-hash={cargo_lock_hash}")
     _path_summary("cache before restore", setup_cache_path)
@@ -309,6 +348,7 @@ def main() -> None:
             "build_cache_restore_key_os_arch": f"{build_cache_prefix}-",
             "build_cache_path": str(zccache_cache_dir),
             "target_cache_path": str(target_cache_path),
+            "target_cache_paths": target_cache_paths,
             "target_cache_key": target_cache_key,
             "target_cache_restore_key_lock": target_cache_lock_prefix,
             "target_lockfile_path": _path_for_output(workspace, lockfile_path),

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -40,6 +40,7 @@ jobs:
           cache: true
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
+          target-cache-paths: zccache/target/debug
           cache-key-suffix: zccache
 
       - name: Show action outputs
@@ -58,6 +59,7 @@ jobs:
           Write-Host "target-cache-hit=${{ steps.setup.outputs.target-cache-hit }}"
           Write-Host "target-cache-key=${{ steps.setup.outputs.target-cache-key }}"
           Write-Host "target-cache-path=${{ steps.setup.outputs.target-cache-path }}"
+          Write-Host "target-cache-paths=${{ steps.setup.outputs.target-cache-paths }}"
           Write-Host "target-cache-restore-status=${{ steps.setup.outputs.target-cache-restore-status }}"
           Write-Host "target-lockfile=${{ steps.setup.outputs.target-lockfile }}"
           Write-Host "target-lockfile-hash=${{ steps.setup.outputs.target-lockfile-hash }}"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ jobs:
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
 | `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `true`; set to `false` to cache only zccache compilation artifacts. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
+| `target-cache-paths` | Optional newline-separated target-cache paths or glob patterns. Defaults to `target-dir`; set to a profile subdirectory such as `target/debug` to avoid caching unrelated profiles. |
 
 ## Outputs
 
@@ -105,6 +106,7 @@ jobs:
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. |
 | `target-cache-key` | Primary key used for the Cargo target directory cache. |
 | `target-cache-path` | Cargo target directory cache path. |
+| `target-cache-paths` | Paths or glob patterns passed to `actions/cache` for target-cache. |
 | `target-cache-restore-status` | Diagnostic restore status for the Cargo target directory cache. |
 | `target-lockfile` | `Cargo.lock` path used for target-cache keying. |
 | `target-lockfile-hash` | Short hash of the `Cargo.lock` used for target-cache keying, or `no-lock`. |

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,14 @@ inputs:
     description: Cargo target directory restored by target-cache.
     required: false
     default: target
+  target-cache-paths:
+    description: >
+      Optional newline-separated paths or glob patterns to cache for
+      target-cache. Defaults to target-dir. Use this to cache only the
+      profile-specific subdirectory a workflow needs, for example
+      target/debug.
+    required: false
+    default: ""
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -111,6 +119,9 @@ outputs:
   target-cache-path:
     description: Cargo target directory cache path.
     value: ${{ steps.resolve.outputs.target_cache_path }}
+  target-cache-paths:
+    description: Paths or glob patterns passed to actions/cache for the Cargo target cache.
+    value: ${{ steps.resolve.outputs.target_cache_paths }}
   target-cache-restore-status:
     description: Diagnostic restore status for the Cargo target directory cache.
     value: ${{ steps.cache-meta.outputs.target_cache_restore_status }}
@@ -138,6 +149,7 @@ runs:
         INPUT_TIMESTAMPS: ${{ inputs.timestamps }}
         INPUT_LOCKFILE: ${{ inputs.lockfile }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
+        INPUT_TARGET_CACHE_PATHS: ${{ inputs.target-cache-paths }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}
@@ -187,7 +199,7 @@ runs:
       if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.target_cache_path }}
+        path: ${{ steps.resolve.outputs.target_cache_paths }}
         key: ${{ steps.resolve.outputs.target_cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
@@ -197,7 +209,7 @@ runs:
       if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.target_cache_path }}
+        path: ${{ steps.resolve.outputs.target_cache_paths }}
         key: ${{ steps.resolve.outputs.target_cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}


### PR DESCRIPTION
## Summary
- add `target-cache-paths`, an optional newline-separated cache path/glob input for the Cargo target cache
- keep the existing default behavior unchanged: empty `target-cache-paths` still caches `target-dir`
- isolate custom target-cache path sets under a `targetcache-v1` namespace keyed by the path-set hash, so scoped caches do not restore old full-target archives
- use `zccache/target/debug` in the action smoke workflow to avoid caching unrelated release-profile artifacts

## Issue #10
The hot run after PR #9 restored the setup and build caches correctly, but target-cache restore downloaded about 722 MB. The actual build took about 6.6s after a full target restore, so the remaining bottleneck is target-cache size.

The zccache smoke workflow only runs `soldr cargo build --locked --package zccache-cli`, which is a debug-profile build. Caching the full target directory also captures release-profile artifacts produced by managed zccache bootstrap experiments and makes the archive much larger than the smoke build needs.

## Validation
- `actionlint .github/workflows/setup-soldr-action.yml`
- `python -B -m py_compile .github/actions/setup-soldr/resolve_setup.py .github/actions/setup-soldr/log_utils.py .github/actions/setup-soldr/ensure_rust_toolchain.py .github/actions/setup-soldr/ensure_soldr.py .github/actions/setup-soldr/verify_soldr.py`
- local resolver simulation confirms custom target-cache path emits a `targetcache-v1` key and absolute `target_cache_paths`

Fixes #10