### PR TITLE
Resolve latest soldr releases before cache reuse

### DIFF
--- a/.github/actions/setup-soldr/ensure_soldr.py
+++ b/.github/actions/setup-soldr/ensure_soldr.py
@@ -24,6 +24,18 @@ def _normalize_version(value: str) -> str:
     return value[1:] if value.startswith("v") else value
 
 
+def _resolved_release_version(repo: str, requested_version: str) -> tuple[str, dict[str, object] | None]:
+    normalized = requested_version.strip()
+    if normalized and normalized.lower() != "latest":
+        return (normalized if normalized.startswith("v") else f"v{normalized}", None)
+
+    release = _fetch_release(repo, "")
+    tag_name = str(release.get("tag_name", "")).strip()
+    if not tag_name:
+        raise RuntimeError(f"failed to resolve latest soldr release tag from {repo}")
+    return tag_name, release
+
+
 def _detect_target() -> tuple[str, str, str]:
     machine = platform.machine().lower()
     if machine in {"x86_64", "amd64"}:
@@ -283,18 +295,22 @@ def main() -> None:
                 fh.write(f"installed_version={(current or requested_ref)}\n")
         return
 
+    resolved_version, resolved_release = _resolved_release_version(repo, requested_version)
     current = _installed_version(binary_path)
     if current is not None:
-        if not requested_version or _normalize_version(current) == _normalize_version(requested_version):
+        if _normalize_version(current) == _normalize_version(resolved_version):
             log(f"Using cached soldr {current} at {binary_path}")
             output = os.environ.get("GITHUB_OUTPUT")
             if output:
                 with open(output, "a", encoding="utf-8") as fh:
                     fh.write(f"installed_version={current}\n")
             return
+        log(
+            f"Cached soldr {current} does not match requested release {resolved_version}; refreshing"
+        )
 
-    log(f"Resolving soldr release from {repo}")
-    release = _fetch_release(repo, requested_version)
+    log(f"Resolving soldr release {resolved_version} from {repo}")
+    release = resolved_release or _fetch_release(repo, resolved_version)
     asset_name, download_url = _select_asset(release, target, archive_ext)
     tag_name = str(release["tag_name"])
 

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -158,6 +158,47 @@ def _short_json_hash(value: dict[str, Any]) -> str:
     ).hexdigest()[:16]
 
 
+def _request_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "setup-soldr-action",
+    }
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _fetch_release(repo: str, version: str) -> dict[str, Any]:
+    if version:
+        tag = version if version.startswith("v") else f"v{version}"
+        url = f"https://api.github.com/repos/{repo}/releases/tags/{tag}"
+    else:
+        url = f"https://api.github.com/repos/{repo}/releases/latest"
+    request = urllib.request.Request(url, headers=_request_headers())
+    with urllib.request.urlopen(request, timeout=10) as response:
+        payload = json.load(response)
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"unexpected GitHub release payload for {repo}")
+    return payload
+
+
+def _resolve_soldr_release_version(repo: str, version: str, ref: str) -> str:
+    if ref.strip():
+        return ""
+
+    requested = version.strip()
+    if requested and requested.lower() != "latest":
+        return requested if requested.startswith("v") else f"v{requested}"
+
+    release = _fetch_release(repo, "")
+    tag_name = str(release.get("tag_name", "")).strip()
+    if not tag_name:
+        raise RuntimeError(f"failed to resolve latest soldr release tag from {repo}")
+    return tag_name
+
+
 def _workspace_manifest_hash(workspace: Path) -> str:
     hasher = hashlib.sha256()
     matched = False
@@ -543,7 +584,12 @@ def main() -> None:
 
     soldr_repo = os.environ.get("INPUT_REPO", "zackees/soldr").strip() or "zackees/soldr"
     soldr_ref = os.environ.get("INPUT_REF", "").strip()
-    soldr_version = os.environ.get("INPUT_VERSION", "").strip()
+    soldr_version_requested = os.environ.get("INPUT_VERSION", "").strip()
+    soldr_version_resolved = _resolve_soldr_release_version(
+        soldr_repo,
+        soldr_version_requested,
+        soldr_ref,
+    )
     toolchain_signature = {
         "channel": toolchain["cache_channel"],
         "profile": toolchain["profile"],
@@ -554,7 +600,7 @@ def main() -> None:
         "setup_cache_layout": setup_cache_layout,
         "soldr_repo": soldr_repo,
         "soldr_ref": soldr_ref or "release",
-        "soldr_version": soldr_version or "latest",
+        "soldr_version": soldr_version_resolved or soldr_ref or "source-ref",
     }
     digest = hashlib.sha256(
         json.dumps(toolchain_signature, sort_keys=True).encode("utf-8")
@@ -751,6 +797,8 @@ def main() -> None:
     log("target-cache backend=local")
     log(f"soldr repo={soldr_repo}")
     log(f"soldr ref={soldr_ref or 'release'}")
+    if soldr_version_resolved:
+        log(f"soldr version={soldr_version_resolved}")
     log(f"toolchain channel={toolchain['channel']}")
     log(f"toolchain cache-channel={toolchain['cache_channel']}")
     log(f"rustup strategy={rustup_strategy}")
@@ -802,7 +850,8 @@ def main() -> None:
             "soldr_path": str(soldr_path),
             "soldr_repo": soldr_repo,
             "soldr_ref": soldr_ref,
-            "soldr_version_requested": soldr_version,
+            "soldr_version_requested": soldr_version_requested,
+            "soldr_version_resolved": soldr_version_resolved,
             "toolchain_channel": toolchain["channel"],
             "toolchain_cache_channel": toolchain["cache_channel"],
             "toolchain_profile": toolchain["profile"],

--- a/.github/workflows/setup-soldr-contract.yml
+++ b/.github/workflows/setup-soldr-contract.yml
@@ -49,6 +49,7 @@ jobs:
           python -m pytest \
             tests/test_action_python_entrypoints.py \
             tests/test_action_target_cache_wiring.py \
+            tests/test_ensure_soldr_release_resolution.py \
             tests/test_ensure_rust_toolchain_refresh.py \
             tests/test_ensure_soldr_source_ref.py \
             tests/test_release_rollout_contract.py \

--- a/action.yml
+++ b/action.yml
@@ -155,6 +155,7 @@ runs:
     - id: resolve
       shell: pwsh
       env:
+        GITHUB_TOKEN: ${{ github.token }}
         INPUT_VERSION: ${{ inputs.version }}
         INPUT_REPO: ${{ inputs.repo }}
         INPUT_REF: ${{ inputs.ref }}
@@ -304,7 +305,7 @@ runs:
         SOLDR_REPO: ${{ steps.resolve.outputs.soldr_repo }}
         SOLDR_REF: ${{ steps.resolve.outputs.soldr_ref }}
         SOLDR_INSTALL_DIR: ${{ steps.resolve.outputs.bin_dir }}
-        SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_requested }}
+        SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_resolved }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_soldr.py"
 
     - id: verify

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -49,6 +49,13 @@ def test_toolchain_step_receives_setup_cache_exact_hit_metadata() -> None:
     assert "steps.resolve.outputs.toolchain_cache_channel" in action
 
 
+def test_install_step_uses_resolved_soldr_release_version() -> None:
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+
+    assert "GITHUB_TOKEN: ${{ github.token }}" in action
+    assert "SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_resolved }}" in action
+
+
 def test_once_mode_skips_build_cache_restore_when_target_cache_is_exact_hit() -> None:
     action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
 

--- a/tests/test_ensure_soldr_release_resolution.py
+++ b/tests/test_ensure_soldr_release_resolution.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ENSURE_SOLDR = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "ensure_soldr.py"
+HELPER_DIR = ENSURE_SOLDR.parent
+
+
+def _load_module():
+    helper_dir = str(HELPER_DIR)
+    if helper_dir not in sys.path:
+        sys.path.insert(0, helper_dir)
+    spec = importlib.util.spec_from_file_location("ensure_soldr", ENSURE_SOLDR)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load ensure_soldr.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class EnsureSoldrReleaseResolutionTests(unittest.TestCase):
+    def test_resolved_release_version_normalizes_explicit_tags(self) -> None:
+        module = _load_module()
+
+        self.assertEqual(
+            module._resolved_release_version("zackees/soldr", "0.7.11"),
+            ("v0.7.11", None),
+        )
+        self.assertEqual(
+            module._resolved_release_version("zackees/soldr", "v0.7.11"),
+            ("v0.7.11", None),
+        )
+
+    def test_main_reuses_cached_binary_when_latest_matches_resolved_tag(self) -> None:
+        module = _load_module()
+
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-latest-") as temp_dir:
+            install_dir = Path(temp_dir)
+            binary_path = install_dir / "soldr"
+            binary_path.write_text("binary", encoding="utf-8")
+            output_path = install_dir / "github-output.txt"
+
+            release = {
+                "tag_name": "v0.7.11",
+                "assets": [],
+            }
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "SOLDR_INSTALL_DIR": str(install_dir),
+                        "SOLDR_REPO": "zackees/soldr",
+                        "SETUP_SOLDR_VERSION": "latest",
+                        "GITHUB_OUTPUT": str(output_path),
+                    },
+                    clear=False,
+                ),
+                patch.object(
+                    module,
+                    "_detect_target",
+                    return_value=("x86_64-unknown-linux-gnu", "tar.gz", "soldr"),
+                ),
+                patch.object(module, "_fetch_release", return_value=release) as mocked_fetch,
+                patch.object(module, "_installed_version", return_value="v0.7.11"),
+                patch.object(module.urllib.request, "urlretrieve") as mocked_download,
+            ):
+                module.main()
+
+            mocked_fetch.assert_called_once_with("zackees/soldr", "")
+            mocked_download.assert_not_called()
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "installed_version=v0.7.11\n")
+
+    def test_main_refreshes_cached_binary_when_latest_tag_changes(self) -> None:
+        module = _load_module()
+
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-latest-") as temp_dir:
+            install_dir = Path(temp_dir)
+            binary_path = install_dir / "soldr"
+            binary_path.write_text("old-binary", encoding="utf-8")
+            extracted_dir = install_dir / "extract"
+            extracted_dir.mkdir()
+            extracted_binary = extracted_dir / "soldr"
+            extracted_binary.write_text("new-binary", encoding="utf-8")
+            output_path = install_dir / "github-output.txt"
+
+            release = {
+                "tag_name": "v0.7.11",
+                "assets": [
+                    {
+                        "name": "soldr-v0.7.11-x86_64-unknown-linux-gnu.tar.gz",
+                        "browser_download_url": "https://example.invalid/soldr.tar.gz",
+                    }
+                ],
+            }
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "SOLDR_INSTALL_DIR": str(install_dir),
+                        "SOLDR_REPO": "zackees/soldr",
+                        "SETUP_SOLDR_VERSION": "",
+                        "GITHUB_OUTPUT": str(output_path),
+                    },
+                    clear=False,
+                ),
+                patch.object(
+                    module,
+                    "_detect_target",
+                    return_value=("x86_64-unknown-linux-gnu", "tar.gz", "soldr"),
+                ),
+                patch.object(module, "_fetch_release", return_value=release) as mocked_fetch,
+                patch.object(module, "_installed_version", return_value="v0.7.10"),
+                patch.object(module.urllib.request, "urlretrieve") as mocked_download,
+                patch.object(module, "_extract_binary", return_value=extracted_binary),
+            ):
+                module.main()
+
+            mocked_fetch.assert_called_once_with("zackees/soldr", "")
+            mocked_download.assert_called_once()
+            self.assertEqual(binary_path.read_text(encoding="utf-8"), "new-binary")
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "installed_version=v0.7.11\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ensure_soldr_source_ref.py
+++ b/tests/test_ensure_soldr_source_ref.py
@@ -162,6 +162,51 @@ class EnsureSoldrSourceRefTests(unittest.TestCase):
             )
             self.assertEqual(output_path.read_text(encoding="utf-8"), "installed_version=0.7.11\n")
 
+    def test_main_with_ref_skips_release_resolution_even_when_version_is_latest(self) -> None:
+        module = _load_module()
+
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-source-") as temp_dir:
+            install_dir = Path(temp_dir)
+            binary_path = install_dir / "soldr"
+            binary_path.write_text("binary", encoding="utf-8")
+            module._write_source_metadata(
+                module._source_metadata_path(install_dir),
+                {
+                    "repo": "zackees/soldr",
+                    "ref": "feature/cache-hit",
+                    "commit_sha": "abc123",
+                    "target": "x86_64-unknown-linux-gnu",
+                    "binary_name": "soldr",
+                },
+            )
+            output_path = install_dir / "github-output.txt"
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "SOLDR_INSTALL_DIR": str(install_dir),
+                        "SOLDR_REF": "feature/cache-hit",
+                        "SOLDR_REPO": "zackees/soldr",
+                        "SETUP_SOLDR_VERSION": "latest",
+                        "GITHUB_OUTPUT": str(output_path),
+                    },
+                    clear=False,
+                ),
+                patch.object(
+                    module,
+                    "_detect_target",
+                    return_value=("x86_64-unknown-linux-gnu", "tar.gz", "soldr"),
+                ),
+                patch.object(module, "_resolve_ref_commit_sha", return_value="abc123"),
+                patch.object(module, "_fetch_release") as mocked_fetch,
+                patch.object(module, "_installed_version", return_value="0.7.11"),
+            ):
+                module.main()
+
+            mocked_fetch.assert_not_called()
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "installed_version=0.7.11\n")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_release_rollout_contract.py
+++ b/tests/test_release_rollout_contract.py
@@ -27,6 +27,7 @@ def test_rollout_contract_workflow_runs_unit_tests_for_the_release_path() -> Non
     assert "tests/test_action_python_entrypoints.py" in workflow
     assert "tests/test_action_target_cache_wiring.py" in workflow
     assert "tests/test_ensure_rust_toolchain_refresh.py" in workflow
+    assert "tests/test_ensure_soldr_release_resolution.py" in workflow
     assert "tests/test_ensure_soldr_source_ref.py" in workflow
     assert "tests/test_release_rollout_contract.py" in workflow
     assert "tests/test_resolve_setup_build_cache_mode.py" in workflow

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -93,6 +93,7 @@ def _run_resolve_setup(
                 "GITHUB_SHA": "0123456789abcdef",
                 "HOME": str(home_dir),
                 "USERPROFILE": str(home_dir),
+                "INPUT_VERSION": "0.7.11",
                 "INPUT_TIMESTAMPS": "false",
                 "INPUT_TOOLCHAIN_FILE": "",
             }
@@ -183,6 +184,7 @@ def _run_resolve_main_with_system_rustup() -> tuple[dict[str, str], dict[str, st
                 "GITHUB_SHA": "0123456789abcdef",
                 "HOME": str(home_dir),
                 "USERPROFILE": str(home_dir),
+                "INPUT_VERSION": "0.7.11",
                 "INPUT_TIMESTAMPS": "false",
                 "INPUT_TOOLCHAIN_FILE": "",
             }
@@ -191,6 +193,82 @@ def _run_resolve_main_with_system_rustup() -> tuple[dict[str, str], dict[str, st
         with patch.dict(os.environ, env, clear=True):
             with patch.object(module, "_system_rustup_satisfies_request", return_value=True):
                 module.main()
+
+        return _parse_github_kv_file(github_env), _parse_github_kv_file(github_output)
+
+
+def _run_resolve_main_direct(
+    extra_env: dict[str, str] | None = None,
+    *,
+    resolved_soldr_version: str | None = None,
+) -> tuple[dict[str, str], dict[str, str]]:
+    module = _load_resolve_module()
+
+    with tempfile.TemporaryDirectory(prefix="setup-soldr-tests-") as temp_dir:
+        root = Path(temp_dir)
+        workspace = root / "workspace"
+        runner_temp = root / "runner-temp"
+        home_dir = root / "home"
+        github_env = root / "github-env"
+        github_output = root / "github-output"
+        github_path = root / "github-path"
+        workspace.mkdir()
+        runner_temp.mkdir()
+        home_dir.mkdir()
+        (workspace / "Cargo.lock").write_text("# test lockfile\n", encoding="utf-8")
+
+        env = os.environ.copy()
+        for key in list(env):
+            if key.startswith(("INPUT_", "ACTION_", "GITHUB_", "SETUP_SOLDR_")):
+                env.pop(key, None)
+        for key in (
+            "CARGO_HOME",
+            "RUSTUP_HOME",
+            "NO_COLOR",
+            "CARGO_TERM_COLOR",
+            "CLICOLOR_FORCE",
+            "FORCE_COLOR",
+        ):
+            env.pop(key, None)
+        env.update(
+            {
+                "ACTION_WORKSPACE": str(workspace),
+                "ACTION_OS": "Linux",
+                "ACTION_ARCH": "X64",
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_ENV": str(github_env),
+                "GITHUB_OUTPUT": str(github_output),
+                "GITHUB_PATH": str(github_path),
+                "GITHUB_SHA": "0123456789abcdef",
+                "HOME": str(home_dir),
+                "USERPROFILE": str(home_dir),
+                "INPUT_VERSION": "0.7.11",
+                "INPUT_TIMESTAMPS": "false",
+                "INPUT_TOOLCHAIN_FILE": "",
+                "CARGO_HOME": str(root / "cargo-home"),
+                "RUSTUP_HOME": str(root / "rustup-home"),
+            }
+        )
+        if extra_env:
+            env.update(extra_env)
+
+        with patch.dict(os.environ, env, clear=True):
+            patchers = []
+            if resolved_soldr_version is not None:
+                patchers.append(
+                    patch.object(
+                        module,
+                        "_resolve_soldr_release_version",
+                        return_value=resolved_soldr_version,
+                    )
+                )
+            for patcher in patchers:
+                patcher.start()
+            try:
+                module.main()
+            finally:
+                for patcher in reversed(patchers):
+                    patcher.stop()
 
         return _parse_github_kv_file(github_env), _parse_github_kv_file(github_output)
 
@@ -433,6 +511,54 @@ class BuildCacheModeResolveTests(unittest.TestCase):
         self.assertEqual(base.returncode, 0)
         self.assertEqual(branch.returncode, 0)
         self.assertNotEqual(base.outputs.get("cache_key"), branch.outputs.get("cache_key"))
+
+    def test_explicit_version_is_normalized_for_setup_cache_keying(self) -> None:
+        plain = _run_resolve_setup({"INPUT_VERSION": "0.7.11"})
+        tagged = _run_resolve_setup({"INPUT_VERSION": "v0.7.11"})
+
+        self.assertEqual(plain.returncode, 0)
+        self.assertEqual(tagged.returncode, 0)
+        self.assertEqual(plain.outputs.get("soldr_version_resolved"), "v0.7.11")
+        self.assertEqual(tagged.outputs.get("soldr_version_resolved"), "v0.7.11")
+        self.assertEqual(plain.outputs.get("cache_key"), tagged.outputs.get("cache_key"))
+
+    def test_latest_version_is_resolved_to_concrete_release_tag(self) -> None:
+        module = _load_resolve_module()
+
+        with patch.object(module, "_fetch_release", return_value={"tag_name": "v0.7.11"}):
+            self.assertEqual(
+                module._resolve_soldr_release_version("zackees/soldr", "latest", ""),
+                "v0.7.11",
+            )
+            self.assertEqual(
+                module._resolve_soldr_release_version("zackees/soldr", "", ""),
+                "v0.7.11",
+            )
+
+    def test_source_ref_skips_release_resolution(self) -> None:
+        module = _load_resolve_module()
+
+        with patch.object(module, "_fetch_release") as mocked_fetch:
+            self.assertEqual(
+                module._resolve_soldr_release_version("zackees/soldr", "latest", "feature/cache-hit"),
+                "",
+            )
+
+        mocked_fetch.assert_not_called()
+
+    def test_latest_resolution_uses_concrete_release_tag_for_cache_keying(self) -> None:
+        _, first_outputs = _run_resolve_main_direct(
+            {"INPUT_VERSION": "latest"},
+            resolved_soldr_version="v0.7.11",
+        )
+        _, second_outputs = _run_resolve_main_direct(
+            {"INPUT_VERSION": ""},
+            resolved_soldr_version="v0.7.12",
+        )
+
+        self.assertEqual(first_outputs["soldr_version_resolved"], "v0.7.11")
+        self.assertEqual(second_outputs["soldr_version_resolved"], "v0.7.12")
+        self.assertNotEqual(first_outputs["cache_key"], second_outputs["cache_key"])
 
     def test_legacy_target_cache_inputs_translate_deterministically(self) -> None:
         cases = (


### PR DESCRIPTION
## Summary
- resolve \\latest\\ or blank Soldr version inputs to the concrete latest release tag before computing setup-cache keys
- use that resolved tag in \\ensure_soldr.py\\ so cached binaries only reuse when they match the real latest release
- cover the release-resolution path in the contract workflow and unit tests

## Why
Issue #48 completed the upstream rollout onto the stable \\main -> release -> @v0\\ path. This follow-up makes \\setup-soldr\\ treat floating Soldr release requests deterministically so cache reuse does not hide a newer published Soldr release.

## Validation
- \\python -m pytest tests\\
