### PR TITLE
Upgrade actions/cache to v5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -194,7 +194,7 @@ runs:
 
     - id: cache-lookup
       if: ${{ inputs.cache == 'true' }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.setup_cache_paths }}
         key: ${{ steps.resolve.outputs.cache_key }}
@@ -204,7 +204,7 @@ runs:
 
     - id: cache-restore
       if: ${{ inputs.cache == 'true' && steps.cache-lookup.outputs.cache-hit == 'true' }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.setup_cache_paths }}
         key: ${{ steps.resolve.outputs.cache_key }}
@@ -213,7 +213,7 @@ runs:
 
     - id: cache-managed
       if: ${{ inputs.cache == 'true' && steps.cache-lookup.outputs.cache-hit != 'true' }}
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.setup_cache_paths }}
         key: ${{ steps.resolve.outputs.cache_key }}
@@ -222,7 +222,7 @@ runs:
 
     - id: target-cache-lookup
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.target_cache_bundle_path }}
         key: ${{ steps.resolve.outputs.target_cache_key }}
@@ -233,7 +233,7 @@ runs:
 
     - id: target-cache
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode == 'once' && (steps.target-cache-lookup.outputs.cache-hit == 'true' || steps.target-cache-lookup.outputs.cache-matched-key != '') }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.target_cache_bundle_path }}
         key: ${{ steps.resolve.outputs.target_cache_key }}
@@ -243,7 +243,7 @@ runs:
 
     - id: target-cache-managed
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || (steps.target-cache-lookup.outputs.cache-hit != 'true' && steps.target-cache-lookup.outputs.cache-matched-key == '')) }}
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.target_cache_bundle_path }}
         key: ${{ steps.resolve.outputs.target_cache_key }}
@@ -253,7 +253,7 @@ runs:
 
     - id: build-cache-lookup
       if: ${{ inputs.build-cache == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || steps.resolve.outputs.target_cache_enabled != 'true' || steps.target-cache-lookup.outputs.cache-hit != 'true') }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.build_cache_path }}
         key: ${{ steps.resolve.outputs.build_cache_key }}
@@ -265,7 +265,7 @@ runs:
 
     - id: build-cache-restore
       if: ${{ inputs.build-cache == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || steps.resolve.outputs.target_cache_enabled != 'true' || steps.target-cache-lookup.outputs.cache-hit != 'true') && steps.resolve.outputs.build_cache_mode == 'once' && (steps.build-cache-lookup.outputs.cache-hit == 'true' || steps.build-cache-lookup.outputs.cache-matched-key != '') }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.build_cache_path }}
         key: ${{ steps.resolve.outputs.build_cache_key }}
@@ -276,7 +276,7 @@ runs:
 
     - id: build-cache-managed
       if: ${{ inputs.build-cache == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || steps.resolve.outputs.target_cache_enabled != 'true' || steps.target-cache-lookup.outputs.cache-hit != 'true') && (steps.resolve.outputs.build_cache_mode != 'once' || (steps.build-cache-lookup.outputs.cache-hit != 'true' && steps.build-cache-lookup.outputs.cache-matched-key == '')) }}
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.build_cache_path }}
         key: ${{ steps.resolve.outputs.build_cache_key }}
@@ -287,7 +287,7 @@ runs:
 
     - id: target-tree-cache-lookup
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode == 'full' }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.target_cache_path }}
         key: ${{ steps.resolve.outputs.target_cache_key }}
@@ -298,7 +298,7 @@ runs:
 
     - id: target-tree-cache
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode == 'full' }}
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.resolve.outputs.target_cache_path }}
         key: ${{ steps.resolve.outputs.target_cache_key }}


### PR DESCRIPTION
## Summary
- upgrade all internal `actions/cache` and `actions/cache/restore` pins from `v4.2.4` to `v5.0.5`
- move setup-soldr's cache wiring onto the Node 24 runtime used by `actions/cache@v5`
- address the GitHub Actions deprecation warning tracked in #53

## Validation
- `pytest -q tests/test_action_target_cache_wiring.py`