### PR TITLE
Restore only the rust-plan bundle in once mode

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -396,6 +396,8 @@ def main() -> None:
     )
     target_cache_bundle_path = thin_target_cache_bundle_path
 
+    target_tree_cache_enabled = target_cache_enabled and build_cache_mode == "full"
+
     if not target_cache_enabled:
         target_cache_paths = (
             str(target_cache_path)
@@ -407,7 +409,7 @@ def main() -> None:
         target_cache_lock_prefix = ""
         target_cache_key = f"{target_cache_prefix}-{target_inputs_hash}"
         target_cache_parent_key = ""
-    elif build_cache_runtime_mode == "full":
+    elif target_tree_cache_enabled:
         # Restore both the full target tree and the separate rust-plan bundle
         # root so soldr/zccache can reuse the local bundle without storing it
         # inside target/ and re-bundling previous bundle contents on save.
@@ -430,8 +432,10 @@ def main() -> None:
         target_cache_parent_key = f"{target_cache_lock_prefix}{parent_sha}" if parent_sha else ""
     else:
         target_cache_paths = str(target_cache_bundle_path)
-        target_cache_effective_mode = "thin"
-        target_cache_prefix = f"setup-soldr-targetcache-thin-v1-{runner_os}-{runner_arch}"
+        target_cache_effective_mode = build_cache_mode
+        target_cache_prefix = (
+            f"setup-soldr-targetcache-{build_cache_mode}-v1-{runner_os}-{runner_arch}"
+        )
         target_cache_suffix_fragment = f"{sanitized_suffix}-" if sanitized_suffix else ""
         target_cache_lock_prefix = (
             f"{target_cache_prefix}-{target_inputs_hash}-{target_cache_suffix_fragment}"
@@ -506,7 +510,7 @@ def main() -> None:
     _path_summary("build-cache before restore", zccache_cache_dir)
     _path_summary(
         "target-cache before restore",
-        target_cache_path if build_cache_runtime_mode == "full" else target_cache_bundle_path,
+        target_cache_path if target_tree_cache_enabled else target_cache_bundle_path,
     )
 
     _write_outputs(

--- a/.github/workflows/zccache-build-demo.yml
+++ b/.github/workflows/zccache-build-demo.yml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   DEMO_CACHE_SUFFIX: zccache-demo
-  INTEGRATION_REF: ${{ github.ref_name }}
+  REQUESTED_INTEGRATION_REF: ${{ github.ref_name }}
 
 jobs:
   purge-demo-caches:
@@ -82,11 +82,49 @@ jobs:
         with:
           path: setup-soldr
 
+      - id: resolve-refs
+        name: Resolve upstream integration refs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          resolve_default_branch() {
+            local repo="$1"
+            git ls-remote --symref "https://github.com/${repo}.git" HEAD |
+              awk '/^ref:/ {sub("refs/heads/", "", $2); print $2; exit}'
+          }
+
+          resolve_ref() {
+            local repo="$1"
+            local requested="$2"
+            if git ls-remote --exit-code --heads "https://github.com/${repo}.git" "$requested" >/dev/null 2>&1; then
+              printf '%s' "$requested"
+              return
+            fi
+            local fallback
+            fallback="$(resolve_default_branch "$repo")"
+            if [ -z "$fallback" ]; then
+              echo "Unable to resolve default branch for $repo" >&2
+              exit 1
+            fi
+            printf '%s' "$fallback"
+          }
+
+          requested="$REQUESTED_INTEGRATION_REF"
+          zccache_ref="$(resolve_ref zackees/zccache "$requested")"
+          soldr_ref="$(resolve_ref zackees/soldr "$requested")"
+
+          {
+            echo "requested_ref=$requested"
+            echo "zccache_ref=$zccache_ref"
+            echo "soldr_ref=$soldr_ref"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Checkout zccache
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: zackees/zccache
-          ref: ${{ env.INTEGRATION_REF }}
+          ref: ${{ steps.resolve-refs.outputs.zccache_ref }}
           path: zccache
           persist-credentials: false
 
@@ -99,7 +137,7 @@ jobs:
           target-dir: zccache/target
           cache-key-suffix: ${{ env.DEMO_CACHE_SUFFIX }}
           repo: zackees/soldr
-          ref: ${{ env.INTEGRATION_REF }}
+          ref: ${{ steps.resolve-refs.outputs.soldr_ref }}
 
       - name: Show cache plan
         shell: bash
@@ -110,7 +148,9 @@ jobs:
             echo "| Output | Value |"
             echo "| --- | --- |"
             echo "| soldr-version | \`${{ steps.setup.outputs.soldr-version }}\` |"
-            echo "| integration-ref | \`${{ env.INTEGRATION_REF }}\` |"
+            echo "| requested-integration-ref | \`${{ steps.resolve-refs.outputs.requested_ref }}\` |"
+            echo "| zccache-ref | \`${{ steps.resolve-refs.outputs.zccache_ref }}\` |"
+            echo "| soldr-ref | \`${{ steps.resolve-refs.outputs.soldr_ref }}\` |"
             echo "| cache-restore-status | \`${{ steps.setup.outputs.cache-restore-status }}\` |"
             echo "| build-cache-restore-status | \`${{ steps.setup.outputs.build-cache-restore-status }}\` |"
             echo "| build-cache-mode | \`${{ steps.setup.outputs.build-cache-mode }}\` |"
@@ -150,11 +190,49 @@ jobs:
         with:
           path: setup-soldr
 
+      - id: resolve-refs
+        name: Resolve upstream integration refs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          resolve_default_branch() {
+            local repo="$1"
+            git ls-remote --symref "https://github.com/${repo}.git" HEAD |
+              awk '/^ref:/ {sub("refs/heads/", "", $2); print $2; exit}'
+          }
+
+          resolve_ref() {
+            local repo="$1"
+            local requested="$2"
+            if git ls-remote --exit-code --heads "https://github.com/${repo}.git" "$requested" >/dev/null 2>&1; then
+              printf '%s' "$requested"
+              return
+            fi
+            local fallback
+            fallback="$(resolve_default_branch "$repo")"
+            if [ -z "$fallback" ]; then
+              echo "Unable to resolve default branch for $repo" >&2
+              exit 1
+            fi
+            printf '%s' "$fallback"
+          }
+
+          requested="$REQUESTED_INTEGRATION_REF"
+          zccache_ref="$(resolve_ref zackees/zccache "$requested")"
+          soldr_ref="$(resolve_ref zackees/soldr "$requested")"
+
+          {
+            echo "requested_ref=$requested"
+            echo "zccache_ref=$zccache_ref"
+            echo "soldr_ref=$soldr_ref"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Checkout zccache
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: zackees/zccache
-          ref: ${{ env.INTEGRATION_REF }}
+          ref: ${{ steps.resolve-refs.outputs.zccache_ref }}
           path: zccache
           persist-credentials: false
 
@@ -167,7 +245,7 @@ jobs:
           target-dir: zccache/target
           cache-key-suffix: ${{ env.DEMO_CACHE_SUFFIX }}
           repo: zackees/soldr
-          ref: ${{ env.INTEGRATION_REF }}
+          ref: ${{ steps.resolve-refs.outputs.soldr_ref }}
 
       - name: Show cache plan
         shell: bash
@@ -178,7 +256,9 @@ jobs:
             echo "| Output | Value |"
             echo "| --- | --- |"
             echo "| soldr-version | \`${{ steps.setup.outputs.soldr-version }}\` |"
-            echo "| integration-ref | \`${{ env.INTEGRATION_REF }}\` |"
+            echo "| requested-integration-ref | \`${{ steps.resolve-refs.outputs.requested_ref }}\` |"
+            echo "| zccache-ref | \`${{ steps.resolve-refs.outputs.zccache_ref }}\` |"
+            echo "| soldr-ref | \`${{ steps.resolve-refs.outputs.soldr_ref }}\` |"
             echo "| cache-restore-status | \`${{ steps.setup.outputs.cache-restore-status }}\` |"
             echo "| build-cache-restore-status | \`${{ steps.setup.outputs.build-cache-restore-status }}\` |"
             echo "| build-cache-mode | \`${{ steps.setup.outputs.build-cache-mode }}\` |"

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ jobs:
 | `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
 | `lockfile` | Optional `Cargo.lock` path used for Rust artifact cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
 | `build-cache` | Restore and save Soldr/zccache build cache state across runs. Default `true`; set to `false` to opt out. |
-| `build-cache-mode` | Rust build cache mode. Default `once` saves a full snapshot on miss, then restores without resaving on later hits. `thin` is the bounded dependency-artifact alternative. `full` opts into normal whole-target restore/save behavior and should be treated as unbounded. |
+| `build-cache-mode` | Rust build cache mode. Default `once` saves a full snapshot on miss, then restores only the local rust-plan bundle on later hits without resaving the full target tree. `thin` is the bounded dependency-artifact alternative. `full` opts into normal whole-target restore/save behavior and should be treated as unbounded. |
 | `target-dir` | Cargo target directory used by soldr when constructing the Rust artifact cache plan. |
 
 ### Legacy Compatibility Inputs
@@ -113,7 +113,7 @@ jobs:
 | `target-cache-hit` | Whether the zccache-owned Rust artifact cache state was restored. |
 | `target-cache-key` | Primary key used for the zccache-owned Rust artifact cache state. |
 | `target-cache-path` | Cargo target directory used by soldr for Rust artifact planning. |
-| `target-cache-paths` | Path passed to `actions/cache` for zccache-owned Rust artifact cache state. |
+| `target-cache-paths` | Path or newline-delimited path list passed to `actions/cache` for zccache-owned Rust artifact cache state. |
 | `target-cache-mode` | Effective setup-soldr Rust target artifact cache mode. |
 | `target-cache-restore-status` | Diagnostic restore status for the Rust target artifact cache state. |
 | `target-lockfile` | `Cargo.lock` path used for Rust artifact cache keying. |
@@ -127,7 +127,7 @@ jobs:
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action rehydrates the Soldr setup root and uses the runner's existing Cargo/rustup homes unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
 - The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
-- The default `build-cache-mode` is `once`, which maps to soldr/zccache full-target planning on a cold run but switches restored sessions to restore-only cache rehydration. Use `build-cache-mode: thin` for the bounded dependency-artifact alternative, or `build-cache-mode: full` when you explicitly want normal whole-target restore/save behavior on every run.
+- The default `build-cache-mode` is `once`, which maps to soldr/zccache full-target planning on a cold run but restores only the local rust-plan bundle on later hits. Use `build-cache-mode: thin` for the bounded dependency-artifact alternative, or `build-cache-mode: full` when you explicitly want normal whole-target restore/save behavior on every run.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
 - The setup cache intentionally keeps Soldr-managed state so the managed zccache binary does not need to be rebuilt on every run.

--- a/action.yml
+++ b/action.yml
@@ -58,9 +58,10 @@ inputs:
   build-cache-mode:
     description: >
       Rust build cache mode. "once" is the default full-snapshot-on-miss mode
-      that restores without resaving on later hits. "thin" is the bounded
-      dependency-artifact alternative. "full" opts into normal whole-target
-      restore/save behavior and should be treated as unbounded.
+      that restores only the local rust-plan bundle on later hits without
+      resaving the full target tree. "thin" is the bounded dependency-artifact
+      alternative. "full" opts into normal whole-target restore/save behavior
+      and should be treated as unbounded.
     required: false
     default: ""
   target-cache:
@@ -131,7 +132,7 @@ outputs:
     description: Cargo target directory used by soldr for Rust artifact planning.
     value: ${{ steps.resolve.outputs.target_cache_path }}
   target-cache-paths:
-    description: Path passed to actions/cache for zccache-owned Rust artifact cache state.
+    description: Path or newline-delimited path list passed to actions/cache for zccache-owned Rust artifact cache state.
     value: ${{ steps.resolve.outputs.target_cache_paths }}
   target-cache-mode:
     description: Effective setup-soldr Rust target artifact cache mode.
@@ -260,7 +261,7 @@ runs:
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
 
     - id: target-tree-cache-lookup
-      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode != 'thin' }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode == 'full' }}
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ${{ steps.resolve.outputs.target_cache_path }}
@@ -271,17 +272,7 @@ runs:
         lookup-only: true
 
     - id: target-tree-cache
-      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode == 'once' && (steps.target-tree-cache-lookup.outputs.cache-hit == 'true' || steps.target-tree-cache-lookup.outputs.cache-matched-key != '') }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: ${{ steps.resolve.outputs.target_cache_path }}
-        key: ${{ steps.resolve.outputs.target_cache_key }}
-        restore-keys: |
-          ${{ steps.resolve.outputs.target_cache_restore_key_parent }}
-          ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
-
-    - id: target-tree-cache-managed
-      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode != 'thin' && (steps.resolve.outputs.build_cache_mode != 'once' || (steps.target-tree-cache-lookup.outputs.cache-hit != 'true' && steps.target-tree-cache-lookup.outputs.cache-matched-key == '')) }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode == 'full' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ${{ steps.resolve.outputs.target_cache_path }}
@@ -326,7 +317,7 @@ runs:
         RAW_TARGET_CACHE_HIT: ${{ steps.target-cache-managed.outputs.cache-hit || steps.target-cache.outputs.cache-hit }}
         LOOKUP_TARGET_CACHE_HIT: ${{ steps.target-cache-lookup.outputs.cache-hit }}
         LOOKUP_TARGET_CACHE_MATCHED_KEY: ${{ steps.target-cache-lookup.outputs.cache-matched-key }}
-        RAW_TARGET_TREE_CACHE_HIT: ${{ steps.target-tree-cache-managed.outputs.cache-hit || steps.target-tree-cache.outputs.cache-hit }}
+        RAW_TARGET_TREE_CACHE_HIT: ${{ steps.target-tree-cache.outputs.cache-hit }}
         LOOKUP_TARGET_TREE_CACHE_HIT: ${{ steps.target-tree-cache-lookup.outputs.cache-hit }}
         LOOKUP_TARGET_TREE_CACHE_MATCHED_KEY: ${{ steps.target-tree-cache-lookup.outputs.cache-matched-key }}
         TARGET_CACHE_KEY: ${{ steps.resolve.outputs.target_cache_key }}
@@ -418,12 +409,12 @@ runs:
         Log "cache restore status=$cacheStatus exact-hit=$value"
         Log "build-cache restore status=$buildStatus exact-hit=$buildValue"
         Log "target-cache bundle restore status=$targetStatus exact-hit=$targetValue"
-        if ($env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true" -and "${{ steps.resolve.outputs.build_cache_mode }}" -ne "thin") {
+        if ($env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true" -and "${{ steps.resolve.outputs.build_cache_mode }}" -eq "full") {
           Log "target-cache tree restore status=$targetTreeStatus exact-hit=$targetTreeValue"
         }
         LogPath "cache after restore" "${{ steps.resolve.outputs.setup_cache_path }}"
         LogPath "build-cache after restore" "${{ steps.resolve.outputs.build_cache_path }}"
-        if ($env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true" -and "${{ steps.resolve.outputs.build_cache_mode }}" -ne "thin") {
+        if ($env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true" -and "${{ steps.resolve.outputs.build_cache_mode }}" -eq "full") {
           LogPath "target-cache tree after restore" "${{ steps.resolve.outputs.target_cache_path }}"
         }
         LogPath "target-cache bundle after restore" "${{ steps.resolve.outputs.target_cache_bundle_path }}"

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -15,3 +15,10 @@ def test_target_cache_uses_separate_bundle_and_tree_paths() -> None:
     assert "path: ${{ steps.resolve.outputs.target_cache_path }}" in action
     assert 'LogPath "target-cache bundle after restore"' in action
     assert 'LogPath "target-cache tree after restore"' in action
+
+
+def test_target_tree_cache_is_only_used_in_full_mode() -> None:
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+
+    assert "steps.resolve.outputs.build_cache_mode == 'full'" in action
+    assert "id: target-tree-cache-managed" not in action

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -142,25 +142,40 @@ class BuildCacheModeResolveTests(unittest.TestCase):
                 result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": mode})
                 self.assert_resolved_build_cache_mode(result, mode, soldr_mode)
 
-    def test_full_modes_restore_target_tree_and_bundle_root_together(self) -> None:
-        for mode in ("once", "full"):
-            with self.subTest(mode=mode):
-                result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": mode})
-                self.assertEqual(result.returncode, 0)
-                target_path = result.outputs.get("target_cache_path")
-                bundle_path = result.outputs.get("target_cache_bundle_path")
-                self.assertTrue(target_path)
-                self.assertTrue(bundle_path)
-                self.assertNotEqual(bundle_path, target_path)
-                self.assertEqual(
-                    result.outputs.get("target_cache_paths"),
-                    f"{target_path}\n{bundle_path}",
-                )
-                self.assertEqual(result.env_exports.get("SOLDR_TARGET_CACHE_DIR"), target_path)
-                self.assertEqual(
-                    result.env_exports.get("SOLDR_TARGET_CACHE_BUNDLE_DIR"),
-                    bundle_path,
-                )
+    def test_once_mode_restores_only_the_local_rust_plan_bundle(self) -> None:
+        result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "once"})
+
+        self.assertEqual(result.returncode, 0)
+        target_path = result.outputs.get("target_cache_path")
+        bundle_path = result.outputs.get("target_cache_bundle_path")
+        self.assertTrue(target_path)
+        self.assertTrue(bundle_path)
+        self.assertNotEqual(bundle_path, target_path)
+        self.assertEqual(result.outputs.get("target_cache_paths"), bundle_path)
+        self.assertEqual(result.env_exports.get("SOLDR_TARGET_CACHE_DIR"), target_path)
+        self.assertEqual(
+            result.env_exports.get("SOLDR_TARGET_CACHE_BUNDLE_DIR"),
+            bundle_path,
+        )
+
+    def test_full_mode_restores_target_tree_and_bundle_root_together(self) -> None:
+        result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "full"})
+
+        self.assertEqual(result.returncode, 0)
+        target_path = result.outputs.get("target_cache_path")
+        bundle_path = result.outputs.get("target_cache_bundle_path")
+        self.assertTrue(target_path)
+        self.assertTrue(bundle_path)
+        self.assertNotEqual(bundle_path, target_path)
+        self.assertEqual(
+            result.outputs.get("target_cache_paths"),
+            f"{target_path}\n{bundle_path}",
+        )
+        self.assertEqual(result.env_exports.get("SOLDR_TARGET_CACHE_DIR"), target_path)
+        self.assertEqual(
+            result.env_exports.get("SOLDR_TARGET_CACHE_BUNDLE_DIR"),
+            bundle_path,
+        )
 
     def test_thin_mode_keeps_local_rust_plan_bundle_separate_from_target_tree(self) -> None:
         result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "thin"})

--- a/tests/test_zccache_build_demo_workflow.py
+++ b/tests/test_zccache_build_demo_workflow.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_demo_workflow_resolves_upstream_refs_with_fallbacks() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/zccache-build-demo.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "REQUESTED_INTEGRATION_REF: ${{ github.ref_name }}" in workflow
+    assert "name: Resolve upstream integration refs" in workflow
+    assert 'requested="$REQUESTED_INTEGRATION_REF"' in workflow
+    assert 'git ls-remote --exit-code --heads "https://github.com/${repo}.git" "$requested"' in workflow
+    assert "ref: ${{ steps.resolve-refs.outputs.zccache_ref }}" in workflow
+    assert "ref: ${{ steps.resolve-refs.outputs.soldr_ref }}" in workflow


### PR DESCRIPTION
﻿## Summary
- keep `build-cache-mode: once` planning in soldr full mode while only restoring the local rust-plan bundle on warm hits
- reserve full target-tree restore/save for explicit `build-cache-mode: full`
- update docs and regression tests to match the narrower `once` restore behavior

## Validation
- `pytest tests/test_resolve_setup_build_cache_mode.py tests/test_action_target_cache_wiring.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('action.yml').read_text(encoding='utf-8')); print('action.yml ok')"`
- `git diff --check`

## Context
Follow-up optimization after #39. The warm-build target is already fixed; this tightens the default `once` path so warm restores skip rehydrating the whole target tree unless the workflow explicitly asks for `full`.
