### PR TITLE
Prefer runner rustup home when compatible

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -5,6 +5,8 @@ import hashlib
 import json
 import os
 import re
+import shutil
+import subprocess
 import time
 import urllib.error
 import urllib.request
@@ -293,6 +295,135 @@ def _default_home_dir(name: str) -> Path:
     return (Path.home() / name).resolve()
 
 
+def _run_rustup_text(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        env=env,
+    )
+
+
+def _rustup_probe_env(cargo_home: Path, rustup_home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["CARGO_HOME"] = str(cargo_home)
+    env["RUSTUP_HOME"] = str(rustup_home)
+    return env
+
+
+def _rustup_installed_names(
+    rustup: str,
+    args: list[str],
+    env: dict[str, str],
+) -> set[str]:
+    result = _run_rustup_text([rustup, *args], env)
+    if result.returncode != 0:
+        return set()
+    return {
+        line.split(maxsplit=1)[0]
+        for line in result.stdout.splitlines()
+        if line.strip()
+    }
+
+
+def _toolchain_list_contains(installed: set[str], channel: str) -> bool:
+    return any(name == channel or name.startswith(f"{channel}-") for name in installed)
+
+
+def _installed_toolchain_release(
+    rustup: str,
+    channel: str,
+    env: dict[str, str],
+) -> str | None:
+    result = _run_rustup_text([rustup, "run", channel, "rustc", "--version"], env)
+    if result.returncode != 0:
+        return None
+    match = re.match(r"^rustc\s+([^\s]+)", result.stdout.strip())
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _component_installed(installed: set[str], component: str) -> bool:
+    return any(name == component or name.startswith(f"{component}-") for name in installed)
+
+
+def _system_rustup_satisfies_request(
+    cargo_home: Path,
+    rustup_home: Path,
+    toolchain: dict[str, Any],
+) -> bool:
+    rustup = shutil.which("rustup")
+    if rustup is None:
+        log("rustup not found on PATH; using managed RUSTUP_HOME under the setup cache root")
+        return False
+
+    env = _rustup_probe_env(cargo_home, rustup_home)
+    channel = str(toolchain["channel"]).strip() or "stable"
+    installed_toolchains = _rustup_installed_names(rustup, ["toolchain", "list"], env)
+    if not _toolchain_list_contains(installed_toolchains, channel):
+        log(
+            f"Runner rustup home {rustup_home} does not already contain toolchain {channel}; "
+            "using managed RUSTUP_HOME under the setup cache root"
+        )
+        return False
+
+    expected_release = str(toolchain.get("cache_channel", "")).strip()
+    if _rolling_toolchain_alias(channel) is not None and expected_release:
+        installed_release = _installed_toolchain_release(rustup, channel, env)
+        if installed_release != expected_release:
+            log(
+                f"Runner rustup home {rustup_home} has {channel} release "
+                f"{installed_release or 'missing'} but exact-hit reuse expects {expected_release}; "
+                "using managed RUSTUP_HOME under the setup cache root"
+            )
+            return False
+
+    components = list(toolchain.get("components", []))
+    if components:
+        installed_components = _rustup_installed_names(
+            rustup,
+            ["component", "list", "--toolchain", channel, "--installed"],
+            env,
+        )
+        missing_components = [
+            component
+            for component in components
+            if not _component_installed(installed_components, component)
+        ]
+        if missing_components:
+            log(
+                f"Runner rustup home {rustup_home} is missing requested components "
+                f"for {channel}: {', '.join(missing_components)}; "
+                "using managed RUSTUP_HOME under the setup cache root"
+            )
+            return False
+
+    targets = list(toolchain.get("targets", []))
+    if targets:
+        installed_targets = _rustup_installed_names(
+            rustup,
+            ["target", "list", "--toolchain", channel, "--installed"],
+            env,
+        )
+        missing_targets = [target for target in targets if target not in installed_targets]
+        if missing_targets:
+            log(
+                f"Runner rustup home {rustup_home} is missing requested targets "
+                f"for {channel}: {', '.join(missing_targets)}; "
+                "using managed RUSTUP_HOME under the setup cache root"
+            )
+            return False
+
+    log(
+        f"Using runner rustup home {rustup_home} for toolchain {channel}; "
+        "setup cache stays bin-only"
+    )
+    return True
+
+
 def _path_summary(label: str, path: Path) -> None:
     if not path.exists():
         log(f"{label} path={path} exists=false files=0 bytes=0")
@@ -348,17 +479,35 @@ def main() -> None:
     cargo_home = Path(os.environ.get("CARGO_HOME", "")).expanduser().resolve() if os.environ.get("CARGO_HOME") else (
         _default_home_dir(".cargo")
     )
-    rustup_home = Path(os.environ.get("RUSTUP_HOME", "")).expanduser().resolve() if os.environ.get("RUSTUP_HOME") else (
-        cache_root / "rustup-home"
-    )
     bin_dir = cache_root / "bin"
     setup_cache_path = cache_root
     soldr_bin_cache_path = soldr_root / "bin"
-    setup_cache_paths = _setup_cache_paths(setup_cache_path, bin_dir, rustup_home)
     zccache_cache_dir = soldr_root / "cache" / "zccache"
     thin_target_cache_bundle_path = cache_root.parent / f"{cache_root.name}-target-thin"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
+
+    toolchain = load_toolchain_spec(
+        workspace=workspace,
+        toolchain_file=os.environ.get("INPUT_TOOLCHAIN_FILE", "rust-toolchain.toml"),
+        toolchain_override=os.environ.get("INPUT_TOOLCHAIN", ""),
+    )
+
+    explicit_rustup_home = os.environ.get("RUSTUP_HOME", "").strip()
+    if explicit_rustup_home:
+        rustup_home = Path(explicit_rustup_home).expanduser().resolve()
+        rustup_strategy = "explicit"
+    else:
+        runner_rustup_home = _default_home_dir(".rustup")
+        if _system_rustup_satisfies_request(cargo_home, runner_rustup_home, toolchain):
+            rustup_home = runner_rustup_home
+            rustup_strategy = "system"
+        else:
+            rustup_home = cache_root / "rustup-home"
+            rustup_strategy = "managed"
+
+    setup_cache_paths = _setup_cache_paths(setup_cache_path, bin_dir, rustup_home)
+    setup_cache_layout = "bin+rustup" if "\n" in setup_cache_paths else "bin-only"
 
     for path in (
         cache_root,
@@ -374,12 +523,6 @@ def main() -> None:
     ):
         path.mkdir(parents=True, exist_ok=True)
 
-    toolchain = load_toolchain_spec(
-        workspace=workspace,
-        toolchain_file=os.environ.get("INPUT_TOOLCHAIN_FILE", "rust-toolchain.toml"),
-        toolchain_override=os.environ.get("INPUT_TOOLCHAIN", ""),
-    )
-
     soldr_repo = os.environ.get("INPUT_REPO", "zackees/soldr").strip() or "zackees/soldr"
     soldr_ref = os.environ.get("INPUT_REF", "").strip()
     soldr_version = os.environ.get("INPUT_VERSION", "").strip()
@@ -390,6 +533,7 @@ def main() -> None:
         "targets": toolchain["targets"],
         "source": toolchain["source"],
         "file_hash": toolchain["file_hash"],
+        "setup_cache_layout": setup_cache_layout,
         "soldr_repo": soldr_repo,
         "soldr_ref": soldr_ref or "release",
         "soldr_version": soldr_version or "latest",
@@ -591,6 +735,8 @@ def main() -> None:
     log(f"soldr ref={soldr_ref or 'release'}")
     log(f"toolchain channel={toolchain['channel']}")
     log(f"toolchain cache-channel={toolchain['cache_channel']}")
+    log(f"rustup strategy={rustup_strategy}")
+    log(f"setup-cache layout={setup_cache_layout}")
     if target_cache_parent_key:
         log(f"target-cache restore-key-parent={target_cache_parent_key}")
     log(f"target-cache restore-key-lock={target_cache_lock_prefix}")
@@ -633,6 +779,7 @@ def main() -> None:
             "soldr_bin_cache_path": str(soldr_bin_cache_path),
             "cargo_home": str(cargo_home),
             "rustup_home": str(rustup_home),
+            "setup_cache_layout": setup_cache_layout,
             "bin_dir": str(bin_dir),
             "soldr_path": str(soldr_path),
             "soldr_repo": soldr_repo,

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -310,6 +310,26 @@ def _path_summary(label: str, path: Path) -> None:
     log(f"{label} path={path} exists=true files={files} bytes={bytes_total}")
 
 
+def _setup_cache_paths(setup_cache_path: Path, bin_dir: Path, rustup_home: Path) -> str:
+    # Exact-hit warm reuse only needs the installed soldr binary plus the
+    # managed rustup metadata and toolchain directories. Caching the whole root
+    # also captures transient rustup files that only bloat the setup payload.
+    paths = [str(bin_dir)]
+    try:
+        rustup_home.relative_to(setup_cache_path)
+    except ValueError:
+        return "\n".join(paths)
+
+    paths.extend(
+        (
+            str(rustup_home / "settings.toml"),
+            str(rustup_home / "toolchains"),
+            str(rustup_home / "update-hashes"),
+        )
+    )
+    return "\n".join(paths)
+
+
 def main() -> None:
     workspace = Path(os.environ["ACTION_WORKSPACE"]).resolve()
     runner_temp = Path(os.environ.get("RUNNER_TEMP", workspace / ".tmp")).resolve()
@@ -334,7 +354,7 @@ def main() -> None:
     bin_dir = cache_root / "bin"
     setup_cache_path = cache_root
     soldr_bin_cache_path = soldr_root / "bin"
-    setup_cache_paths = "\n".join((str(setup_cache_path), str(soldr_bin_cache_path)))
+    setup_cache_paths = _setup_cache_paths(setup_cache_path, bin_dir, rustup_home)
     zccache_cache_dir = soldr_root / "cache" / "zccache"
     thin_target_cache_bundle_path = cache_root.parent / f"{cache_root.name}-target-thin"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
@@ -379,8 +399,8 @@ def main() -> None:
     ).hexdigest()[:16]
     runner_os = _sanitize_fragment(os.environ.get("ACTION_OS", os.name).lower())
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
-    # v4 keeps the dedicated zccache build cache separate while restoring the
-    # managed rustup home under the setup-cache root for exact-hit reuse.
+    # v4 keeps the dedicated zccache build cache separate while restoring only
+    # the managed rustup state needed for exact-hit toolchain reuse.
     cache_prefix = f"setup-soldr-v4-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
     workspace_manifest_hash = _workspace_manifest_hash(workspace)

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -419,7 +419,7 @@ def _system_rustup_satisfies_request(
 
     log(
         f"Using runner rustup home {rustup_home} for toolchain {channel}; "
-        "setup cache stays bin-only"
+        "setup cache stays binary-only without managed rustup"
     )
     return True
 
@@ -441,11 +441,16 @@ def _path_summary(label: str, path: Path) -> None:
     log(f"{label} path={path} exists=true files={files} bytes={bytes_total}")
 
 
-def _setup_cache_paths(setup_cache_path: Path, bin_dir: Path, rustup_home: Path) -> str:
-    # Exact-hit warm reuse only needs the installed soldr binary plus the
-    # managed rustup metadata and toolchain directories. Caching the whole root
-    # also captures transient rustup files that only bloat the setup payload.
-    paths = [str(bin_dir)]
+def _setup_cache_paths(
+    setup_cache_path: Path,
+    bin_dir: Path,
+    soldr_bin_cache_path: Path,
+    rustup_home: Path,
+) -> str:
+    # Exact-hit warm reuse needs the installed soldr binary plus the soldr-
+    # managed helper binaries under soldr/bin. Only add rustup state when this
+    # action is managing RUSTUP_HOME under the setup cache root.
+    paths = [str(bin_dir), str(soldr_bin_cache_path)]
     try:
         rustup_home.relative_to(setup_cache_path)
     except ValueError:
@@ -459,6 +464,14 @@ def _setup_cache_paths(setup_cache_path: Path, bin_dir: Path, rustup_home: Path)
         )
     )
     return "\n".join(paths)
+
+
+def _setup_cache_layout(setup_cache_path: Path, rustup_home: Path) -> str:
+    try:
+        rustup_home.relative_to(setup_cache_path)
+    except ValueError:
+        return "bin+soldr-bin"
+    return "bin+soldr-bin+rustup"
 
 
 def main() -> None:
@@ -506,8 +519,13 @@ def main() -> None:
             rustup_home = cache_root / "rustup-home"
             rustup_strategy = "managed"
 
-    setup_cache_paths = _setup_cache_paths(setup_cache_path, bin_dir, rustup_home)
-    setup_cache_layout = "bin+rustup" if "\n" in setup_cache_paths else "bin-only"
+    setup_cache_paths = _setup_cache_paths(
+        setup_cache_path,
+        bin_dir,
+        soldr_bin_cache_path,
+        rustup_home,
+    )
+    setup_cache_layout = _setup_cache_layout(setup_cache_path, rustup_home)
 
     for path in (
         cache_root,

--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.10`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
-- The action rehydrates the installed `soldr` binary plus the managed `RUSTUP_HOME` state it needs for warm reuse when that rustup home lives under the action-managed cache root, and continues to use the runner's existing `CARGO_HOME` unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
+- The action keeps using the runner's existing `CARGO_HOME` unless `CARGO_HOME` is already set by the workflow. When `RUSTUP_HOME` is not explicitly set, setup-soldr prefers the runner's existing rustup home if it already satisfies the requested toolchain/components/targets; otherwise it falls back to a managed `RUSTUP_HOME` under the action cache root and rehydrates that state on later warm runs.
 - The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
 - The default `build-cache-mode` is `once`, which maps to soldr/zccache full-target planning on a cold run but restores only the local rust-plan bundle on later hits. Use `build-cache-mode: thin` for the bounded dependency-artifact alternative, or `build-cache-mode: full` when you explicitly want normal whole-target restore/save behavior on every run.
 - In `once` mode, an exact rust-plan bundle hit skips the separate build-cache restore because the target bundle already rehydrates the warm artifacts needed for the following build.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
-- The setup cache intentionally keeps the installed `soldr` binary and any managed rustup state that lives under the setup cache root, while the dedicated `ZCCACHE_CACHE_DIR` payload is stored in its own cache so warm runs do not restore the same build-cache bytes twice.
+- The setup cache intentionally keeps the installed `soldr` binary and only includes rustup state when setup-soldr had to fall back to a managed `RUSTUP_HOME` under the setup cache root. The dedicated `ZCCACHE_CACHE_DIR` payload stays in its own cache so warm runs do not restore the same build-cache bytes twice.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
 |---|---|
 | `version` | Soldr release tag or version to install. Defaults to `0.7.10`. |
 | `cache` | Restore and save the action-managed cache/state root. |
-| `cache-dir` | Override the runner-local cache/state root. |
+| `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
 | `cache-key-suffix` | Optional escape hatch appended to the cache key. |
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty; `components` and `targets` in the file are provisioned during setup. |
@@ -125,13 +125,13 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.10`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
-- The action rehydrates the Soldr setup root, keeps a managed `RUSTUP_HOME` inside that cache by default, and continues to use the runner's existing `CARGO_HOME` unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
+- The action rehydrates the installed `soldr` binary plus the managed `RUSTUP_HOME` state it needs for warm reuse when that rustup home lives under the action-managed cache root, and continues to use the runner's existing `CARGO_HOME` unless `CARGO_HOME` or `RUSTUP_HOME` are already set by the workflow.
 - The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
 - The default `build-cache-mode` is `once`, which maps to soldr/zccache full-target planning on a cold run but restores only the local rust-plan bundle on later hits. Use `build-cache-mode: thin` for the bounded dependency-artifact alternative, or `build-cache-mode: full` when you explicitly want normal whole-target restore/save behavior on every run.
 - In `once` mode, an exact rust-plan bundle hit skips the separate build-cache restore because the target bundle already rehydrates the warm artifacts needed for the following build.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
-- The setup cache intentionally keeps Soldr setup state, while the dedicated `ZCCACHE_CACHE_DIR` payload is stored in its own cache so warm runs do not restore the same build-cache bytes twice.
+- The setup cache intentionally keeps the installed `soldr` binary and any managed rustup state that lives under the setup cache root, while the dedicated `ZCCACHE_CACHE_DIR` payload is stored in its own cache so warm runs do not restore the same build-cache bytes twice.
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: "true"
   cache-dir:
-    description: Override the runner-local cache/state root used for Soldr, Cargo, and rustup state rehydrated by this action.
+    description: Override the runner-local cache/state root used for the installed soldr binary and any managed rustup state rehydrated by this action.
     required: false
     default: ""
   cache-key-suffix:

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -183,11 +183,9 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         self.assertEqual(build_cache_path, soldr_root / "cache" / "zccache")
         self.assertNotIn(setup_cache_path, build_cache_path.parents)
         self.assertEqual(result.outputs["soldr_bin_cache_path"], str(soldr_root / "bin"))
+        self.assertNotIn(str(setup_cache_path), result.outputs["setup_cache_paths"].splitlines())
         self.assertEqual(result.env_exports.get("ZCCACHE_CACHE_DIR"), str(build_cache_path))
-        self.assertEqual(
-            result.outputs["setup_cache_paths"],
-            f"{setup_cache_path}\n{soldr_root / 'bin'}",
-        )
+        self.assertEqual(result.outputs["setup_cache_paths"], str(setup_cache_path / "bin"))
 
     def test_default_rustup_home_lives_under_setup_cache_root(self) -> None:
         result = _run_resolve_setup(include_explicit_toolchain_homes=False)
@@ -200,6 +198,17 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         self.assertEqual(result.env_exports.get("RUSTUP_HOME"), str(rustup_home))
         self.assertEqual(cargo_home, Path(result.env_exports["CARGO_HOME"]))
         self.assertNotIn(setup_cache_path, cargo_home.parents)
+        self.assertEqual(
+            result.outputs["setup_cache_paths"],
+            "\n".join(
+                (
+                    str(setup_cache_path / "bin"),
+                    str(rustup_home / "settings.toml"),
+                    str(rustup_home / "toolchains"),
+                    str(rustup_home / "update-hashes"),
+                )
+            ),
+        )
 
     def test_full_mode_restores_target_tree_and_bundle_root_together(self) -> None:
         result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "full"})

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -258,7 +258,10 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         self.assertEqual(result.outputs["soldr_bin_cache_path"], str(soldr_root / "bin"))
         self.assertNotIn(str(setup_cache_path), result.outputs["setup_cache_paths"].splitlines())
         self.assertEqual(result.env_exports.get("ZCCACHE_CACHE_DIR"), str(build_cache_path))
-        self.assertEqual(result.outputs["setup_cache_paths"], str(setup_cache_path / "bin"))
+        self.assertEqual(
+            result.outputs["setup_cache_paths"],
+            "\n".join((str(setup_cache_path / "bin"), str(soldr_root / "bin"))),
+        )
 
     def test_default_rustup_home_lives_under_setup_cache_root(self) -> None:
         result = _run_resolve_setup(
@@ -279,6 +282,7 @@ class BuildCacheModeResolveTests(unittest.TestCase):
             "\n".join(
                 (
                     str(setup_cache_path / "bin"),
+                    str(Path(result.outputs["soldr_bin_cache_path"])),
                     str(rustup_home / "settings.toml"),
                     str(rustup_home / "toolchains"),
                     str(rustup_home / "update-hashes"),
@@ -292,8 +296,11 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         rustup_home = Path(outputs["rustup_home"])
 
         self.assertEqual(rustup_home, Path(outputs["cargo_home"]).parent / ".rustup")
-        self.assertEqual(outputs["setup_cache_layout"], "bin-only")
-        self.assertEqual(outputs["setup_cache_paths"], str(setup_cache_path / "bin"))
+        self.assertEqual(outputs["setup_cache_layout"], "bin+soldr-bin")
+        self.assertEqual(
+            outputs["setup_cache_paths"],
+            "\n".join((str(setup_cache_path / "bin"), outputs["soldr_bin_cache_path"])),
+        )
         self.assertEqual(env_exports.get("RUSTUP_HOME"), str(rustup_home))
 
     def test_system_rustup_match_requires_release_components_and_targets(self) -> None:
@@ -356,8 +363,8 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         _, system_outputs = _run_resolve_main_with_system_rustup()
 
         self.assertEqual(managed.returncode, 0)
-        self.assertEqual(managed.outputs["setup_cache_layout"], "bin+rustup")
-        self.assertEqual(system_outputs["setup_cache_layout"], "bin-only")
+        self.assertEqual(managed.outputs["setup_cache_layout"], "bin+soldr-bin+rustup")
+        self.assertEqual(system_outputs["setup_cache_layout"], "bin+soldr-bin")
         self.assertNotEqual(managed.outputs["cache_key"], system_outputs["cache_key"])
 
     def test_full_mode_restores_target_tree_and_bundle_root_together(self) -> None:

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
@@ -7,6 +8,7 @@ import tempfile
 import unittest
 from dataclasses import dataclass
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -50,6 +52,7 @@ def _run_resolve_setup(
     extra_env: dict[str, str] | None = None,
     *,
     include_explicit_toolchain_homes: bool = True,
+    clear_path: bool = False,
 ) -> ResolveResult:
     with tempfile.TemporaryDirectory(prefix="setup-soldr-tests-") as temp_dir:
         root = Path(temp_dir)
@@ -101,6 +104,10 @@ def _run_resolve_setup(
                     "RUSTUP_HOME": str(root / "rustup-home"),
                 }
             )
+        if clear_path:
+            empty_path = root / "empty-path"
+            empty_path.mkdir()
+            env["PATH"] = str(empty_path)
         if extra_env:
             env.update(extra_env)
 
@@ -120,6 +127,72 @@ def _run_resolve_setup(
             env_exports=_parse_github_kv_file(github_env),
             outputs=_parse_github_kv_file(github_output),
         )
+
+
+def _load_resolve_module():
+    helper_dir = REPO_ROOT / ".github" / "actions" / "setup-soldr"
+    helper_dir_str = str(helper_dir)
+    if helper_dir_str not in sys.path:
+        sys.path.insert(0, helper_dir_str)
+    spec = importlib.util.spec_from_file_location("resolve_setup", RESOLVE_SETUP)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load resolve_setup.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_resolve_main_with_system_rustup() -> tuple[dict[str, str], dict[str, str]]:
+    module = _load_resolve_module()
+
+    with tempfile.TemporaryDirectory(prefix="setup-soldr-tests-") as temp_dir:
+        root = Path(temp_dir)
+        workspace = root / "workspace"
+        runner_temp = root / "runner-temp"
+        home_dir = root / "home"
+        github_env = root / "github-env"
+        github_output = root / "github-output"
+        github_path = root / "github-path"
+        workspace.mkdir()
+        runner_temp.mkdir()
+        home_dir.mkdir()
+        (workspace / "Cargo.lock").write_text("# test lockfile\n", encoding="utf-8")
+
+        env = os.environ.copy()
+        for key in list(env):
+            if key.startswith(("INPUT_", "ACTION_", "GITHUB_", "SETUP_SOLDR_")):
+                env.pop(key, None)
+        for key in (
+            "CARGO_HOME",
+            "RUSTUP_HOME",
+            "NO_COLOR",
+            "CARGO_TERM_COLOR",
+            "CLICOLOR_FORCE",
+            "FORCE_COLOR",
+        ):
+            env.pop(key, None)
+        env.update(
+            {
+                "ACTION_WORKSPACE": str(workspace),
+                "ACTION_OS": "Linux",
+                "ACTION_ARCH": "X64",
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_ENV": str(github_env),
+                "GITHUB_OUTPUT": str(github_output),
+                "GITHUB_PATH": str(github_path),
+                "GITHUB_SHA": "0123456789abcdef",
+                "HOME": str(home_dir),
+                "USERPROFILE": str(home_dir),
+                "INPUT_TIMESTAMPS": "false",
+                "INPUT_TOOLCHAIN_FILE": "",
+            }
+        )
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(module, "_system_rustup_satisfies_request", return_value=True):
+                module.main()
+
+        return _parse_github_kv_file(github_env), _parse_github_kv_file(github_output)
 
 
 class BuildCacheModeResolveTests(unittest.TestCase):
@@ -188,7 +261,10 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         self.assertEqual(result.outputs["setup_cache_paths"], str(setup_cache_path / "bin"))
 
     def test_default_rustup_home_lives_under_setup_cache_root(self) -> None:
-        result = _run_resolve_setup(include_explicit_toolchain_homes=False)
+        result = _run_resolve_setup(
+            include_explicit_toolchain_homes=False,
+            clear_path=True,
+        )
 
         self.assertEqual(result.returncode, 0)
         setup_cache_path = Path(result.outputs["setup_cache_path"])
@@ -209,6 +285,80 @@ class BuildCacheModeResolveTests(unittest.TestCase):
                 )
             ),
         )
+
+    def test_runner_rustup_home_keeps_setup_cache_bin_only_when_it_already_matches(self) -> None:
+        env_exports, outputs = _run_resolve_main_with_system_rustup()
+        setup_cache_path = Path(outputs["setup_cache_path"])
+        rustup_home = Path(outputs["rustup_home"])
+
+        self.assertEqual(rustup_home, Path(outputs["cargo_home"]).parent / ".rustup")
+        self.assertEqual(outputs["setup_cache_layout"], "bin-only")
+        self.assertEqual(outputs["setup_cache_paths"], str(setup_cache_path / "bin"))
+        self.assertEqual(env_exports.get("RUSTUP_HOME"), str(rustup_home))
+
+    def test_system_rustup_match_requires_release_components_and_targets(self) -> None:
+        module = _load_resolve_module()
+        toolchain = {
+            "channel": "stable",
+            "cache_channel": "1.95.0",
+            "components": ["clippy"],
+            "targets": ["wasm32-unknown-unknown"],
+        }
+
+        with (
+            patch.object(module.shutil, "which", return_value="/fake/rustup"),
+            patch.object(
+                module,
+                "_rustup_installed_names",
+                side_effect=[
+                    {"stable-x86_64-unknown-linux-gnu"},
+                    {"clippy-x86_64-unknown-linux-gnu"},
+                    {"wasm32-unknown-unknown"},
+                ],
+            ),
+            patch.object(module, "_installed_toolchain_release", return_value="1.95.0"),
+        ):
+            self.assertTrue(
+                module._system_rustup_satisfies_request(
+                    Path("/fake/cargo-home"),
+                    Path("/fake/rustup-home"),
+                    toolchain,
+                )
+            )
+
+    def test_system_rustup_mismatch_falls_back_to_managed_rustup_home(self) -> None:
+        module = _load_resolve_module()
+        toolchain = {
+            "channel": "stable",
+            "cache_channel": "1.95.0",
+            "components": ["clippy"],
+            "targets": ["wasm32-unknown-unknown"],
+        }
+
+        with (
+            patch.object(module.shutil, "which", return_value="/fake/rustup"),
+            patch.object(module, "_rustup_installed_names", return_value={"stable"}),
+            patch.object(module, "_installed_toolchain_release", return_value="1.94.1"),
+        ):
+            self.assertFalse(
+                module._system_rustup_satisfies_request(
+                    Path("/fake/cargo-home"),
+                    Path("/fake/rustup-home"),
+                    toolchain,
+                )
+            )
+
+    def test_setup_cache_key_changes_when_layout_switches_between_bin_only_and_managed(self) -> None:
+        managed = _run_resolve_setup(
+            include_explicit_toolchain_homes=False,
+            clear_path=True,
+        )
+        _, system_outputs = _run_resolve_main_with_system_rustup()
+
+        self.assertEqual(managed.returncode, 0)
+        self.assertEqual(managed.outputs["setup_cache_layout"], "bin+rustup")
+        self.assertEqual(system_outputs["setup_cache_layout"], "bin-only")
+        self.assertNotEqual(managed.outputs["cache_key"], system_outputs["cache_key"])
 
     def test_full_mode_restores_target_tree_and_bundle_root_together(self) -> None:
         result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "full"})


### PR DESCRIPTION
## Summary
- prefer the runner's existing `RUSTUP_HOME` when it already satisfies the requested toolchain, components, and targets
- keep the setup cache `bin`-only in that exact-hit case instead of restoring a managed rustup payload unnecessarily
- keep the managed-rustup fallback path and document the new selection behavior

## Validation
- `pytest tests/test_resolve_setup_build_cache_mode.py tests/test_ensure_rust_toolchain_refresh.py tests/test_resolve_setup_toolchain_resolution.py tests/test_action_target_cache_wiring.py tests/test_zccache_build_demo_workflow.py`
- `git diff --check`

## Context
- continues the warm-path work tracked in #39
- intended next measurement is the existing `Soldr Cache Speed Demo` workflow on this branch to confirm whether reusing the runner rustup installation reduces warm exact-hit setup time further than PR #46