### PR TITLE
Cache target metadata with debug profile

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -40,7 +40,10 @@ jobs:
           cache: true
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
-          target-cache-paths: zccache/target/debug
+          target-cache-paths: |
+            zccache/target/.rustc_info.json
+            zccache/target/CACHEDIR.TAG
+            zccache/target/debug
           cache-key-suffix: zccache
 
       - name: Show action outputs


### PR DESCRIPTION
## Summary
- expand the zccache smoke workflow scoped target cache from only `target/debug` to target root metadata plus `target/debug`
- keep release-profile artifacts out of the smoke workflow target cache

## Context
PR #11 added `target-cache-paths` and changed the smoke workflow to cache only `zccache/target/debug`. The cache restored, but Cargo still rebuilt every crate on rerun. This follow-up includes the target root metadata files Cargo may need to validate restored fingerprints while still avoiding `target/release`.

## Validation
- `actionlint .github/workflows/setup-soldr-action.yml`
- `python -B -m py_compile .github/actions/setup-soldr/resolve_setup.py .github/actions/setup-soldr/log_utils.py .github/actions/setup-soldr/ensure_rust_toolchain.py .github/actions/setup-soldr/ensure_soldr.py .github/actions/setup-soldr/verify_soldr.py`

Refs #10