### PR TITLE
feat(action): warn on shared target-dir reuse pitfall (#53)

### DIFF
--- a/.github/actions/setup-soldr/detect_shared_target_warning.py
+++ b/.github/actions/setup-soldr/detect_shared_target_warning.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Emit a GitHub Actions warning when the target-dir is pre-populated.
+
+Repeated ``soldr cargo build`` invocations in one job that share the same
+Cargo ``target/`` directory can hit a stale rust-plan and fail with a
+missing ``.rmeta`` error (see https://github.com/zackees/setup-soldr/issues/53).
+This helper inspects the restored target directory and, when it already
+contains compiled artifacts under ``deps/``, prints a ``::warning::`` line so
+workflow authors notice the pitfall before Cargo trips on it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from log_utils import log
+
+
+_WARNING_MESSAGE = (
+    "setup-soldr detected a pre-populated shared target directory; a "
+    "subsequent `soldr cargo build` using the same `--target-dir` may fail "
+    "with a missing .rmeta error - see README 'Known limitations'."
+)
+
+
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() == "true"
+
+
+def target_dir_has_compiled_artifacts(target_dir: Path) -> bool:
+    """Return True when ``target_dir`` already has compiled deps artifacts.
+
+    We look for any ``deps/`` subtree containing a ``.rmeta`` file because
+    that is the exact payload Cargo relies on when rebuilding against a
+    restored target directory. An empty ``deps/`` directory (or a missing
+    one) indicates a clean first run and must not trip the warning.
+    """
+
+    if not target_dir.exists() or not target_dir.is_dir():
+        return False
+    for deps_dir in target_dir.rglob("deps"):
+        if not deps_dir.is_dir():
+            continue
+        try:
+            entries = deps_dir.iterdir()
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_file() and entry.suffix == ".rmeta":
+                return True
+    return False
+
+
+def should_emit_shared_target_warning(
+    *,
+    build_cache_enabled: bool,
+    build_cache_mode: str,
+    target_cache_enabled: bool,
+    target_dir: Path,
+) -> bool:
+    if not build_cache_enabled:
+        return False
+    if build_cache_mode.strip().lower() != "once":
+        return False
+    if not target_cache_enabled:
+        return False
+    return target_dir_has_compiled_artifacts(target_dir)
+
+
+def main() -> None:
+    build_cache_enabled = _is_truthy(os.environ.get("BUILD_CACHE_ENABLED"))
+    target_cache_enabled = _is_truthy(
+        os.environ.get("EFFECTIVE_TARGET_CACHE_ENABLED")
+    )
+    build_cache_mode = os.environ.get("BUILD_CACHE_MODE", "")
+    target_dir_raw = os.environ.get("TARGET_DIR", "").strip()
+
+    if not target_dir_raw:
+        log("shared-target-dir check skipped: no target dir resolved")
+        return
+
+    target_dir = Path(target_dir_raw)
+    if should_emit_shared_target_warning(
+        build_cache_enabled=build_cache_enabled,
+        build_cache_mode=build_cache_mode,
+        target_cache_enabled=target_cache_enabled,
+        target_dir=target_dir,
+    ):
+        print(f"::warning::{_WARNING_MESSAGE}", flush=True)
+        log(
+            "shared-target-dir warning emitted for "
+            f"target_dir={target_dir} build_cache_mode={build_cache_mode}"
+        )
+    else:
+        log(
+            "shared-target-dir check clean for "
+            f"target_dir={target_dir} build_cache_mode={build_cache_mode} "
+            f"build_cache_enabled={build_cache_enabled} "
+            f"target_cache_enabled={target_cache_enabled}"
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # pragma: no cover - defensive: never fail the action
+        log(f"shared-target-dir check failed: {exc}")
+        sys.exit(0)

--- a/.github/workflows/setup-soldr-contract.yml
+++ b/.github/workflows/setup-soldr-contract.yml
@@ -49,6 +49,7 @@ jobs:
           python -m pytest \
             tests/test_action_python_entrypoints.py \
             tests/test_action_target_cache_wiring.py \
+            tests/test_detect_shared_target_warning.py \
             tests/test_ensure_soldr_release_resolution.py \
             tests/test_ensure_rust_toolchain_refresh.py \
             tests/test_ensure_soldr_source_ref.py \

--- a/README.md
+++ b/README.md
@@ -140,6 +140,40 @@ jobs:
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
 - The setup cache intentionally keeps the installed `soldr` binary and only includes rustup state when setup-soldr had to fall back to a managed `RUSTUP_HOME` under the setup cache root. The dedicated `ZCCACHE_CACHE_DIR` payload stays in its own cache so warm runs do not restore the same build-cache bytes twice.
 
+## Known limitations
+
+### Repeated `soldr cargo build` sharing a target directory
+
+Running `soldr cargo build` twice in a single job against the same Cargo
+`target/` directory is currently best-effort and not guaranteed to succeed.
+When `build-cache-mode: once` (the default) is combined with a pre-populated
+target directory, the second invocation can restore a stale rust-plan bundle
+whose `restored_file_count` is `0`, and Cargo then fails with
+`error: extern location for ring does not exist: .../libring-*.rmeta`.
+
+When setup-soldr detects that the restored `target-dir` already contains
+compiled artifacts (a `deps/` subtree with `.rmeta` files) under the
+risky configuration, it emits a GitHub Actions log warning so the pitfall
+surfaces before Cargo trips on it.
+
+Recommended workaround: give the second invocation its own `--target-dir`,
+or call `cargo build` directly.
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: zackees/setup-soldr@v0
+    with:
+      cache: true
+  - run: soldr cargo build --locked --release
+  # Use a distinct target dir for the second build so the first build's
+  # rust-plan is not reused with a stale dependency map.
+  - run: soldr cargo build --locked --release --target-dir target/python-extension
+```
+
+See [issue #53](https://github.com/zackees/setup-soldr/issues/53) for
+background.
+
 ## Development
 
 Clone with submodules, or initialize them after clone:

--- a/action.yml
+++ b/action.yml
@@ -511,3 +511,12 @@ runs:
           LogPath "target-cache tree after restore" "${{ steps.resolve.outputs.target_cache_path }}"
         }
         LogPath "target-cache bundle after restore" "${{ steps.resolve.outputs.target_cache_bundle_path }}"
+
+    - id: shared-target-warning
+      shell: pwsh
+      env:
+        BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
+        EFFECTIVE_TARGET_CACHE_ENABLED: ${{ steps.resolve.outputs.target_cache_enabled }}
+        BUILD_CACHE_MODE: ${{ steps.resolve.outputs.build_cache_mode }}
+        TARGET_DIR: ${{ steps.resolve.outputs.target_cache_path }}
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/detect_shared_target_warning.py"

--- a/tests/test_action_python_entrypoints.py
+++ b/tests/test_action_python_entrypoints.py
@@ -18,6 +18,7 @@ EXPECTED_ENTRYPOINTS = {
     ".github/actions/setup-soldr/ensure_rust_toolchain.py",
     ".github/actions/setup-soldr/ensure_soldr.py",
     ".github/actions/setup-soldr/verify_soldr.py",
+    ".github/actions/setup-soldr/detect_shared_target_warning.py",
 }
 
 

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -71,6 +71,22 @@ def test_install_step_uses_resolved_soldr_release_version() -> None:
     assert "SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_resolved }}" in action
 
 
+def test_shared_target_dir_warning_step_is_wired() -> None:
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+
+    assert "id: shared-target-warning" in action
+    assert "detect_shared_target_warning.py" in action
+    assert "BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}" in action
+    assert (
+        "EFFECTIVE_TARGET_CACHE_ENABLED: ${{ steps.resolve.outputs.target_cache_enabled }}"
+        in action
+    )
+    assert (
+        "BUILD_CACHE_MODE: ${{ steps.resolve.outputs.build_cache_mode }}" in action
+    )
+    assert "TARGET_DIR: ${{ steps.resolve.outputs.target_cache_path }}" in action
+
+
 def test_once_mode_skips_build_cache_restore_when_target_cache_is_exact_hit() -> None:
     action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
 

--- a/tests/test_detect_shared_target_warning.py
+++ b/tests/test_detect_shared_target_warning.py
@@ -1,0 +1,220 @@
+"""Unit coverage for the shared-target-dir warning helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELPER_DIR = REPO_ROOT / ".github" / "actions" / "setup-soldr"
+HELPER_PATH = HELPER_DIR / "detect_shared_target_warning.py"
+
+
+def _load_helper():
+    if str(HELPER_DIR) not in sys.path:
+        sys.path.insert(0, str(HELPER_DIR))
+    spec = importlib.util.spec_from_file_location(
+        "detect_shared_target_warning", HELPER_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_populated_target(root: Path) -> Path:
+    target = root / "target"
+    deps = target / "debug" / "deps"
+    deps.mkdir(parents=True)
+    (deps / "libring-deadbeef.rmeta").write_bytes(b"fake rmeta payload")
+    return target
+
+
+def _make_empty_target(root: Path) -> Path:
+    target = root / "target"
+    target.mkdir()
+    return target
+
+
+def _make_target_with_empty_deps(root: Path) -> Path:
+    target = root / "target"
+    (target / "debug" / "deps").mkdir(parents=True)
+    return target
+
+
+def test_target_dir_has_compiled_artifacts_detects_rmeta(tmp_path: Path) -> None:
+    helper = _load_helper()
+    target = _make_populated_target(tmp_path)
+    assert helper.target_dir_has_compiled_artifacts(target) is True
+
+
+def test_target_dir_has_compiled_artifacts_ignores_empty_deps(tmp_path: Path) -> None:
+    helper = _load_helper()
+    target = _make_target_with_empty_deps(tmp_path)
+    assert helper.target_dir_has_compiled_artifacts(target) is False
+
+
+def test_target_dir_has_compiled_artifacts_ignores_missing_target(tmp_path: Path) -> None:
+    helper = _load_helper()
+    assert helper.target_dir_has_compiled_artifacts(tmp_path / "target") is False
+
+
+def test_target_dir_has_compiled_artifacts_ignores_non_rmeta_files(tmp_path: Path) -> None:
+    helper = _load_helper()
+    target = _make_target_with_empty_deps(tmp_path)
+    (target / "debug" / "deps" / "some.txt").write_text("not rmeta")
+    assert helper.target_dir_has_compiled_artifacts(target) is False
+
+
+def test_should_emit_shared_target_warning_triggers_in_once_mode(tmp_path: Path) -> None:
+    helper = _load_helper()
+    target = _make_populated_target(tmp_path)
+    assert (
+        helper.should_emit_shared_target_warning(
+            build_cache_enabled=True,
+            build_cache_mode="once",
+            target_cache_enabled=True,
+            target_dir=target,
+        )
+        is True
+    )
+
+
+def test_should_emit_shared_target_warning_skips_thin_mode(tmp_path: Path) -> None:
+    helper = _load_helper()
+    target = _make_populated_target(tmp_path)
+    assert (
+        helper.should_emit_shared_target_warning(
+            build_cache_enabled=True,
+            build_cache_mode="thin",
+            target_cache_enabled=True,
+            target_dir=target,
+        )
+        is False
+    )
+
+
+def test_should_emit_shared_target_warning_skips_when_build_cache_disabled(tmp_path: Path) -> None:
+    helper = _load_helper()
+    target = _make_populated_target(tmp_path)
+    assert (
+        helper.should_emit_shared_target_warning(
+            build_cache_enabled=False,
+            build_cache_mode="once",
+            target_cache_enabled=True,
+            target_dir=target,
+        )
+        is False
+    )
+
+
+def test_should_emit_shared_target_warning_skips_when_target_cache_disabled(tmp_path: Path) -> None:
+    helper = _load_helper()
+    target = _make_populated_target(tmp_path)
+    assert (
+        helper.should_emit_shared_target_warning(
+            build_cache_enabled=True,
+            build_cache_mode="once",
+            target_cache_enabled=False,
+            target_dir=target,
+        )
+        is False
+    )
+
+
+def test_should_emit_shared_target_warning_skips_on_clean_first_run(tmp_path: Path) -> None:
+    helper = _load_helper()
+    target = _make_empty_target(tmp_path)
+    assert (
+        helper.should_emit_shared_target_warning(
+            build_cache_enabled=True,
+            build_cache_mode="once",
+            target_cache_enabled=True,
+            target_dir=target,
+        )
+        is False
+    )
+
+
+def _run_helper_subprocess(
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HELPER_PATH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def helper_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    env = {
+        "PATH": __import__("os").environ.get("PATH", ""),
+        "PYTHONPATH": str(HELPER_DIR),
+        "SETUP_SOLDR_TIMESTAMPS": "false",
+    }
+    return env
+
+
+def test_helper_cli_prints_warning_for_risky_shape(
+    tmp_path: Path, helper_env: dict[str, str]
+) -> None:
+    target = _make_populated_target(tmp_path)
+    env = dict(helper_env)
+    env.update(
+        {
+            "BUILD_CACHE_ENABLED": "true",
+            "EFFECTIVE_TARGET_CACHE_ENABLED": "true",
+            "BUILD_CACHE_MODE": "once",
+            "TARGET_DIR": str(target),
+        }
+    )
+    result = _run_helper_subprocess(env)
+
+    assert result.returncode == 0, result.stderr
+    assert "::warning::setup-soldr detected a pre-populated shared target directory" in result.stdout
+    assert "Known limitations" in result.stdout
+
+
+def test_helper_cli_stays_quiet_for_clean_first_run(
+    tmp_path: Path, helper_env: dict[str, str]
+) -> None:
+    target = _make_empty_target(tmp_path)
+    env = dict(helper_env)
+    env.update(
+        {
+            "BUILD_CACHE_ENABLED": "true",
+            "EFFECTIVE_TARGET_CACHE_ENABLED": "true",
+            "BUILD_CACHE_MODE": "once",
+            "TARGET_DIR": str(target),
+        }
+    )
+    result = _run_helper_subprocess(env)
+
+    assert result.returncode == 0, result.stderr
+    assert "::warning::" not in result.stdout
+
+
+def test_helper_cli_skips_when_target_dir_missing_env(
+    helper_env: dict[str, str],
+) -> None:
+    env = dict(helper_env)
+    env.update(
+        {
+            "BUILD_CACHE_ENABLED": "true",
+            "EFFECTIVE_TARGET_CACHE_ENABLED": "true",
+            "BUILD_CACHE_MODE": "once",
+            "TARGET_DIR": "",
+        }
+    )
+    result = _run_helper_subprocess(env)
+
+    assert result.returncode == 0
+    assert "::warning::" not in result.stdout

--- a/tests/test_release_rollout_contract.py
+++ b/tests/test_release_rollout_contract.py
@@ -26,6 +26,7 @@ def test_rollout_contract_workflow_runs_unit_tests_for_the_release_path() -> Non
     assert "python -m pytest" in workflow
     assert "tests/test_action_python_entrypoints.py" in workflow
     assert "tests/test_action_target_cache_wiring.py" in workflow
+    assert "tests/test_detect_shared_target_warning.py" in workflow
     assert "tests/test_ensure_rust_toolchain_refresh.py" in workflow
     assert "tests/test_ensure_soldr_release_resolution.py" in workflow
     assert "tests/test_ensure_soldr_source_ref.py" in workflow


### PR DESCRIPTION
## Summary
- Detect the known-risky shape (`build-cache=true`, `build-cache-mode=once`, `target-cache-enabled=true`, target dir already populated with `deps/*.rmeta`) and emit a single-line `::warning::` annotation from a new `detect_shared_target_warning.py` helper wired into `action.yml` after `cache-meta`.
- Document the limitation and recommended distinct `--target-dir` workaround in `README.md` under a new "Known limitations" section cross-linking issue #53.
- Add `tests/test_detect_shared_target_warning.py` with pytest fixtures for populated vs. empty `deps/` and a CLI smoke test; update the Python entrypoint parity guard, target-cache wiring contract test, release rollout contract test, and contract workflow to include the new script and test.

## Test plan
- [x] `python -m pytest tests/` (69 passed)
- [x] `python -c "import yaml; yaml.safe_load(open('action.yml'))"` confirms `action.yml` still parses

Refs #53