### PR TITLE
feat(action): add opt-in source mtime normalization

### DIFF
--- a/.github/actions/setup-soldr/normalize_source_mtime.py
+++ b/.github/actions/setup-soldr/normalize_source_mtime.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Normalize mtimes of tracked Rust build-input files under the workspace.
+
+Opt-in helper that rewrites each tracked file's mtime to the Unix timestamp of
+the last git commit that touched it. The goal is to keep Cargo fingerprints
+stable across fresh GitHub checkouts that share the same source SHA, so
+restored target-cache state can be reused as a no-op when the sources have
+not actually changed.
+
+This script is intentionally conservative:
+
+* It only runs when ``INPUT_SOURCE_MTIME_NORMALIZE`` is truthy.
+* It only touches tracked files matching known Rust build-input globs.
+* It skips files under ``target/``, ``.git/``, and ``node_modules/``.
+* Files with no matching commit (new / untracked) are left alone, so genuine
+  source edits still invalidate Cargo fingerprints.
+"""
+from __future__ import annotations
+
+import fnmatch
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path, PurePosixPath
+
+from log_utils import log
+
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Globs evaluated against the repo-relative POSIX path of each tracked file.
+_INCLUDE_GLOBS: tuple[str, ...] = (
+    "*.rs",
+    "**/*.rs",
+    "Cargo.toml",
+    "**/Cargo.toml",
+    "Cargo.lock",
+    "**/Cargo.lock",
+    "build.rs",
+    "**/build.rs",
+    "rust-toolchain",
+    "rust-toolchain.toml",
+)
+
+# Directory prefixes to skip regardless of glob matches.
+_EXCLUDE_PREFIXES: tuple[str, ...] = (
+    "target/",
+    ".git/",
+    "node_modules/",
+)
+
+
+def _is_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in _TRUTHY
+
+
+def _is_git_repo(workspace: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(workspace), "rev-parse", "--is-inside-work-tree"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _list_tracked_files(workspace: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(workspace), "ls-files", "-z"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=False,
+    )
+    if not result.stdout:
+        return []
+    raw = result.stdout.split(b"\x00")
+    return [entry.decode("utf-8", errors="replace") for entry in raw if entry]
+
+
+def _is_excluded(relative_posix: str) -> bool:
+    for prefix in _EXCLUDE_PREFIXES:
+        if relative_posix == prefix.rstrip("/") or relative_posix.startswith(prefix):
+            return True
+        # Also skip any nested occurrence (e.g. "crates/foo/target/...").
+        if f"/{prefix}" in f"/{relative_posix}":
+            return True
+    return False
+
+
+def _matches_include(relative_posix: str) -> bool:
+    basename = PurePosixPath(relative_posix).name
+    for pattern in _INCLUDE_GLOBS:
+        if fnmatch.fnmatchcase(relative_posix, pattern):
+            return True
+        if fnmatch.fnmatchcase(basename, pattern):
+            return True
+    return False
+
+
+def select_candidate_files(tracked: list[str]) -> list[str]:
+    """Filter ``tracked`` to the repo-relative files we intend to touch."""
+    candidates: list[str] = []
+    for entry in tracked:
+        relative_posix = entry.replace("\\", "/")
+        if _is_excluded(relative_posix):
+            continue
+        if not _matches_include(relative_posix):
+            continue
+        candidates.append(relative_posix)
+    return candidates
+
+
+def _last_commit_timestamp(workspace: Path, relative_posix: str) -> int | None:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(workspace),
+            "log",
+            "-1",
+            "--format=%ct",
+            "--",
+            relative_posix,
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def normalize_workspace(workspace: Path) -> tuple[int, int]:
+    """Touch eligible tracked files to their last-commit timestamp.
+
+    Returns a ``(normalized, skipped)`` tuple where ``skipped`` counts files
+    that matched the include globs but had no git history (new / untracked
+    additions that arrived via some other mechanism).
+    """
+    tracked = _list_tracked_files(workspace)
+    candidates = select_candidate_files(tracked)
+
+    normalized = 0
+    skipped = 0
+    for relative_posix in candidates:
+        absolute = workspace / Path(*relative_posix.split("/"))
+        if not absolute.is_file():
+            # Could be a symlink or removed file between ls-files and now.
+            continue
+        timestamp = _last_commit_timestamp(workspace, relative_posix)
+        if timestamp is None:
+            skipped += 1
+            continue
+        try:
+            os.utime(absolute, (timestamp, timestamp))
+        except OSError as exc:
+            log(f"source-mtime-normalize: failed to touch {relative_posix}: {exc}")
+            skipped += 1
+            continue
+        normalized += 1
+    return normalized, skipped
+
+
+def main() -> None:
+    enabled_raw = os.environ.get("INPUT_SOURCE_MTIME_NORMALIZE", "")
+    if not _is_truthy(enabled_raw):
+        log(
+            "source-mtime-normalize: skipped (input=%r; set 'true' to enable)"
+            % enabled_raw
+        )
+        return
+
+    workspace_value = os.environ.get("ACTION_WORKSPACE", "").strip()
+    if not workspace_value:
+        log("source-mtime-normalize: skipped (ACTION_WORKSPACE is not set)")
+        return
+
+    workspace = Path(workspace_value)
+    if not workspace.is_dir():
+        log(
+            f"source-mtime-normalize: skipped (workspace {workspace} is not a directory)"
+        )
+        return
+
+    if not _is_git_repo(workspace):
+        log(
+            f"source-mtime-normalize: skipped ({workspace} is not a git work tree)"
+        )
+        return
+
+    start = time.monotonic()
+    try:
+        normalized, skipped = normalize_workspace(workspace)
+    except subprocess.CalledProcessError as exc:
+        log(f"source-mtime-normalize: git invocation failed: {exc}")
+        raise
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+    log(
+        "source-mtime-normalize: normalized="
+        f"{normalized} skipped={skipped} workspace={workspace} elapsed_ms={elapsed_ms}"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        sys.exit(str(exc))

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ jobs:
 | `build-cache` | Restore and save Soldr/zccache build cache state across runs. Default `true`; set to `false` to opt out. |
 | `build-cache-mode` | Rust build cache mode. Default `once` saves a full snapshot on miss, then restores only the local rust-plan bundle on later hits without resaving the full target tree. `thin` is the bounded dependency-artifact alternative. `full` opts into normal whole-target restore/save behavior and should be treated as unbounded. |
 | `target-dir` | Cargo target directory used by soldr when constructing the Rust artifact cache plan. |
+| `source-mtime-normalize` | Opt-in. When `true`, rewrite the mtime of tracked Rust build-input files under `${{ github.workspace }}` to each file's last-commit timestamp before the target-cache restore. Default `false`. See "Source mtime normalization" below. |
 
 ### Legacy Compatibility Inputs
 
@@ -176,6 +177,20 @@ steps:
 
 See [issue #53](https://github.com/zackees/setup-soldr/issues/53) for
 background.
+
+## Source mtime normalization
+
+Fresh GitHub checkouts assign new mtimes to every file, which can cause Cargo to invalidate fingerprints for packages whose sources did not actually change between a parent branch and a pull request. When `source-mtime-normalize: true` is set, `setup-soldr` rewrites the mtime of tracked Rust build-input files (`**/*.rs`, `**/Cargo.toml`, `**/Cargo.lock`, `**/build.rs`, `rust-toolchain`, `rust-toolchain.toml`) under `${{ github.workspace }}` to each file's last-commit timestamp from `git log -1 --format=%ct`. Files under `target/`, `.git/`, and `node_modules/` are always skipped, and untracked files are left alone, so genuine source edits still invalidate Cargo fingerprints. This is action-side behavior, not a substitute for upstream build-script hygiene, and it is a no-op when the input is `false` or the workspace is not a git work tree.
+
+```yaml
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+          source-mtime-normalize: true
+      - run: soldr cargo build --locked --release
+```
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,16 @@ inputs:
     description: Cargo target directory used by soldr when constructing the Rust artifact cache plan.
     required: false
     default: target
+  source-mtime-normalize:
+    description: >
+      Opt-in. When "true", rewrite the mtime of tracked Rust build-input files
+      under the GitHub Actions workspace to each file's last-commit timestamp
+      before the target-cache restore runs. This keeps Cargo fingerprints
+      stable across fresh checkouts of the same SHA so restored target caches
+      can be reused as a no-op. Files with no git history are left alone, so
+      real source edits still invalidate fingerprints. Defaults to "false".
+    required: false
+    default: "false"
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -209,6 +219,15 @@ runs:
     - id: phase-resolve-end
       shell: pwsh
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" finish resolve
+
+    - id: normalize-source-mtime
+      if: ${{ inputs.source-mtime-normalize == 'true' }}
+      shell: pwsh
+      env:
+        INPUT_SOURCE_MTIME_NORMALIZE: ${{ inputs.source-mtime-normalize }}
+        ACTION_WORKSPACE: ${{ github.workspace }}
+        SETUP_SOLDR_TIMESTAMPS: ${{ inputs.timestamps }}
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/normalize_source_mtime.py"
 
     - id: phase-setup-cache-start
       shell: pwsh

--- a/tests/test_action_python_entrypoints.py
+++ b/tests/test_action_python_entrypoints.py
@@ -16,6 +16,7 @@ ACTION_YML = REPO_ROOT / "action.yml"
 EXPECTED_ENTRYPOINTS = {
     ".github/actions/setup-soldr/phase_timing.py",
     ".github/actions/setup-soldr/resolve_setup.py",
+    ".github/actions/setup-soldr/normalize_source_mtime.py",
     ".github/actions/setup-soldr/ensure_rust_toolchain.py",
     ".github/actions/setup-soldr/ensure_soldr.py",
     ".github/actions/setup-soldr/verify_soldr.py",

--- a/tests/test_normalize_source_mtime.py
+++ b/tests/test_normalize_source_mtime.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NORMALIZE_SCRIPT = (
+    REPO_ROOT / ".github" / "actions" / "setup-soldr" / "normalize_source_mtime.py"
+)
+HELPER_DIR = NORMALIZE_SCRIPT.parent
+
+
+def _load_module():
+    helper_dir = str(HELPER_DIR)
+    if helper_dir not in sys.path:
+        sys.path.insert(0, helper_dir)
+    spec = importlib.util.spec_from_file_location(
+        "normalize_source_mtime", NORMALIZE_SCRIPT
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load normalize_source_mtime.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(workspace: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(workspace), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _init_repo(workspace: Path) -> None:
+    _git(workspace, "init", "--quiet", "--initial-branch=main")
+    _git(workspace, "config", "user.email", "test@example.com")
+    _git(workspace, "config", "user.name", "Test Author")
+    _git(workspace, "config", "commit.gpgsign", "false")
+
+
+def _commit_at(workspace: Path, timestamp: int, message: str) -> None:
+    env = os.environ.copy()
+    iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(timestamp)) + "+0000"
+    env["GIT_AUTHOR_DATE"] = iso
+    env["GIT_COMMITTER_DATE"] = iso
+    env["GIT_AUTHOR_EMAIL"] = "test@example.com"
+    env["GIT_AUTHOR_NAME"] = "Test Author"
+    env["GIT_COMMITTER_EMAIL"] = "test@example.com"
+    env["GIT_COMMITTER_NAME"] = "Test Author"
+    subprocess.run(
+        ["git", "-C", str(workspace), "commit", "--quiet", "-m", message],
+        check=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+class SelectCandidateFilesTests(unittest.TestCase):
+    def test_matches_rust_build_inputs_and_skips_target_and_vcs(self) -> None:
+        module = _load_module()
+        tracked = [
+            "src/main.rs",
+            "crates/foo/Cargo.toml",
+            "Cargo.lock",
+            "build.rs",
+            "rust-toolchain",
+            "rust-toolchain.toml",
+            "target/debug/build/generated.rs",
+            "crates/foo/target/debug/generated.rs",
+            "node_modules/pkg/index.rs",
+            "README.md",
+            "scripts/release.py",
+            ".git/hooks/pre-commit",
+        ]
+        selected = module.select_candidate_files(tracked)
+        self.assertEqual(
+            sorted(selected),
+            sorted(
+                [
+                    "src/main.rs",
+                    "crates/foo/Cargo.toml",
+                    "Cargo.lock",
+                    "build.rs",
+                    "rust-toolchain",
+                    "rust-toolchain.toml",
+                ]
+            ),
+        )
+
+
+class NormalizeWorkspaceTests(unittest.TestCase):
+    def _write_and_commit(
+        self,
+        workspace: Path,
+        relative_path: str,
+        content: str,
+        timestamp: int,
+    ) -> None:
+        absolute = workspace / Path(relative_path)
+        absolute.parent.mkdir(parents=True, exist_ok=True)
+        absolute.write_text(content, encoding="utf-8")
+        _git(workspace, "add", relative_path)
+        _commit_at(workspace, timestamp, f"add {relative_path}")
+
+    def test_touches_tracked_rust_files_to_last_commit_timestamp(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-mtime-") as tmp:
+            workspace = Path(tmp)
+            _init_repo(workspace)
+
+            rs_time = 1_700_000_000
+            toml_time = 1_700_100_000
+            self._write_and_commit(workspace, "src/main.rs", "fn main(){}", rs_time)
+            self._write_and_commit(
+                workspace,
+                "crates/foo/Cargo.toml",
+                '[package]\nname="foo"\nversion="0.1.0"\n',
+                toml_time,
+            )
+
+            # Untracked file should be left alone.
+            untracked_path = workspace / "untracked.rs"
+            untracked_path.write_text("fn u(){}", encoding="utf-8")
+            original_untracked_mtime = untracked_path.stat().st_mtime
+
+            # File inside target/ is tracked but must be skipped.
+            target_path = workspace / "target" / "debug" / "build.rs"
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text("// generated", encoding="utf-8")
+            _git(workspace, "add", "-f", "target/debug/build.rs")
+            _commit_at(workspace, 1_700_200_000, "add target file")
+            target_mtime_before = target_path.stat().st_mtime
+
+            normalized, skipped = module.normalize_workspace(workspace)
+
+            self.assertEqual(normalized, 2)
+            self.assertEqual(skipped, 0)
+            self.assertEqual(
+                int((workspace / "src/main.rs").stat().st_mtime), rs_time
+            )
+            self.assertEqual(
+                int((workspace / "crates/foo/Cargo.toml").stat().st_mtime),
+                toml_time,
+            )
+            # Untracked file mtime unchanged.
+            self.assertEqual(untracked_path.stat().st_mtime, original_untracked_mtime)
+            # target/ file mtime unchanged.
+            self.assertEqual(target_path.stat().st_mtime, target_mtime_before)
+
+
+class MainEntrypointTests(unittest.TestCase):
+    def test_skips_when_input_is_false(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-mtime-off-") as tmp:
+            workspace = Path(tmp)
+            with patch.dict(
+                os.environ,
+                {
+                    "INPUT_SOURCE_MTIME_NORMALIZE": "false",
+                    "ACTION_WORKSPACE": str(workspace),
+                },
+                clear=False,
+            ):
+                with patch.object(module, "normalize_workspace") as mocked:
+                    module.main()
+                    mocked.assert_not_called()
+
+    def test_skips_when_workspace_is_not_git_repo(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-mtime-nogit-") as tmp:
+            workspace = Path(tmp)
+            with patch.dict(
+                os.environ,
+                {
+                    "INPUT_SOURCE_MTIME_NORMALIZE": "true",
+                    "ACTION_WORKSPACE": str(workspace),
+                },
+                clear=False,
+            ):
+                with patch.object(module, "normalize_workspace") as mocked:
+                    module.main()
+                    mocked.assert_not_called()
+
+    def test_runs_when_enabled_and_in_git_repo(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-mtime-on-") as tmp:
+            workspace = Path(tmp)
+            _init_repo(workspace)
+            (workspace / "lib.rs").write_text("pub fn x(){}", encoding="utf-8")
+            _git(workspace, "add", "lib.rs")
+            _commit_at(workspace, 1_700_300_000, "seed")
+
+            with patch.dict(
+                os.environ,
+                {
+                    "INPUT_SOURCE_MTIME_NORMALIZE": "true",
+                    "ACTION_WORKSPACE": str(workspace),
+                    "SETUP_SOLDR_TIMESTAMPS": "false",
+                },
+                clear=False,
+            ):
+                module.main()
+
+            self.assertEqual(
+                int((workspace / "lib.rs").stat().st_mtime), 1_700_300_000
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a new `source-mtime-normalize` action input (default `"false"`) that, when enabled, rewrites the mtime of tracked Rust build-input files under `${{ github.workspace }}` to each file's last-commit timestamp (`git log -1 --format=%ct`) before the target-cache restore runs, so restored Cargo fingerprints stay valid across fresh checkouts of the same SHA.
- New Python entrypoint `.github/actions/setup-soldr/normalize_source_mtime.py` (`log_utils.log`, type hints, `from __future__ import annotations`). Only touches tracked files matching `**/*.rs`, `**/Cargo.toml`, `**/Cargo.lock`, `**/build.rs`, `rust-toolchain`, `rust-toolchain.toml`; skips `target/`, `.git/`, `node_modules/`; leaves untracked files alone so real edits still invalidate Cargo fingerprints; no-ops when input is `false` or the workspace is not a git work tree.
- Wire the new step between `resolve` and `cache-lookup` (gated by `inputs.source-mtime-normalize == 'true'`), extend the entrypoint parity guard, add pytest coverage with a temp-dir git repo fixture, and document the new input in README.

Refs #16

## Test plan

- [x] `python -m pytest tests/` (61 passed, including 5 new tests)
- [x] `python -c "import yaml; yaml.safe_load(open('action.yml'))"` to confirm the updated action still parses
- [ ] Observe target-cache reuse on a follow-up PR run against unchanged sources with `source-mtime-normalize: true` enabled