### PR TITLE
feat(action): add forward-compatible target-cache pruning inputs (#58)

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -263,6 +263,23 @@ def normalize_target_cache_profile(value: str) -> str:
     return profile
 
 
+_TARGET_CACHE_BOOL_TRUE = {"true", "1", "yes", "on"}
+_TARGET_CACHE_BOOL_FALSE = {"false", "0", "no", "off"}
+
+
+def normalize_target_cache_bool(input_name: str, value: str) -> str | None:
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized in _TARGET_CACHE_BOOL_TRUE:
+        return "true"
+    if normalized in _TARGET_CACHE_BOOL_FALSE:
+        return "false"
+    raise RuntimeError(
+        f"invalid {input_name} {value!r}; expected true, false, 1, 0, yes, no, on, or off"
+    )
+
+
 def _normalize_legacy_target_cache_mode(value: str) -> str:
     mode = value.strip().lower()
     if not mode:
@@ -806,6 +823,30 @@ def main() -> None:
     _write_env("SOLDR_TARGET_CACHE_DIR", str(target_cache_path))
     _write_env("SOLDR_TARGET_CACHE_BUNDLE_DIR", str(target_cache_bundle_path))
     _write_env("SOLDR_TARGET_CACHE_PROFILE", target_cache_profile)
+    target_cache_strip_debuginfo = normalize_target_cache_bool(
+        "target-cache-strip-debuginfo",
+        os.environ.get("INPUT_TARGET_CACHE_STRIP_DEBUGINFO", ""),
+    )
+    if target_cache_strip_debuginfo is not None:
+        _write_env("SOLDR_TARGET_CACHE_STRIP_DEBUGINFO", target_cache_strip_debuginfo)
+    target_cache_include_incremental = normalize_target_cache_bool(
+        "target-cache-include-incremental",
+        os.environ.get("INPUT_TARGET_CACHE_INCLUDE_INCREMENTAL", ""),
+    )
+    if target_cache_include_incremental is not None:
+        _write_env(
+            "SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL",
+            target_cache_include_incremental,
+        )
+    target_cache_include_build_script_binaries = normalize_target_cache_bool(
+        "target-cache-include-build-script-binaries",
+        os.environ.get("INPUT_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES", ""),
+    )
+    if target_cache_include_build_script_binaries is not None:
+        _write_env(
+            "SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES",
+            target_cache_include_build_script_binaries,
+        )
     # setup-soldr already rehydrates the rust-plan bundle directory with
     # actions/cache, so the soldr/zccache layer should operate on that local
     # bundle instead of switching to zccache's separate direct GHA backend.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ jobs:
 | `build-cache-mode` | Rust build cache mode. Default `once` saves a full snapshot on miss, then restores only the local rust-plan bundle on later hits without resaving the full target tree. `thin` is the bounded dependency-artifact alternative. `full` opts into normal whole-target restore/save behavior and should be treated as unbounded. |
 | `target-dir` | Cargo target directory used by soldr when constructing the Rust artifact cache plan. |
 | `target-cache-profile` | Thin-slice pruning policy for the `target/` cache. `thin-v1` (default) keeps `.rlib`/`.rmeta`/proc-macro outputs. `thin-v2` is the aggressive prune that keeps fingerprints + dep-info + final outputs only and relies on the zccache compilation cache to repopulate library bytes. See "Target cache profile" below before opting in. |
+| `target-cache-strip-debuginfo` | Forward-compatible pass-through. When `true`, requests that soldr strip debug-info-bearing artifacts from the target-cache before saving. Requires soldr#237 to take effect; current soldr releases ignore the flag. Default unset (soldr default applies). See "Forward-compatible target-cache pruning inputs" below. |
+| `target-cache-include-incremental` | Forward-compatible pass-through. When `false`, requests that soldr exclude `target/*/incremental/` directories from the target-cache. Requires soldr#237 to take effect. Default unset (soldr default applies). See "Forward-compatible target-cache pruning inputs" below. |
+| `target-cache-include-build-script-binaries` | Forward-compatible pass-through. When `false`, requests that soldr exclude `target/*/build/*-{hash}/build-script-build` binaries from the target-cache. Requires soldr#237 to take effect. Default unset (soldr default applies). See "Forward-compatible target-cache pruning inputs" below. |
 | `source-mtime-normalize` | Opt-in. When `true`, rewrite the mtime of tracked Rust build-input files under `${{ github.workspace }}` to each file's last-commit timestamp before the target-cache restore. Default `false`. See "Source mtime normalization" below. |
 
 ### Legacy Compatibility Inputs
@@ -207,6 +210,35 @@ library bytes that the build still needs.
         with:
           cache: true
           target-cache-profile: thin-v2
+      - run: soldr cargo build --locked --release
+```
+
+## Forward-compatible target-cache pruning inputs
+
+`target-cache-strip-debuginfo`, `target-cache-include-incremental`, and
+`target-cache-include-build-script-binaries` are pass-through knobs that
+export `SOLDR_TARGET_CACHE_STRIP_DEBUGINFO`,
+`SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL`, and
+`SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES` env vars for the
+downstream soldr CLI when they are set to a non-empty value. They have no
+effect on current soldr releases and become active once
+[soldr#237](https://github.com/zackees/soldr/pull/237) ships. Leaving these
+inputs unset preserves byte-identical default behavior, so callers can adopt
+the inputs ahead of the upstream landing without changing today's cache
+shape. Accepted values are `true`/`false`/`1`/`0`/`yes`/`no`/`on`/`off`;
+they are normalized to literal `"true"` or `"false"` before being exported.
+See [issue #58](https://github.com/zackees/setup-soldr/issues/58) for
+background.
+
+```yaml
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+          target-cache-strip-debuginfo: true
+          target-cache-include-incremental: false
+          target-cache-include-build-script-binaries: false
       - run: soldr cargo build --locked --release
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,29 @@ inputs:
       for at least one week.
     required: false
     default: thin-v1
+  target-cache-strip-debuginfo:
+    description: >
+      When "true", requests that soldr strip debug-info-bearing artifacts from
+      the target-cache before saving. Forward-compatible: requires soldr#237 to
+      take effect; current soldr releases ignore the flag. Default "" (unset -
+      soldr default applies).
+    required: false
+    default: ""
+  target-cache-include-incremental:
+    description: >
+      When "false", requests that soldr exclude target/*/incremental/
+      directories from the target-cache. Forward-compatible: requires
+      soldr#237 to take effect. Default "" (unset - soldr default applies).
+    required: false
+    default: ""
+  target-cache-include-build-script-binaries:
+    description: >
+      When "false", requests that soldr exclude
+      target/*/build/*-{hash}/build-script-build binaries from the
+      target-cache. Forward-compatible: requires soldr#237 to take effect.
+      Default "" (unset - soldr default applies).
+    required: false
+    default: ""
   source-mtime-normalize:
     description: >
       Opt-in. When "true", rewrite the mtime of tracked Rust build-input files
@@ -225,6 +248,9 @@ runs:
         INPUT_TARGET_CACHE_MODE: ${{ inputs.target-cache-mode }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
         INPUT_TARGET_CACHE_PROFILE: ${{ inputs.target-cache-profile }}
+        INPUT_TARGET_CACHE_STRIP_DEBUGINFO: ${{ inputs.target-cache-strip-debuginfo }}
+        INPUT_TARGET_CACHE_INCLUDE_INCREMENTAL: ${{ inputs.target-cache-include-incremental }}
+        INPUT_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES: ${{ inputs.target-cache-include-build-script-binaries }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}

--- a/tests/test_resolve_setup_target_cache_pruning_inputs.py
+++ b/tests/test_resolve_setup_target_cache_pruning_inputs.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESOLVE_SETUP = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "resolve_setup.py"
+
+PRUNING_ENV_VARS = (
+    "SOLDR_TARGET_CACHE_STRIP_DEBUGINFO",
+    "SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL",
+    "SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES",
+)
+
+PRUNING_INPUT_TO_ENV = (
+    ("INPUT_TARGET_CACHE_STRIP_DEBUGINFO", "SOLDR_TARGET_CACHE_STRIP_DEBUGINFO"),
+    ("INPUT_TARGET_CACHE_INCLUDE_INCREMENTAL", "SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL"),
+    (
+        "INPUT_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES",
+        "SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    env_exports: dict[str, str]
+    outputs: dict[str, str]
+
+
+def _parse_github_kv_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if "<<" in line:
+            key, delimiter = line.split("<<", 1)
+            index += 1
+            body: list[str] = []
+            while index < len(lines) and lines[index] != delimiter:
+                body.append(lines[index])
+                index += 1
+            values[key] = "\n".join(body)
+        elif "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+        index += 1
+    return values
+
+
+def _run_resolve_setup(
+    extra_env: dict[str, str] | None = None,
+    root_override: Path | None = None,
+) -> ResolveResult:
+    cm = (
+        tempfile.TemporaryDirectory(prefix="setup-soldr-tests-")
+        if root_override is None
+        else None
+    )
+    try:
+        if root_override is not None:
+            root = root_override
+        else:
+            assert cm is not None
+            root = Path(cm.__enter__())
+        workspace = root / "workspace"
+        runner_temp = root / "runner-temp"
+        home_dir = root / "home"
+        github_env = root / "github-env"
+        github_output = root / "github-output"
+        github_path = root / "github-path"
+        workspace.mkdir(exist_ok=True)
+        runner_temp.mkdir(exist_ok=True)
+        home_dir.mkdir(exist_ok=True)
+        (workspace / "Cargo.lock").write_text("# test lockfile\n", encoding="utf-8")
+        if github_env.exists():
+            github_env.unlink()
+        if github_output.exists():
+            github_output.unlink()
+        if github_path.exists():
+            github_path.unlink()
+
+        env = os.environ.copy()
+        for key in list(env):
+            if key.startswith(("INPUT_", "ACTION_", "GITHUB_", "SETUP_SOLDR_")):
+                env.pop(key, None)
+        for key in (
+            "CARGO_HOME",
+            "RUSTUP_HOME",
+            "NO_COLOR",
+            "CARGO_TERM_COLOR",
+            "CLICOLOR_FORCE",
+            "FORCE_COLOR",
+        ):
+            env.pop(key, None)
+
+        env.update(
+            {
+                "ACTION_WORKSPACE": str(workspace),
+                "ACTION_OS": "Linux",
+                "ACTION_ARCH": "X64",
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_ENV": str(github_env),
+                "GITHUB_OUTPUT": str(github_output),
+                "GITHUB_PATH": str(github_path),
+                "GITHUB_SHA": "0123456789abcdef",
+                "HOME": str(home_dir),
+                "USERPROFILE": str(home_dir),
+                "INPUT_VERSION": "0.7.11",
+                "INPUT_TIMESTAMPS": "false",
+                "INPUT_TOOLCHAIN_FILE": "",
+                "CARGO_HOME": str(root / "cargo-home"),
+                "RUSTUP_HOME": str(root / "rustup-home"),
+            }
+        )
+        if extra_env:
+            env.update(extra_env)
+
+        proc = subprocess.run(
+            [sys.executable, str(RESOLVE_SETUP)],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        return ResolveResult(
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            env_exports=_parse_github_kv_file(github_env),
+            outputs=_parse_github_kv_file(github_output),
+        )
+    finally:
+        if cm is not None:
+            cm.__exit__(None, None, None)
+
+
+class TargetCachePruningInputsResolveTests(unittest.TestCase):
+    def test_defaults_do_not_export_pruning_env_vars(self) -> None:
+        result = _run_resolve_setup()
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"resolve_setup.py failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        for name in PRUNING_ENV_VARS:
+            self.assertNotIn(name, result.env_exports)
+
+    def test_empty_pruning_inputs_do_not_export_env_vars(self) -> None:
+        result = _run_resolve_setup(
+            {
+                "INPUT_TARGET_CACHE_STRIP_DEBUGINFO": "",
+                "INPUT_TARGET_CACHE_INCLUDE_INCREMENTAL": "",
+                "INPUT_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES": "",
+            }
+        )
+
+        self.assertEqual(result.returncode, 0)
+        for name in PRUNING_ENV_VARS:
+            self.assertNotIn(name, result.env_exports)
+
+    def test_each_pruning_input_true_exports_literal_true(self) -> None:
+        for input_name, env_name in PRUNING_INPUT_TO_ENV:
+            with self.subTest(input_name=input_name):
+                result = _run_resolve_setup({input_name: "true"})
+
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(result.env_exports.get(env_name), "true")
+
+    def test_each_pruning_input_false_exports_literal_false(self) -> None:
+        for input_name, env_name in PRUNING_INPUT_TO_ENV:
+            with self.subTest(input_name=input_name):
+                result = _run_resolve_setup({input_name: "false"})
+
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(result.env_exports.get(env_name), "false")
+
+    def test_alternate_truthy_aliases_normalize_to_true(self) -> None:
+        for raw in ("1", "yes", "on", "TRUE", " True "):
+            with self.subTest(raw=raw):
+                result = _run_resolve_setup(
+                    {"INPUT_TARGET_CACHE_STRIP_DEBUGINFO": raw}
+                )
+
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(
+                    result.env_exports.get("SOLDR_TARGET_CACHE_STRIP_DEBUGINFO"),
+                    "true",
+                )
+
+    def test_alternate_falsy_aliases_normalize_to_false(self) -> None:
+        for raw in ("0", "no", "off", "FALSE", " False "):
+            with self.subTest(raw=raw):
+                result = _run_resolve_setup(
+                    {"INPUT_TARGET_CACHE_INCLUDE_INCREMENTAL": raw}
+                )
+
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(
+                    result.env_exports.get("SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL"),
+                    "false",
+                )
+
+    def test_invalid_pruning_value_raises_clear_error(self) -> None:
+        for input_name in (
+            "INPUT_TARGET_CACHE_STRIP_DEBUGINFO",
+            "INPUT_TARGET_CACHE_INCLUDE_INCREMENTAL",
+            "INPUT_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES",
+        ):
+            with self.subTest(input_name=input_name):
+                result = _run_resolve_setup({input_name: "maybe"})
+
+                self.assertNotEqual(result.returncode, 0)
+                combined_output = f"{result.stdout}\n{result.stderr}".lower()
+                expected_flag = input_name.removeprefix("INPUT_").lower().replace(
+                    "_", "-"
+                )
+                self.assertIn(f"invalid {expected_flag}", combined_output)
+                self.assertIn("'maybe'", combined_output)
+
+    def test_pruning_inputs_do_not_change_cache_keys(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-tests-shared-") as shared:
+            root = Path(shared)
+            baseline = _run_resolve_setup(root_override=root)
+            with_inputs = _run_resolve_setup(
+                {
+                    "INPUT_TARGET_CACHE_STRIP_DEBUGINFO": "true",
+                    "INPUT_TARGET_CACHE_INCLUDE_INCREMENTAL": "false",
+                    "INPUT_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES": "false",
+                },
+                root_override=root,
+            )
+
+        self.assertEqual(baseline.returncode, 0)
+        self.assertEqual(with_inputs.returncode, 0)
+        self.assertEqual(
+            baseline.outputs.get("cache_key"),
+            with_inputs.outputs.get("cache_key"),
+        )
+        self.assertEqual(
+            baseline.outputs.get("target_cache_key"),
+            with_inputs.outputs.get("target_cache_key"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds three new optional pass-through inputs that export \`SOLDR_TARGET_CACHE_STRIP_DEBUGINFO\`, \`SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL\`, and \`SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES\` env vars to subsequent soldr cargo steps.
- All three default to unset (\`\"\"\`) so byte-identical action behavior is preserved.
- Forward-compatible only: these env vars are no-ops on current soldr releases and activate once [soldr#237](https://github.com/zackees/soldr/issues/237) ships.
- Accepts \`true/false/1/0/yes/no/on/off\` (case-insensitive, trimmed); normalizes to literal \`\"true\"\` / \`\"false\"\`; raises a clear error on invalid values.
- Slice of #58 — the action-side input surface only; pruning content policy stays upstream in soldr#237.

Refs #58.

## Test plan
- [x] \`python -m pytest tests/ -q\` — 100 passed locally (92 prior + 8 new)
- [x] \`pyright .github/actions/setup-soldr/resolve_setup.py\` — 0 errors / 0 warnings
- [x] Regression guard: setting any of the three inputs does not change \`cache_key\` or \`target_cache_key\` (see \`test_pruning_inputs_do_not_change_cache_keys\`)
- [x] Empty / unset inputs do not write any \`SOLDR_TARGET_CACHE_*\` env var (see \`test_defaults_do_not_export_pruning_env_vars\`)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)