### PR TITLE
Skip build-cache restore on exact target hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ jobs:
 | `build-cache-key` | Primary key used for the Soldr-owned zccache compilation cache. |
 | `build-cache-path` | Soldr-owned zccache compilation cache path. |
 | `build-cache-mode` | Effective setup-soldr Rust build cache mode. |
-| `build-cache-restore-status` | Diagnostic restore status for the Soldr-owned zccache compilation cache. |
+| `build-cache-restore-status` | Diagnostic restore status for the Soldr-owned zccache compilation cache. In `once` mode this may report `skipped-target-cache-exact-hit` when the rust-plan bundle was already an exact hit and the separate compile-cache restore was intentionally skipped. |
 | `target-cache-hit` | Whether the zccache-owned Rust artifact cache state was restored. |
 | `target-cache-key` | Primary key used for the zccache-owned Rust artifact cache state. |
 | `target-cache-path` | Cargo target directory used by soldr for Rust artifact planning. |
@@ -128,6 +128,7 @@ jobs:
 - The action rehydrates the Soldr setup root and uses the runner's existing Cargo/rustup homes unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
 - The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
 - The default `build-cache-mode` is `once`, which maps to soldr/zccache full-target planning on a cold run but restores only the local rust-plan bundle on later hits. Use `build-cache-mode: thin` for the bounded dependency-artifact alternative, or `build-cache-mode: full` when you explicitly want normal whole-target restore/save behavior on every run.
+- In `once` mode, an exact rust-plan bundle hit skips the separate build-cache restore because the target bundle already rehydrates the warm artifacts needed for the following build.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
 - The setup cache intentionally keeps Soldr setup state, while the dedicated `ZCCACHE_CACHE_DIR` payload is stored in its own cache so warm runs do not restore the same build-cache bytes twice.

--- a/action.yml
+++ b/action.yml
@@ -204,40 +204,6 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
 
-    - id: build-cache-lookup
-      if: ${{ inputs.build-cache == 'true' }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: ${{ steps.resolve.outputs.build_cache_path }}
-        key: ${{ steps.resolve.outputs.build_cache_key }}
-        restore-keys: |
-          ${{ steps.resolve.outputs.build_cache_restore_key_parent }}
-          ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
-          ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
-        lookup-only: true
-
-    - id: build-cache-restore
-      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.build_cache_mode == 'once' && (steps.build-cache-lookup.outputs.cache-hit == 'true' || steps.build-cache-lookup.outputs.cache-matched-key != '') }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: ${{ steps.resolve.outputs.build_cache_path }}
-        key: ${{ steps.resolve.outputs.build_cache_key }}
-        restore-keys: |
-          ${{ steps.resolve.outputs.build_cache_restore_key_parent }}
-          ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
-          ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
-
-    - id: build-cache-managed
-      if: ${{ inputs.build-cache == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || (steps.build-cache-lookup.outputs.cache-hit != 'true' && steps.build-cache-lookup.outputs.cache-matched-key == '')) }}
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: ${{ steps.resolve.outputs.build_cache_path }}
-        key: ${{ steps.resolve.outputs.build_cache_key }}
-        restore-keys: |
-          ${{ steps.resolve.outputs.build_cache_restore_key_parent }}
-          ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
-          ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
-
     - id: target-cache-lookup
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -268,6 +234,40 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_parent }}
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+
+    - id: build-cache-lookup
+      if: ${{ inputs.build-cache == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || steps.resolve.outputs.target_cache_enabled != 'true' || steps.target-cache-lookup.outputs.cache-hit != 'true') }}
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.build_cache_path }}
+        key: ${{ steps.resolve.outputs.build_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.build_cache_restore_key_parent }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
+        lookup-only: true
+
+    - id: build-cache-restore
+      if: ${{ inputs.build-cache == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || steps.resolve.outputs.target_cache_enabled != 'true' || steps.target-cache-lookup.outputs.cache-hit != 'true') && steps.resolve.outputs.build_cache_mode == 'once' && (steps.build-cache-lookup.outputs.cache-hit == 'true' || steps.build-cache-lookup.outputs.cache-matched-key != '') }}
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.build_cache_path }}
+        key: ${{ steps.resolve.outputs.build_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.build_cache_restore_key_parent }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
+
+    - id: build-cache-managed
+      if: ${{ inputs.build-cache == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || steps.resolve.outputs.target_cache_enabled != 'true' || steps.target-cache-lookup.outputs.cache-hit != 'true') && (steps.resolve.outputs.build_cache_mode != 'once' || (steps.build-cache-lookup.outputs.cache-hit != 'true' && steps.build-cache-lookup.outputs.cache-matched-key == '')) }}
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.build_cache_path }}
+        key: ${{ steps.resolve.outputs.build_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.build_cache_restore_key_parent }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
 
     - id: target-tree-cache-lookup
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode == 'full' }}
@@ -333,6 +333,7 @@ runs:
         BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
         TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
         EFFECTIVE_TARGET_CACHE_ENABLED: ${{ steps.resolve.outputs.target_cache_enabled }}
+        SKIP_BUILD_CACHE_FOR_TARGET_EXACT_HIT: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.build_cache_mode == 'once' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.target-cache-lookup.outputs.cache-hit == 'true' }}
       run: |
         function TimestampEnabled {
           $value = "$env:SETUP_SOLDR_TIMESTAMPS".Trim().ToLowerInvariant()
@@ -386,15 +387,21 @@ runs:
         "cache_restore_status=$cacheStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
         if ($env:BUILD_CACHE_ENABLED -eq "true") {
-          $buildValue = $env:RAW_BUILD_CACHE_HIT
-          if ([string]::IsNullOrWhiteSpace($buildValue)) {
+          if ($env:SKIP_BUILD_CACHE_FOR_TARGET_EXACT_HIT -eq "true") {
             $buildValue = "false"
+            $buildStatus = "skipped-target-cache-exact-hit"
+          } else {
+            $buildValue = $env:RAW_BUILD_CACHE_HIT
+            if ([string]::IsNullOrWhiteSpace($buildValue)) {
+              $buildValue = "false"
+            }
+            $buildStatus = RestoreStatus $env:BUILD_CACHE_ENABLED $env:LOOKUP_BUILD_CACHE_HIT $env:LOOKUP_BUILD_CACHE_MATCHED_KEY $env:BUILD_CACHE_KEY
           }
         } else {
           $buildValue = ""
+          $buildStatus = "disabled"
         }
         "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-        $buildStatus = RestoreStatus $env:BUILD_CACHE_ENABLED $env:LOOKUP_BUILD_CACHE_HIT $env:LOOKUP_BUILD_CACHE_MATCHED_KEY $env:BUILD_CACHE_KEY
         "build_cache_restore_status=$buildStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
         if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true") {
@@ -416,6 +423,9 @@ runs:
         }
 
         Log "cache restore status=$cacheStatus exact-hit=$value"
+        if ($env:SKIP_BUILD_CACHE_FOR_TARGET_EXACT_HIT -eq "true") {
+          Log "build-cache restore skipped because once-mode target cache was an exact hit"
+        }
         Log "build-cache restore status=$buildStatus exact-hit=$buildValue"
         Log "target-cache bundle restore status=$targetStatus exact-hit=$targetValue"
         if ($env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true" -and "${{ steps.resolve.outputs.build_cache_mode }}" -eq "full") {

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -38,3 +38,14 @@ def test_setup_cache_uses_lookup_exact_restore_and_managed_fallback() -> None:
     assert "steps.resolve.outputs.setup_cache_paths" in action
     assert 'LogPath "soldr-bin after restore"' in action
     assert "id: cache-save" not in action
+
+
+def test_once_mode_skips_build_cache_restore_when_target_cache_is_exact_hit() -> None:
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+
+    assert "id: target-cache-lookup" in action
+    assert "id: build-cache-lookup" in action
+    assert "steps.target-cache-lookup.outputs.cache-hit != 'true'" in action
+    assert "SKIP_BUILD_CACHE_FOR_TARGET_EXACT_HIT" in action
+    assert "skipped-target-cache-exact-hit" in action
+    assert "build-cache restore skipped because once-mode target cache was an exact hit" in action


### PR DESCRIPTION
## Summary
- skip the separate build-cache lookup/restore path when `build-cache-mode: once` already got an exact hit on the rust-plan target bundle
- surface that branch decision as `build-cache-restore-status=skipped-target-cache-exact-hit`
- document and test the new once-mode exact-hit behavior

## Why
PR #44 removed the duplicated zccache payload from the setup cache, but warm exact-hit runs in `once` mode can still spend time doing a second cache lookup/restore for the managed build cache even when the exact-hit rust-plan bundle has already rehydrated the warm artifacts needed for the following build.

This change trims that redundant path so the next benchmark can measure whether exact-hit warm runs get cheaper without affecting the existing warm-cache behavior.

## Validation
- `pytest tests/test_resolve_setup_build_cache_mode.py tests/test_action_target_cache_wiring.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('action.yml').read_text(encoding='utf-8')); [yaml.safe_load(p.read_text(encoding='utf-8')) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('yaml ok')"`
- `git diff --check`

## Context
Follow-up optimization after #44 / issue #39.
