### PR TITLE
Add per-phase timing diagnostics to setup-soldr

### DIFF
--- a/.github/actions/setup-soldr/phase_timing.py
+++ b/.github/actions/setup-soldr/phase_timing.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import time
+
+
+def _phase_env_name(name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_").upper() or "PHASE"
+    return f"SETUP_SOLDR_PHASE_{cleaned}_START_MS"
+
+
+def _write_env(name: str, value: str) -> None:
+    output = os.environ.get("GITHUB_ENV", "").strip()
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def _write_outputs(values: dict[str, str]) -> None:
+    output = os.environ.get("GITHUB_OUTPUT", "").strip()
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as fh:
+        for key, value in values.items():
+            fh.write(f"{key}={value}\n")
+
+
+def _now_ms() -> int:
+    return time.time_ns() // 1_000_000
+
+
+def mark_phase(name: str) -> None:
+    _write_env(_phase_env_name(name), str(_now_ms()))
+
+
+def finish_phase(name: str) -> None:
+    start_raw = os.environ.get(_phase_env_name(name), "").strip()
+    try:
+        start_ms = int(start_raw)
+    except ValueError:
+        start_ms = 0
+    elapsed_ms = max(0, _now_ms() - start_ms) if start_ms else 0
+    _write_outputs(
+        {
+            "milliseconds": str(elapsed_ms),
+            "seconds": f"{elapsed_ms / 1000:.3f}",
+        }
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Record setup-soldr phase timing markers.")
+    parser.add_argument("command", choices=("mark", "finish"))
+    parser.add_argument("phase")
+    args = parser.parse_args()
+
+    if args.command == "mark":
+        mark_phase(args.phase)
+    else:
+        finish_phase(args.phase)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/setup-soldr-contract.yml
+++ b/.github/workflows/setup-soldr-contract.yml
@@ -52,6 +52,7 @@ jobs:
             tests/test_ensure_soldr_release_resolution.py \
             tests/test_ensure_rust_toolchain_refresh.py \
             tests/test_ensure_soldr_source_ref.py \
+            tests/test_phase_timing.py \
             tests/test_release_rollout_contract.py \
             tests/test_resolve_setup_build_cache_mode.py \
             tests/test_resolve_setup_toolchain_resolution.py \

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ jobs:
 | `soldr-path` | Installed Soldr binary path added to `PATH`. |
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
+| `setup-duration-seconds` | Total wall-clock time spent inside the setup-soldr action. |
+| `setup-phase-summary` | JSON timing summary for the main setup phases and cache restore statuses. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `cache-key` | Primary key used for the action-managed cache/state root. |
 | `cache-restore-status` | Diagnostic restore status for the action-managed cache/state root. |
@@ -136,6 +138,7 @@ jobs:
 - In `once` mode, an exact rust-plan bundle hit skips the separate build-cache restore because the target bundle already rehydrates the warm artifacts needed for the following build.
 - setup-soldr now emits soft target-cache footprint budgets by mode: `once` warns above `1 GiB` or `8000` files, `thin` warns above `512 MiB` or `4000` files, and `full` warns above `2 GiB` or `12000` files.
 - When the restored target-cache footprint exceeds that soft budget, the setup step emits a warning and reports `target-cache-budget-status=over-soft-budget:...` so workflows can spot cache shapes that are unlikely to stay fast.
+- setup-soldr also emits `setup-duration-seconds` plus a JSON `setup-phase-summary` output so warm-path investigations can compare cache restore time against toolchain/install/verify overhead.
 - zccache is the artifact cache authority; soldr interprets the Rust build and passes zccache a structured Rust artifact plan.
 - Inspect `soldr cache`, zccache session stats, and the setup step's restore-status outputs when warm cache reuse is unexpectedly low.
 - The setup cache intentionally keeps the installed `soldr` binary and only includes rustup state when setup-soldr had to fall back to a managed `RUSTUP_HOME` under the setup cache root. The dedicated `ZCCACHE_CACHE_DIR` payload stays in its own cache so warm runs do not restore the same build-cache bytes twice.

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,12 @@ outputs:
   cache-dir:
     description: Runner-local cache/state root used by the action.
     value: ${{ steps.resolve.outputs.cache_root }}
+  setup-duration-seconds:
+    description: Total wall-clock time spent inside the setup-soldr action.
+    value: ${{ steps.cache-meta.outputs.setup_duration_seconds }}
+  setup-phase-summary:
+    description: JSON timing summary for the main setup phases and cache restore statuses.
+    value: ${{ steps.cache-meta.outputs.setup_phase_summary }}
   cache-hit:
     description: Whether the action restored an exact cache hit for the selected cache/state root.
     value: ${{ steps.cache-meta.outputs.cache_hit }}
@@ -167,6 +173,14 @@ outputs:
 runs:
   using: composite
   steps:
+    - id: phase-action-start
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" mark action
+
+    - id: phase-resolve-start
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" mark resolve
+
     - id: resolve
       shell: pwsh
       env:
@@ -191,6 +205,14 @@ runs:
         ACTION_ARCH: ${{ runner.arch }}
         ACTION_PARENT_SHA: ${{ github.event.pull_request.base.sha }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/resolve_setup.py"
+
+    - id: phase-resolve-end
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" finish resolve
+
+    - id: phase-setup-cache-start
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" mark setup-cache
 
     - id: cache-lookup
       if: ${{ inputs.cache == 'true' }}
@@ -219,6 +241,14 @@ runs:
         key: ${{ steps.resolve.outputs.cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
+
+    - id: phase-setup-cache-end
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" finish setup-cache
+
+    - id: phase-target-cache-start
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" mark target-cache
 
     - id: target-cache-lookup
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
@@ -250,6 +280,14 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_parent }}
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+
+    - id: phase-target-cache-end
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" finish target-cache
+
+    - id: phase-build-cache-start
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" mark build-cache
 
     - id: build-cache-lookup
       if: ${{ inputs.build-cache == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || steps.resolve.outputs.target_cache_enabled != 'true' || steps.target-cache-lookup.outputs.cache-hit != 'true') }}
@@ -285,6 +323,14 @@ runs:
           ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
           ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
 
+    - id: phase-build-cache-end
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" finish build-cache
+
+    - id: phase-target-tree-start
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" mark target-tree
+
     - id: target-tree-cache-lookup
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.resolve.outputs.build_cache_mode == 'full' }}
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -306,12 +352,28 @@ runs:
           ${{ steps.resolve.outputs.target_cache_restore_key_parent }}
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
 
+    - id: phase-target-tree-end
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" finish target-tree
+
+    - id: phase-toolchain-start
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" mark toolchain
+
     - id: toolchain
       shell: pwsh
       env:
         SETUP_SOLDR_SETUP_CACHE_EXACT_HIT: ${{ steps.cache-lookup.outputs.cache-hit }}
         SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL: ${{ steps.resolve.outputs.toolchain_cache_channel }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_rust_toolchain.py"
+
+    - id: phase-toolchain-end
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" finish toolchain
+
+    - id: phase-install-start
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" mark install
 
     - id: install
       shell: pwsh
@@ -323,6 +385,14 @@ runs:
         SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_resolved }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_soldr.py"
 
+    - id: phase-install-end
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" finish install
+
+    - id: phase-verify-start
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" mark verify
+
     - id: verify
       shell: pwsh
       env:
@@ -330,6 +400,10 @@ runs:
         SETUP_SOLDR_BUILD_CACHE_MODE: ${{ steps.resolve.outputs.build_cache_mode }}
         SETUP_SOLDR_REQUIRE_RUST_PLAN: ${{ steps.resolve.outputs.target_cache_enabled }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
+
+    - id: phase-verify-end
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/phase_timing.py" finish verify
 
     - id: cache-meta
       shell: pwsh
@@ -356,6 +430,14 @@ runs:
         TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
         EFFECTIVE_TARGET_CACHE_ENABLED: ${{ steps.resolve.outputs.target_cache_enabled }}
         SKIP_BUILD_CACHE_FOR_TARGET_EXACT_HIT: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.build_cache_mode == 'once' && steps.resolve.outputs.target_cache_enabled == 'true' && steps.target-cache-lookup.outputs.cache-hit == 'true' }}
+        PHASE_RESOLVE_SECONDS: ${{ steps.phase-resolve-end.outputs.seconds }}
+        PHASE_SETUP_CACHE_SECONDS: ${{ steps.phase-setup-cache-end.outputs.seconds }}
+        PHASE_TARGET_CACHE_SECONDS: ${{ steps.phase-target-cache-end.outputs.seconds }}
+        PHASE_BUILD_CACHE_SECONDS: ${{ steps.phase-build-cache-end.outputs.seconds }}
+        PHASE_TARGET_TREE_SECONDS: ${{ steps.phase-target-tree-end.outputs.seconds }}
+        PHASE_TOOLCHAIN_SECONDS: ${{ steps.phase-toolchain-end.outputs.seconds }}
+        PHASE_INSTALL_SECONDS: ${{ steps.phase-install-end.outputs.seconds }}
+        PHASE_VERIFY_SECONDS: ${{ steps.phase-verify-end.outputs.seconds }}
       run: |
         function TimestampEnabled {
           $value = "$env:SETUP_SOLDR_TIMESTAMPS".Trim().ToLowerInvariant()
@@ -418,6 +500,11 @@ runs:
             Files = $files
             Bytes = $bytes
           }
+        }
+        function ParsePhaseSeconds($value) {
+          $seconds = 0.0
+          [double]::TryParse($value, [ref]$seconds) | Out-Null
+          return [Math]::Round($seconds, 3)
         }
 
         $value = $env:RAW_CACHE_HIT
@@ -487,6 +574,44 @@ runs:
         if ([string]::IsNullOrWhiteSpace($targetTreeValue)) {
           $targetTreeValue = "false"
         }
+        $setupDurationSeconds = 0.0
+        $actionStartMs = 0L
+        if ([long]::TryParse($env:SETUP_SOLDR_PHASE_ACTION_START_MS, [ref]$actionStartMs)) {
+          $setupDurationSeconds = [Math]::Round(
+            [Math]::Max(0, [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() - $actionStartMs) / 1000.0,
+            3
+          )
+        } else {
+          $startEpoch = 0L
+          if ([long]::TryParse($env:SETUP_SOLDR_LOG_START_EPOCH, [ref]$startEpoch)) {
+            $setupDurationSeconds = [Math]::Round(
+              [Math]::Max(0, [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - $startEpoch),
+              3
+            )
+          }
+        }
+        $setupPhaseSummary = (
+          [ordered]@{
+            resolve_seconds = ParsePhaseSeconds $env:PHASE_RESOLVE_SECONDS
+            setup_cache_seconds = ParsePhaseSeconds $env:PHASE_SETUP_CACHE_SECONDS
+            setup_cache_status = $cacheStatus
+            target_cache_seconds = ParsePhaseSeconds $env:PHASE_TARGET_CACHE_SECONDS
+            target_cache_status = $targetStatus
+            target_tree_seconds = ParsePhaseSeconds $env:PHASE_TARGET_TREE_SECONDS
+            target_tree_status = $targetTreeStatus
+            build_cache_seconds = ParsePhaseSeconds $env:PHASE_BUILD_CACHE_SECONDS
+            build_cache_status = $buildStatus
+            toolchain_seconds = ParsePhaseSeconds $env:PHASE_TOOLCHAIN_SECONDS
+            install_seconds = ParsePhaseSeconds $env:PHASE_INSTALL_SECONDS
+            verify_seconds = ParsePhaseSeconds $env:PHASE_VERIFY_SECONDS
+            build_cache_mode = "${{ steps.resolve.outputs.build_cache_mode }}"
+            target_cache_mode = "${{ steps.resolve.outputs.target_cache_mode }}"
+            target_cache_budget_status = $targetBudgetStatus
+            total_seconds = $setupDurationSeconds
+          } | ConvertTo-Json -Compress
+        )
+        "setup_duration_seconds=$setupDurationSeconds" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        "setup_phase_summary=$setupPhaseSummary" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
         Log "cache restore status=$cacheStatus exact-hit=$value"
         if ($env:SKIP_BUILD_CACHE_FOR_TARGET_EXACT_HIT -eq "true") {
@@ -504,6 +629,7 @@ runs:
             Write-Host "::warning::target-cache footprint files=$($targetFootprint.Files) bytes=$($targetFootprint.Bytes) exceeded soft budget files=$targetBudgetFiles bytes=$targetBudgetBytes; consider build-cache-mode 'thin' or narrower target-cache paths."
           }
         }
+        Log "setup-phase summary=$setupPhaseSummary"
         LogPath "cache after restore" "${{ steps.resolve.outputs.setup_cache_path }}"
         LogPath "soldr-bin after restore" "${{ steps.resolve.outputs.soldr_bin_cache_path }}"
         LogPath "build-cache after restore" "${{ steps.resolve.outputs.build_cache_path }}"

--- a/tests/test_action_python_entrypoints.py
+++ b/tests/test_action_python_entrypoints.py
@@ -14,6 +14,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ACTION_YML = REPO_ROOT / "action.yml"
 EXPECTED_ENTRYPOINTS = {
+    ".github/actions/setup-soldr/phase_timing.py",
     ".github/actions/setup-soldr/resolve_setup.py",
     ".github/actions/setup-soldr/ensure_rust_toolchain.py",
     ".github/actions/setup-soldr/ensure_soldr.py",

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -27,6 +27,8 @@ def test_target_tree_cache_is_only_used_in_full_mode() -> None:
 def test_target_cache_budget_outputs_and_warning_are_wired() -> None:
     action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
 
+    assert "setup-duration-seconds:" in action
+    assert "setup-phase-summary:" in action
     assert "target-cache-budget-bytes:" in action
     assert "target-cache-budget-files:" in action
     assert "target-cache-footprint-bytes:" in action
@@ -36,7 +38,27 @@ def test_target_cache_budget_outputs_and_warning_are_wired() -> None:
     assert "TARGET_CACHE_BUDGET_FILES" in action
     assert "MeasurePaths" in action
     assert "over-soft-budget:" in action
+    assert "setup_phase_summary" in action
+    assert "phase_timing.py" in action
     assert "::warning::target-cache footprint" in action
+
+
+def test_phase_timing_steps_are_non_overlapping() -> None:
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+
+    action_start = action.index("id: phase-action-start")
+    resolve_start = action.index("id: phase-resolve-start")
+    target_start = action.index("id: phase-target-cache-start")
+    target_end = action.index("id: phase-target-cache-end")
+    build_start = action.index("id: phase-build-cache-start")
+    build_end = action.index("id: phase-build-cache-end")
+    tree_start = action.index("id: phase-target-tree-start")
+    tree_end = action.index("id: phase-target-tree-end")
+
+    assert action_start < resolve_start < target_start < target_end < build_start < build_end < tree_start < tree_end
+    assert "SETUP_SOLDR_PHASE_ACTION_START_MS" in action
+    assert "PHASE_TARGET_TREE_SECONDS" in action
+    assert "target_tree_seconds" in action
 
 
 def test_setup_cache_uses_lookup_exact_restore_and_managed_fallback() -> None:

--- a/tests/test_phase_timing.py
+++ b/tests/test_phase_timing.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PHASE_TIMING = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "phase_timing.py"
+HELPER_DIR = PHASE_TIMING.parent
+
+
+def _load_module():
+    helper_dir = str(HELPER_DIR)
+    if helper_dir not in sys.path:
+        sys.path.insert(0, helper_dir)
+    spec = importlib.util.spec_from_file_location("phase_timing", PHASE_TIMING)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load phase_timing.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PhaseTimingTests(unittest.TestCase):
+    def test_mark_phase_writes_start_timestamp_to_github_env(self) -> None:
+        module = _load_module()
+
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-phase-") as temp_dir:
+            env_path = Path(temp_dir) / "github-env.txt"
+
+            with (
+                patch.dict(os.environ, {"GITHUB_ENV": str(env_path)}, clear=False),
+                patch.object(module, "_now_ms", return_value=12345),
+            ):
+                module.mark_phase("setup-cache")
+
+            self.assertEqual(
+                env_path.read_text(encoding="utf-8"),
+                "SETUP_SOLDR_PHASE_SETUP_CACHE_START_MS=12345\n",
+            )
+
+    def test_finish_phase_writes_elapsed_outputs(self) -> None:
+        module = _load_module()
+
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-phase-") as temp_dir:
+            output_path = Path(temp_dir) / "github-output.txt"
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "GITHUB_OUTPUT": str(output_path),
+                        "SETUP_SOLDR_PHASE_TARGET_CACHE_START_MS": "1000",
+                    },
+                    clear=False,
+                ),
+                patch.object(module, "_now_ms", return_value=3456),
+            ):
+                module.finish_phase("target-cache")
+
+            self.assertEqual(
+                output_path.read_text(encoding="utf-8"),
+                "milliseconds=2456\nseconds=2.456\n",
+            )
+
+    def test_finish_phase_defaults_to_zero_when_start_is_missing(self) -> None:
+        module = _load_module()
+
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-phase-") as temp_dir:
+            output_path = Path(temp_dir) / "github-output.txt"
+
+            with (
+                patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_path)}, clear=False),
+                patch.object(module, "_now_ms", return_value=3456),
+            ):
+                module.finish_phase("verify")
+
+            self.assertEqual(
+                output_path.read_text(encoding="utf-8"),
+                "milliseconds=0\nseconds=0.000\n",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_rollout_contract.py
+++ b/tests/test_release_rollout_contract.py
@@ -29,6 +29,7 @@ def test_rollout_contract_workflow_runs_unit_tests_for_the_release_path() -> Non
     assert "tests/test_ensure_rust_toolchain_refresh.py" in workflow
     assert "tests/test_ensure_soldr_release_resolution.py" in workflow
     assert "tests/test_ensure_soldr_source_ref.py" in workflow
+    assert "tests/test_phase_timing.py" in workflow
     assert "tests/test_release_rollout_contract.py" in workflow
     assert "tests/test_resolve_setup_build_cache_mode.py" in workflow
     assert "tests/test_resolve_setup_toolchain_resolution.py" in workflow


### PR DESCRIPTION
## Summary
- Adds a `phase_timing.py` helper that records per-phase start markers in `$GITHUB_ENV` and emits elapsed `seconds`/`milliseconds` outputs.
- Wraps each major step of the composite action (resolve, setup-cache, target-cache, build-cache, target-tree, toolchain, install, verify) with non-overlapping mark/finish steps.
- Exposes two new outputs: `setup-duration-seconds` and a compact JSON `setup-phase-summary` containing per-phase seconds, cache restore statuses, modes, and target-cache budget status — making warm-path investigations easier.

## Test plan
- [x] `python -m pytest tests/` (60 passed)
- [x] `python -m pytest tests/test_phase_timing.py tests/test_action_python_entrypoints.py tests/test_action_target_cache_wiring.py tests/test_release_rollout_contract.py` (15 passed, including the new wiring guard `test_phase_timing_steps_are_non_overlapping`)
- [ ] Confirm `setup-soldr-contract` workflow passes on this PR (it now also runs `tests/test_phase_timing.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)