### PR TITLE
feat(action): add lockfile-only target-cache restore-key fallback (#57)

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -730,6 +730,12 @@ def main() -> None:
             "toolchain": digest,
         }
     )
+    lockfile_only_hash = _short_json_hash(
+        {
+            "cargo_lock": cargo_lock_hash,
+            "toolchain": digest,
+        }
+    )
     target_cache_bundle_path = thin_target_cache_bundle_path
 
     target_tree_cache_enabled = target_cache_enabled and build_cache_mode == "full"
@@ -739,6 +745,7 @@ def main() -> None:
         target_cache_effective_mode = "off"
         target_cache_prefix = f"setup-soldr-targetcache-off-v1-{runner_os}-{runner_arch}"
         target_cache_lock_prefix = ""
+        target_cache_lockfile_prefix = ""
         target_cache_key = f"{target_cache_prefix}-{target_inputs_hash}"
         target_cache_parent_key = ""
     elif target_tree_cache_enabled:
@@ -760,6 +767,9 @@ def main() -> None:
             f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
             f"{target_shape_hash}-{target_cache_suffix_fragment}"
         )
+        target_cache_lockfile_prefix = (
+            f"{target_cache_prefix}-{lockfile_only_hash}-{target_cache_suffix_fragment}"
+        )
         target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
         target_cache_parent_key = f"{target_cache_lock_prefix}{parent_sha}" if parent_sha else ""
     else:
@@ -771,6 +781,9 @@ def main() -> None:
         target_cache_suffix_fragment = f"{sanitized_suffix}-" if sanitized_suffix else ""
         target_cache_lock_prefix = (
             f"{target_cache_prefix}-{target_inputs_hash}-{target_cache_suffix_fragment}"
+        )
+        target_cache_lockfile_prefix = (
+            f"{target_cache_prefix}-{lockfile_only_hash}-{target_cache_suffix_fragment}"
         )
         target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
         target_cache_parent_key = f"{target_cache_lock_prefix}{parent_sha}" if parent_sha else ""
@@ -845,6 +858,7 @@ def main() -> None:
     if target_cache_parent_key:
         log(f"target-cache restore-key-parent={target_cache_parent_key}")
     log(f"target-cache restore-key-lock={target_cache_lock_prefix}")
+    log(f"target-cache restore-key-lockfile={target_cache_lockfile_prefix}")
     log(f"target-cache paths={target_cache_paths}")
     log(f"target-cache bundle-dir={target_cache_bundle_path}")
     log(f"target-cache lockfile={_path_for_output(workspace, lockfile_path)}")
@@ -879,6 +893,7 @@ def main() -> None:
             "target_cache_key": target_cache_key,
             "target_cache_restore_key_parent": target_cache_parent_key,
             "target_cache_restore_key_lock": target_cache_lock_prefix,
+            "target_cache_restore_key_lockfile": target_cache_lockfile_prefix,
             "target_cache_budget_bytes": target_cache_budget_bytes,
             "target_cache_budget_files": target_cache_budget_files,
             "target_lockfile_path": _path_for_output(workspace, lockfile_path),

--- a/action.yml
+++ b/action.yml
@@ -293,6 +293,7 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_parent }}
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+          ${{ steps.resolve.outputs.target_cache_restore_key_lockfile }}
         lookup-only: true
 
     - id: target-cache
@@ -304,6 +305,7 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_parent }}
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+          ${{ steps.resolve.outputs.target_cache_restore_key_lockfile }}
 
     - id: target-cache-managed
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' && (steps.resolve.outputs.build_cache_mode != 'once' || (steps.target-cache-lookup.outputs.cache-hit != 'true' && steps.target-cache-lookup.outputs.cache-matched-key == '')) }}
@@ -314,6 +316,7 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_parent }}
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+          ${{ steps.resolve.outputs.target_cache_restore_key_lockfile }}
 
     - id: phase-target-cache-end
       shell: pwsh
@@ -374,6 +377,7 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_parent }}
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+          ${{ steps.resolve.outputs.target_cache_restore_key_lockfile }}
         lookup-only: true
 
     - id: target-tree-cache
@@ -385,6 +389,7 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_parent }}
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+          ${{ steps.resolve.outputs.target_cache_restore_key_lockfile }}
 
     - id: phase-target-tree-end
       shell: pwsh

--- a/tests/test_resolve_setup_lockfile_only_restore_key.py
+++ b/tests/test_resolve_setup_lockfile_only_restore_key.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESOLVE_SETUP = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "resolve_setup.py"
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    env_exports: dict[str, str]
+    outputs: dict[str, str]
+
+
+def _parse_github_kv_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if "<<" in line:
+            key, delimiter = line.split("<<", 1)
+            index += 1
+            body: list[str] = []
+            while index < len(lines) and lines[index] != delimiter:
+                body.append(lines[index])
+                index += 1
+            values[key] = "\n".join(body)
+        elif "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+        index += 1
+    return values
+
+
+def _run_resolve_setup(
+    extra_env: dict[str, str] | None = None,
+    *,
+    lockfile_contents: str = "# test lockfile\n",
+    workspace_files: dict[str, str] | None = None,
+) -> ResolveResult:
+    with tempfile.TemporaryDirectory(prefix="setup-soldr-tests-") as temp_dir:
+        root = Path(temp_dir)
+        workspace = root / "workspace"
+        runner_temp = root / "runner-temp"
+        home_dir = root / "home"
+        github_env = root / "github-env"
+        github_output = root / "github-output"
+        github_path = root / "github-path"
+        workspace.mkdir()
+        runner_temp.mkdir()
+        home_dir.mkdir()
+        (workspace / "Cargo.lock").write_text(lockfile_contents, encoding="utf-8")
+        if workspace_files:
+            for relative, contents in workspace_files.items():
+                file_path = workspace / relative
+                file_path.parent.mkdir(parents=True, exist_ok=True)
+                file_path.write_text(contents, encoding="utf-8")
+
+        env = os.environ.copy()
+        for key in list(env):
+            if key.startswith(("INPUT_", "ACTION_", "GITHUB_", "SETUP_SOLDR_")):
+                env.pop(key, None)
+        for key in (
+            "CARGO_HOME",
+            "RUSTUP_HOME",
+            "NO_COLOR",
+            "CARGO_TERM_COLOR",
+            "CLICOLOR_FORCE",
+            "FORCE_COLOR",
+        ):
+            env.pop(key, None)
+
+        env.update(
+            {
+                "ACTION_WORKSPACE": str(workspace),
+                "ACTION_OS": "Linux",
+                "ACTION_ARCH": "X64",
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_ENV": str(github_env),
+                "GITHUB_OUTPUT": str(github_output),
+                "GITHUB_PATH": str(github_path),
+                "GITHUB_SHA": "0123456789abcdef",
+                "HOME": str(home_dir),
+                "USERPROFILE": str(home_dir),
+                "INPUT_VERSION": "0.7.11",
+                "INPUT_TIMESTAMPS": "false",
+                "INPUT_TOOLCHAIN_FILE": "",
+                "CARGO_HOME": str(root / "cargo-home"),
+                "RUSTUP_HOME": str(root / "rustup-home"),
+            }
+        )
+        if extra_env:
+            env.update(extra_env)
+
+        proc = subprocess.run(
+            [sys.executable, str(RESOLVE_SETUP)],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        return ResolveResult(
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            env_exports=_parse_github_kv_file(github_env),
+            outputs=_parse_github_kv_file(github_output),
+        )
+
+
+class LockfileOnlyRestoreKeyTests(unittest.TestCase):
+    def test_lockfile_restore_key_emitted_in_once_mode(self) -> None:
+        result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "once"})
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"resolve_setup.py failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        self.assertEqual(result.outputs.get("target_cache_enabled"), "true")
+        lockfile_prefix = result.outputs.get("target_cache_restore_key_lockfile", "")
+        self.assertTrue(
+            lockfile_prefix.startswith("setup-soldr-targetcache-once-v1-linux-x64-"),
+            msg=f"unexpected lockfile prefix shape: {lockfile_prefix!r}",
+        )
+        self.assertTrue(
+            lockfile_prefix.endswith("-"),
+            msg=f"lockfile prefix must be a restore-key (no SHA): {lockfile_prefix!r}",
+        )
+        sha = "0123456789abcdef"
+        self.assertNotIn(sha, lockfile_prefix)
+
+    def test_lockfile_restore_key_emitted_in_full_mode(self) -> None:
+        result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "full"})
+
+        self.assertEqual(result.returncode, 0)
+        lockfile_prefix = result.outputs.get("target_cache_restore_key_lockfile", "")
+        self.assertTrue(
+            lockfile_prefix.startswith("setup-soldr-targetcache-full-v1-linux-x64-"),
+            msg=f"unexpected lockfile prefix shape: {lockfile_prefix!r}",
+        )
+        self.assertTrue(lockfile_prefix.endswith("-"))
+
+    def test_lockfile_restore_key_emitted_in_thin_mode(self) -> None:
+        result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "thin"})
+
+        self.assertEqual(result.returncode, 0)
+        lockfile_prefix = result.outputs.get("target_cache_restore_key_lockfile", "")
+        self.assertTrue(
+            lockfile_prefix.startswith("setup-soldr-targetcache-thin-v1-linux-x64-"),
+            msg=f"unexpected lockfile prefix shape: {lockfile_prefix!r}",
+        )
+
+    def test_lockfile_restore_key_stable_across_manifest_changes(self) -> None:
+        baseline = _run_resolve_setup(
+            {"INPUT_BUILD_CACHE_MODE": "once"},
+            workspace_files={
+                "Cargo.toml": "[package]\nname = \"a\"\nversion = \"0.1.0\"\n",
+            },
+        )
+        manifest_changed = _run_resolve_setup(
+            {"INPUT_BUILD_CACHE_MODE": "once"},
+            workspace_files={
+                "Cargo.toml": (
+                    "[package]\nname = \"a\"\nversion = \"0.1.0\"\n"
+                    "[[bin]]\nname = \"new_bin\"\npath = \"src/main.rs\"\n"
+                ),
+            },
+        )
+
+        self.assertEqual(baseline.returncode, 0)
+        self.assertEqual(manifest_changed.returncode, 0)
+        self.assertNotEqual(
+            baseline.outputs.get("target_cache_restore_key_lock"),
+            manifest_changed.outputs.get("target_cache_restore_key_lock"),
+            msg="manifest change should still alter the narrow restore-key",
+        )
+        self.assertEqual(
+            baseline.outputs.get("target_cache_restore_key_lockfile"),
+            manifest_changed.outputs.get("target_cache_restore_key_lockfile"),
+            msg="lockfile-only restore-key must be stable across manifest changes",
+        )
+
+    def test_lockfile_restore_key_changes_when_lockfile_changes(self) -> None:
+        baseline = _run_resolve_setup(
+            {"INPUT_BUILD_CACHE_MODE": "once"},
+            lockfile_contents="# baseline lockfile\n",
+        )
+        changed = _run_resolve_setup(
+            {"INPUT_BUILD_CACHE_MODE": "once"},
+            lockfile_contents="# different lockfile contents\n",
+        )
+
+        self.assertEqual(baseline.returncode, 0)
+        self.assertEqual(changed.returncode, 0)
+        self.assertNotEqual(
+            baseline.outputs.get("target_cache_restore_key_lockfile"),
+            changed.outputs.get("target_cache_restore_key_lockfile"),
+            msg="lockfile-only restore-key must change when Cargo.lock changes",
+        )
+
+    def test_target_cache_key_unchanged_by_addition(self) -> None:
+        result = _run_resolve_setup({"INPUT_BUILD_CACHE_MODE": "once"})
+
+        self.assertEqual(result.returncode, 0)
+        target_cache_key = result.outputs.get("target_cache_key", "")
+        narrow_prefix = result.outputs.get("target_cache_restore_key_lock", "")
+        lockfile_prefix = result.outputs.get("target_cache_restore_key_lockfile", "")
+
+        self.assertTrue(
+            target_cache_key.startswith(narrow_prefix),
+            msg=(
+                "primary target_cache_key must continue to be derived from the narrow "
+                f"restore-key prefix: key={target_cache_key!r} prefix={narrow_prefix!r}"
+            ),
+        )
+        self.assertTrue(
+            target_cache_key.endswith("0123456789abcdef"),
+            msg=f"primary target_cache_key must end with GITHUB_SHA: {target_cache_key!r}",
+        )
+        self.assertNotEqual(
+            narrow_prefix,
+            lockfile_prefix,
+            msg="lockfile-only prefix must be a distinct fallback, not the narrow prefix",
+        )
+
+    def test_lockfile_restore_key_empty_when_target_cache_disabled(self) -> None:
+        result = _run_resolve_setup({"INPUT_BUILD_CACHE": "false"})
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.outputs.get("target_cache_enabled"), "false")
+        self.assertEqual(result.outputs.get("target_cache_restore_key_lock", ""), "")
+        self.assertEqual(result.outputs.get("target_cache_restore_key_lockfile", ""), "")
+
+    def test_lockfile_restore_key_includes_suffix_fragment(self) -> None:
+        result = _run_resolve_setup(
+            {
+                "INPUT_BUILD_CACHE_MODE": "once",
+                "INPUT_CACHE_KEY_SUFFIX": "myjob",
+            }
+        )
+
+        self.assertEqual(result.returncode, 0)
+        lockfile_prefix = result.outputs.get("target_cache_restore_key_lockfile", "")
+        self.assertTrue(
+            lockfile_prefix.endswith("-myjob-"),
+            msg=f"expected suffix fragment in lockfile prefix: {lockfile_prefix!r}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a second restore-key keyed on \`{Cargo.lock, toolchain}\` after the existing narrow \`{cargo_config, Cargo.lock, manifest, target_shape, toolchain}\` prefix.
- Closes the race where a Rust PR merges to main minutes before an unrelated (UI/docs) PR runs CI: under the new fallback, the unrelated PR can still hit a recent target cache instead of cold-building for ~10 minutes.
- Applied to \`once\`, \`thin\`, and \`full\` target-cache code paths (all 5 \`actions/cache\` steps in \`action.yml\`); emitted empty when target-cache is disabled.

Closes #57.

## Test plan
- [x] \`python -m pytest tests/ -q\` — 92 passed locally (84 prior + 8 new)
- [x] \`pyright .github/actions/setup-soldr/resolve_setup.py\` — 0 errors / 0 warnings
- [x] Primary \`target_cache_key\` is byte-identical (regression test \`test_target_cache_key_unchanged_by_addition\`)
- [x] Lockfile-only prefix stable across manifest-only edits (regression test \`test_lockfile_restore_key_stable_across_manifest_changes\`)
- [x] Lockfile-only prefix changes when \`Cargo.lock\` changes
- [x] Empty when \`target-cache\` disabled
- [ ] CI green on this PR
- [ ] Live verification: a UI-only PR opened minutes after a Rust PR merges hits the lockfile-only restore-key

🤖 Generated with [Claude Code](https://claude.com/claude-code)