### PR TITLE
Slim setup cache payload

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -310,6 +310,26 @@ def _path_summary(label: str, path: Path) -> None:
     log(f"{label} path={path} exists=true files={files} bytes={bytes_total}")
 
 
+def _setup_cache_paths(setup_cache_path: Path, bin_dir: Path, rustup_home: Path) -> str:
+    # Exact-hit warm reuse only needs the installed soldr binary plus the
+    # managed rustup metadata and toolchain directories. Caching the whole root
+    # also captures transient rustup files that only bloat the setup payload.
+    paths = [str(bin_dir)]
+    try:
+        rustup_home.relative_to(setup_cache_path)
+    except ValueError:
+        return "\n".join(paths)
+
+    paths.extend(
+        (
+            str(rustup_home / "settings.toml"),
+            str(rustup_home / "toolchains"),
+            str(rustup_home / "update-hashes"),
+        )
+    )
+    return "\n".join(paths)
+
+
 def main() -> None:
     workspace = Path(os.environ["ACTION_WORKSPACE"]).resolve()
     runner_temp = Path(os.environ.get("RUNNER_TEMP", workspace / ".tmp")).resolve()
@@ -334,7 +354,7 @@ def main() -> None:
     bin_dir = cache_root / "bin"
     setup_cache_path = cache_root
     soldr_bin_cache_path = soldr_root / "bin"
-    setup_cache_paths = "\n".join((str(setup_cache_path), str(soldr_bin_cache_path)))
+    setup_cache_paths = _setup_cache_paths(setup_cache_path, bin_dir, rustup_home)
     zccache_cache_dir = soldr_root / "cache" / "zccache"
     thin_target_cache_bundle_path = cache_root.parent / f"{cache_root.name}-target-thin"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
@@ -379,8 +399,8 @@ def main() -> None:
     ).hexdigest()[:16]
     runner_os = _sanitize_fragment(os.environ.get("ACTION_OS", os.name).lower())
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
-    # v4 keeps the dedicated zccache build cache separate while restoring the
-    # managed rustup home under the setup-cache root for exact-hit reuse.
+    # v4 keeps the dedicated zccache build cache separate while restoring only
+    # the managed rustup state needed for exact-hit toolchain reuse.
     cache_prefix = f"setup-soldr-v4-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
     workspace_manifest_hash = _workspace_manifest_hash(workspace)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
 |---|---|
 | `version` | Soldr release tag or version to install. Defaults to `0.7.10`. |
 | `cache` | Restore and save the action-managed cache/state root. |
-| `cache-dir` | Override the runner-local cache/state root. |
+| `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
 | `cache-key-suffix` | Optional escape hatch appended to the cache key. |
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty; `components` and `targets` in the file are provisioned during setup. |
@@ -125,13 +125,13 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.10`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
-- The action rehydrates the Soldr setup root, keeps a managed `RUSTUP_HOME` inside that cache by default, and continues to use the runner's existing `CARGO_HOME` unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
+- The action rehydrates the installed `soldr` binary plus the managed `RUSTUP_HOME` state it needs for warm reuse when that rustup home lives under the action-managed cache root, and continues to use the runner's existing `CARGO_HOME` unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
 - The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
 - The default `build-cache-mode` is `once`, which maps to soldr/zccache full-target planning on a cold run but restores only the local rust-plan bundle on later hits. Use `build-cache-mode: thin` for the bounded dependency-artifact alternative, or `build-cache-mode: full` when you explicitly want normal whole-target restore/save behavior on every run.
 - In `once` mode, an exact rust-plan bundle hit skips the separate build-cache restore because the target bundle already rehydrates the warm artifacts needed for the following build.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
-- The setup cache intentionally keeps Soldr setup state, while the dedicated `ZCCACHE_CACHE_DIR` payload is stored in its own cache so warm runs do not restore the same build-cache bytes twice.
+- The setup cache intentionally keeps the installed `soldr` binary and any managed rustup state that lives under the setup cache root, while the dedicated `ZCCACHE_CACHE_DIR` payload is stored in its own cache so warm runs do not restore the same build-cache bytes twice.
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: "true"
   cache-dir:
-    description: Override the runner-local cache/state root used for Soldr, Cargo, and rustup state rehydrated by this action.
+    description: Override the runner-local cache/state root used for the installed soldr binary and any managed rustup state rehydrated by this action.
     required: false
     default: ""
   cache-key-suffix:

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -183,11 +183,9 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         self.assertEqual(build_cache_path, soldr_root / "cache" / "zccache")
         self.assertNotIn(setup_cache_path, build_cache_path.parents)
         self.assertEqual(result.outputs["soldr_bin_cache_path"], str(soldr_root / "bin"))
+        self.assertNotIn(str(setup_cache_path), result.outputs["setup_cache_paths"].splitlines())
         self.assertEqual(result.env_exports.get("ZCCACHE_CACHE_DIR"), str(build_cache_path))
-        self.assertEqual(
-            result.outputs["setup_cache_paths"],
-            f"{setup_cache_path}\n{soldr_root / 'bin'}",
-        )
+        self.assertEqual(result.outputs["setup_cache_paths"], str(setup_cache_path / "bin"))
 
     def test_default_rustup_home_lives_under_setup_cache_root(self) -> None:
         result = _run_resolve_setup(include_explicit_toolchain_homes=False)
@@ -200,6 +198,17 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         self.assertEqual(result.env_exports.get("RUSTUP_HOME"), str(rustup_home))
         self.assertEqual(cargo_home, Path(result.env_exports["CARGO_HOME"]))
         self.assertNotIn(setup_cache_path, cargo_home.parents)
+        self.assertEqual(
+            result.outputs["setup_cache_paths"],
+            "\n".join(
+                (
+                    str(setup_cache_path / "bin"),
+                    str(rustup_home / "settings.toml"),
+                    str(rustup_home / "toolchains"),
+                    str(rustup_home / "update-hashes"),
+                )
+            ),
+        )
 
     def test_full_mode_restores_target_tree_and_bundle_root_together(self) -> None:
         result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "full"})


### PR DESCRIPTION
## Summary
- narrow the setup cache payload to the installed soldr binary plus the managed rustup state needed for exact-hit warm reuse
- avoid caching the entire setup root when the remaining files are transient rustup artifacts that do not help warm-path reuse
- update docs and cache-path tests to match the slimmer restore/save contract

## Validation
- pytest tests/test_resolve_setup_build_cache_mode.py tests/test_ensure_rust_toolchain_refresh.py tests/test_resolve_setup_toolchain_resolution.py tests/test_action_target_cache_wiring.py tests/test_zccache_build_demo_workflow.py
- git diff --check

## Context
- continues the warm-path work tracked in #39
- intended next measurement is the existing Soldr Cache Speed Demo workflow on this branch to see whether shrinking the setup-cache payload reduces warm exact-hit restore time further