### PR TITLE
Use default cache mode in workflow testers

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -38,7 +38,6 @@ jobs:
         uses: ./setup-soldr
         with:
           cache: true
-          build-cache-mode: thin
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
           cache-key-suffix: zccache

--- a/.github/workflows/zccache-build-demo.yml
+++ b/.github/workflows/zccache-build-demo.yml
@@ -88,7 +88,6 @@ jobs:
         uses: zackees/setup-soldr@v0
         with:
           cache: true
-          build-cache-mode: thin
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
           cache-key-suffix: ${{ env.DEMO_CACHE_SUFFIX }}
@@ -148,7 +147,6 @@ jobs:
         uses: zackees/setup-soldr@v0
         with:
           cache: true
-          build-cache-mode: thin
           lockfile: zccache/Cargo.lock
           target-dir: zccache/target
           cache-key-suffix: ${{ env.DEMO_CACHE_SUFFIX }}


### PR DESCRIPTION
## Summary
- remove explicit `build-cache-mode: thin` from the workflow testers in this repo
- make the local action workflow and zccache demo jobs exercise setup-soldr's default cache mode instead of forcing an override
- keep the test/demo lockfile, target-dir, and cache suffix wiring unchanged

## Validation
- python -c "import yaml, pathlib; [yaml.safe_load(p.read_text(encoding='utf-8')) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('workflow yaml ok')"
- git diff --check

Follow-up to #37
