### PR TITLE
Keep soldr cache outside setup cache root

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -259,7 +259,9 @@ def main() -> None:
     cache_root = Path(requested_cache_dir).expanduser().resolve() if requested_cache_dir else (
         runner_temp / "setup-soldr"
     )
-    soldr_root = cache_root / "soldr"
+    # Keep soldr's own cache tree outside the setup cache root so the managed
+    # zccache store is not restored through both setup-cache and build-cache.
+    soldr_root = cache_root.parent / f"{cache_root.name}-soldr"
     cargo_home = Path(os.environ.get("CARGO_HOME", "")).expanduser().resolve() if os.environ.get("CARGO_HOME") else (
         _default_home_dir(".cargo")
     )
@@ -268,10 +270,9 @@ def main() -> None:
     )
     bin_dir = cache_root / "bin"
     setup_cache_path = cache_root
-    # Keep the Soldr-managed zccache store outside the setup cache root so the
-    # same payload is not restored twice through both setup-cache and
-    # build-cache layers on warm exact hits.
-    zccache_cache_dir = cache_root.parent / f"{cache_root.name}-buildcache"
+    soldr_bin_cache_path = soldr_root / "bin"
+    setup_cache_paths = "\n".join((str(setup_cache_path), str(soldr_bin_cache_path)))
+    zccache_cache_dir = soldr_root / "cache" / "zccache"
     thin_target_cache_bundle_path = cache_root.parent / f"{cache_root.name}-target-thin"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
@@ -280,7 +281,7 @@ def main() -> None:
         cache_root,
         soldr_root,
         soldr_root / "cache",
-        soldr_root / "bin",
+        soldr_bin_cache_path,
         cargo_home,
         cargo_home / "bin",
         rustup_home,
@@ -511,6 +512,7 @@ def main() -> None:
     log(f"target-cache lockfile={_path_for_output(workspace, lockfile_path)}")
     log(f"target-cache lockfile-hash={cargo_lock_hash}")
     _path_summary("cache before restore", setup_cache_path)
+    _path_summary("soldr-bin before restore", soldr_bin_cache_path)
     _path_summary("build-cache before restore", zccache_cache_dir)
     _path_summary(
         "target-cache before restore",
@@ -521,6 +523,7 @@ def main() -> None:
         {
             "cache_root": str(cache_root),
             "setup_cache_path": str(setup_cache_path),
+            "setup_cache_paths": setup_cache_paths,
             "cache_key": cache_key,
             "cache_restore_prefix": f"{cache_prefix}-",
             "build_cache_key": build_cache_key,
@@ -540,6 +543,7 @@ def main() -> None:
             "target_lockfile_path": _path_for_output(workspace, lockfile_path),
             "target_lockfile_hash": cargo_lock_hash,
             "soldr_root": str(soldr_root),
+            "soldr_bin_cache_path": str(soldr_bin_cache_path),
             "cargo_home": str(cargo_home),
             "rustup_home": str(rustup_home),
             "bin_dir": str(bin_dir),

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -268,7 +268,10 @@ def main() -> None:
     )
     bin_dir = cache_root / "bin"
     setup_cache_path = cache_root
-    zccache_cache_dir = soldr_root / "cache" / "zccache"
+    # Keep the Soldr-managed zccache store outside the setup cache root so the
+    # same payload is not restored twice through both setup-cache and
+    # build-cache layers on warm exact hits.
+    zccache_cache_dir = cache_root.parent / f"{cache_root.name}-buildcache"
     thin_target_cache_bundle_path = cache_root.parent / f"{cache_root.name}-target-thin"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
@@ -312,7 +315,8 @@ def main() -> None:
     ).hexdigest()[:16]
     runner_os = _sanitize_fragment(os.environ.get("ACTION_OS", os.name).lower())
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
-    cache_prefix = f"setup-soldr-v2-{runner_os}-{runner_arch}"
+    # v3 excludes the dedicated zccache build cache from the setup-cache root.
+    cache_prefix = f"setup-soldr-v3-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
     workspace_manifest_hash = _workspace_manifest_hash(workspace)
     cargo_config_hash = _cargo_config_hash(workspace)

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ jobs:
 - The default `build-cache-mode` is `once`, which maps to soldr/zccache full-target planning on a cold run but restores only the local rust-plan bundle on later hits. Use `build-cache-mode: thin` for the bounded dependency-artifact alternative, or `build-cache-mode: full` when you explicitly want normal whole-target restore/save behavior on every run.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
-- The setup cache intentionally keeps Soldr-managed state so the managed zccache binary does not need to be rebuilt on every run.
+- The setup cache intentionally keeps Soldr setup state, while the dedicated `ZCCACHE_CACHE_DIR` payload is stored in its own cache so warm runs do not restore the same build-cache bytes twice.
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -180,7 +180,7 @@ runs:
       if: ${{ inputs.cache == 'true' }}
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.setup_cache_path }}
+        path: ${{ steps.resolve.outputs.setup_cache_paths }}
         key: ${{ steps.resolve.outputs.cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
@@ -190,7 +190,7 @@ runs:
       if: ${{ inputs.cache == 'true' && steps.cache-lookup.outputs.cache-hit == 'true' }}
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.setup_cache_path }}
+        path: ${{ steps.resolve.outputs.setup_cache_paths }}
         key: ${{ steps.resolve.outputs.cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
@@ -199,7 +199,7 @@ runs:
       if: ${{ inputs.cache == 'true' && steps.cache-lookup.outputs.cache-hit != 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.setup_cache_path }}
+        path: ${{ steps.resolve.outputs.setup_cache_paths }}
         key: ${{ steps.resolve.outputs.cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
@@ -422,6 +422,7 @@ runs:
           Log "target-cache tree restore status=$targetTreeStatus exact-hit=$targetTreeValue"
         }
         LogPath "cache after restore" "${{ steps.resolve.outputs.setup_cache_path }}"
+        LogPath "soldr-bin after restore" "${{ steps.resolve.outputs.soldr_bin_cache_path }}"
         LogPath "build-cache after restore" "${{ steps.resolve.outputs.build_cache_path }}"
         if ($env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true" -and "${{ steps.resolve.outputs.build_cache_mode }}" -eq "full") {
           LogPath "target-cache tree after restore" "${{ steps.resolve.outputs.target_cache_path }}"

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -35,4 +35,6 @@ def test_setup_cache_uses_lookup_exact_restore_and_managed_fallback() -> None:
     assert "lookup-only: true" in action
     assert "steps.cache-lookup.outputs.cache-hit == 'true'" in action
     assert "steps.cache-lookup.outputs.cache-hit != 'true'" in action
+    assert "steps.resolve.outputs.setup_cache_paths" in action
+    assert 'LogPath "soldr-bin after restore"' in action
     assert "id: cache-save" not in action

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -158,6 +158,18 @@ class BuildCacheModeResolveTests(unittest.TestCase):
             bundle_path,
         )
 
+    def test_build_cache_path_is_outside_the_setup_cache_root(self) -> None:
+        result = _run_resolve_setup()
+
+        self.assertEqual(result.returncode, 0)
+        setup_cache_path = Path(result.outputs["setup_cache_path"])
+        build_cache_path = Path(result.outputs["build_cache_path"])
+        self.assertNotEqual(build_cache_path, setup_cache_path)
+        self.assertNotIn(setup_cache_path, build_cache_path.parents)
+        self.assertEqual(build_cache_path.parent, setup_cache_path.parent)
+        self.assertEqual(build_cache_path.name, f"{setup_cache_path.name}-buildcache")
+        self.assertEqual(result.env_exports.get("ZCCACHE_CACHE_DIR"), str(build_cache_path))
+
     def test_full_mode_restores_target_tree_and_bundle_root_together(self) -> None:
         result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "full"})
 

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -158,17 +158,23 @@ class BuildCacheModeResolveTests(unittest.TestCase):
             bundle_path,
         )
 
-    def test_build_cache_path_is_outside_the_setup_cache_root(self) -> None:
+    def test_build_cache_path_stays_under_soldr_root_outside_setup_cache_root(self) -> None:
         result = _run_resolve_setup()
 
         self.assertEqual(result.returncode, 0)
         setup_cache_path = Path(result.outputs["setup_cache_path"])
+        soldr_root = Path(result.outputs["soldr_root"])
         build_cache_path = Path(result.outputs["build_cache_path"])
-        self.assertNotEqual(build_cache_path, setup_cache_path)
+        self.assertNotEqual(soldr_root, setup_cache_path)
+        self.assertNotIn(setup_cache_path, soldr_root.parents)
+        self.assertEqual(build_cache_path, soldr_root / "cache" / "zccache")
         self.assertNotIn(setup_cache_path, build_cache_path.parents)
-        self.assertEqual(build_cache_path.parent, setup_cache_path.parent)
-        self.assertEqual(build_cache_path.name, f"{setup_cache_path.name}-buildcache")
+        self.assertEqual(result.outputs["soldr_bin_cache_path"], str(soldr_root / "bin"))
         self.assertEqual(result.env_exports.get("ZCCACHE_CACHE_DIR"), str(build_cache_path))
+        self.assertEqual(
+            result.outputs["setup_cache_paths"],
+            f"{setup_cache_path}\n{soldr_root / 'bin'}",
+        )
 
     def test_full_mode_restores_target_tree_and_bundle_root_together(self) -> None:
         result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "full"})


### PR DESCRIPTION
## Summary
- keep `SOLDR_CACHE_DIR` outside the setup-cache root so the managed zccache store is not restored through both cache layers
- cache the setup root and `soldr/bin` together while leaving the managed zccache state to the dedicated build-cache path
- keep the setup-cache key prefix at `v3` so the new cache layout takes effect immediately

## Why
The current exact-hit warm path restores the zccache payload twice:
- the setup cache exact-hit restores the full `setup-soldr` root
- the build-cache step then restores the managed zccache directory again

A first attempt to move `ZCCACHE_CACHE_DIR` directly outside `SOLDR_CACHE_DIR` broke `soldr` validation, because current `soldr` expects the managed zccache dir to stay under its own cache root.

This revision avoids that compatibility problem by moving `SOLDR_CACHE_DIR` itself outside the setup-cache root while keeping the managed zccache path under `SOLDR_CACHE_DIR/cache/zccache`.

## Validation
- `pytest tests/test_resolve_setup_build_cache_mode.py tests/test_action_target_cache_wiring.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('action.yml').read_text(encoding='utf-8')); [yaml.safe_load(p.read_text(encoding='utf-8')) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('yaml ok')"`
- `git diff --check`
