### PR TITLE
Add agent release tagging note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Notes
+
+- When an important action feature or compatibility fix is merged, move the floating major tag forward, for example `v0`, so downstream workflows using `zackees/setup-soldr@v0` receive the fix. Keep immutable release tags such as `v0.1.0` unchanged.


### PR DESCRIPTION
## Summary
- add root AGENTS.md with a note to move the floating major action tag, such as v0, after important feature or compatibility merges
- clarify immutable release tags should not be moved

## Validation
- documentation-only change

Note: the remote v0 tag has already been moved to current main, 098f8ab.