### PR TITLE
Prefer zccache session logs in verbose mode

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 import re
+import stat
 import time
 from pathlib import Path
 from typing import Any
@@ -69,6 +70,13 @@ def load_toolchain_spec(
 
 def _sanitize_fragment(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-") or "default"
+
+
+def _is_enabled(value: str, default: bool = False) -> bool:
+    cleaned = value.strip().lower()
+    if not cleaned:
+        return default
+    return cleaned not in {"0", "false", "no", "off"}
 
 
 def _short_file_hash(path: Path, missing: str) -> str:
@@ -246,8 +254,65 @@ def _path_summary(label: str, path: Path) -> None:
     log(f"{label} path={path} exists=true files={files} bytes={bytes_total}")
 
 
+def _merge_rust_log(existing: str) -> str:
+    wanted = [
+        "zccache_cli=trace",
+        "zccache_daemon=trace",
+        "zccache_artifact=trace",
+        "zccache_gha=trace",
+        "zccache_compiler=trace",
+        "zccache_core=trace",
+        "zccache_depgraph=trace",
+        "zccache_fingerprint=trace",
+    ]
+    parts = [part.strip() for part in existing.split(",") if part.strip()]
+    seen = {part.split("=", 1)[0] for part in parts}
+    for part in wanted:
+        target = part.split("=", 1)[0]
+        if target not in seen:
+            parts.append(part)
+            seen.add(target)
+    return ",".join(parts)
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def _create_verbose_shims(shim_dir: Path, action_path: Path) -> tuple[Path, Path]:
+    wrapper_script = action_path / ".github" / "actions" / "setup-soldr" / "verbose_soldr_wrapper.py"
+    unix_shim = shim_dir / "soldr"
+    cmd_shim = shim_dir / "soldr.cmd"
+
+    _write_text(
+        unix_shim,
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                'exec python "${SETUP_SOLDR_VERBOSE_WRAPPER}" "$@"',
+                "",
+            ]
+        ),
+    )
+    unix_shim.chmod(unix_shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    _write_text(
+        cmd_shim,
+        "\r\n".join(
+            [
+                "@echo off",
+                'python "%SETUP_SOLDR_VERBOSE_WRAPPER%" %*',
+                "",
+            ]
+        ),
+    )
+    return wrapper_script, unix_shim
+
+
 def main() -> None:
     workspace = Path(os.environ["ACTION_WORKSPACE"]).resolve()
+    action_path = Path(os.environ["ACTION_PATH"]).resolve()
     runner_temp = Path(os.environ.get("RUNNER_TEMP", workspace / ".tmp")).resolve()
     log_start = str(int(time.time()))
     timestamps = os.environ.get("INPUT_TIMESTAMPS", "true").strip() or "true"
@@ -266,8 +331,13 @@ def main() -> None:
         _default_home_dir(".rustup")
     )
     bin_dir = cache_root / "bin"
+    shim_dir = cache_root / "shims"
     setup_cache_path = cache_root
     zccache_cache_dir = soldr_root / "cache" / "zccache"
+    zccache_logs_dir = zccache_cache_dir / "logs"
+    zccache_daemon_log_path = zccache_logs_dir / "daemon.log"
+    zccache_journal_log_path = zccache_logs_dir / "last-session.jsonl"
+    verbose_state_dir = cache_root.parent / f"{cache_root.name}-verbose"
     target_cache_bundle_path = cache_root.parent / f"{cache_root.name}-target-thin"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
@@ -281,7 +351,10 @@ def main() -> None:
         cargo_home / "bin",
         rustup_home,
         bin_dir,
+        shim_dir,
         zccache_cache_dir,
+        zccache_logs_dir,
+        verbose_state_dir,
         target_cache_bundle_path,
     ):
         path.mkdir(parents=True, exist_ok=True)
@@ -366,6 +439,7 @@ def main() -> None:
         os.environ.get("INPUT_BUILD_CACHE", "true").strip().lower()
         not in {"0", "false", "no", "off"}
     )
+    verbose_enabled = _is_enabled(os.environ.get("INPUT_VERBOSE", ""), default=False)
     target_cache_enabled = (
         build_cache_enabled
         and target_cache_requested
@@ -445,6 +519,12 @@ def main() -> None:
     _write_env("SETUP_SOLDR_TOOLCHAIN_TARGETS", json.dumps(toolchain["targets"]))
     _write_env("SETUP_SOLDR_LOG_START_EPOCH", log_start)
     _write_env("SETUP_SOLDR_TIMESTAMPS", timestamps)
+    _write_env("SETUP_SOLDR_VERBOSE", str(verbose_enabled).lower())
+    _write_env("SETUP_SOLDR_REAL_BIN", str(soldr_path))
+    _write_env("SETUP_SOLDR_VERBOSE_WRAPPER", str(action_path / ".github" / "actions" / "setup-soldr" / "verbose_soldr_wrapper.py"))
+    _write_env("SETUP_SOLDR_ZCCACHE_DAEMON_LOG", str(zccache_daemon_log_path))
+    _write_env("SETUP_SOLDR_ZCCACHE_JOURNAL_LOG", str(zccache_journal_log_path))
+    _write_env("SETUP_SOLDR_ZCCACHE_LOG_STATE_DIR", str(verbose_state_dir))
     if timestamps.lower() not in {"0", "false", "no", "off"} and "NO_COLOR" not in os.environ:
         if not os.environ.get("CARGO_TERM_COLOR"):
             _write_env("CARGO_TERM_COLOR", "always")
@@ -452,6 +532,14 @@ def main() -> None:
             _write_env("CLICOLOR_FORCE", "1")
         if not os.environ.get("FORCE_COLOR"):
             _write_env("FORCE_COLOR", "1")
+    if verbose_enabled:
+        rust_log = _merge_rust_log(os.environ.get("RUST_LOG", ""))
+        _write_env("RUST_LOG", rust_log)
+        if not os.environ.get("RUST_BACKTRACE"):
+            _write_env("RUST_BACKTRACE", "1")
+        wrapper_script, _ = _create_verbose_shims(shim_dir, action_path)
+        _write_env("SETUP_SOLDR_VERBOSE_WRAPPER", str(wrapper_script))
+        _write_path(str(shim_dir))
     if os.environ.get("INPUT_TRUST_MODE", "").strip():
         _write_env("SOLDR_TRUST_MODE", os.environ["INPUT_TRUST_MODE"].strip())
 
@@ -463,6 +551,7 @@ def main() -> None:
     log(f"cache restore-key={cache_prefix}-")
     log(f"build-cache key={build_cache_key}")
     log(f"build-cache mode={build_cache_mode}")
+    log(f"verbose={str(verbose_enabled).lower()}")
     if build_cache_parent_key:
         log(f"build-cache restore-key-parent={build_cache_parent_key}")
     log(f"build-cache restore-key-toolchain={build_cache_toolchain_prefix}")
@@ -477,6 +566,8 @@ def main() -> None:
     log(f"target-cache bundle-dir={target_cache_bundle_path}")
     log(f"target-cache lockfile={_path_for_output(workspace, lockfile_path)}")
     log(f"target-cache lockfile-hash={cargo_lock_hash}")
+    log(f"zccache daemon log={zccache_daemon_log_path}")
+    log(f"zccache session journal={zccache_journal_log_path}")
     _path_summary("cache before restore", setup_cache_path)
     _path_summary("build-cache before restore", zccache_cache_dir)
     _path_summary(
@@ -496,6 +587,7 @@ def main() -> None:
             "build_cache_restore_key_os_arch": f"{build_cache_prefix}-",
             "build_cache_path": str(zccache_cache_dir),
             "build_cache_mode": build_cache_mode,
+            "verbose": str(verbose_enabled).lower(),
             "target_cache_path": str(target_cache_path),
             "target_cache_bundle_path": str(target_cache_bundle_path),
             "target_cache_paths": target_cache_paths,
@@ -510,9 +602,12 @@ def main() -> None:
             "cargo_home": str(cargo_home),
             "rustup_home": str(rustup_home),
             "bin_dir": str(bin_dir),
+            "shim_dir": str(shim_dir),
             "soldr_path": str(soldr_path),
             "soldr_repo": soldr_repo,
             "soldr_version_requested": soldr_version,
+            "zccache_daemon_log_path": str(zccache_daemon_log_path),
+            "zccache_journal_log_path": str(zccache_journal_log_path),
             "toolchain_channel": toolchain["channel"],
             "toolchain_profile": toolchain["profile"],
             "toolchain_source": toolchain["source"],

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -336,6 +336,7 @@ def main() -> None:
     zccache_cache_dir = soldr_root / "cache" / "zccache"
     zccache_logs_dir = zccache_cache_dir / "logs"
     zccache_daemon_log_path = zccache_logs_dir / "daemon.log"
+    zccache_session_log_path = zccache_logs_dir / "last-session.log"
     zccache_journal_log_path = zccache_logs_dir / "last-session.jsonl"
     verbose_state_dir = cache_root.parent / f"{cache_root.name}-verbose"
     target_cache_bundle_path = cache_root.parent / f"{cache_root.name}-target-thin"
@@ -523,6 +524,7 @@ def main() -> None:
     _write_env("SETUP_SOLDR_REAL_BIN", str(soldr_path))
     _write_env("SETUP_SOLDR_VERBOSE_WRAPPER", str(action_path / ".github" / "actions" / "setup-soldr" / "verbose_soldr_wrapper.py"))
     _write_env("SETUP_SOLDR_ZCCACHE_DAEMON_LOG", str(zccache_daemon_log_path))
+    _write_env("SETUP_SOLDR_ZCCACHE_SESSION_LOG", str(zccache_session_log_path))
     _write_env("SETUP_SOLDR_ZCCACHE_JOURNAL_LOG", str(zccache_journal_log_path))
     _write_env("SETUP_SOLDR_ZCCACHE_LOG_STATE_DIR", str(verbose_state_dir))
     if timestamps.lower() not in {"0", "false", "no", "off"} and "NO_COLOR" not in os.environ:
@@ -567,6 +569,7 @@ def main() -> None:
     log(f"target-cache lockfile={_path_for_output(workspace, lockfile_path)}")
     log(f"target-cache lockfile-hash={cargo_lock_hash}")
     log(f"zccache daemon log={zccache_daemon_log_path}")
+    log(f"zccache session log={zccache_session_log_path}")
     log(f"zccache session journal={zccache_journal_log_path}")
     _path_summary("cache before restore", setup_cache_path)
     _path_summary("build-cache before restore", zccache_cache_dir)
@@ -607,6 +610,7 @@ def main() -> None:
             "soldr_repo": soldr_repo,
             "soldr_version_requested": soldr_version,
             "zccache_daemon_log_path": str(zccache_daemon_log_path),
+            "zccache_session_log_path": str(zccache_session_log_path),
             "zccache_journal_log_path": str(zccache_journal_log_path),
             "toolchain_channel": toolchain["channel"],
             "toolchain_profile": toolchain["profile"],

--- a/.github/actions/setup-soldr/verbose_soldr_wrapper.py
+++ b/.github/actions/setup-soldr/verbose_soldr_wrapper.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _timestamp_prefix() -> str:
+    value = os.environ.get("SETUP_SOLDR_TIMESTAMPS", "true").strip().lower()
+    if value in {"0", "false", "no", "off"}:
+        return ""
+    try:
+        start = int(os.environ.get("SETUP_SOLDR_LOG_START_EPOCH", "0"))
+    except ValueError:
+        start = 0
+    elapsed = max(0, int(time.time()) - start) if start else 0
+    minutes, seconds = divmod(elapsed, 60)
+    return f"{minutes:02d}:{seconds:02d} "
+
+
+def _log(message: str) -> None:
+    print(f"{_timestamp_prefix()}{message}", flush=True)
+
+
+def _offset_path(state_dir: Path, log_path: Path) -> Path:
+    safe_name = log_path.name.replace(".", "_")
+    return state_dir / f"{safe_name}.offset"
+
+
+def _read_offset(path: Path) -> int:
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except (FileNotFoundError, OSError, ValueError):
+        return 0
+
+
+def _write_offset(path: Path, offset: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(offset), encoding="utf-8")
+
+
+def _dump_log(label: str, raw_path: str, state_dir: Path) -> None:
+    if not raw_path:
+        return
+    path = Path(raw_path)
+    if not path.exists() or not path.is_file():
+        return
+
+    offset_file = _offset_path(state_dir, path)
+    previous_offset = _read_offset(offset_file)
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return
+    if previous_offset < 0 or previous_offset > size:
+        previous_offset = 0
+
+    try:
+        with path.open("rb") as fh:
+            fh.seek(previous_offset)
+            chunk = fh.read()
+    except OSError:
+        return
+
+    _write_offset(offset_file, size)
+    if not chunk:
+        return
+
+    _log(f"{label} path={path}")
+    text = chunk.decode("utf-8", errors="replace")
+    for line in text.splitlines():
+        print(line, flush=True)
+
+
+def main() -> int:
+    real_bin = os.environ.get("SETUP_SOLDR_REAL_BIN", "").strip()
+    if not real_bin:
+        print("setup-soldr verbose wrapper: SETUP_SOLDR_REAL_BIN is not set", file=sys.stderr)
+        return 1
+
+    command = [real_bin, *sys.argv[1:]]
+    result = subprocess.run(command, check=False)
+
+    if os.environ.get("SETUP_SOLDR_VERBOSE", "").strip().lower() in {"1", "true", "yes", "on"}:
+        state_dir = Path(os.environ.get("SETUP_SOLDR_ZCCACHE_LOG_STATE_DIR", ".")).resolve()
+        _dump_log(
+            "setup-soldr verbose zccache daemon log",
+            os.environ.get("SETUP_SOLDR_ZCCACHE_DAEMON_LOG", ""),
+            state_dir,
+        )
+        _dump_log(
+            "setup-soldr verbose zccache session journal",
+            os.environ.get("SETUP_SOLDR_ZCCACHE_JOURNAL_LOG", ""),
+            state_dir,
+        )
+
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/setup-soldr/verbose_soldr_wrapper.py
+++ b/.github/actions/setup-soldr/verbose_soldr_wrapper.py
@@ -92,8 +92,8 @@ def main() -> int:
             state_dir,
         )
         _dump_log(
-            "setup-soldr verbose zccache session journal",
-            os.environ.get("SETUP_SOLDR_ZCCACHE_JOURNAL_LOG", ""),
+            "setup-soldr verbose zccache session log",
+            os.environ.get("SETUP_SOLDR_ZCCACHE_SESSION_LOG", ""),
             state_dir,
         )
 

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -68,6 +68,7 @@ jobs:
           Write-Host "target-lockfile=${{ steps.setup.outputs.target-lockfile }}"
           Write-Host "target-lockfile-hash=${{ steps.setup.outputs.target-lockfile-hash }}"
           Write-Host "zccache-daemon-log=${{ steps.setup.outputs.zccache-daemon-log }}"
+          Write-Host "zccache-session-log=${{ steps.setup.outputs.zccache-session-log }}"
           Write-Host "zccache-journal-log=${{ steps.setup.outputs.zccache-journal-log }}"
           Write-Host "toolchain=${{ steps.setup.outputs.toolchain }}"
 
@@ -135,7 +136,7 @@ jobs:
           set -o pipefail
           for path in \
             "${{ steps.setup.outputs.zccache-daemon-log }}" \
-            "${{ steps.setup.outputs.zccache-journal-log }}"; do
+            "${{ steps.setup.outputs.zccache-session-log }}"; do
             if [ -f "$path" ]; then
               echo "::group::$path"
               cat "$path"

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           cache: true
           build-cache-mode: thin
+          verbose: true
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
           cache-key-suffix: zccache
@@ -57,6 +58,7 @@ jobs:
           Write-Host "build-cache-path=${{ steps.setup.outputs.build-cache-path }}"
           Write-Host "build-cache-mode=${{ steps.setup.outputs.build-cache-mode }}"
           Write-Host "build-cache-restore-status=${{ steps.setup.outputs.build-cache-restore-status }}"
+          Write-Host "verbose=${{ steps.setup.outputs.verbose }}"
           Write-Host "target-cache-hit=${{ steps.setup.outputs.target-cache-hit }}"
           Write-Host "target-cache-key=${{ steps.setup.outputs.target-cache-key }}"
           Write-Host "target-cache-path=${{ steps.setup.outputs.target-cache-path }}"
@@ -65,6 +67,8 @@ jobs:
           Write-Host "target-cache-restore-status=${{ steps.setup.outputs.target-cache-restore-status }}"
           Write-Host "target-lockfile=${{ steps.setup.outputs.target-lockfile }}"
           Write-Host "target-lockfile-hash=${{ steps.setup.outputs.target-lockfile-hash }}"
+          Write-Host "zccache-daemon-log=${{ steps.setup.outputs.zccache-daemon-log }}"
+          Write-Host "zccache-journal-log=${{ steps.setup.outputs.zccache-journal-log }}"
           Write-Host "toolchain=${{ steps.setup.outputs.toolchain }}"
 
       - name: Build zccache through soldr
@@ -123,3 +127,18 @@ jobs:
           path_summary "build-cache after build" "$BUILD_CACHE_PATH"
           path_summary "target-cache after build" "$TARGET_CACHE_PATH"
           exit "$status"
+
+      - name: Dump verbose zccache logs
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -o pipefail
+          for path in \
+            "${{ steps.setup.outputs.zccache-daemon-log }}" \
+            "${{ steps.setup.outputs.zccache-journal-log }}"; do
+            if [ -f "$path" ]; then
+              echo "::group::$path"
+              cat "$path"
+              echo "::endgroup::"
+            fi
+          done

--- a/.github/workflows/zccache-build-demo.yml
+++ b/.github/workflows/zccache-build-demo.yml
@@ -109,6 +109,7 @@ jobs:
             echo "| verbose | \`${{ steps.setup.outputs.verbose }}\` |"
             echo "| target-lockfile-hash | \`${{ steps.setup.outputs.target-lockfile-hash }}\` |"
             echo "| zccache-daemon-log | \`${{ steps.setup.outputs.zccache-daemon-log }}\` |"
+            echo "| zccache-session-log | \`${{ steps.setup.outputs.zccache-session-log }}\` |"
             echo "| zccache-journal-log | \`${{ steps.setup.outputs.zccache-journal-log }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -136,7 +137,7 @@ jobs:
           set -o pipefail
           for path in \
             "${{ steps.setup.outputs.zccache-daemon-log }}" \
-            "${{ steps.setup.outputs.zccache-journal-log }}"; do
+            "${{ steps.setup.outputs.zccache-session-log }}"; do
             if [ -f "$path" ]; then
               echo "::group::$path"
               cat "$path"
@@ -186,6 +187,7 @@ jobs:
             echo "| verbose | \`${{ steps.setup.outputs.verbose }}\` |"
             echo "| target-lockfile-hash | \`${{ steps.setup.outputs.target-lockfile-hash }}\` |"
             echo "| zccache-daemon-log | \`${{ steps.setup.outputs.zccache-daemon-log }}\` |"
+            echo "| zccache-session-log | \`${{ steps.setup.outputs.zccache-session-log }}\` |"
             echo "| zccache-journal-log | \`${{ steps.setup.outputs.zccache-journal-log }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -213,7 +215,7 @@ jobs:
           set -o pipefail
           for path in \
             "${{ steps.setup.outputs.zccache-daemon-log }}" \
-            "${{ steps.setup.outputs.zccache-journal-log }}"; do
+            "${{ steps.setup.outputs.zccache-session-log }}"; do
             if [ -f "$path" ]; then
               echo "::group::$path"
               cat "$path"

--- a/.github/workflows/zccache-build-demo.yml
+++ b/.github/workflows/zccache-build-demo.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           cache: true
           build-cache-mode: thin
+          verbose: true
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
           cache-key-suffix: ${{ env.DEMO_CACHE_SUFFIX }}
@@ -105,9 +106,10 @@ jobs:
             echo "| cache-restore-status | \`${{ steps.setup.outputs.cache-restore-status }}\` |"
             echo "| build-cache-restore-status | \`${{ steps.setup.outputs.build-cache-restore-status }}\` |"
             echo "| build-cache-mode | \`${{ steps.setup.outputs.build-cache-mode }}\` |"
-            echo "| target-cache-restore-status | \`${{ steps.setup.outputs.target-cache-restore-status }}\` |"
-            echo "| target-cache-mode | \`${{ steps.setup.outputs.target-cache-mode }}\` |"
+            echo "| verbose | \`${{ steps.setup.outputs.verbose }}\` |"
             echo "| target-lockfile-hash | \`${{ steps.setup.outputs.target-lockfile-hash }}\` |"
+            echo "| zccache-daemon-log | \`${{ steps.setup.outputs.zccache-daemon-log }}\` |"
+            echo "| zccache-journal-log | \`${{ steps.setup.outputs.zccache-journal-log }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build zccache cold
@@ -126,6 +128,21 @@ jobs:
             echo
             echo "Built \`zccache-cli\` in \`${elapsed}s\` after purging demo caches."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dump verbose zccache logs
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -o pipefail
+          for path in \
+            "${{ steps.setup.outputs.zccache-daemon-log }}" \
+            "${{ steps.setup.outputs.zccache-journal-log }}"; do
+            if [ -f "$path" ]; then
+              echo "::group::$path"
+              cat "$path"
+              echo "::endgroup::"
+            fi
+          done
 
   warm-build:
     name: Warm zccache build with setup-soldr@v0
@@ -149,6 +166,7 @@ jobs:
         with:
           cache: true
           build-cache-mode: thin
+          verbose: true
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
           cache-key-suffix: ${{ env.DEMO_CACHE_SUFFIX }}
@@ -165,9 +183,10 @@ jobs:
             echo "| cache-restore-status | \`${{ steps.setup.outputs.cache-restore-status }}\` |"
             echo "| build-cache-restore-status | \`${{ steps.setup.outputs.build-cache-restore-status }}\` |"
             echo "| build-cache-mode | \`${{ steps.setup.outputs.build-cache-mode }}\` |"
-            echo "| target-cache-restore-status | \`${{ steps.setup.outputs.target-cache-restore-status }}\` |"
-            echo "| target-cache-mode | \`${{ steps.setup.outputs.target-cache-mode }}\` |"
+            echo "| verbose | \`${{ steps.setup.outputs.verbose }}\` |"
             echo "| target-lockfile-hash | \`${{ steps.setup.outputs.target-lockfile-hash }}\` |"
+            echo "| zccache-daemon-log | \`${{ steps.setup.outputs.zccache-daemon-log }}\` |"
+            echo "| zccache-journal-log | \`${{ steps.setup.outputs.zccache-journal-log }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build zccache warm
@@ -186,3 +205,18 @@ jobs:
             echo
             echo "Built \`zccache-cli\` in \`${elapsed}s\`."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dump verbose zccache logs
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -o pipefail
+          for path in \
+            "${{ steps.setup.outputs.zccache-daemon-log }}" \
+            "${{ steps.setup.outputs.zccache-journal-log }}"; do
+            if [ -f "$path" ]; then
+              echo "::group::$path"
+              cat "$path"
+              echo "::endgroup::"
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -71,22 +71,46 @@ jobs:
       - run: soldr cargo test --locked
 ```
 
+### Verbose cache debugging
+
+```yaml
+- uses: zackees/setup-soldr@v0
+  id: setup
+  with:
+    cache: true
+    verbose: true
+
+- run: soldr cargo build --locked
+
+- if: ${{ always() }}
+  shell: bash
+  run: |
+    test -f "${{ steps.setup.outputs.zccache-daemon-log }}" && cat "${{ steps.setup.outputs.zccache-daemon-log }}"
+    test -f "${{ steps.setup.outputs.zccache-journal-log }}" && cat "${{ steps.setup.outputs.zccache-journal-log }}"
+```
+
 ## Inputs
 
 | Input | Meaning |
 |---|---|
 | `version` | Soldr release tag or version to install. Defaults to `0.7.10`. |
 | `cache` | Restore and save the action-managed cache/state root. |
-| `cache-dir` | Override the runner-local cache/state root. |
-| `cache-key-suffix` | Optional escape hatch appended to the cache key. |
+| `build-cache-mode` | Rust build cache mode. Default `thin` restores bounded dependency artifacts through soldr/zccache. `full` opts into whole-target caching and should be treated as unbounded. |
+| `verbose` | Turn on zccache trace logging and expose the daemon/session log paths for debug dump steps. |
+| `lockfile` | Optional `Cargo.lock` path used for Rust artifact cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
+| `target-dir` | Cargo target directory used by soldr when constructing the Rust artifact cache plan. |
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty; `components` and `targets` in the file are provisioned during setup. |
-| `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
-| `lockfile` | Optional `Cargo.lock` path used for Rust artifact cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
-| `build-cache` | Restore and save Soldr/zccache build cache state across runs. Default `true`; set to `false` to opt out. |
-| `build-cache-mode` | Rust build cache mode. Default `thin` restores bounded dependency artifacts through soldr/zccache. `full` opts into whole-target caching and should be treated as unbounded. |
-| `target-dir` | Cargo target directory used by soldr when constructing the Rust artifact cache plan. |
+
+### Advanced Inputs
+
+| Input | Meaning |
+|---|---|
+| `cache-dir` | Override the runner-local cache/state root. |
+| `cache-key-suffix` | Optional escape hatch appended to the cache key. |
+| `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
+| `build-cache` | Advanced escape hatch for disabling Soldr/zccache compilation cache restore/save entirely. Default `true`. |
 
 ### Legacy Compatibility Inputs
 
@@ -105,20 +129,28 @@ jobs:
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `cache-key` | Primary key used for the action-managed cache/state root. |
 | `cache-restore-status` | Diagnostic restore status for the action-managed cache/state root. |
+| `build-cache-mode` | Effective Rust build cache mode selected for soldr/zccache. |
+| `target-cache-path` | Cargo target directory used by soldr for Rust artifact planning. |
+| `target-lockfile` | `Cargo.lock` path used for Rust artifact cache keying. |
+| `target-lockfile-hash` | Short hash of the `Cargo.lock` used for Rust artifact cache keying, or `no-lock`. |
+| `verbose` | Whether verbose zccache logging is enabled. |
+| `zccache-daemon-log` | Path to the managed zccache daemon log. |
+| `zccache-journal-log` | Path to the managed zccache session journal. |
+| `toolchain` | Exact Rust toolchain channel configured for the action. |
+
+### Diagnostic And Compatibility Outputs
+
+| Output | Meaning |
+|---|---|
 | `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is disabled. |
 | `build-cache-key` | Primary key used for the Soldr-owned zccache compilation cache. |
 | `build-cache-path` | Soldr-owned zccache compilation cache path. |
-| `build-cache-mode` | Effective Rust build cache mode selected for soldr/zccache. |
 | `build-cache-restore-status` | Diagnostic restore status for the Soldr-owned zccache compilation cache. |
 | `target-cache-hit` | Whether the zccache-owned Rust artifact cache state was restored. |
 | `target-cache-key` | Primary key used for the zccache-owned Rust artifact cache state. |
-| `target-cache-path` | Cargo target directory used by soldr for Rust artifact planning. |
 | `target-cache-paths` | Path passed to `actions/cache` for zccache-owned Rust artifact cache state. |
 | `target-cache-mode` | Effective Rust target artifact cache mode. |
 | `target-cache-restore-status` | Diagnostic restore status for the Rust target artifact cache state. |
-| `target-lockfile` | `Cargo.lock` path used for Rust artifact cache keying. |
-| `target-lockfile-hash` | Short hash of the `Cargo.lock` used for Rust artifact cache keying, or `no-lock`. |
-| `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes
 
@@ -129,6 +161,7 @@ jobs:
 - The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
 - The default `build-cache-mode` is `thin`, which asks soldr to generate a bounded dependency-artifact plan and lets zccache restore/save the artifacts and report stats. Use `build-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
+- `verbose: true` appends zccache trace filters to `RUST_LOG`, keeps the managed daemon log and session journal paths stable, and makes downstream `soldr ...` invocations dump newly-written zccache log content after each command.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
 - The setup cache intentionally keeps Soldr-managed state so the managed zccache binary does not need to be rebuilt on every run.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ jobs:
   shell: bash
   run: |
     test -f "${{ steps.setup.outputs.zccache-daemon-log }}" && cat "${{ steps.setup.outputs.zccache-daemon-log }}"
-    test -f "${{ steps.setup.outputs.zccache-journal-log }}" && cat "${{ steps.setup.outputs.zccache-journal-log }}"
+    test -f "${{ steps.setup.outputs.zccache-session-log }}" && cat "${{ steps.setup.outputs.zccache-session-log }}"
 ```
 
 ## Inputs
@@ -135,7 +135,8 @@ jobs:
 | `target-lockfile-hash` | Short hash of the `Cargo.lock` used for Rust artifact cache keying, or `no-lock`. |
 | `verbose` | Whether verbose zccache logging is enabled. |
 | `zccache-daemon-log` | Path to the managed zccache daemon log. |
-| `zccache-journal-log` | Path to the managed zccache session journal. |
+| `zccache-session-log` | Path to the managed zccache session log. |
+| `zccache-journal-log` | Path to the managed zccache structured session journal. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ### Diagnostic And Compatibility Outputs
@@ -161,7 +162,7 @@ jobs:
 - The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
 - The default `build-cache-mode` is `thin`, which asks soldr to generate a bounded dependency-artifact plan and lets zccache restore/save the artifacts and report stats. Use `build-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
-- `verbose: true` appends zccache trace filters to `RUST_LOG`, keeps the managed daemon log and session journal paths stable, and makes downstream `soldr ...` invocations dump newly-written zccache log content after each command.
+- `verbose: true` appends zccache trace filters to `RUST_LOG`, keeps the managed daemon log and session log paths stable, and makes downstream `soldr ...` invocations dump newly-written zccache log content after each command.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
 - The setup cache intentionally keeps Soldr-managed state so the managed zccache binary does not need to be rebuilt on every run.
 

--- a/action.yml
+++ b/action.yml
@@ -37,14 +37,20 @@ inputs:
     description: Prefix setup-soldr diagnostic and streamed command output with elapsed mm:ss timestamps.
     required: false
     default: "true"
+  verbose:
+    description: >
+      Turn on zccache trace logging and expose daemon/session logs for dump-on-failure
+      workflow steps. Intended for cache debugging.
+    required: false
+    default: "false"
   lockfile:
     description: Optional Cargo.lock path used for Rust artifact cache keying. Empty infers Cargo.lock next to target-dir, then workspace Cargo.lock.
     required: false
     default: ""
   build-cache:
     description: >
-      Restore and save Soldr/zccache build cache state across workflow runs.
-      Default "true"; set to "false" to opt out of zccache artifact caching.
+      Advanced escape hatch for disabling Soldr/zccache compilation cache restore/save.
+      Default "true"; set to "false" only when debugging or isolating cache behavior.
     required: false
     default: "true"
   build-cache-mode:
@@ -106,6 +112,9 @@ outputs:
   build-cache-mode:
     description: Effective Rust build cache mode selected for soldr/zccache.
     value: ${{ steps.resolve.outputs.build_cache_mode }}
+  verbose:
+    description: Whether verbose zccache logging is enabled for downstream soldr commands.
+    value: ${{ steps.resolve.outputs.verbose }}
   build-cache-restore-status:
     description: Diagnostic restore status for the Soldr-owned zccache compilation cache.
     value: ${{ steps.cache-meta.outputs.build_cache_restore_status }}
@@ -136,6 +145,12 @@ outputs:
   target-lockfile-hash:
     description: Short hash of the Cargo.lock used for Rust artifact cache keying, or no-lock.
     value: ${{ steps.resolve.outputs.target_lockfile_hash }}
+  zccache-daemon-log:
+    description: Path to the managed zccache daemon log written during soldr-driven builds.
+    value: ${{ steps.resolve.outputs.zccache_daemon_log_path }}
+  zccache-journal-log:
+    description: Path to the managed zccache session journal written during soldr-driven builds.
+    value: ${{ steps.resolve.outputs.zccache_journal_log_path }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
@@ -152,12 +167,14 @@ runs:
         INPUT_TOOLCHAIN_FILE: ${{ inputs.toolchain-file }}
         INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
         INPUT_TIMESTAMPS: ${{ inputs.timestamps }}
+        INPUT_VERBOSE: ${{ inputs.verbose }}
         INPUT_LOCKFILE: ${{ inputs.lockfile }}
         INPUT_BUILD_CACHE: ${{ inputs.build-cache }}
         INPUT_BUILD_CACHE_MODE: ${{ inputs.build-cache-mode }}
         INPUT_TARGET_CACHE: ${{ inputs.target-cache }}
         INPUT_TARGET_CACHE_MODE: ${{ inputs.target-cache-mode }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
+        ACTION_PATH: ${{ github.action_path }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}

--- a/action.yml
+++ b/action.yml
@@ -148,8 +148,11 @@ outputs:
   zccache-daemon-log:
     description: Path to the managed zccache daemon log written during soldr-driven builds.
     value: ${{ steps.resolve.outputs.zccache_daemon_log_path }}
+  zccache-session-log:
+    description: Path to the managed zccache session log written during soldr-driven builds.
+    value: ${{ steps.resolve.outputs.zccache_session_log_path }}
   zccache-journal-log:
-    description: Path to the managed zccache session journal written during soldr-driven builds.
+    description: Path to the managed zccache structured session journal written during soldr-driven builds.
     value: ${{ steps.resolve.outputs.zccache_journal_log_path }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -75,6 +75,7 @@ def _run_resolve_setup(extra_env: dict[str, str] | None = None) -> ResolveResult
         env.update(
             {
                 "ACTION_WORKSPACE": str(workspace),
+                "ACTION_PATH": str(REPO_ROOT),
                 "ACTION_OS": "Linux",
                 "ACTION_ARCH": "X64",
                 "RUNNER_TEMP": str(runner_temp),
@@ -177,6 +178,22 @@ class BuildCacheModeResolveTests(unittest.TestCase):
             with self.subTest(env=env):
                 result = _run_resolve_setup(env)
                 self.assert_resolved_build_cache_mode(result, expected, target_expected)
+
+    def test_verbose_mode_exports_log_paths_and_trace_logging(self) -> None:
+        result = _run_resolve_setup({"INPUT_VERBOSE": "true"})
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"resolve_setup.py failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        self.assertEqual(result.outputs.get("verbose"), "true")
+        self.assertEqual(result.env_exports.get("SETUP_SOLDR_VERBOSE"), "true")
+        self.assertIn("zccache_daemon=trace", result.env_exports.get("RUST_LOG", ""))
+        self.assertTrue(result.outputs.get("zccache_daemon_log_path", "").endswith("daemon.log"))
+        self.assertTrue(
+            result.outputs.get("zccache_journal_log_path", "").endswith("last-session.jsonl")
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_verbose_soldr_wrapper.py
+++ b/tests/test_verbose_soldr_wrapper.py
@@ -18,6 +18,7 @@ class VerboseSoldrWrapperTests(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="setup-soldr-wrapper-") as temp_dir:
             root = Path(temp_dir)
             daemon_log = root / "daemon.log"
+            session_log = root / "last-session.log"
             journal_log = root / "last-session.jsonl"
             state_dir = root / "state"
             real_soldr = root / "real_soldr.py"
@@ -29,6 +30,7 @@ class VerboseSoldrWrapperTests(unittest.TestCase):
                     import sys
 
                     pathlib.Path({str(daemon_log)!r}).write_text("daemon line\\n", encoding="utf-8")
+                    pathlib.Path({str(session_log)!r}).write_text("session line\\n", encoding="utf-8")
                     pathlib.Path({str(journal_log)!r}).write_text('{{"event":"session"}}\\n', encoding="utf-8")
                     raise SystemExit(7)
                     """
@@ -43,6 +45,7 @@ class VerboseSoldrWrapperTests(unittest.TestCase):
                     "SETUP_SOLDR_VERBOSE": "true",
                     "SETUP_SOLDR_TIMESTAMPS": "false",
                     "SETUP_SOLDR_ZCCACHE_DAEMON_LOG": str(daemon_log),
+                    "SETUP_SOLDR_ZCCACHE_SESSION_LOG": str(session_log),
                     "SETUP_SOLDR_ZCCACHE_JOURNAL_LOG": str(journal_log),
                     "SETUP_SOLDR_ZCCACHE_LOG_STATE_DIR": str(state_dir),
                 }
@@ -60,8 +63,10 @@ class VerboseSoldrWrapperTests(unittest.TestCase):
             self.assertEqual(result.returncode, 7)
             self.assertIn("setup-soldr verbose zccache daemon log", result.stdout)
             self.assertIn("daemon line", result.stdout)
-            self.assertIn("setup-soldr verbose zccache session journal", result.stdout)
-            self.assertIn('"event":"session"', result.stdout)
+            self.assertIn("setup-soldr verbose zccache session log", result.stdout)
+            self.assertIn("session line", result.stdout)
+            self.assertNotIn("setup-soldr verbose zccache session journal", result.stdout)
+            self.assertNotIn('"event":"session"', result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_verbose_soldr_wrapper.py
+++ b/tests/test_verbose_soldr_wrapper.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "verbose_soldr_wrapper.py"
+
+
+class VerboseSoldrWrapperTests(unittest.TestCase):
+    def test_wrapper_preserves_exit_code_and_dumps_new_logs(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-wrapper-") as temp_dir:
+            root = Path(temp_dir)
+            daemon_log = root / "daemon.log"
+            journal_log = root / "last-session.jsonl"
+            state_dir = root / "state"
+            real_soldr = root / "real_soldr.py"
+
+            real_soldr.write_text(
+                textwrap.dedent(
+                    f"""\
+                    import pathlib
+                    import sys
+
+                    pathlib.Path({str(daemon_log)!r}).write_text("daemon line\\n", encoding="utf-8")
+                    pathlib.Path({str(journal_log)!r}).write_text('{{"event":"session"}}\\n', encoding="utf-8")
+                    raise SystemExit(7)
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "SETUP_SOLDR_REAL_BIN": sys.executable,
+                    "SETUP_SOLDR_VERBOSE": "true",
+                    "SETUP_SOLDR_TIMESTAMPS": "false",
+                    "SETUP_SOLDR_ZCCACHE_DAEMON_LOG": str(daemon_log),
+                    "SETUP_SOLDR_ZCCACHE_JOURNAL_LOG": str(journal_log),
+                    "SETUP_SOLDR_ZCCACHE_LOG_STATE_DIR": str(state_dir),
+                }
+            )
+
+            result = subprocess.run(
+                [sys.executable, str(WRAPPER), str(real_soldr)],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 7)
+            self.assertIn("setup-soldr verbose zccache daemon log", result.stdout)
+            self.assertIn("daemon line", result.stdout)
+            self.assertIn("setup-soldr verbose zccache session journal", result.stdout)
+            self.assertIn('"event":"session"', result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose a dedicated zccache-session-log output for the managed human-readable session log
- make verbose soldr wrapper and workflow log dumps print the session log instead of the structured JSON journal
- update docs and wrapper tests to match the new verbose logging contract

## Notes
- This pairs with zackees/soldr#225, which teaches soldr to request last-session.log from zccache.
- The structured journal remains available through zccache-journal-log for deeper inspection.

## Validation
- python -m py_compile .github/actions/setup-soldr/resolve_setup.py .github/actions/setup-soldr/verbose_soldr_wrapper.py .github/actions/setup-soldr/log_utils.py
- python -m unittest discover -s tests
- YAML parse check for action.yml and touched workflows
- git diff --check