### PR TITLE
Add target-cache soft budget diagnostics

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -22,6 +22,13 @@ except ModuleNotFoundError:  # pragma: no cover
 
 
 _ROLLING_TOOLCHAIN_ALIASES = ("stable", "beta", "nightly")
+_MIB = 1024 * 1024
+_GIB = 1024 * _MIB
+_TARGET_CACHE_SOFT_BUDGETS: dict[str, tuple[int, int]] = {
+    "once": (1024 * 1024 * 1024, 8_000),
+    "thin": (512 * 1024 * 1024, 4_000),
+    "full": (2 * _GIB, 12_000),
+}
 
 
 def _normalize_list(value: Any) -> list[str]:
@@ -254,6 +261,17 @@ def _normalize_legacy_target_cache_mode(value: str) -> str:
             f"invalid target-cache-mode {value!r}; expected thin, full, or off"
         )
     return mode
+
+
+def _target_cache_soft_budget(
+    target_cache_enabled: bool,
+    build_cache_mode: str,
+) -> tuple[str, str]:
+    if not target_cache_enabled:
+        return "", ""
+
+    bytes_budget, files_budget = _TARGET_CACHE_SOFT_BUDGETS[build_cache_mode]
+    return str(bytes_budget), str(files_budget)
 
 
 def normalize_build_cache_mode(
@@ -674,6 +692,10 @@ def main() -> None:
     if build_cache_mode == "thin" and cargo_lock_hash == "no-lock":
         log("build-cache-mode 'thin' requires Cargo.lock; target artifact cache disabled.")
         target_cache_enabled = False
+    target_cache_budget_bytes, target_cache_budget_files = _target_cache_soft_budget(
+        target_cache_enabled,
+        build_cache_mode,
+    )
 
     target_shape_hash = _short_json_hash(
         {
@@ -696,11 +718,7 @@ def main() -> None:
     target_tree_cache_enabled = target_cache_enabled and build_cache_mode == "full"
 
     if not target_cache_enabled:
-        target_cache_paths = (
-            str(target_cache_path)
-            if build_cache_runtime_mode == "full"
-            else str(target_cache_bundle_path)
-        )
+        target_cache_paths = ""
         target_cache_effective_mode = "off"
         target_cache_prefix = f"setup-soldr-targetcache-off-v1-{runner_os}-{runner_arch}"
         target_cache_lock_prefix = ""
@@ -795,6 +813,9 @@ def main() -> None:
     log(f"target-cache enabled={str(target_cache_enabled).lower()}")
     log(f"target-cache mode={target_cache_effective_mode}")
     log("target-cache backend=local")
+    if target_cache_enabled:
+        log(f"target-cache soft-budget-bytes={target_cache_budget_bytes}")
+        log(f"target-cache soft-budget-files={target_cache_budget_files}")
     log(f"soldr repo={soldr_repo}")
     log(f"soldr ref={soldr_ref or 'release'}")
     if soldr_version_resolved:
@@ -839,6 +860,8 @@ def main() -> None:
             "target_cache_key": target_cache_key,
             "target_cache_restore_key_parent": target_cache_parent_key,
             "target_cache_restore_key_lock": target_cache_lock_prefix,
+            "target_cache_budget_bytes": target_cache_budget_bytes,
+            "target_cache_budget_files": target_cache_budget_files,
             "target_lockfile_path": _path_for_output(workspace, lockfile_path),
             "target_lockfile_hash": cargo_lock_hash,
             "soldr_root": str(soldr_root),

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ jobs:
 | `target-cache-paths` | Path or newline-delimited path list passed to `actions/cache` for zccache-owned Rust artifact cache state. |
 | `target-cache-mode` | Effective setup-soldr Rust target artifact cache mode. |
 | `target-cache-restore-status` | Diagnostic restore status for the Rust target artifact cache state. |
+| `target-cache-budget-bytes` | Soft byte budget used to warn when the restored Rust artifact cache footprint is likely too large for fast CI reuse. |
+| `target-cache-budget-files` | Soft file-count budget used to warn when the restored Rust artifact cache footprint is likely too large for fast CI reuse. |
+| `target-cache-footprint-bytes` | Observed byte size of the restored Rust artifact cache footprint across the cache paths selected for the current mode. |
+| `target-cache-footprint-files` | Observed file count of the restored Rust artifact cache footprint across the cache paths selected for the current mode. |
+| `target-cache-budget-status` | Soft-budget diagnostic for the restored Rust artifact cache footprint. |
 | `target-lockfile` | `Cargo.lock` path used for Rust artifact cache keying. |
 | `target-lockfile-hash` | Short hash of the `Cargo.lock` used for Rust artifact cache keying, or `no-lock`. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
@@ -129,6 +134,8 @@ jobs:
 - The action restores Soldr/zccache cache state by default so child branches can reuse parent-branch build state.
 - The default `build-cache-mode` is `once`, which maps to soldr/zccache full-target planning on a cold run but restores only the local rust-plan bundle on later hits. Use `build-cache-mode: thin` for the bounded dependency-artifact alternative, or `build-cache-mode: full` when you explicitly want normal whole-target restore/save behavior on every run.
 - In `once` mode, an exact rust-plan bundle hit skips the separate build-cache restore because the target bundle already rehydrates the warm artifacts needed for the following build.
+- setup-soldr now emits soft target-cache footprint budgets by mode: `once` warns above `1 GiB` or `8000` files, `thin` warns above `512 MiB` or `4000` files, and `full` warns above `2 GiB` or `12000` files.
+- When the restored target-cache footprint exceeds that soft budget, the setup step emits a warning and reports `target-cache-budget-status=over-soft-budget:...` so workflows can spot cache shapes that are unlikely to stay fast.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
 - The setup cache intentionally keeps the installed `soldr` binary and only includes rustup state when setup-soldr had to fall back to a managed `RUSTUP_HOME` under the setup cache root. The dedicated `ZCCACHE_CACHE_DIR` payload stays in its own cache so warm runs do not restore the same build-cache bytes twice.

--- a/action.yml
+++ b/action.yml
@@ -140,6 +140,21 @@ outputs:
   target-cache-restore-status:
     description: Diagnostic restore status for the Rust target artifact cache state.
     value: ${{ steps.cache-meta.outputs.target_cache_restore_status }}
+  target-cache-budget-bytes:
+    description: Soft byte budget used to warn when the restored Rust artifact cache footprint is likely too large for fast CI reuse.
+    value: ${{ steps.resolve.outputs.target_cache_budget_bytes }}
+  target-cache-budget-files:
+    description: Soft file-count budget used to warn when the restored Rust artifact cache footprint is likely too large for fast CI reuse.
+    value: ${{ steps.resolve.outputs.target_cache_budget_files }}
+  target-cache-footprint-bytes:
+    description: Observed byte size of the restored Rust artifact cache footprint across the cache paths selected for the current mode.
+    value: ${{ steps.cache-meta.outputs.target_cache_footprint_bytes }}
+  target-cache-footprint-files:
+    description: Observed file count of the restored Rust artifact cache footprint across the cache paths selected for the current mode.
+    value: ${{ steps.cache-meta.outputs.target_cache_footprint_files }}
+  target-cache-budget-status:
+    description: Soft-budget diagnostic for the restored Rust artifact cache footprint.
+    value: ${{ steps.cache-meta.outputs.target_cache_budget_status }}
   target-lockfile:
     description: Cargo.lock path used for Rust artifact cache keying.
     value: ${{ steps.resolve.outputs.target_lockfile_path }}
@@ -334,6 +349,9 @@ runs:
         LOOKUP_TARGET_TREE_CACHE_HIT: ${{ steps.target-tree-cache-lookup.outputs.cache-hit }}
         LOOKUP_TARGET_TREE_CACHE_MATCHED_KEY: ${{ steps.target-tree-cache-lookup.outputs.cache-matched-key }}
         TARGET_CACHE_KEY: ${{ steps.resolve.outputs.target_cache_key }}
+        TARGET_CACHE_PATHS: ${{ steps.resolve.outputs.target_cache_paths }}
+        TARGET_CACHE_BUDGET_BYTES: ${{ steps.resolve.outputs.target_cache_budget_bytes }}
+        TARGET_CACHE_BUDGET_FILES: ${{ steps.resolve.outputs.target_cache_budget_files }}
         BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
         TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
         EFFECTIVE_TARGET_CACHE_ENABLED: ${{ steps.resolve.outputs.target_cache_enabled }}
@@ -381,6 +399,26 @@ runs:
           $bytes = if ($measure.Sum) { [int64]$measure.Sum } else { 0 }
           Log "$label path=$path exists=true files=$($measure.Count) bytes=$bytes"
         }
+        function MeasurePaths($pathsText) {
+          $files = 0
+          $bytes = [int64]0
+          foreach ($path in ($pathsText -split "`r?`n")) {
+            $trimmed = $path.Trim()
+            if ([string]::IsNullOrWhiteSpace($trimmed) -or -not (Test-Path -LiteralPath $trimmed)) {
+              continue
+            }
+            $measure = Get-ChildItem -LiteralPath $trimmed -Recurse -File -Force -ErrorAction SilentlyContinue |
+              Measure-Object -Property Length -Sum
+            $files += [int]$measure.Count
+            if ($measure.Sum) {
+              $bytes += [int64]$measure.Sum
+            }
+          }
+          return [pscustomobject]@{
+            Files = $files
+            Bytes = $bytes
+          }
+        }
 
         $value = $env:RAW_CACHE_HIT
         if ([string]::IsNullOrWhiteSpace($value)) {
@@ -420,6 +458,30 @@ runs:
         $targetEnabled = if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true") { "true" } else { "false" }
         $targetStatus = RestoreStatus $targetEnabled $env:LOOKUP_TARGET_CACHE_HIT $env:LOOKUP_TARGET_CACHE_MATCHED_KEY $env:TARGET_CACHE_KEY
         "target_cache_restore_status=$targetStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        $targetFootprint = MeasurePaths $env:TARGET_CACHE_PATHS
+        $targetBudgetBytes = 0L
+        [long]::TryParse($env:TARGET_CACHE_BUDGET_BYTES, [ref]$targetBudgetBytes) | Out-Null
+        $targetBudgetFiles = 0
+        [int]::TryParse($env:TARGET_CACHE_BUDGET_FILES, [ref]$targetBudgetFiles) | Out-Null
+        if ($targetEnabled -eq "true") {
+          $budgetOver = @()
+          if ($targetBudgetBytes -gt 0 -and $targetFootprint.Bytes -gt $targetBudgetBytes) {
+            $budgetOver += "bytes"
+          }
+          if ($targetBudgetFiles -gt 0 -and $targetFootprint.Files -gt $targetBudgetFiles) {
+            $budgetOver += "files"
+          }
+          if ($budgetOver.Count -gt 0) {
+            $targetBudgetStatus = "over-soft-budget:$($budgetOver -join ',')"
+          } else {
+            $targetBudgetStatus = "within-soft-budget"
+          }
+        } else {
+          $targetBudgetStatus = "disabled"
+        }
+        "target_cache_footprint_bytes=$($targetFootprint.Bytes)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        "target_cache_footprint_files=$($targetFootprint.Files)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        "target_cache_budget_status=$targetBudgetStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         $targetTreeStatus = RestoreStatus $targetEnabled $env:LOOKUP_TARGET_TREE_CACHE_HIT $env:LOOKUP_TARGET_TREE_CACHE_MATCHED_KEY $env:TARGET_CACHE_KEY
         $targetTreeValue = $env:RAW_TARGET_TREE_CACHE_HIT
         if ([string]::IsNullOrWhiteSpace($targetTreeValue)) {
@@ -434,6 +496,13 @@ runs:
         Log "target-cache bundle restore status=$targetStatus exact-hit=$targetValue"
         if ($env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true" -and "${{ steps.resolve.outputs.build_cache_mode }}" -eq "full") {
           Log "target-cache tree restore status=$targetTreeStatus exact-hit=$targetTreeValue"
+        }
+        Log "target-cache footprint files=$($targetFootprint.Files) bytes=$($targetFootprint.Bytes)"
+        if ($targetEnabled -eq "true") {
+          Log "target-cache soft budget files=$targetBudgetFiles bytes=$targetBudgetBytes status=$targetBudgetStatus"
+          if ($targetBudgetStatus.StartsWith("over-soft-budget:")) {
+            Write-Host "::warning::target-cache footprint files=$($targetFootprint.Files) bytes=$($targetFootprint.Bytes) exceeded soft budget files=$targetBudgetFiles bytes=$targetBudgetBytes; consider build-cache-mode 'thin' or narrower target-cache paths."
+          }
         }
         LogPath "cache after restore" "${{ steps.resolve.outputs.setup_cache_path }}"
         LogPath "soldr-bin after restore" "${{ steps.resolve.outputs.soldr_bin_cache_path }}"

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -24,6 +24,21 @@ def test_target_tree_cache_is_only_used_in_full_mode() -> None:
     assert "id: target-tree-cache-managed" not in action
 
 
+def test_target_cache_budget_outputs_and_warning_are_wired() -> None:
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+
+    assert "target-cache-budget-bytes:" in action
+    assert "target-cache-budget-files:" in action
+    assert "target-cache-footprint-bytes:" in action
+    assert "target-cache-footprint-files:" in action
+    assert "target-cache-budget-status:" in action
+    assert "TARGET_CACHE_BUDGET_BYTES" in action
+    assert "TARGET_CACHE_BUDGET_FILES" in action
+    assert "MeasurePaths" in action
+    assert "over-soft-budget:" in action
+    assert "::warning::target-cache footprint" in action
+
+
 def test_setup_cache_uses_lookup_exact_restore_and_managed_fallback() -> None:
     action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
 

--- a/tests/test_resolve_setup_build_cache_mode.py
+++ b/tests/test_resolve_setup_build_cache_mode.py
@@ -53,6 +53,7 @@ def _run_resolve_setup(
     *,
     include_explicit_toolchain_homes: bool = True,
     clear_path: bool = False,
+    create_lockfile: bool = True,
 ) -> ResolveResult:
     with tempfile.TemporaryDirectory(prefix="setup-soldr-tests-") as temp_dir:
         root = Path(temp_dir)
@@ -65,7 +66,8 @@ def _run_resolve_setup(
         workspace.mkdir()
         runner_temp.mkdir()
         home_dir.mkdir()
-        (workspace / "Cargo.lock").write_text("# test lockfile\n", encoding="utf-8")
+        if create_lockfile:
+            (workspace / "Cargo.lock").write_text("# test lockfile\n", encoding="utf-8")
 
         env = os.environ.copy()
         for key in list(env):
@@ -274,6 +276,15 @@ def _run_resolve_main_direct(
 
 
 class BuildCacheModeResolveTests(unittest.TestCase):
+    def assert_target_cache_budget(
+        self,
+        result: ResolveResult,
+        expected_bytes: str,
+        expected_files: str,
+    ) -> None:
+        self.assertEqual(result.outputs.get("target_cache_budget_bytes"), expected_bytes)
+        self.assertEqual(result.outputs.get("target_cache_budget_files"), expected_files)
+
     def assert_resolved_build_cache_mode(
         self,
         result: ResolveResult,
@@ -305,6 +316,44 @@ class BuildCacheModeResolveTests(unittest.TestCase):
             with self.subTest(mode=mode):
                 result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": mode})
                 self.assert_resolved_build_cache_mode(result, mode, soldr_mode)
+
+    def test_effective_target_cache_mode_sets_soft_budget_outputs(self) -> None:
+        cases = (
+            ({"INPUT_BUILD_CACHE_MODE": "once"}, "1073741824", "8000"),
+            ({"INPUT_BUILD_CACHE_MODE": "thin"}, "536870912", "4000"),
+            ({"INPUT_BUILD_CACHE_MODE": "full"}, "2147483648", "12000"),
+            ({"INPUT_TARGET_CACHE": "false"}, "", ""),
+        )
+
+        for env, expected_bytes, expected_files in cases:
+            with self.subTest(env=env):
+                result = _run_resolve_setup(env)
+                self.assertEqual(result.returncode, 0)
+                self.assert_target_cache_budget(result, expected_bytes, expected_files)
+
+    def test_disabled_target_cache_clears_cache_path_outputs(self) -> None:
+        result = _run_resolve_setup({"INPUT_TARGET_CACHE": "false"})
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.outputs.get("target_cache_enabled"), "false")
+        self.assertEqual(result.outputs.get("target_cache_mode"), "off")
+        self.assertEqual(result.outputs.get("target_cache_paths"), "")
+        self.assertEqual(result.outputs.get("target_cache_budget_bytes"), "")
+        self.assertEqual(result.outputs.get("target_cache_budget_files"), "")
+
+    def test_thin_mode_without_lockfile_disables_target_cache_budget_outputs(self) -> None:
+        result = _run_resolve_setup(
+            {"INPUT_BUILD_CACHE_MODE": "thin"},
+            create_lockfile=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.outputs.get("target_lockfile_hash"), "no-lock")
+        self.assertEqual(result.outputs.get("target_cache_enabled"), "false")
+        self.assertEqual(result.outputs.get("target_cache_mode"), "off")
+        self.assertEqual(result.outputs.get("target_cache_paths"), "")
+        self.assertEqual(result.outputs.get("target_cache_budget_bytes"), "")
+        self.assertEqual(result.outputs.get("target_cache_budget_files"), "")
 
     def test_once_mode_restores_only_the_local_rust_plan_bundle(self) -> None:
         result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "once"})


### PR DESCRIPTION
## Summary
- emit per-mode soft target-cache byte/file budgets from `resolve_setup.py`
- measure restored target-cache footprint in the action and warn when it exceeds the documented soft budget
- expose the budget and observed footprint as action outputs, and document the new diagnostics
- extend unit coverage for the budget outputs and disabled-cache edge cases

## Why
This is a concrete step on the open target-cache restore-overhead work:
- `#29` asks for size/file-count budget diagnostics that warn when target-cache restore/save is unlikely to meet a fast CI target
- `#20` tracks the large fixed restore cost from multi-GB target caches in downstream repos

## Validation
- `python -m pytest tests`

Refs #29
Refs #20