### PR TITLE
Add once as the default cache mode

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -155,14 +155,15 @@ def normalize_build_cache_mode(
     legacy_target_mode: str = "",
     allow_legacy_translation: bool = True,
 ) -> str:
-    mode = value.strip().lower() or "thin"
-    if mode not in {"thin", "full"}:
+    explicit_mode = value.strip().lower()
+    mode = explicit_mode or "once"
+    if mode not in {"once", "thin", "full"}:
         raise RuntimeError(
-            f"invalid build-cache-mode {value!r}; expected thin or full"
+            f"invalid build-cache-mode {value!r}; expected once, thin, or full"
         )
 
     legacy_mode = _normalize_legacy_target_cache_mode(legacy_target_mode)
-    if allow_legacy_translation and legacy_mode == "full" and mode == "thin":
+    if allow_legacy_translation and not explicit_mode and legacy_mode in {"thin", "full"}:
         log(
             f"target-cache-mode '{legacy_mode}' is deprecated; "
             f"translating to build-cache-mode '{legacy_mode}'."
@@ -366,6 +367,7 @@ def main() -> None:
         os.environ.get("INPUT_BUILD_CACHE", "true").strip().lower()
         not in {"0", "false", "no", "off"}
     )
+    build_cache_runtime_mode = "full" if build_cache_mode == "once" else build_cache_mode
     target_cache_enabled = (
         build_cache_enabled
         and target_cache_requested
@@ -392,17 +394,21 @@ def main() -> None:
     )
     if not target_cache_enabled:
         target_cache_paths = (
-            str(target_cache_path) if build_cache_mode == "full" else str(target_cache_bundle_path)
+            str(target_cache_path)
+            if build_cache_runtime_mode == "full"
+            else str(target_cache_bundle_path)
         )
         target_cache_effective_mode = "off"
         target_cache_prefix = f"setup-soldr-targetcache-off-v1-{runner_os}-{runner_arch}"
         target_cache_lock_prefix = ""
         target_cache_key = f"{target_cache_prefix}-{target_inputs_hash}"
         target_cache_parent_key = ""
-    elif build_cache_mode == "full":
+    elif build_cache_runtime_mode == "full":
         target_cache_paths = str(target_cache_path)
-        target_cache_effective_mode = "full"
-        target_cache_prefix = f"setup-soldr-targetcache-full-v1-{runner_os}-{runner_arch}"
+        target_cache_effective_mode = build_cache_mode
+        target_cache_prefix = (
+            f"setup-soldr-targetcache-{build_cache_mode}-v1-{runner_os}-{runner_arch}"
+        )
         target_cache_suffix_fragment = f"{sanitized_suffix}-" if sanitized_suffix else ""
         target_cache_lock_prefix = (
             f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
@@ -431,10 +437,10 @@ def main() -> None:
     _write_env("RUSTUP_HOME", str(rustup_home))
     _write_env("ZCCACHE_CACHE_DIR", str(zccache_cache_dir))
     _write_env("SETUP_SOLDR_BUILD_CACHE_MODE", build_cache_mode)
-    _write_env("SOLDR_BUILD_CACHE_MODE", build_cache_mode)
+    _write_env("SOLDR_BUILD_CACHE_MODE", build_cache_runtime_mode)
     _write_env(
         "SOLDR_TARGET_CACHE_MODE",
-        target_cache_effective_mode if target_cache_enabled else "off",
+        build_cache_runtime_mode if target_cache_enabled else "off",
     )
     _write_env("SOLDR_TARGET_CACHE_DIR", str(target_cache_path))
     _write_env("SOLDR_TARGET_CACHE_BUNDLE_DIR", str(target_cache_bundle_path))
@@ -463,6 +469,7 @@ def main() -> None:
     log(f"cache restore-key={cache_prefix}-")
     log(f"build-cache key={build_cache_key}")
     log(f"build-cache mode={build_cache_mode}")
+    log(f"build-cache soldr-mode={build_cache_runtime_mode}")
     if build_cache_parent_key:
         log(f"build-cache restore-key-parent={build_cache_parent_key}")
     log(f"build-cache restore-key-toolchain={build_cache_toolchain_prefix}")
@@ -481,7 +488,7 @@ def main() -> None:
     _path_summary("build-cache before restore", zccache_cache_dir)
     _path_summary(
         "target-cache before restore",
-        target_cache_path if build_cache_mode == "full" else target_cache_bundle_path,
+        target_cache_path if build_cache_runtime_mode == "full" else target_cache_bundle_path,
     )
 
     _write_outputs(

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ jobs:
 | `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
 | `lockfile` | Optional `Cargo.lock` path used for Rust artifact cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
 | `build-cache` | Restore and save Soldr/zccache build cache state across runs. Default `true`; set to `false` to opt out. |
-| `build-cache-mode` | Rust build cache mode. Default `thin` restores bounded dependency artifacts through soldr/zccache. `full` opts into whole-target caching and should be treated as unbounded. |
+| `build-cache-mode` | Rust build cache mode. Default `once` saves a full snapshot on miss, then restores without resaving on later hits. `thin` is the bounded dependency-artifact alternative. `full` opts into normal whole-target restore/save behavior and should be treated as unbounded. |
 | `target-dir` | Cargo target directory used by soldr when constructing the Rust artifact cache plan. |
 
 ### Legacy Compatibility Inputs
@@ -108,13 +108,13 @@ jobs:
 | `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is disabled. |
 | `build-cache-key` | Primary key used for the Soldr-owned zccache compilation cache. |
 | `build-cache-path` | Soldr-owned zccache compilation cache path. |
-| `build-cache-mode` | Effective Rust build cache mode selected for soldr/zccache. |
+| `build-cache-mode` | Effective setup-soldr Rust build cache mode. |
 | `build-cache-restore-status` | Diagnostic restore status for the Soldr-owned zccache compilation cache. |
 | `target-cache-hit` | Whether the zccache-owned Rust artifact cache state was restored. |
 | `target-cache-key` | Primary key used for the zccache-owned Rust artifact cache state. |
 | `target-cache-path` | Cargo target directory used by soldr for Rust artifact planning. |
 | `target-cache-paths` | Path passed to `actions/cache` for zccache-owned Rust artifact cache state. |
-| `target-cache-mode` | Effective Rust target artifact cache mode. |
+| `target-cache-mode` | Effective setup-soldr Rust target artifact cache mode. |
 | `target-cache-restore-status` | Diagnostic restore status for the Rust target artifact cache state. |
 | `target-lockfile` | `Cargo.lock` path used for Rust artifact cache keying. |
 | `target-lockfile-hash` | Short hash of the `Cargo.lock` used for Rust artifact cache keying, or `no-lock`. |
@@ -127,7 +127,7 @@ jobs:
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action rehydrates the Soldr setup root and uses the runner's existing Cargo/rustup homes unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
 - The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
-- The default `build-cache-mode` is `thin`, which asks soldr to generate a bounded dependency-artifact plan and lets zccache restore/save the artifacts and report stats. Use `build-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
+- The default `build-cache-mode` is `once`, which maps to soldr/zccache full-target planning on a cold run but switches restored sessions to restore-only cache rehydration. Use `build-cache-mode: thin` for the bounded dependency-artifact alternative, or `build-cache-mode: full` when you explicitly want normal whole-target restore/save behavior on every run.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
 - The setup cache intentionally keeps Soldr-managed state so the managed zccache binary does not need to be rebuilt on every run.

--- a/action.yml
+++ b/action.yml
@@ -49,15 +49,16 @@ inputs:
     default: "true"
   build-cache-mode:
     description: >
-      Rust build cache mode. "thin" is the default bounded dependency-artifact
-      mode. "full" opts into whole-target caching and should be treated as
-      unbounded.
+      Rust build cache mode. "once" is the default full-snapshot-on-miss mode
+      that restores without resaving on later hits. "thin" is the bounded
+      dependency-artifact alternative. "full" opts into normal whole-target
+      restore/save behavior and should be treated as unbounded.
     required: false
     default: ""
   target-cache:
     description: >
       Deprecated compatibility input. Set to "false" to disable Rust target
-      artifact caching; prefer build-cache-mode for selecting thin or full.
+      artifact caching; prefer build-cache-mode for selecting once, thin, or full.
     required: false
     default: "true"
   target-cache-mode:
@@ -104,7 +105,7 @@ outputs:
     description: Soldr-owned zccache compilation cache path.
     value: ${{ steps.resolve.outputs.build_cache_path }}
   build-cache-mode:
-    description: Effective Rust build cache mode selected for soldr/zccache.
+    description: Effective setup-soldr Rust build cache mode.
     value: ${{ steps.resolve.outputs.build_cache_mode }}
   build-cache-restore-status:
     description: Diagnostic restore status for the Soldr-owned zccache compilation cache.
@@ -125,7 +126,7 @@ outputs:
     description: Path passed to actions/cache for zccache-owned Rust artifact cache state.
     value: ${{ steps.resolve.outputs.target_cache_paths }}
   target-cache-mode:
-    description: Effective Rust target artifact cache mode.
+    description: Effective setup-soldr Rust target artifact cache mode.
     value: ${{ steps.resolve.outputs.target_cache_mode }}
   target-cache-restore-status:
     description: Diagnostic restore status for the Rust target artifact cache state.
@@ -196,7 +197,18 @@ runs:
         lookup-only: true
 
     - id: build-cache-restore
-      if: ${{ inputs.build-cache == 'true' }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.build_cache_mode == 'once' && (steps.build-cache-lookup.outputs.cache-hit == 'true' || steps.build-cache-lookup.outputs.cache-matched-key != '') }}
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.build_cache_path }}
+        key: ${{ steps.resolve.outputs.build_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.build_cache_restore_key_parent }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
+
+    - id: build-cache-managed
+      if: ${{ inputs.build-cache == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || (steps.build-cache-lookup.outputs.cache-hit != 'true' && steps.build-cache-lookup.outputs.cache-matched-key == '')) }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ${{ steps.resolve.outputs.build_cache_path }}
@@ -218,7 +230,17 @@ runs:
         lookup-only: true
 
     - id: target-cache
-      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode == 'once' && (steps.target-cache-lookup.outputs.cache-hit == 'true' || steps.target-cache-lookup.outputs.cache-matched-key != '') }}
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.target_cache_paths }}
+        key: ${{ steps.resolve.outputs.target_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.target_cache_restore_key_parent }}
+          ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+
+    - id: target-cache-managed
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || (steps.target-cache-lookup.outputs.cache-hit != 'true' && steps.target-cache-lookup.outputs.cache-matched-key == '')) }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ${{ steps.resolve.outputs.target_cache_paths }}
@@ -255,11 +277,11 @@ runs:
         LOOKUP_CACHE_HIT: ${{ steps.cache-lookup.outputs.cache-hit }}
         LOOKUP_CACHE_MATCHED_KEY: ${{ steps.cache-lookup.outputs.cache-matched-key }}
         CACHE_KEY: ${{ steps.resolve.outputs.cache_key }}
-        RAW_BUILD_CACHE_HIT: ${{ steps.build-cache-restore.outputs.cache-hit }}
+        RAW_BUILD_CACHE_HIT: ${{ steps.build-cache-managed.outputs.cache-hit || steps.build-cache-restore.outputs.cache-hit }}
         LOOKUP_BUILD_CACHE_HIT: ${{ steps.build-cache-lookup.outputs.cache-hit }}
         LOOKUP_BUILD_CACHE_MATCHED_KEY: ${{ steps.build-cache-lookup.outputs.cache-matched-key }}
         BUILD_CACHE_KEY: ${{ steps.resolve.outputs.build_cache_key }}
-        RAW_TARGET_CACHE_HIT: ${{ steps.target-cache.outputs.cache-hit }}
+        RAW_TARGET_CACHE_HIT: ${{ steps.target-cache-managed.outputs.cache-hit || steps.target-cache.outputs.cache-hit }}
         LOOKUP_TARGET_CACHE_HIT: ${{ steps.target-cache-lookup.outputs.cache-hit }}
         LOOKUP_TARGET_CACHE_MATCHED_KEY: ${{ steps.target-cache-lookup.outputs.cache-matched-key }}
         TARGET_CACHE_KEY: ${{ steps.resolve.outputs.target_cache_key }}

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -111,7 +111,12 @@ def _run_resolve_setup(extra_env: dict[str, str] | None = None) -> ResolveResult
 
 class BuildCacheModeResolveTests(unittest.TestCase):
     def assert_resolved_build_cache_mode(
-        self, result: ResolveResult, expected: str, target_expected: str | None = None
+        self,
+        result: ResolveResult,
+        expected: str,
+        soldr_expected: str | None = None,
+        target_expected: str | None = None,
+        output_target_expected: str | None = None,
     ) -> None:
         self.assertEqual(
             result.returncode,
@@ -119,20 +124,22 @@ class BuildCacheModeResolveTests(unittest.TestCase):
             msg=f"resolve_setup.py failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
         )
         self.assertEqual(result.outputs.get("build_cache_mode"), expected)
-        self.assertEqual(result.env_exports.get("SOLDR_BUILD_CACHE_MODE"), expected)
+        self.assertEqual(result.outputs.get("target_cache_mode"), output_target_expected or expected)
+        self.assertEqual(result.env_exports.get("SETUP_SOLDR_BUILD_CACHE_MODE"), expected)
+        self.assertEqual(result.env_exports.get("SOLDR_BUILD_CACHE_MODE"), soldr_expected or expected)
         self.assertEqual(
             result.env_exports.get("SOLDR_TARGET_CACHE_MODE"),
-            target_expected or expected,
+            target_expected or soldr_expected or expected,
         )
 
-    def test_default_build_cache_mode_resolves_to_thin(self) -> None:
-        self.assert_resolved_build_cache_mode(_run_resolve_setup(), "thin")
+    def test_default_build_cache_mode_resolves_to_once(self) -> None:
+        self.assert_resolved_build_cache_mode(_run_resolve_setup(), "once", "full")
 
-    def test_thin_and_full_build_cache_modes_are_accepted(self) -> None:
-        for mode in ("thin", "full"):
+    def test_once_thin_and_full_build_cache_modes_are_accepted(self) -> None:
+        for mode, soldr_mode in (("once", "full"), ("thin", "thin"), ("full", "full")):
             with self.subTest(mode=mode):
                 result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": mode})
-                self.assert_resolved_build_cache_mode(result, mode)
+                self.assert_resolved_build_cache_mode(result, mode, soldr_mode)
 
     def test_unknown_build_cache_mode_fails_clearly(self) -> None:
         result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "wide"})
@@ -140,6 +147,7 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         combined_output = f"{result.stdout}\n{result.stderr}".lower()
         self.assertIn("invalid build-cache-mode", combined_output)
+        self.assertIn("once", combined_output)
         self.assertIn("thin", combined_output)
         self.assertIn("full", combined_output)
 
@@ -147,10 +155,12 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         cases = (
             ({"INPUT_TARGET_CACHE_MODE": "hot"}, "thin", "thin"),
             ({"INPUT_TARGET_CACHE_MODE": "full"}, "full", "full"),
-            ({"INPUT_TARGET_CACHE_MODE": "off"}, "thin", "off"),
+            ({"INPUT_TARGET_CACHE_MODE": "off"}, "once", "full", "off", "off"),
             (
                 {"INPUT_TARGET_CACHE": "false", "INPUT_TARGET_CACHE_MODE": "full"},
-                "thin",
+                "once",
+                "full",
+                "off",
                 "off",
             ),
             (
@@ -169,14 +179,27 @@ class BuildCacheModeResolveTests(unittest.TestCase):
                     "INPUT_TARGET_CACHE_MODE": "hot",
                 },
                 "full",
+                "full",
+                "off",
                 "off",
             ),
         )
 
-        for env, expected, target_expected in cases:
+        for case in cases:
+            env = case[0]
+            expected = case[1]
+            soldr_expected = case[2]
+            target_expected = case[3] if len(case) > 3 else None
+            output_target_expected = case[4] if len(case) > 4 else None
             with self.subTest(env=env):
                 result = _run_resolve_setup(env)
-                self.assert_resolved_build_cache_mode(result, expected, target_expected)
+                self.assert_resolved_build_cache_mode(
+                    result,
+                    expected,
+                    soldr_expected,
+                    target_expected,
+                    output_target_expected,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `build-cache-mode: once` and make it the default setup-soldr cache mode
- map `once` to soldr-side `full` planning while keeping `once`/`full`/`thin` distinct in setup-soldr outputs and docs
- switch artifact cache restore wiring so restored `once` sessions use restore-only cache steps and cold `once` misses still arm the normal post-job save path
- extend resolver tests to cover the new default, soldr-facing mode translation, and legacy target-cache compatibility

## Validation
- python -m unittest discover -s tests
- python -m py_compile .github/actions/setup-soldr/resolve_setup.py tests/test_resolve_setup_build_cache_mode.py
- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('action.yml').read_text(encoding='utf-8')); print('action.yml ok')"
- git diff --check

Closes #36
