### PR TITLE
Expose build cache mode enum

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -87,72 +87,88 @@ def _resolve_workspace_path(workspace: Path, value: str) -> Path | None:
     return path.resolve()
 
 
-def _path_or_pattern_for_output(workspace: Path, value: str) -> str:
-    cleaned = value.strip()
-    if not cleaned:
+def _short_json_hash(value: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+
+
+def _workspace_manifest_hash(workspace: Path) -> str:
+    hasher = hashlib.sha256()
+    matched = False
+    ignored_dirs = {".git", "target", ".soldr", "node_modules"}
+    for path in sorted(workspace.rglob("Cargo.toml")):
+        if any(part in ignored_dirs for part in path.relative_to(workspace).parts):
+            continue
+        matched = True
+        relative = path.relative_to(workspace).as_posix()
+        hasher.update(relative.encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(path.read_bytes())
+        hasher.update(b"\0")
+    return hasher.hexdigest()[:16] if matched else "no-manifest"
+
+
+def _cargo_config_hash(workspace: Path) -> str:
+    hasher = hashlib.sha256()
+    matched = False
+    for relative in (".cargo/config.toml", ".cargo/config"):
+        path = workspace / relative
+        if path.exists():
+            matched = True
+            hasher.update(relative.encode("utf-8"))
+            hasher.update(b"\0")
+            hasher.update(path.read_bytes())
+            hasher.update(b"\0")
+    return hasher.hexdigest()[:16] if matched else "no-config"
+
+
+def _target_env_hash() -> str:
+    relevant: dict[str, str] = {}
+    for name, value in os.environ.items():
+        if name in {
+            "CARGO_BUILD_TARGET",
+            "CARGO_ENCODED_RUSTFLAGS",
+            "CARGO_TARGET_DIR",
+            "RUSTFLAGS",
+        } or (name.startswith("CARGO_TARGET_") and name.endswith("_RUSTFLAGS")):
+            relevant[name] = value
+    return _short_json_hash(relevant)
+
+
+def _normalize_legacy_target_cache_mode(value: str) -> str:
+    mode = value.strip().lower()
+    if not mode:
         return ""
-
-    negate = cleaned.startswith("!")
-    if negate:
-        cleaned = cleaned[1:].strip()
-
-    path = Path(cleaned).expanduser()
-    if not path.is_absolute():
-        path = workspace / path
-    rendered = str(path)
-    return f"!{rendered}" if negate else rendered
-
-
-HOT_TARGET_CACHE_PATTERNS = (
-    ".rustc_info.json",
-    "CACHEDIR.TAG",
-    "**/.fingerprint/**",
-    "**/deps/*.d",
-    "**/deps/*.rmeta",
-    "**/build/**/output",
-    "**/build/**/invoked.timestamp",
-    "**/build/**/root-output",
-    "!**/incremental/**",
-)
-
-
-def normalize_target_cache_mode(value: str) -> str:
-    mode = value.strip().lower() or "hot"
-    if mode not in {"hot", "full", "off"}:
+    if mode == "hot":
+        log("target-cache-mode 'hot' is deprecated; using build-cache-mode 'thin'.")
+        return "thin"
+    if mode not in {"thin", "full", "off"}:
         raise RuntimeError(
-            f"invalid target-cache-mode {value!r}; expected hot, full, or off"
+            f"invalid target-cache-mode {value!r}; expected thin, full, or off"
         )
     return mode
 
 
-def hot_target_cache_paths(target_cache_path: Path) -> str:
-    values: list[str] = []
-    for pattern in HOT_TARGET_CACHE_PATTERNS:
-        negate = pattern.startswith("!")
-        cleaned = pattern[1:] if negate else pattern
-        rendered = str(target_cache_path / cleaned)
-        values.append(f"!{rendered}" if negate else rendered)
-    return "\n".join(values)
+def normalize_build_cache_mode(
+    value: str,
+    legacy_target_mode: str = "",
+    allow_legacy_translation: bool = True,
+) -> str:
+    mode = value.strip().lower() or "thin"
+    if mode not in {"thin", "full"}:
+        raise RuntimeError(
+            f"invalid build-cache-mode {value!r}; expected thin or full"
+        )
 
-
-def resolve_target_cache_paths(
-    workspace: Path,
-    target_cache_path: Path,
-    target_cache_paths_input: str,
-    target_cache_mode: str,
-) -> tuple[str, str]:
-    values = [
-        _path_or_pattern_for_output(workspace, line)
-        for line in target_cache_paths_input.splitlines()
-        if line.strip()
-    ]
-    if values:
-        return "\n".join(values), "custom"
-    if target_cache_mode == "off":
-        return str(target_cache_path), "off"
-    if target_cache_mode == "full":
-        return str(target_cache_path), "full"
-    return hot_target_cache_paths(target_cache_path), "hot"
+    legacy_mode = _normalize_legacy_target_cache_mode(legacy_target_mode)
+    if allow_legacy_translation and legacy_mode == "full" and mode == "thin":
+        log(
+            f"target-cache-mode '{legacy_mode}' is deprecated; "
+            f"translating to build-cache-mode '{legacy_mode}'."
+        )
+        return legacy_mode
+    return mode
 
 
 def resolve_lockfile_path(workspace: Path, target_cache_path: Path, lockfile_input: str) -> Path | None:
@@ -252,6 +268,7 @@ def main() -> None:
     bin_dir = cache_root / "bin"
     setup_cache_path = cache_root
     zccache_cache_dir = soldr_root / "cache" / "zccache"
+    target_cache_bundle_path = cache_root.parent / f"{cache_root.name}-target-thin"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
 
@@ -265,6 +282,7 @@ def main() -> None:
         rustup_home,
         bin_dir,
         zccache_cache_dir,
+        target_cache_bundle_path,
     ):
         path.mkdir(parents=True, exist_ok=True)
 
@@ -293,10 +311,13 @@ def main() -> None:
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
     cache_prefix = f"setup-soldr-v2-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
+    workspace_manifest_hash = _workspace_manifest_hash(workspace)
+    cargo_config_hash = _cargo_config_hash(workspace)
 
     suffix = os.environ.get("INPUT_CACHE_KEY_SUFFIX", "").strip()
+    sanitized_suffix = _sanitize_fragment(suffix) if suffix else ""
     if suffix:
-        cache_key = f"{cache_key}-{_sanitize_fragment(suffix)}"
+        cache_key = f"{cache_key}-{sanitized_suffix}"
 
     # Build-artifact cache (Soldr-owned zccache compilation cache).
     # Key shape: setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{sha}.
@@ -324,43 +345,100 @@ def main() -> None:
         os.environ.get("INPUT_LOCKFILE", ""),
     )
     cargo_lock_hash = _short_file_hash(lockfile_path, "no-lock") if lockfile_path else "no-lock"
-    target_cache_mode = normalize_target_cache_mode(
-        os.environ.get("INPUT_TARGET_CACHE_MODE", "hot")
+    legacy_target_cache_mode = _normalize_legacy_target_cache_mode(
+        os.environ.get("INPUT_TARGET_CACHE_MODE", "")
     )
-    target_cache_enabled = (
+    target_cache_requested = (
         os.environ.get("INPUT_TARGET_CACHE", "true").strip().lower()
         not in {"0", "false", "no", "off"}
-        and target_cache_mode != "off"
+        and legacy_target_cache_mode != "off"
     )
-    target_cache_paths, target_cache_effective_mode = resolve_target_cache_paths(
-        workspace,
-        target_cache_path,
-        os.environ.get("INPUT_TARGET_CACHE_PATHS", ""),
-        target_cache_mode,
+    build_cache_mode = normalize_build_cache_mode(
+        os.environ.get("INPUT_BUILD_CACHE_MODE", ""),
+        legacy_target_cache_mode,
+        (
+            "INPUT_BUILD_CACHE_MODE" not in os.environ
+            or not os.environ.get("INPUT_BUILD_CACHE_MODE", "").strip()
+        )
+        and target_cache_requested,
     )
-    if target_cache_effective_mode == "full":
+    build_cache_enabled = (
+        os.environ.get("INPUT_BUILD_CACHE", "true").strip().lower()
+        not in {"0", "false", "no", "off"}
+    )
+    target_cache_enabled = (
+        build_cache_enabled
+        and target_cache_requested
+    )
+    if build_cache_mode == "thin" and cargo_lock_hash == "no-lock":
+        log("build-cache-mode 'thin' requires Cargo.lock; target artifact cache disabled.")
+        target_cache_enabled = False
+
+    target_shape_hash = _short_json_hash(
+        {
+            "target_dir": str(target_cache_path),
+            "target_dir_input": target_dir_input,
+            "target_env": _target_env_hash(),
+        }
+    )
+    target_inputs_hash = _short_json_hash(
+        {
+            "cargo_config": cargo_config_hash,
+            "cargo_lock": cargo_lock_hash,
+            "manifest": workspace_manifest_hash,
+            "target_shape": target_shape_hash,
+            "toolchain": digest,
+        }
+    )
+    if not target_cache_enabled:
+        target_cache_paths = (
+            str(target_cache_path) if build_cache_mode == "full" else str(target_cache_bundle_path)
+        )
+        target_cache_effective_mode = "off"
+        target_cache_prefix = f"setup-soldr-targetcache-off-v1-{runner_os}-{runner_arch}"
+        target_cache_lock_prefix = ""
+        target_cache_key = f"{target_cache_prefix}-{target_inputs_hash}"
+        target_cache_parent_key = ""
+    elif build_cache_mode == "full":
+        target_cache_paths = str(target_cache_path)
+        target_cache_effective_mode = "full"
         target_cache_prefix = f"setup-soldr-targetcache-full-v1-{runner_os}-{runner_arch}"
-        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+        target_cache_suffix_fragment = f"{sanitized_suffix}-" if sanitized_suffix else ""
+        target_cache_lock_prefix = (
+            f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+            f"{target_shape_hash}-{target_cache_suffix_fragment}"
+        )
+        target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
+        target_cache_parent_key = f"{target_cache_lock_prefix}{parent_sha}" if parent_sha else ""
     else:
-        target_paths_hash = hashlib.sha256(target_cache_paths.encode("utf-8")).hexdigest()[:16]
-        target_cache_prefix = f"setup-soldr-targetcache-{target_cache_effective_mode}-v1-{runner_os}-{runner_arch}"
-        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-{target_paths_hash}-"
-    target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
-    target_cache_parent_key = f"{target_cache_lock_prefix}{parent_sha}" if parent_sha else ""
+        target_cache_paths = str(target_cache_bundle_path)
+        target_cache_effective_mode = "thin"
+        target_cache_prefix = f"setup-soldr-targetcache-thin-v1-{runner_os}-{runner_arch}"
+        target_cache_suffix_fragment = f"{sanitized_suffix}-" if sanitized_suffix else ""
+        target_cache_lock_prefix = (
+            f"{target_cache_prefix}-{target_inputs_hash}-{target_cache_suffix_fragment}"
+        )
+        target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
+        target_cache_parent_key = f"{target_cache_lock_prefix}{parent_sha}" if parent_sha else ""
 
     if suffix:
-        sanitized_suffix = _sanitize_fragment(suffix)
         build_cache_key = f"{build_cache_key}-{sanitized_suffix}"
-        target_cache_key = f"{target_cache_key}-{sanitized_suffix}"
         if build_cache_parent_key:
             build_cache_parent_key = f"{build_cache_parent_key}-{sanitized_suffix}"
-        if target_cache_parent_key:
-            target_cache_parent_key = f"{target_cache_parent_key}-{sanitized_suffix}"
 
     _write_env("SOLDR_CACHE_DIR", str(soldr_root))
     _write_env("CARGO_HOME", str(cargo_home))
     _write_env("RUSTUP_HOME", str(rustup_home))
     _write_env("ZCCACHE_CACHE_DIR", str(zccache_cache_dir))
+    _write_env("SETUP_SOLDR_BUILD_CACHE_MODE", build_cache_mode)
+    _write_env("SOLDR_BUILD_CACHE_MODE", build_cache_mode)
+    _write_env(
+        "SOLDR_TARGET_CACHE_MODE",
+        target_cache_effective_mode if target_cache_enabled else "off",
+    )
+    _write_env("SOLDR_TARGET_CACHE_DIR", str(target_cache_path))
+    _write_env("SOLDR_TARGET_CACHE_BUNDLE_DIR", str(target_cache_bundle_path))
+    _write_env("SOLDR_TARGET_CACHE_BACKEND", "auto")
     _write_env("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain["channel"])
     _write_env("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain["profile"])
     _write_env("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", json.dumps(toolchain["components"]))
@@ -384,6 +462,7 @@ def main() -> None:
     log(f"cache key={cache_key}")
     log(f"cache restore-key={cache_prefix}-")
     log(f"build-cache key={build_cache_key}")
+    log(f"build-cache mode={build_cache_mode}")
     if build_cache_parent_key:
         log(f"build-cache restore-key-parent={build_cache_parent_key}")
     log(f"build-cache restore-key-toolchain={build_cache_toolchain_prefix}")
@@ -395,11 +474,15 @@ def main() -> None:
         log(f"target-cache restore-key-parent={target_cache_parent_key}")
     log(f"target-cache restore-key-lock={target_cache_lock_prefix}")
     log(f"target-cache paths={target_cache_paths}")
+    log(f"target-cache bundle-dir={target_cache_bundle_path}")
     log(f"target-cache lockfile={_path_for_output(workspace, lockfile_path)}")
     log(f"target-cache lockfile-hash={cargo_lock_hash}")
     _path_summary("cache before restore", setup_cache_path)
     _path_summary("build-cache before restore", zccache_cache_dir)
-    _path_summary("target-cache before restore", target_cache_path)
+    _path_summary(
+        "target-cache before restore",
+        target_cache_path if build_cache_mode == "full" else target_cache_bundle_path,
+    )
 
     _write_outputs(
         {
@@ -412,7 +495,9 @@ def main() -> None:
             "build_cache_restore_key_toolchain": build_cache_toolchain_prefix,
             "build_cache_restore_key_os_arch": f"{build_cache_prefix}-",
             "build_cache_path": str(zccache_cache_dir),
+            "build_cache_mode": build_cache_mode,
             "target_cache_path": str(target_cache_path),
+            "target_cache_bundle_path": str(target_cache_bundle_path),
             "target_cache_paths": target_cache_paths,
             "target_cache_enabled": str(target_cache_enabled).lower(),
             "target_cache_mode": target_cache_effective_mode,

--- a/.github/actions/setup-soldr/verify_soldr.py
+++ b/.github/actions/setup-soldr/verify_soldr.py
@@ -9,6 +9,17 @@ import sys
 from log_utils import log, run
 
 
+def _version_tuple(value: str) -> tuple[int, int, int] | None:
+    cleaned = value.strip().lstrip("v")
+    parts = cleaned.split(".")
+    if len(parts) < 3:
+        return None
+    try:
+        return int(parts[0]), int(parts[1]), int(parts[2].split("-", 1)[0])
+    except ValueError:
+        return None
+
+
 def _is_transient_zccache_status_failure(exc: subprocess.CalledProcessError) -> bool:
     combined = "\n".join(
         part
@@ -32,6 +43,17 @@ def main() -> None:
 
     with open(output_path, "a", encoding="utf-8") as fh:
         fh.write(f"soldr_version={payload['soldr_version']}\n")
+
+    if os.environ.get("SETUP_SOLDR_REQUIRE_RUST_PLAN", "").lower() == "true":
+        soldr_version = str(payload["soldr_version"])
+        parsed = _version_tuple(soldr_version)
+        if parsed is None or parsed < (0, 7, 10):
+            mode = os.environ.get("SETUP_SOLDR_BUILD_CACHE_MODE", "thin")
+            raise RuntimeError(
+                "setup-soldr build-cache-mode "
+                f"{mode!r} requires soldr v0.7.10 or newer for the "
+                f"zccache Rust artifact plan API; installed {soldr_version}."
+            )
 
     run(["cargo", "--version"])
     run(["rustc", "--version"])

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -38,12 +38,9 @@ jobs:
         uses: ./setup-soldr
         with:
           cache: true
+          build-cache-mode: thin
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
-          target-cache-paths: |
-            zccache/target/.rustc_info.json
-            zccache/target/CACHEDIR.TAG
-            zccache/target/debug
           cache-key-suffix: zccache
 
       - name: Show action outputs
@@ -58,6 +55,7 @@ jobs:
           Write-Host "build-cache-hit=${{ steps.setup.outputs.build-cache-hit }}"
           Write-Host "build-cache-key=${{ steps.setup.outputs.build-cache-key }}"
           Write-Host "build-cache-path=${{ steps.setup.outputs.build-cache-path }}"
+          Write-Host "build-cache-mode=${{ steps.setup.outputs.build-cache-mode }}"
           Write-Host "build-cache-restore-status=${{ steps.setup.outputs.build-cache-restore-status }}"
           Write-Host "target-cache-hit=${{ steps.setup.outputs.target-cache-hit }}"
           Write-Host "target-cache-key=${{ steps.setup.outputs.target-cache-key }}"

--- a/.github/workflows/zccache-build-demo.yml
+++ b/.github/workflows/zccache-build-demo.yml
@@ -88,12 +88,9 @@ jobs:
         uses: zackees/setup-soldr@v0
         with:
           cache: true
+          build-cache-mode: thin
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
-          target-cache-paths: |
-            zccache/target/.rustc_info.json
-            zccache/target/CACHEDIR.TAG
-            zccache/target/debug
           cache-key-suffix: ${{ env.DEMO_CACHE_SUFFIX }}
 
       - name: Show cache plan
@@ -107,6 +104,7 @@ jobs:
             echo "| soldr-version | \`${{ steps.setup.outputs.soldr-version }}\` |"
             echo "| cache-restore-status | \`${{ steps.setup.outputs.cache-restore-status }}\` |"
             echo "| build-cache-restore-status | \`${{ steps.setup.outputs.build-cache-restore-status }}\` |"
+            echo "| build-cache-mode | \`${{ steps.setup.outputs.build-cache-mode }}\` |"
             echo "| target-cache-restore-status | \`${{ steps.setup.outputs.target-cache-restore-status }}\` |"
             echo "| target-cache-mode | \`${{ steps.setup.outputs.target-cache-mode }}\` |"
             echo "| target-lockfile-hash | \`${{ steps.setup.outputs.target-lockfile-hash }}\` |"
@@ -150,12 +148,9 @@ jobs:
         uses: zackees/setup-soldr@v0
         with:
           cache: true
+          build-cache-mode: thin
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
-          target-cache-paths: |
-            zccache/target/.rustc_info.json
-            zccache/target/CACHEDIR.TAG
-            zccache/target/debug
           cache-key-suffix: ${{ env.DEMO_CACHE_SUFFIX }}
 
       - name: Show cache plan
@@ -169,6 +164,7 @@ jobs:
             echo "| soldr-version | \`${{ steps.setup.outputs.soldr-version }}\` |"
             echo "| cache-restore-status | \`${{ steps.setup.outputs.cache-restore-status }}\` |"
             echo "| build-cache-restore-status | \`${{ steps.setup.outputs.build-cache-restore-status }}\` |"
+            echo "| build-cache-mode | \`${{ steps.setup.outputs.build-cache-mode }}\` |"
             echo "| target-cache-restore-status | \`${{ steps.setup.outputs.target-cache-restore-status }}\` |"
             echo "| target-cache-mode | \`${{ steps.setup.outputs.target-cache-mode }}\` |"
             echo "| target-lockfile-hash | \`${{ steps.setup.outputs.target-lockfile-hash }}\` |"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.9`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.10`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -75,7 +75,7 @@ jobs:
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.9`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.10`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root. |
 | `cache-key-suffix` | Optional escape hatch appended to the cache key. |
@@ -83,12 +83,17 @@ jobs:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty; `components` and `targets` in the file are provisioned during setup. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
-| `lockfile` | Optional `Cargo.lock` path used for target-cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
-| `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
-| `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. Default `true`; set to `false` to cache only zccache compilation artifacts. |
-| `target-cache-mode` | Target cache mode. Default `hot` caches Cargo freshness metadata and lightweight type metadata; `full` caches the whole `target-dir`; `off` disables target caching. |
-| `target-dir` | Cargo target directory restored by `target-cache`. |
-| `target-cache-paths` | Optional newline-separated target-cache paths or glob patterns. Overrides `target-cache-mode`; use this to pin a profile-specific or job-specific cache shape. |
+| `lockfile` | Optional `Cargo.lock` path used for Rust artifact cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
+| `build-cache` | Restore and save Soldr/zccache build cache state across runs. Default `true`; set to `false` to opt out. |
+| `build-cache-mode` | Rust build cache mode. Default `thin` restores bounded dependency artifacts through soldr/zccache. `full` opts into whole-target caching and should be treated as unbounded. |
+| `target-dir` | Cargo target directory used by soldr when constructing the Rust artifact cache plan. |
+
+### Legacy Compatibility Inputs
+
+| Input | Meaning |
+|---|---|
+| `target-cache` | Deprecated compatibility input. Set to `false` to disable Rust target artifact caching. |
+| `target-cache-mode` | Deprecated compatibility input translated into `build-cache-mode`: `hot` maps to `thin`, `full` maps to `full`, and `off` disables Rust target artifact caching. |
 
 ## Outputs
 
@@ -103,25 +108,28 @@ jobs:
 | `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is disabled. |
 | `build-cache-key` | Primary key used for the Soldr-owned zccache compilation cache. |
 | `build-cache-path` | Soldr-owned zccache compilation cache path. |
+| `build-cache-mode` | Effective Rust build cache mode selected for soldr/zccache. |
 | `build-cache-restore-status` | Diagnostic restore status for the Soldr-owned zccache compilation cache. |
-| `target-cache-hit` | Whether the Cargo target directory cache was restored. |
-| `target-cache-key` | Primary key used for the Cargo target directory cache. |
-| `target-cache-path` | Cargo target directory cache path. |
-| `target-cache-paths` | Paths or glob patterns passed to `actions/cache` for target-cache. |
-| `target-cache-mode` | Effective target cache mode. |
-| `target-cache-restore-status` | Diagnostic restore status for the Cargo target directory cache. |
-| `target-lockfile` | `Cargo.lock` path used for target-cache keying. |
-| `target-lockfile-hash` | Short hash of the `Cargo.lock` used for target-cache keying, or `no-lock`. |
+| `target-cache-hit` | Whether the zccache-owned Rust artifact cache state was restored. |
+| `target-cache-key` | Primary key used for the zccache-owned Rust artifact cache state. |
+| `target-cache-path` | Cargo target directory used by soldr for Rust artifact planning. |
+| `target-cache-paths` | Path passed to `actions/cache` for zccache-owned Rust artifact cache state. |
+| `target-cache-mode` | Effective Rust target artifact cache mode. |
+| `target-cache-restore-status` | Diagnostic restore status for the Rust target artifact cache state. |
+| `target-lockfile` | `Cargo.lock` path used for Rust artifact cache keying. |
+| `target-lockfile-hash` | Short hash of the `Cargo.lock` used for Rust artifact cache keying, or `no-lock`. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.9`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.10`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action rehydrates the Soldr setup root and uses the runner's existing Cargo/rustup homes unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
-- The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
-- The default target cache mode is `hot`, which avoids archiving the full Cargo `target/` tree and caches only Cargo freshness metadata plus lightweight type metadata. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
+- The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
+- The default `build-cache-mode` is `thin`, which asks soldr to generate a bounded dependency-artifact plan and lets zccache restore/save the artifacts and report stats. Use `build-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
+- zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
+- Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
 - The setup cache intentionally keeps Soldr-managed state so the managed zccache binary does not need to be rebuilt on every run.
 
 ## Development

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,9 @@ branding:
   color: green
 inputs:
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.9.
+    description: Soldr version or tag to install. Defaults to 0.7.10.
     required: false
-    default: "0.7.9"
+    default: "0.7.10"
   cache:
     description: Restore and save the action-managed cache/state root across workflow runs.
     required: false
@@ -38,48 +38,39 @@ inputs:
     required: false
     default: "true"
   lockfile:
-    description: Optional Cargo.lock path used for target-cache keying. Empty infers Cargo.lock next to target-dir, then workspace Cargo.lock.
+    description: Optional Cargo.lock path used for Rust artifact cache keying. Empty infers Cargo.lock next to target-dir, then workspace Cargo.lock.
     required: false
     default: ""
   build-cache:
     description: >
-      Restore and save the Soldr-owned zccache compilation artifact cache
-      across workflow runs. Default "true"; the action restores the
-      action-managed zccache cache root with a toolchain-scoped key and
-      saves it at end-of-job, letting
-      GitHub's own-branch -> PR base -> default-branch restore order seed
-      feature-branch runs from the latest main-branch save without any
-      repo-side configuration. Set to "false" to opt out.
+      Restore and save Soldr/zccache build cache state across workflow runs.
+      Default "true"; set to "false" to opt out of zccache artifact caching.
     required: false
     default: "true"
+  build-cache-mode:
+    description: >
+      Rust build cache mode. "thin" is the default bounded dependency-artifact
+      mode. "full" opts into whole-target caching and should be treated as
+      unbounded.
+    required: false
+    default: ""
   target-cache:
     description: >
-      Restore and save the Cargo target directory across workflow runs.
-      Default "true"; target-cache-mode controls whether this is a bounded hot
-      metadata cache or an explicit full target cache. Set to "false" to cache
-      only zccache compilation artifacts.
+      Deprecated compatibility input. Set to "false" to disable Rust target
+      artifact caching; prefer build-cache-mode for selecting thin or full.
     required: false
     default: "true"
   target-cache-mode:
     description: >
-      Cargo target cache mode. "hot" caches a bounded set of Cargo freshness
-      metadata and lightweight type metadata by default. "full" caches the
-      entire target-dir and should only be used for tightly scoped jobs.
-      "off" disables target caching even when target-cache is true.
-    required: false
-    default: hot
-  target-dir:
-    description: Cargo target directory restored by target-cache.
-    required: false
-    default: target
-  target-cache-paths:
-    description: >
-      Optional newline-separated paths or glob patterns to cache for
-      target-cache. Defaults to target-dir. Use this to cache only the
-      profile-specific subdirectory a workflow needs, for example
-      target/debug.
+      Deprecated compatibility input translated into build-cache-mode.
+      "hot" maps to "thin", "full" maps to "full", and "off" disables Rust
+      target artifact caching.
     required: false
     default: ""
+  target-dir:
+    description: Cargo target directory used by soldr when constructing the Rust artifact cache plan.
+    required: false
+    default: target
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -112,35 +103,38 @@ outputs:
   build-cache-path:
     description: Soldr-owned zccache compilation cache path.
     value: ${{ steps.resolve.outputs.build_cache_path }}
+  build-cache-mode:
+    description: Effective Rust build cache mode selected for soldr/zccache.
+    value: ${{ steps.resolve.outputs.build_cache_mode }}
   build-cache-restore-status:
     description: Diagnostic restore status for the Soldr-owned zccache compilation cache.
     value: ${{ steps.cache-meta.outputs.build_cache_restore_status }}
   target-cache-hit:
     description: >
-      Whether the action restored the Cargo target directory cache. "true"
+      Whether the action restored the zccache-owned Rust artifact cache state. "true"
       for an exact key match, "false" for a restore-key fallback or no cache,
       empty string when `target-cache` or `build-cache` is disabled.
     value: ${{ steps.cache-meta.outputs.target_cache_hit }}
   target-cache-key:
-    description: Primary key used for the Cargo target directory cache.
+    description: Primary key used for the zccache-owned Rust artifact cache state.
     value: ${{ steps.resolve.outputs.target_cache_key }}
   target-cache-path:
-    description: Cargo target directory cache path.
+    description: Cargo target directory used by soldr for Rust artifact planning.
     value: ${{ steps.resolve.outputs.target_cache_path }}
   target-cache-paths:
-    description: Paths or glob patterns passed to actions/cache for the Cargo target cache.
+    description: Path passed to actions/cache for zccache-owned Rust artifact cache state.
     value: ${{ steps.resolve.outputs.target_cache_paths }}
   target-cache-mode:
-    description: Effective Cargo target cache mode.
+    description: Effective Rust target artifact cache mode.
     value: ${{ steps.resolve.outputs.target_cache_mode }}
   target-cache-restore-status:
-    description: Diagnostic restore status for the Cargo target directory cache.
+    description: Diagnostic restore status for the Rust target artifact cache state.
     value: ${{ steps.cache-meta.outputs.target_cache_restore_status }}
   target-lockfile:
-    description: Cargo.lock path used for target-cache keying.
+    description: Cargo.lock path used for Rust artifact cache keying.
     value: ${{ steps.resolve.outputs.target_lockfile_path }}
   target-lockfile-hash:
-    description: Short hash of the Cargo.lock used for target-cache keying, or no-lock.
+    description: Short hash of the Cargo.lock used for Rust artifact cache keying, or no-lock.
     value: ${{ steps.resolve.outputs.target_lockfile_hash }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
@@ -159,10 +153,11 @@ runs:
         INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
         INPUT_TIMESTAMPS: ${{ inputs.timestamps }}
         INPUT_LOCKFILE: ${{ inputs.lockfile }}
+        INPUT_BUILD_CACHE: ${{ inputs.build-cache }}
+        INPUT_BUILD_CACHE_MODE: ${{ inputs.build-cache-mode }}
         INPUT_TARGET_CACHE: ${{ inputs.target-cache }}
         INPUT_TARGET_CACHE_MODE: ${{ inputs.target-cache-mode }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
-        INPUT_TARGET_CACHE_PATHS: ${{ inputs.target-cache-paths }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}
@@ -249,50 +244,9 @@ runs:
       shell: pwsh
       env:
         SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
+        SETUP_SOLDR_BUILD_CACHE_MODE: ${{ steps.resolve.outputs.build_cache_mode }}
+        SETUP_SOLDR_REQUIRE_RUST_PLAN: ${{ steps.resolve.outputs.target_cache_enabled }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
-
-    - id: zccache-warm-target
-      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
-      shell: pwsh
-      env:
-        TARGET_CACHE_PATH: ${{ steps.resolve.outputs.target_cache_path }}
-      run: |
-        $target = $env:TARGET_CACHE_PATH
-        if ([string]::IsNullOrWhiteSpace($target) -or -not (Test-Path -LiteralPath $target)) {
-          Write-Host "No restored target directory to warm."
-          exit 0
-        }
-
-        $exeName = if ($IsWindows) { "zccache.exe" } else { "zccache" }
-        $zccache = $null
-        if (-not [string]::IsNullOrWhiteSpace($env:SOLDR_CACHE_DIR)) {
-          $soldrBin = Join-Path -Path $env:SOLDR_CACHE_DIR -ChildPath "bin"
-          if (Test-Path -LiteralPath $soldrBin) {
-            $zccache = Get-ChildItem -LiteralPath $soldrBin -Recurse -Filter $exeName -File -ErrorAction SilentlyContinue |
-              Select-Object -First 1 -ExpandProperty FullName
-          }
-        }
-        if ([string]::IsNullOrWhiteSpace($zccache)) {
-          $command = Get-Command zccache -ErrorAction SilentlyContinue
-          if ($command) {
-            $zccache = $command.Source
-          }
-        }
-        if ([string]::IsNullOrWhiteSpace($zccache)) {
-          Write-Host "zccache binary is not available yet; refreshing target mtimes only."
-        } else {
-          Write-Host "Warming target directory from zccache: $target"
-          & $zccache warm --target-dir $target
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "zccache warm did not complete successfully; continuing."
-          }
-        }
-
-        $stamp = (Get-Date).AddMinutes(1)
-        Get-ChildItem -LiteralPath $target -Recurse -File -Force -ErrorAction SilentlyContinue |
-          ForEach-Object { $_.LastWriteTime = $stamp }
-        Write-Host "Refreshed target file mtimes."
-        exit 0
 
     - id: cache-meta
       shell: pwsh
@@ -394,4 +348,4 @@ runs:
         Log "target-cache restore status=$targetStatus exact-hit=$targetValue"
         LogPath "cache after restore" "${{ steps.resolve.outputs.setup_cache_path }}"
         LogPath "build-cache after restore" "${{ steps.resolve.outputs.build_cache_path }}"
-        LogPath "target-cache after restore" "${{ steps.resolve.outputs.target_cache_path }}"
+        LogPath "target-cache after restore" "${{ steps.resolve.outputs.target_cache_paths }}"

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESOLVE_SETUP = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "resolve_setup.py"
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    env_exports: dict[str, str]
+    outputs: dict[str, str]
+
+
+def _parse_github_kv_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if "<<" in line:
+            key, delimiter = line.split("<<", 1)
+            index += 1
+            body: list[str] = []
+            while index < len(lines) and lines[index] != delimiter:
+                body.append(lines[index])
+                index += 1
+            values[key] = "\n".join(body)
+        elif "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+        index += 1
+    return values
+
+
+def _run_resolve_setup(extra_env: dict[str, str] | None = None) -> ResolveResult:
+    with tempfile.TemporaryDirectory(prefix="setup-soldr-tests-") as temp_dir:
+        root = Path(temp_dir)
+        workspace = root / "workspace"
+        runner_temp = root / "runner-temp"
+        github_env = root / "github-env"
+        github_output = root / "github-output"
+        github_path = root / "github-path"
+        workspace.mkdir()
+        runner_temp.mkdir()
+        (workspace / "Cargo.lock").write_text("# test lockfile\n", encoding="utf-8")
+
+        env = os.environ.copy()
+        for key in list(env):
+            if key.startswith(("INPUT_", "ACTION_", "GITHUB_", "SETUP_SOLDR_")):
+                env.pop(key, None)
+        for key in (
+            "CARGO_HOME",
+            "RUSTUP_HOME",
+            "NO_COLOR",
+            "CARGO_TERM_COLOR",
+            "CLICOLOR_FORCE",
+            "FORCE_COLOR",
+        ):
+            env.pop(key, None)
+
+        env.update(
+            {
+                "ACTION_WORKSPACE": str(workspace),
+                "ACTION_OS": "Linux",
+                "ACTION_ARCH": "X64",
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_ENV": str(github_env),
+                "GITHUB_OUTPUT": str(github_output),
+                "GITHUB_PATH": str(github_path),
+                "GITHUB_SHA": "0123456789abcdef",
+                "CARGO_HOME": str(root / "cargo-home"),
+                "RUSTUP_HOME": str(root / "rustup-home"),
+                "INPUT_TIMESTAMPS": "false",
+                "INPUT_TOOLCHAIN_FILE": "",
+            }
+        )
+        if extra_env:
+            env.update(extra_env)
+
+        proc = subprocess.run(
+            [sys.executable, str(RESOLVE_SETUP)],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        return ResolveResult(
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            env_exports=_parse_github_kv_file(github_env),
+            outputs=_parse_github_kv_file(github_output),
+        )
+
+
+class BuildCacheModeResolveTests(unittest.TestCase):
+    def assert_resolved_build_cache_mode(
+        self, result: ResolveResult, expected: str, target_expected: str | None = None
+    ) -> None:
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"resolve_setup.py failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        self.assertEqual(result.outputs.get("build_cache_mode"), expected)
+        self.assertEqual(result.env_exports.get("SOLDR_BUILD_CACHE_MODE"), expected)
+        self.assertEqual(
+            result.env_exports.get("SOLDR_TARGET_CACHE_MODE"),
+            target_expected or expected,
+        )
+
+    def test_default_build_cache_mode_resolves_to_thin(self) -> None:
+        self.assert_resolved_build_cache_mode(_run_resolve_setup(), "thin")
+
+    def test_thin_and_full_build_cache_modes_are_accepted(self) -> None:
+        for mode in ("thin", "full"):
+            with self.subTest(mode=mode):
+                result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": mode})
+                self.assert_resolved_build_cache_mode(result, mode)
+
+    def test_unknown_build_cache_mode_fails_clearly(self) -> None:
+        result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "wide"})
+
+        self.assertNotEqual(result.returncode, 0)
+        combined_output = f"{result.stdout}\n{result.stderr}".lower()
+        self.assertIn("invalid build-cache-mode", combined_output)
+        self.assertIn("thin", combined_output)
+        self.assertIn("full", combined_output)
+
+    def test_legacy_target_cache_inputs_translate_deterministically(self) -> None:
+        cases = (
+            ({"INPUT_TARGET_CACHE_MODE": "hot"}, "thin", "thin"),
+            ({"INPUT_TARGET_CACHE_MODE": "full"}, "full", "full"),
+            ({"INPUT_TARGET_CACHE_MODE": "off"}, "thin", "off"),
+            (
+                {"INPUT_TARGET_CACHE": "false", "INPUT_TARGET_CACHE_MODE": "full"},
+                "thin",
+                "off",
+            ),
+            (
+                {
+                    "INPUT_BUILD_CACHE_MODE": "thin",
+                    "INPUT_TARGET_CACHE": "true",
+                    "INPUT_TARGET_CACHE_MODE": "full",
+                },
+                "thin",
+                "thin",
+            ),
+            (
+                {
+                    "INPUT_BUILD_CACHE_MODE": "full",
+                    "INPUT_TARGET_CACHE": "false",
+                    "INPUT_TARGET_CACHE_MODE": "hot",
+                },
+                "full",
+                "off",
+            ),
+        )
+
+        for env, expected, target_expected in cases:
+            with self.subTest(env=env):
+                result = _run_resolve_setup(env)
+                self.assert_resolved_build_cache_mode(result, expected, target_expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add \uild-cache-mode\ as the primary thin/full Rust build cache mode input and output.
- Default setup-soldr to soldr \