### PR TITLE
Bump default Soldr version to 0.7.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.11`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.14`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -75,7 +75,7 @@ jobs:
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.11`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.14`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
 | `cache-key-suffix` | Optional escape hatch appended to the cache key. |
@@ -129,7 +129,7 @@ jobs:
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.11`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.14`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action keeps using the runner's existing `CARGO_HOME` unless `CARGO_HOME` is already set by the workflow. When `RUSTUP_HOME` is not explicitly set, setup-soldr prefers the runner's existing rustup home if it already satisfies the requested toolchain/components/targets; otherwise it falls back to a managed `RUSTUP_HOME` under the action cache root and rehydrates that state on later warm runs.

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,9 @@ branding:
   color: green
 inputs:
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.11.
+    description: Soldr version or tag to install. Defaults to 0.7.14.
     required: false
-    default: "0.7.11"
+    default: "0.7.14"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary
- Bumps the action's default `version` input from `0.7.11` to `0.7.14` in `action.yml` and the matching README references.
- Moves the pinned `soldr/` submodule to the `v0.7.14` release commit (`597a52d`) so contract/test fixtures track the binary consumers will install by default.

## Notable upstream changes (v0.7.11 → v0.7.14)
- soldr#243 — point zccache and sccache at soldr-owned cache roots.
- soldr#234 — track target/ dirs in a sqlite registry, add `soldr gc`.
- soldr#244 / #246 / #248 — tighten thin target-cache allowlist, emit manifest.v2, verifier coverage.
- soldr#247 — preserve cargo fingerprints across split `soldr cargo test` steps.
- soldr#250 — seed soldr's dogfood zccache on main pushes (workflow-only fix that resolved setup-soldr#60).
- soldr#252-256 — release-machinery fixes for the v0.7.13/v0.7.14 publish path.

Full release notes: https://github.com/zackees/soldr/releases/tag/v0.7.14

## Test plan
- [x] `python -m pytest tests/` — 73 passed (no fixture/test changes needed; the `0.7.11` references in tests are mocked release fixtures and explicit `INPUT_VERSION` test inputs, not assertions about the action's default).
- [ ] CI Setup Soldr Action / Contract Tests / zccache demo workflows green on this PR.
- [ ] Smoke a downstream consumer (`zackees/soldr` dogfood or any caller pinning `zackees/setup-soldr@v0`) and confirm it resolves and installs `v0.7.14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)