### PR TITLE
Avoid managed setup-cache post-step on exact hits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -186,8 +186,17 @@ runs:
           ${{ steps.resolve.outputs.cache_restore_prefix }}
         lookup-only: true
 
-    - id: cache
-      if: ${{ inputs.cache == 'true' }}
+    - id: cache-restore
+      if: ${{ inputs.cache == 'true' && steps.cache-lookup.outputs.cache-hit == 'true' }}
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.setup_cache_path }}
+        key: ${{ steps.resolve.outputs.cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.cache_restore_prefix }}
+
+    - id: cache-managed
+      if: ${{ inputs.cache == 'true' && steps.cache-lookup.outputs.cache-hit != 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ${{ steps.resolve.outputs.setup_cache_path }}
@@ -306,7 +315,7 @@ runs:
     - id: cache-meta
       shell: pwsh
       env:
-        RAW_CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        RAW_CACHE_HIT: ${{ steps.cache-managed.outputs.cache-hit || steps.cache-restore.outputs.cache-hit }}
         LOOKUP_CACHE_HIT: ${{ steps.cache-lookup.outputs.cache-hit }}
         LOOKUP_CACHE_MATCHED_KEY: ${{ steps.cache-lookup.outputs.cache-matched-key }}
         CACHE_KEY: ${{ steps.resolve.outputs.cache_key }}

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -22,3 +22,17 @@ def test_target_tree_cache_is_only_used_in_full_mode() -> None:
 
     assert "steps.resolve.outputs.build_cache_mode == 'full'" in action
     assert "id: target-tree-cache-managed" not in action
+
+
+def test_setup_cache_uses_lookup_exact_restore_and_managed_fallback() -> None:
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+
+    assert "id: cache-lookup" in action
+    assert "id: cache-restore" in action
+    assert "id: cache-managed" in action
+    assert "uses: actions/cache/restore@" in action
+    assert "uses: actions/cache@" in action
+    assert "lookup-only: true" in action
+    assert "steps.cache-lookup.outputs.cache-hit == 'true'" in action
+    assert "steps.cache-lookup.outputs.cache-hit != 'true'" in action
+    assert "id: cache-save" not in action


### PR DESCRIPTION
## Summary
- split the setup cache path into lookup-only exact-hit restore vs managed fallback
- use `actions/cache/restore` when the setup cache key is an exact hit so the action skips the managed cache post-step on warm runs
- keep `actions/cache` for misses and prefix fallback restores so the cache can still be updated when needed

## Validation
- `pytest tests/test_resolve_setup_build_cache_mode.py tests/test_zccache_build_demo_workflow.py tests/test_action_target_cache_wiring.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('action.yml').read_text(encoding='utf-8')); print('action.yml ok')"`
- `git diff --check`

## Context
Issue #39 is already fixed and merged. This is a follow-up optimization aimed at shaving setup overhead from warm runs by avoiding unnecessary managed-cache post-job work when the setup cache already matches exactly.
