### PR TITLE
feat(action): add target-cache-profile input for thin-v2 rollout (#59)

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -249,6 +249,20 @@ def _target_env_hash() -> str:
     return _short_json_hash(relevant)
 
 
+_TARGET_CACHE_PROFILES = ("thin-v1", "thin-v2")
+
+
+def normalize_target_cache_profile(value: str) -> str:
+    profile = value.strip().lower()
+    if not profile:
+        return "thin-v1"
+    if profile not in _TARGET_CACHE_PROFILES:
+        raise RuntimeError(
+            f"invalid target-cache-profile {value!r}; expected thin-v1 or thin-v2"
+        )
+    return profile
+
+
 def _normalize_legacy_target_cache_mode(value: str) -> str:
     mode = value.strip().lower()
     if not mode:
@@ -666,6 +680,9 @@ def main() -> None:
     legacy_target_cache_mode = _normalize_legacy_target_cache_mode(
         os.environ.get("INPUT_TARGET_CACHE_MODE", "")
     )
+    target_cache_profile = normalize_target_cache_profile(
+        os.environ.get("INPUT_TARGET_CACHE_PROFILE", "")
+    )
     target_cache_requested = (
         os.environ.get("INPUT_TARGET_CACHE", "true").strip().lower()
         not in {"0", "false", "no", "off"}
@@ -775,6 +792,7 @@ def main() -> None:
     )
     _write_env("SOLDR_TARGET_CACHE_DIR", str(target_cache_path))
     _write_env("SOLDR_TARGET_CACHE_BUNDLE_DIR", str(target_cache_bundle_path))
+    _write_env("SOLDR_TARGET_CACHE_PROFILE", target_cache_profile)
     # setup-soldr already rehydrates the rust-plan bundle directory with
     # actions/cache, so the soldr/zccache layer should operate on that local
     # bundle instead of switching to zccache's separate direct GHA backend.
@@ -857,6 +875,7 @@ def main() -> None:
             "target_cache_paths": target_cache_paths,
             "target_cache_enabled": str(target_cache_enabled).lower(),
             "target_cache_mode": target_cache_effective_mode,
+            "target_cache_profile": target_cache_profile,
             "target_cache_key": target_cache_key,
             "target_cache_restore_key_parent": target_cache_parent_key,
             "target_cache_restore_key_lock": target_cache_lock_prefix,

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ jobs:
 | `build-cache` | Restore and save Soldr/zccache build cache state across runs. Default `true`; set to `false` to opt out. |
 | `build-cache-mode` | Rust build cache mode. Default `once` saves a full snapshot on miss, then restores only the local rust-plan bundle on later hits without resaving the full target tree. `thin` is the bounded dependency-artifact alternative. `full` opts into normal whole-target restore/save behavior and should be treated as unbounded. |
 | `target-dir` | Cargo target directory used by soldr when constructing the Rust artifact cache plan. |
+| `target-cache-profile` | Thin-slice pruning policy for the `target/` cache. `thin-v1` (default) keeps `.rlib`/`.rmeta`/proc-macro outputs. `thin-v2` is the aggressive prune that keeps fingerprints + dep-info + final outputs only and relies on the zccache compilation cache to repopulate library bytes. See "Target cache profile" below before opting in. |
 | `source-mtime-normalize` | Opt-in. When `true`, rewrite the mtime of tracked Rust build-input files under `${{ github.workspace }}` to each file's last-commit timestamp before the target-cache restore. Default `false`. See "Source mtime normalization" below. |
 
 ### Legacy Compatibility Inputs
@@ -118,6 +119,7 @@ jobs:
 | `target-cache-path` | Cargo target directory used by soldr for Rust artifact planning. |
 | `target-cache-paths` | Path or newline-delimited path list passed to `actions/cache` for zccache-owned Rust artifact cache state. |
 | `target-cache-mode` | Effective setup-soldr Rust target artifact cache mode. |
+| `target-cache-profile` | Effective setup-soldr thin-slice pruning policy (`thin-v1` or `thin-v2`). |
 | `target-cache-restore-status` | Diagnostic restore status for the Rust target artifact cache state. |
 | `target-cache-budget-bytes` | Soft byte budget used to warn when the restored Rust artifact cache footprint is likely too large for fast CI reuse. |
 | `target-cache-budget-files` | Soft file-count budget used to warn when the restored Rust artifact cache footprint is likely too large for fast CI reuse. |
@@ -177,6 +179,36 @@ steps:
 
 See [issue #53](https://github.com/zackees/setup-soldr/issues/53) for
 background.
+
+## Target cache profile
+
+`target-cache-profile` selects the thin-slice pruning policy used when soldr
+builds the cached `target/` slice. Two values are accepted:
+
+- `thin-v1` (default): the legacy slice that keeps `.rlib`, `.rmeta`, and
+  proc-macro outputs alongside fingerprints, dep-info, and final outputs.
+  This preserves the byte-identical behavior shipped before this input
+  existed, so no caller regresses by leaving the input unset.
+- `thin-v2`: an aggressive prune that keeps only fingerprints, dep-info, and
+  final outputs and relies on the zccache compilation cache to repopulate
+  library bytes on warm runs.
+
+`thin-v2` is opt-in. **Stay on `thin-v1` until the zccache repopulation hook
+(soldr#237 Phase 2) has shipped and the
+[`thin-v2-verify`](https://github.com/zackees/soldr/blob/main/.github/workflows/thin-v2-verify.yml)
+gate has been green on soldr `main` for at least one week.** Setting
+`thin-v2` before that point can leave the restored target slice missing
+library bytes that the build still needs.
+
+```yaml
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+          target-cache-profile: thin-v2
+      - run: soldr cargo build --locked --release
+```
 
 ## Source mtime normalization
 

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,17 @@ inputs:
     description: Cargo target directory used by soldr when constructing the Rust artifact cache plan.
     required: false
     default: target
+  target-cache-profile:
+    description: >
+      Thin-slice pruning policy for the target/ cache. Values:
+        - thin-v1 (default): legacy slice, keeps .rlib/.rmeta/proc-macro outputs
+        - thin-v2: aggressive prune (fingerprints + dep-info + final outputs only),
+                   relies on zccache compilation cache to repopulate library bytes
+      Stay on thin-v1 until the zccache repopulation hook (soldr#237 Phase 2)
+      has shipped and the thin-v2-verify gate has been green on soldr main
+      for at least one week.
+    required: false
+    default: thin-v1
   source-mtime-normalize:
     description: >
       Opt-in. When "true", rewrite the mtime of tracked Rust build-input files
@@ -153,6 +164,9 @@ outputs:
   target-cache-mode:
     description: Effective setup-soldr Rust target artifact cache mode.
     value: ${{ steps.resolve.outputs.target_cache_mode }}
+  target-cache-profile:
+    description: Effective setup-soldr thin-slice pruning policy (thin-v1 or thin-v2).
+    value: ${{ steps.resolve.outputs.target_cache_profile }}
   target-cache-restore-status:
     description: Diagnostic restore status for the Rust target artifact cache state.
     value: ${{ steps.cache-meta.outputs.target_cache_restore_status }}
@@ -210,6 +224,7 @@ runs:
         INPUT_TARGET_CACHE: ${{ inputs.target-cache }}
         INPUT_TARGET_CACHE_MODE: ${{ inputs.target-cache-mode }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
+        INPUT_TARGET_CACHE_PROFILE: ${{ inputs.target-cache-profile }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}

--- a/tests/test_resolve_setup_target_cache_profile.py
+++ b/tests/test_resolve_setup_target_cache_profile.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESOLVE_SETUP = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "resolve_setup.py"
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    env_exports: dict[str, str]
+    outputs: dict[str, str]
+
+
+def _parse_github_kv_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if "<<" in line:
+            key, delimiter = line.split("<<", 1)
+            index += 1
+            body: list[str] = []
+            while index < len(lines) and lines[index] != delimiter:
+                body.append(lines[index])
+                index += 1
+            values[key] = "\n".join(body)
+        elif "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+        index += 1
+    return values
+
+
+def _run_resolve_setup(extra_env: dict[str, str] | None = None) -> ResolveResult:
+    with tempfile.TemporaryDirectory(prefix="setup-soldr-tests-") as temp_dir:
+        root = Path(temp_dir)
+        workspace = root / "workspace"
+        runner_temp = root / "runner-temp"
+        home_dir = root / "home"
+        github_env = root / "github-env"
+        github_output = root / "github-output"
+        github_path = root / "github-path"
+        workspace.mkdir()
+        runner_temp.mkdir()
+        home_dir.mkdir()
+        (workspace / "Cargo.lock").write_text("# test lockfile\n", encoding="utf-8")
+
+        env = os.environ.copy()
+        for key in list(env):
+            if key.startswith(("INPUT_", "ACTION_", "GITHUB_", "SETUP_SOLDR_")):
+                env.pop(key, None)
+        for key in (
+            "CARGO_HOME",
+            "RUSTUP_HOME",
+            "NO_COLOR",
+            "CARGO_TERM_COLOR",
+            "CLICOLOR_FORCE",
+            "FORCE_COLOR",
+        ):
+            env.pop(key, None)
+
+        env.update(
+            {
+                "ACTION_WORKSPACE": str(workspace),
+                "ACTION_OS": "Linux",
+                "ACTION_ARCH": "X64",
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_ENV": str(github_env),
+                "GITHUB_OUTPUT": str(github_output),
+                "GITHUB_PATH": str(github_path),
+                "GITHUB_SHA": "0123456789abcdef",
+                "HOME": str(home_dir),
+                "USERPROFILE": str(home_dir),
+                "INPUT_VERSION": "0.7.11",
+                "INPUT_TIMESTAMPS": "false",
+                "INPUT_TOOLCHAIN_FILE": "",
+                "CARGO_HOME": str(root / "cargo-home"),
+                "RUSTUP_HOME": str(root / "rustup-home"),
+            }
+        )
+        if extra_env:
+            env.update(extra_env)
+
+        proc = subprocess.run(
+            [sys.executable, str(RESOLVE_SETUP)],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        return ResolveResult(
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            env_exports=_parse_github_kv_file(github_env),
+            outputs=_parse_github_kv_file(github_output),
+        )
+
+
+class TargetCacheProfileResolveTests(unittest.TestCase):
+    def test_default_profile_is_thin_v1_when_input_absent(self) -> None:
+        result = _run_resolve_setup()
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"resolve_setup.py failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        self.assertEqual(result.env_exports.get("SOLDR_TARGET_CACHE_PROFILE"), "thin-v1")
+        self.assertEqual(result.outputs.get("target_cache_profile"), "thin-v1")
+
+    def test_empty_profile_input_falls_back_to_thin_v1(self) -> None:
+        result = _run_resolve_setup({"INPUT_TARGET_CACHE_PROFILE": ""})
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.env_exports.get("SOLDR_TARGET_CACHE_PROFILE"), "thin-v1")
+        self.assertEqual(result.outputs.get("target_cache_profile"), "thin-v1")
+
+    def test_explicit_thin_v1_profile_propagates_to_env(self) -> None:
+        result = _run_resolve_setup({"INPUT_TARGET_CACHE_PROFILE": "thin-v1"})
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.env_exports.get("SOLDR_TARGET_CACHE_PROFILE"), "thin-v1")
+        self.assertEqual(result.outputs.get("target_cache_profile"), "thin-v1")
+
+    def test_thin_v2_profile_propagates_to_env(self) -> None:
+        result = _run_resolve_setup({"INPUT_TARGET_CACHE_PROFILE": "thin-v2"})
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.env_exports.get("SOLDR_TARGET_CACHE_PROFILE"), "thin-v2")
+        self.assertEqual(result.outputs.get("target_cache_profile"), "thin-v2")
+
+    def test_invalid_profile_raises_clear_error(self) -> None:
+        result = _run_resolve_setup({"INPUT_TARGET_CACHE_PROFILE": "thick"})
+
+        self.assertNotEqual(result.returncode, 0)
+        combined_output = f"{result.stdout}\n{result.stderr}".lower()
+        self.assertIn("invalid target-cache-profile", combined_output)
+        self.assertIn("thin-v1", combined_output)
+        self.assertIn("thin-v2", combined_output)
+
+    def test_default_profile_does_not_change_setup_cache_key(self) -> None:
+        baseline = _run_resolve_setup()
+        explicit_v1 = _run_resolve_setup({"INPUT_TARGET_CACHE_PROFILE": "thin-v1"})
+        explicit_v2 = _run_resolve_setup({"INPUT_TARGET_CACHE_PROFILE": "thin-v2"})
+
+        self.assertEqual(baseline.returncode, 0)
+        self.assertEqual(explicit_v1.returncode, 0)
+        self.assertEqual(explicit_v2.returncode, 0)
+        self.assertEqual(
+            baseline.outputs.get("cache_key"),
+            explicit_v1.outputs.get("cache_key"),
+        )
+        self.assertEqual(
+            baseline.outputs.get("cache_key"),
+            explicit_v2.outputs.get("cache_key"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds opt-in \`target-cache-profile\` input (default \`thin-v1\`, opt-in \`thin-v2\`) and propagates it via \`SOLDR_TARGET_CACHE_PROFILE\` so subsequent \`soldr cargo\` steps see it.
- Documents the input + opt-in warning in README and emits a matching \`target-cache-profile\` action output.
- New unit tests cover default, empty input, explicit values, invalid value, and that switching profile does not change the setup cache key (byte-identical default).

Closes #59. Soldr-side prerequisites (#244, #246, #248) are already merged on soldr \`main\` (v0.7.12+).

## Test plan
- [x] \`python -m pytest tests/ -q\` — 84 passed locally
- [x] \`pyright .github/actions/setup-soldr/resolve_setup.py\` — 0 errors / 0 warnings
- [ ] CI green on this PR
- [ ] Manual smoke: workflow with \`target-cache-profile: thin-v2\` exports \`SOLDR_TARGET_CACHE_PROFILE=thin-v2\` to the next step
- [ ] Default (\`thin-v1\`) preserves byte-identical behavior — no callers regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)