### PR TITLE
Skip rolling toolchain refresh on exact cache hits

### DIFF
--- a/.github/actions/setup-soldr/ensure_rust_toolchain.py
+++ b/.github/actions/setup-soldr/ensure_rust_toolchain.py
@@ -118,6 +118,22 @@ def toolchain_available(rustup: str, channel: str) -> bool:
     return False
 
 
+def installed_toolchain_release(rustup: str, channel: str) -> str | None:
+    result = subprocess.run(
+        [rustup, "run", channel, "rustc", "--version"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    match = re.match(r"^rustc\s+([^\s]+)", result.stdout.strip())
+    if match is None:
+        return None
+    return match.group(1)
+
+
 def should_refresh_toolchain(channel: str) -> bool:
     normalized = channel.strip().lower()
     if not normalized:
@@ -128,6 +144,21 @@ def should_refresh_toolchain(channel: str) -> bool:
         if normalized.startswith(f"{alias}-") and not re.match(rf"^{alias}-\d", normalized):
             return True
     return False
+
+
+def should_skip_refresh_for_exact_hit(
+    channel: str,
+    expected_release: str,
+    setup_cache_exact_hit: bool,
+    installed_release: str | None,
+) -> bool:
+    if not should_refresh_toolchain(channel):
+        return False
+    if not setup_cache_exact_hit:
+        return False
+    if not expected_release.strip():
+        return False
+    return installed_release == expected_release
 
 
 def _json_list_env(name: str) -> list[str]:
@@ -304,6 +335,10 @@ def main() -> None:
     profile = os.environ.get("SETUP_SOLDR_TOOLCHAIN_PROFILE", "").strip() or "minimal"
     components = _json_list_env("SETUP_SOLDR_TOOLCHAIN_COMPONENTS")
     targets = _json_list_env("SETUP_SOLDR_TOOLCHAIN_TARGETS")
+    cache_channel = os.environ.get("SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL", "").strip()
+    setup_cache_exact_hit = (
+        os.environ.get("SETUP_SOLDR_SETUP_CACHE_EXACT_HIT", "").strip().lower() == "true"
+    )
 
     log(f"Resolved Rust toolchain channel={channel} profile={profile}")
     log(f"Requested Rust components: {', '.join(components) if components else 'none'}")
@@ -311,8 +346,31 @@ def main() -> None:
 
     run([rustup, "set", "profile", profile])
     if should_refresh_toolchain(channel):
-        log(f"Refreshing rolling Rust toolchain {channel} with profile {profile}")
-        run([rustup, "toolchain", "install", channel, "--profile", profile])
+        installed_release = (
+            installed_toolchain_release(rustup, channel)
+            if toolchain_available(rustup, channel)
+            else None
+        )
+        if should_skip_refresh_for_exact_hit(
+            channel,
+            cache_channel,
+            setup_cache_exact_hit,
+            installed_release,
+        ):
+            log(
+                "Using installed rolling Rust toolchain "
+                f"{channel} without refresh because the setup cache exact-hit "
+                f"matches release {cache_channel}"
+            )
+        else:
+            if setup_cache_exact_hit and cache_channel:
+                log(
+                    f"Rolling Rust toolchain {channel} exact-hit expected release {cache_channel}; "
+                    f"installed release is {installed_release or 'missing'}, refreshing"
+                )
+            else:
+                log(f"Refreshing rolling Rust toolchain {channel} with profile {profile}")
+            run([rustup, "toolchain", "install", channel, "--profile", profile])
     elif not toolchain_available(rustup, channel):
         log(f"Installing Rust toolchain {channel} with profile {profile}")
         run([rustup, "toolchain", "install", channel, "--profile", profile])

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -6,6 +6,8 @@ import json
 import os
 import re
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +17,9 @@ try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover
     tomllib = None
+
+
+_ROLLING_TOOLCHAIN_ALIASES = ("stable", "beta", "nightly")
 
 
 def _normalize_list(value: Any) -> list[str]:
@@ -57,14 +62,72 @@ def load_toolchain_spec(
         channel = toolchain_override.strip()
         source = "input"
 
+    cache_channel = resolve_toolchain_cache_channel(channel)
+
     return {
         "channel": channel,
+        "cache_channel": cache_channel,
         "profile": profile,
         "components": components,
         "targets": targets,
         "source": source,
         "file_hash": file_hash,
     }
+
+
+def _rolling_toolchain_alias(channel: str) -> str | None:
+    normalized = channel.strip().lower()
+    for alias in _ROLLING_TOOLCHAIN_ALIASES:
+        if normalized == alias:
+            return alias
+        if normalized.startswith(f"{alias}-") and not re.match(rf"^{alias}-\d", normalized):
+            return alias
+    return None
+
+
+def _rust_channel_manifest_release(channel_alias: str) -> str | None:
+    if tomllib is None:
+        return None
+
+    url = f"https://static.rust-lang.org/dist/channel-rust-{channel_alias}.toml"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as response:
+            payload = tomllib.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, TimeoutError, ValueError) as exc:
+        log(
+            f"Unable to resolve rolling Rust channel {channel_alias} to a release version: {exc}. "
+            "Falling back to the requested channel string for cache keying."
+        )
+        return None
+
+    rust_pkg = payload.get("pkg", {}).get("rust", {})
+    if not isinstance(rust_pkg, dict):
+        log(
+            f"Rust manifest for rolling channel {channel_alias} did not contain pkg.rust metadata. "
+            "Falling back to the requested channel string for cache keying."
+        )
+        return None
+
+    raw_version = str(rust_pkg.get("version", "")).strip()
+    if not raw_version:
+        log(
+            f"Rust manifest for rolling channel {channel_alias} did not contain a version string. "
+            "Falling back to the requested channel string for cache keying."
+        )
+        return None
+
+    return raw_version.split(" ", 1)[0]
+
+
+def resolve_toolchain_cache_channel(channel: str) -> str:
+    alias = _rolling_toolchain_alias(channel)
+    if alias is None:
+        return channel
+
+    resolved = _rust_channel_manifest_release(alias)
+    if resolved:
+        return resolved
+    return channel
 
 
 def _sanitize_fragment(value: str) -> str:
@@ -301,7 +364,7 @@ def main() -> None:
     soldr_ref = os.environ.get("INPUT_REF", "").strip()
     soldr_version = os.environ.get("INPUT_VERSION", "").strip()
     toolchain_signature = {
-        "channel": toolchain["channel"],
+        "channel": toolchain["cache_channel"],
         "profile": toolchain["profile"],
         "components": toolchain["components"],
         "targets": toolchain["targets"],
@@ -470,6 +533,7 @@ def main() -> None:
     # bundle instead of switching to zccache's separate direct GHA backend.
     _write_env("SOLDR_TARGET_CACHE_BACKEND", "local")
     _write_env("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain["channel"])
+    _write_env("SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL", toolchain["cache_channel"])
     _write_env("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain["profile"])
     _write_env("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", json.dumps(toolchain["components"]))
     _write_env("SETUP_SOLDR_TOOLCHAIN_TARGETS", json.dumps(toolchain["targets"]))
@@ -504,6 +568,8 @@ def main() -> None:
     log("target-cache backend=local")
     log(f"soldr repo={soldr_repo}")
     log(f"soldr ref={soldr_ref or 'release'}")
+    log(f"toolchain channel={toolchain['channel']}")
+    log(f"toolchain cache-channel={toolchain['cache_channel']}")
     if target_cache_parent_key:
         log(f"target-cache restore-key-parent={target_cache_parent_key}")
     log(f"target-cache restore-key-lock={target_cache_lock_prefix}")
@@ -552,6 +618,7 @@ def main() -> None:
             "soldr_ref": soldr_ref,
             "soldr_version_requested": soldr_version,
             "toolchain_channel": toolchain["channel"],
+            "toolchain_cache_channel": toolchain["cache_channel"],
             "toolchain_profile": toolchain["profile"],
             "toolchain_source": toolchain["source"],
             "toolchain": toolchain["channel"],

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -329,7 +329,7 @@ def main() -> None:
         _default_home_dir(".cargo")
     )
     rustup_home = Path(os.environ.get("RUSTUP_HOME", "")).expanduser().resolve() if os.environ.get("RUSTUP_HOME") else (
-        _default_home_dir(".rustup")
+        cache_root / "rustup-home"
     )
     bin_dir = cache_root / "bin"
     setup_cache_path = cache_root
@@ -379,8 +379,9 @@ def main() -> None:
     ).hexdigest()[:16]
     runner_os = _sanitize_fragment(os.environ.get("ACTION_OS", os.name).lower())
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
-    # v3 excludes the dedicated zccache build cache from the setup-cache root.
-    cache_prefix = f"setup-soldr-v3-{runner_os}-{runner_arch}"
+    # v4 keeps the dedicated zccache build cache separate while restoring the
+    # managed rustup home under the setup-cache root for exact-hit reuse.
+    cache_prefix = f"setup-soldr-v4-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
     workspace_manifest_hash = _workspace_manifest_hash(workspace)
     cargo_config_hash = _cargo_config_hash(workspace)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.10`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
-- The action rehydrates the Soldr setup root and uses the runner's existing Cargo/rustup homes unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
+- The action rehydrates the Soldr setup root, keeps a managed `RUSTUP_HOME` inside that cache by default, and continues to use the runner's existing `CARGO_HOME` unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
 - The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
 - The default `build-cache-mode` is `once`, which maps to soldr/zccache full-target planning on a cold run but restores only the local rust-plan bundle on later hits. Use `build-cache-mode: thin` for the bounded dependency-artifact alternative, or `build-cache-mode: full` when you explicitly want normal whole-target restore/save behavior on every run.
 - In `once` mode, an exact rust-plan bundle hit skips the separate build-cache restore because the target bundle already rehydrates the warm artifacts needed for the following build.

--- a/action.yml
+++ b/action.yml
@@ -292,6 +292,9 @@ runs:
 
     - id: toolchain
       shell: pwsh
+      env:
+        SETUP_SOLDR_SETUP_CACHE_EXACT_HIT: ${{ steps.cache-lookup.outputs.cache-hit }}
+        SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL: ${{ steps.resolve.outputs.toolchain_cache_channel }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_rust_toolchain.py"
 
     - id: install

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -40,6 +40,15 @@ def test_setup_cache_uses_lookup_exact_restore_and_managed_fallback() -> None:
     assert "id: cache-save" not in action
 
 
+def test_toolchain_step_receives_setup_cache_exact_hit_metadata() -> None:
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+
+    assert "SETUP_SOLDR_SETUP_CACHE_EXACT_HIT" in action
+    assert "steps.cache-lookup.outputs.cache-hit" in action
+    assert "SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL" in action
+    assert "steps.resolve.outputs.toolchain_cache_channel" in action
+
+
 def test_once_mode_skips_build_cache_restore_when_target_cache_is_exact_hit() -> None:
     action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
 

--- a/tests/test_ensure_rust_toolchain_refresh.py
+++ b/tests/test_ensure_rust_toolchain_refresh.py
@@ -121,6 +121,135 @@ class EnsureRustToolchainRefreshTests(unittest.TestCase):
             commands,
         )
 
+    def test_main_skips_refresh_for_exact_hit_when_release_matches(self) -> None:
+        module = _load_module()
+        commands: list[list[str]] = []
+
+        def fake_run(command: list[str]) -> None:
+            commands.append(command)
+
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-toolchain-") as temp_dir:
+            root = Path(temp_dir)
+            env = {
+                "CARGO_HOME": str(root / "cargo-home"),
+                "RUSTUP_HOME": str(root / "rustup-home"),
+                "SOLDR_CACHE_DIR": str(root / "soldr"),
+                "SETUP_SOLDR_TOOLCHAIN_CHANNEL": "stable",
+                "SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL": "1.95.0",
+                "SETUP_SOLDR_TOOLCHAIN_PROFILE": "minimal",
+                "SETUP_SOLDR_SETUP_CACHE_EXACT_HIT": "true",
+            }
+
+            with patch.dict(os.environ, env, clear=False):
+                with (
+                    patch.object(module, "ensure_rustup_available", return_value="rustup"),
+                    patch.object(module, "toolchain_available", return_value=True),
+                    patch.object(module, "installed_toolchain_release", return_value="1.95.0"),
+                    patch.object(module, "_json_list_env", return_value=[]),
+                    patch.object(module, "add_components"),
+                    patch.object(module, "add_targets"),
+                    patch.object(module, "run", side_effect=fake_run),
+                    patch.object(
+                        module.shutil,
+                        "which",
+                        side_effect=lambda name: f"/fake/{name}"
+                        if name in {"cargo", "rustc", "rustup"}
+                        else None,
+                    ),
+                ):
+                    module.main()
+
+        self.assertNotIn(
+            ["rustup", "toolchain", "install", "stable", "--profile", "minimal"],
+            commands,
+        )
+
+    def test_main_skips_refresh_for_beta_exact_hit_when_release_matches(self) -> None:
+        module = _load_module()
+        commands: list[list[str]] = []
+
+        def fake_run(command: list[str]) -> None:
+            commands.append(command)
+
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-toolchain-") as temp_dir:
+            root = Path(temp_dir)
+            env = {
+                "CARGO_HOME": str(root / "cargo-home"),
+                "RUSTUP_HOME": str(root / "rustup-home"),
+                "SOLDR_CACHE_DIR": str(root / "soldr"),
+                "SETUP_SOLDR_TOOLCHAIN_CHANNEL": "beta",
+                "SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL": "1.96.0-beta.3",
+                "SETUP_SOLDR_TOOLCHAIN_PROFILE": "minimal",
+                "SETUP_SOLDR_SETUP_CACHE_EXACT_HIT": "true",
+            }
+
+            with patch.dict(os.environ, env, clear=False):
+                with (
+                    patch.object(module, "ensure_rustup_available", return_value="rustup"),
+                    patch.object(module, "toolchain_available", return_value=True),
+                    patch.object(module, "installed_toolchain_release", return_value="1.96.0-beta.3"),
+                    patch.object(module, "_json_list_env", return_value=[]),
+                    patch.object(module, "add_components"),
+                    patch.object(module, "add_targets"),
+                    patch.object(module, "run", side_effect=fake_run),
+                    patch.object(
+                        module.shutil,
+                        "which",
+                        side_effect=lambda name: f"/fake/{name}"
+                        if name in {"cargo", "rustc", "rustup"}
+                        else None,
+                    ),
+                ):
+                    module.main()
+
+        self.assertNotIn(
+            ["rustup", "toolchain", "install", "beta", "--profile", "minimal"],
+            commands,
+        )
+
+    def test_main_refreshes_exact_hit_when_release_does_not_match(self) -> None:
+        module = _load_module()
+        commands: list[list[str]] = []
+
+        def fake_run(command: list[str]) -> None:
+            commands.append(command)
+
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-toolchain-") as temp_dir:
+            root = Path(temp_dir)
+            env = {
+                "CARGO_HOME": str(root / "cargo-home"),
+                "RUSTUP_HOME": str(root / "rustup-home"),
+                "SOLDR_CACHE_DIR": str(root / "soldr"),
+                "SETUP_SOLDR_TOOLCHAIN_CHANNEL": "stable",
+                "SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL": "1.95.0",
+                "SETUP_SOLDR_TOOLCHAIN_PROFILE": "minimal",
+                "SETUP_SOLDR_SETUP_CACHE_EXACT_HIT": "true",
+            }
+
+            with patch.dict(os.environ, env, clear=False):
+                with (
+                    patch.object(module, "ensure_rustup_available", return_value="rustup"),
+                    patch.object(module, "toolchain_available", return_value=True),
+                    patch.object(module, "installed_toolchain_release", return_value="1.94.1"),
+                    patch.object(module, "_json_list_env", return_value=[]),
+                    patch.object(module, "add_components"),
+                    patch.object(module, "add_targets"),
+                    patch.object(module, "run", side_effect=fake_run),
+                    patch.object(
+                        module.shutil,
+                        "which",
+                        side_effect=lambda name: f"/fake/{name}"
+                        if name in {"cargo", "rustc", "rustup"}
+                        else None,
+                    ),
+                ):
+                    module.main()
+
+        self.assertIn(
+            ["rustup", "toolchain", "install", "stable", "--profile", "minimal"],
+            commands,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -46,16 +46,22 @@ def _parse_github_kv_file(path: Path) -> dict[str, str]:
     return values
 
 
-def _run_resolve_setup(extra_env: dict[str, str] | None = None) -> ResolveResult:
+def _run_resolve_setup(
+    extra_env: dict[str, str] | None = None,
+    *,
+    include_explicit_toolchain_homes: bool = True,
+) -> ResolveResult:
     with tempfile.TemporaryDirectory(prefix="setup-soldr-tests-") as temp_dir:
         root = Path(temp_dir)
         workspace = root / "workspace"
         runner_temp = root / "runner-temp"
+        home_dir = root / "home"
         github_env = root / "github-env"
         github_output = root / "github-output"
         github_path = root / "github-path"
         workspace.mkdir()
         runner_temp.mkdir()
+        home_dir.mkdir()
         (workspace / "Cargo.lock").write_text("# test lockfile\n", encoding="utf-8")
 
         env = os.environ.copy()
@@ -82,12 +88,19 @@ def _run_resolve_setup(extra_env: dict[str, str] | None = None) -> ResolveResult
                 "GITHUB_OUTPUT": str(github_output),
                 "GITHUB_PATH": str(github_path),
                 "GITHUB_SHA": "0123456789abcdef",
-                "CARGO_HOME": str(root / "cargo-home"),
-                "RUSTUP_HOME": str(root / "rustup-home"),
+                "HOME": str(home_dir),
+                "USERPROFILE": str(home_dir),
                 "INPUT_TIMESTAMPS": "false",
                 "INPUT_TOOLCHAIN_FILE": "",
             }
         )
+        if include_explicit_toolchain_homes:
+            env.update(
+                {
+                    "CARGO_HOME": str(root / "cargo-home"),
+                    "RUSTUP_HOME": str(root / "rustup-home"),
+                }
+            )
         if extra_env:
             env.update(extra_env)
 
@@ -175,6 +188,18 @@ class BuildCacheModeResolveTests(unittest.TestCase):
             result.outputs["setup_cache_paths"],
             f"{setup_cache_path}\n{soldr_root / 'bin'}",
         )
+
+    def test_default_rustup_home_lives_under_setup_cache_root(self) -> None:
+        result = _run_resolve_setup(include_explicit_toolchain_homes=False)
+
+        self.assertEqual(result.returncode, 0)
+        setup_cache_path = Path(result.outputs["setup_cache_path"])
+        rustup_home = Path(result.outputs["rustup_home"])
+        cargo_home = Path(result.outputs["cargo_home"])
+        self.assertEqual(rustup_home, setup_cache_path / "rustup-home")
+        self.assertEqual(result.env_exports.get("RUSTUP_HOME"), str(rustup_home))
+        self.assertEqual(cargo_home, Path(result.env_exports["CARGO_HOME"]))
+        self.assertNotIn(setup_cache_path, cargo_home.parents)
 
     def test_full_mode_restores_target_tree_and_bundle_root_together(self) -> None:
         result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "full"})

--- a/tests/test_resolve_setup_toolchain_resolution.py
+++ b/tests/test_resolve_setup_toolchain_resolution.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESOLVE_SETUP = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "resolve_setup.py"
+HELPER_DIR = RESOLVE_SETUP.parent
+
+
+def _load_module():
+    helper_dir = str(HELPER_DIR)
+    if helper_dir not in sys.path:
+        sys.path.insert(0, helper_dir)
+    spec = importlib.util.spec_from_file_location("resolve_setup", RESOLVE_SETUP)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load resolve_setup.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ResolveSetupToolchainResolutionTests(unittest.TestCase):
+    def test_rolling_stable_uses_manifest_release_for_cache_channel(self) -> None:
+        module = _load_module()
+        payload = b'[pkg.rust]\nversion = "1.95.0 (59807616e 2026-04-14)"\n'
+
+        with patch.object(module.urllib.request, "urlopen", return_value=io.BytesIO(payload)):
+            self.assertEqual(module.resolve_toolchain_cache_channel("stable"), "1.95.0")
+
+    def test_rolling_beta_uses_manifest_release_for_cache_channel(self) -> None:
+        module = _load_module()
+        payload = b'[pkg.rust]\nversion = "1.96.0-beta.3 (123456789 2026-04-20)"\n'
+
+        with patch.object(module.urllib.request, "urlopen", return_value=io.BytesIO(payload)):
+            self.assertEqual(module.resolve_toolchain_cache_channel("beta"), "1.96.0-beta.3")
+
+    def test_host_suffixed_rolling_alias_uses_same_manifest_release(self) -> None:
+        module = _load_module()
+        payload = b'[pkg.rust]\nversion = "1.95.0 (59807616e 2026-04-14)"\n'
+
+        with patch.object(module.urllib.request, "urlopen", return_value=io.BytesIO(payload)):
+            self.assertEqual(
+                module.resolve_toolchain_cache_channel("stable-x86_64-unknown-linux-gnu"),
+                "1.95.0",
+            )
+
+    def test_host_suffixed_nightly_alias_uses_same_manifest_release(self) -> None:
+        module = _load_module()
+        payload = b'[pkg.rust]\nversion = "1.97.0-nightly (abcdef012 2026-04-22)"\n'
+
+        with patch.object(module.urllib.request, "urlopen", return_value=io.BytesIO(payload)):
+            self.assertEqual(
+                module.resolve_toolchain_cache_channel("nightly-x86_64-unknown-linux-gnu"),
+                "1.97.0-nightly",
+            )
+
+    def test_pinned_toolchain_keeps_original_cache_channel(self) -> None:
+        module = _load_module()
+
+        with patch.object(module.urllib.request, "urlopen") as mocked:
+            self.assertEqual(module.resolve_toolchain_cache_channel("1.95.0"), "1.95.0")
+
+        mocked.assert_not_called()
+
+    def test_manifest_failure_falls_back_to_requested_channel(self) -> None:
+        module = _load_module()
+
+        with patch.object(
+            module.urllib.request,
+            "urlopen",
+            side_effect=module.urllib.error.URLError("offline"),
+        ):
+            self.assertEqual(module.resolve_toolchain_cache_channel("stable"), "stable")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- resolve rolling Rust channels like `stable`, `beta`, and `nightly` to a concrete release version for setup-cache keying
- pass the exact-hit and resolved release metadata into the toolchain setup step
- skip `rustup toolchain install` on exact setup-cache hits when the installed rolling toolchain already matches the cached release

## Validation
- `pytest tests/test_resolve_setup_build_cache_mode.py tests/test_zccache_build_demo_workflow.py tests/test_action_target_cache_wiring.py tests/test_ensure_rust_toolchain_refresh.py tests/test_resolve_setup_toolchain_resolution.py`
- `python -c "import yaml, pathlib; [yaml.safe_load(p.read_text(encoding='utf-8')) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('workflow yaml ok')"`
- `git diff --check`
