### PR TITLE
Add bounded hot target cache mode

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -103,15 +103,56 @@ def _path_or_pattern_for_output(workspace: Path, value: str) -> str:
     return f"!{rendered}" if negate else rendered
 
 
-def resolve_target_cache_paths(workspace: Path, target_cache_path: Path, target_cache_paths_input: str) -> str:
+HOT_TARGET_CACHE_PATTERNS = (
+    ".rustc_info.json",
+    "CACHEDIR.TAG",
+    "**/.fingerprint/**",
+    "**/deps/*.d",
+    "**/deps/*.rmeta",
+    "**/build/**/output",
+    "**/build/**/invoked.timestamp",
+    "**/build/**/root-output",
+    "!**/incremental/**",
+)
+
+
+def normalize_target_cache_mode(value: str) -> str:
+    mode = value.strip().lower() or "hot"
+    if mode not in {"hot", "full", "off"}:
+        raise RuntimeError(
+            f"invalid target-cache-mode {value!r}; expected hot, full, or off"
+        )
+    return mode
+
+
+def hot_target_cache_paths(target_cache_path: Path) -> str:
+    values: list[str] = []
+    for pattern in HOT_TARGET_CACHE_PATTERNS:
+        negate = pattern.startswith("!")
+        cleaned = pattern[1:] if negate else pattern
+        rendered = str(target_cache_path / cleaned)
+        values.append(f"!{rendered}" if negate else rendered)
+    return "\n".join(values)
+
+
+def resolve_target_cache_paths(
+    workspace: Path,
+    target_cache_path: Path,
+    target_cache_paths_input: str,
+    target_cache_mode: str,
+) -> tuple[str, str]:
     values = [
         _path_or_pattern_for_output(workspace, line)
         for line in target_cache_paths_input.splitlines()
         if line.strip()
     ]
-    if not values:
-        return str(target_cache_path)
-    return "\n".join(values)
+    if values:
+        return "\n".join(values), "custom"
+    if target_cache_mode == "off":
+        return str(target_cache_path), "off"
+    if target_cache_mode == "full":
+        return str(target_cache_path), "full"
+    return hot_target_cache_paths(target_cache_path), "hot"
 
 
 def resolve_lockfile_path(workspace: Path, target_cache_path: Path, lockfile_input: str) -> Path | None:
@@ -283,19 +324,27 @@ def main() -> None:
         os.environ.get("INPUT_LOCKFILE", ""),
     )
     cargo_lock_hash = _short_file_hash(lockfile_path, "no-lock") if lockfile_path else "no-lock"
-    target_cache_paths = resolve_target_cache_paths(
+    target_cache_mode = normalize_target_cache_mode(
+        os.environ.get("INPUT_TARGET_CACHE_MODE", "hot")
+    )
+    target_cache_enabled = (
+        os.environ.get("INPUT_TARGET_CACHE", "true").strip().lower()
+        not in {"0", "false", "no", "off"}
+        and target_cache_mode != "off"
+    )
+    target_cache_paths, target_cache_effective_mode = resolve_target_cache_paths(
         workspace,
         target_cache_path,
         os.environ.get("INPUT_TARGET_CACHE_PATHS", ""),
+        target_cache_mode,
     )
-    target_paths_customized = target_cache_paths != str(target_cache_path)
-    if target_paths_customized:
-        target_paths_hash = hashlib.sha256(target_cache_paths.encode("utf-8")).hexdigest()[:16]
-        target_cache_prefix = f"setup-soldr-targetcache-v1-{runner_os}-{runner_arch}"
-        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-{target_paths_hash}-"
-    else:
-        target_cache_prefix = f"setup-soldr-targetcache-v0-{runner_os}-{runner_arch}"
+    if target_cache_effective_mode == "full":
+        target_cache_prefix = f"setup-soldr-targetcache-full-v1-{runner_os}-{runner_arch}"
         target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+    else:
+        target_paths_hash = hashlib.sha256(target_cache_paths.encode("utf-8")).hexdigest()[:16]
+        target_cache_prefix = f"setup-soldr-targetcache-{target_cache_effective_mode}-v1-{runner_os}-{runner_arch}"
+        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-{target_paths_hash}-"
     target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
     target_cache_parent_key = f"{target_cache_lock_prefix}{parent_sha}" if parent_sha else ""
 
@@ -340,6 +389,8 @@ def main() -> None:
     log(f"build-cache restore-key-toolchain={build_cache_toolchain_prefix}")
     log(f"build-cache restore-key-os-arch={build_cache_prefix}-")
     log(f"target-cache key={target_cache_key}")
+    log(f"target-cache enabled={str(target_cache_enabled).lower()}")
+    log(f"target-cache mode={target_cache_effective_mode}")
     if target_cache_parent_key:
         log(f"target-cache restore-key-parent={target_cache_parent_key}")
     log(f"target-cache restore-key-lock={target_cache_lock_prefix}")
@@ -363,6 +414,8 @@ def main() -> None:
             "build_cache_path": str(zccache_cache_dir),
             "target_cache_path": str(target_cache_path),
             "target_cache_paths": target_cache_paths,
+            "target_cache_enabled": str(target_cache_enabled).lower(),
+            "target_cache_mode": target_cache_effective_mode,
             "target_cache_key": target_cache_key,
             "target_cache_restore_key_parent": target_cache_parent_key,
             "target_cache_restore_key_lock": target_cache_lock_prefix,

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -63,6 +63,7 @@ jobs:
           Write-Host "target-cache-key=${{ steps.setup.outputs.target-cache-key }}"
           Write-Host "target-cache-path=${{ steps.setup.outputs.target-cache-path }}"
           Write-Host "target-cache-paths=${{ steps.setup.outputs.target-cache-paths }}"
+          Write-Host "target-cache-mode=${{ steps.setup.outputs.target-cache-mode }}"
           Write-Host "target-cache-restore-status=${{ steps.setup.outputs.target-cache-restore-status }}"
           Write-Host "target-lockfile=${{ steps.setup.outputs.target-lockfile }}"
           Write-Host "target-lockfile-hash=${{ steps.setup.outputs.target-lockfile-hash }}"

--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ jobs:
 | `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
 | `lockfile` | Optional `Cargo.lock` path used for target-cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
-| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `true`; set to `false` to cache only zccache compilation artifacts. |
+| `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. Default `true`; set to `false` to cache only zccache compilation artifacts. |
+| `target-cache-mode` | Target cache mode. Default `hot` caches Cargo freshness metadata and lightweight type metadata; `full` caches the whole `target-dir`; `off` disables target caching. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
-| `target-cache-paths` | Optional newline-separated target-cache paths or glob patterns. Defaults to `target-dir`; set to a profile subdirectory such as `target/debug` to avoid caching unrelated profiles. |
+| `target-cache-paths` | Optional newline-separated target-cache paths or glob patterns. Overrides `target-cache-mode`; use this to pin a profile-specific or job-specific cache shape. |
 
 ## Outputs
 
@@ -107,6 +108,7 @@ jobs:
 | `target-cache-key` | Primary key used for the Cargo target directory cache. |
 | `target-cache-path` | Cargo target directory cache path. |
 | `target-cache-paths` | Paths or glob patterns passed to `actions/cache` for target-cache. |
+| `target-cache-mode` | Effective target cache mode. |
 | `target-cache-restore-status` | Diagnostic restore status for the Cargo target directory cache. |
 | `target-lockfile` | `Cargo.lock` path used for target-cache keying. |
 | `target-lockfile-hash` | Short hash of the `Cargo.lock` used for target-cache keying, or `no-lock`. |
@@ -119,6 +121,7 @@ jobs:
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action rehydrates the Soldr setup root and uses the runner's existing Cargo/rustup homes unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
 - The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
+- The default target cache mode is `hot`, which avoids archiving the full Cargo `target/` tree and caches only Cargo freshness metadata plus lightweight type metadata. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - The setup cache intentionally keeps Soldr-managed state so the managed zccache binary does not need to be rebuilt on every run.
 
 ## Development

--- a/action.yml
+++ b/action.yml
@@ -55,11 +55,19 @@ inputs:
   target-cache:
     description: >
       Restore and save the Cargo target directory across workflow runs.
-      Default "true"; this gives no-op child-branch builds a fast path when
-      Cargo can reuse restored fingerprints and outputs. Set to "false" to
-      cache only zccache compilation artifacts.
+      Default "true"; target-cache-mode controls whether this is a bounded hot
+      metadata cache or an explicit full target cache. Set to "false" to cache
+      only zccache compilation artifacts.
     required: false
     default: "true"
+  target-cache-mode:
+    description: >
+      Cargo target cache mode. "hot" caches a bounded set of Cargo freshness
+      metadata and lightweight type metadata by default. "full" caches the
+      entire target-dir and should only be used for tightly scoped jobs.
+      "off" disables target caching even when target-cache is true.
+    required: false
+    default: hot
   target-dir:
     description: Cargo target directory restored by target-cache.
     required: false
@@ -122,6 +130,9 @@ outputs:
   target-cache-paths:
     description: Paths or glob patterns passed to actions/cache for the Cargo target cache.
     value: ${{ steps.resolve.outputs.target_cache_paths }}
+  target-cache-mode:
+    description: Effective Cargo target cache mode.
+    value: ${{ steps.resolve.outputs.target_cache_mode }}
   target-cache-restore-status:
     description: Diagnostic restore status for the Cargo target directory cache.
     value: ${{ steps.cache-meta.outputs.target_cache_restore_status }}
@@ -148,6 +159,8 @@ runs:
         INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
         INPUT_TIMESTAMPS: ${{ inputs.timestamps }}
         INPUT_LOCKFILE: ${{ inputs.lockfile }}
+        INPUT_TARGET_CACHE: ${{ inputs.target-cache }}
+        INPUT_TARGET_CACHE_MODE: ${{ inputs.target-cache-mode }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
         INPUT_TARGET_CACHE_PATHS: ${{ inputs.target-cache-paths }}
         ACTION_WORKSPACE: ${{ github.workspace }}
@@ -199,7 +212,7 @@ runs:
           ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
 
     - id: target-cache-lookup
-      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ${{ steps.resolve.outputs.target_cache_paths }}
@@ -210,7 +223,7 @@ runs:
         lookup-only: true
 
     - id: target-cache
-      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ${{ steps.resolve.outputs.target_cache_paths }}
@@ -239,7 +252,7 @@ runs:
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
 
     - id: zccache-warm-target
-      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
       shell: pwsh
       env:
         TARGET_CACHE_PATH: ${{ steps.resolve.outputs.target_cache_path }}
@@ -298,6 +311,7 @@ runs:
         TARGET_CACHE_KEY: ${{ steps.resolve.outputs.target_cache_key }}
         BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
         TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
+        EFFECTIVE_TARGET_CACHE_ENABLED: ${{ steps.resolve.outputs.target_cache_enabled }}
       run: |
         function TimestampEnabled {
           $value = "$env:SETUP_SOLDR_TIMESTAMPS".Trim().ToLowerInvariant()
@@ -362,7 +376,7 @@ runs:
         $buildStatus = RestoreStatus $env:BUILD_CACHE_ENABLED $env:LOOKUP_BUILD_CACHE_HIT $env:LOOKUP_BUILD_CACHE_MATCHED_KEY $env:BUILD_CACHE_KEY
         "build_cache_restore_status=$buildStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:TARGET_CACHE_ENABLED -eq "true") {
+        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true") {
           $targetValue = $env:RAW_TARGET_CACHE_HIT
           if ([string]::IsNullOrWhiteSpace($targetValue)) {
             $targetValue = "false"
@@ -371,7 +385,7 @@ runs:
           $targetValue = ""
         }
         "target_cache_hit=$targetValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-        $targetEnabled = if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:TARGET_CACHE_ENABLED -eq "true") { "true" } else { "false" }
+        $targetEnabled = if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true") { "true" } else { "false" }
         $targetStatus = RestoreStatus $targetEnabled $env:LOOKUP_TARGET_CACHE_HIT $env:LOOKUP_TARGET_CACHE_MATCHED_KEY $env:TARGET_CACHE_KEY
         "target_cache_restore_status=$targetStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 


### PR DESCRIPTION
## Summary

- add target-cache-mode with default hot, explicit full, and off
- make default target caching use bounded Cargo metadata/type metadata patterns instead of full target/
- expose target cache mode/enabled outputs and log the effective mode
- document the hot/full/off behavior

Closes #25.

## Validation

- Python resolve helper checks
- resolve_setup.py smoke run with target-cache-mode=hot
- actionlint .github/workflows/setup-soldr-action.yml
- git diff --check