### PR TITLE
chore: bump default Soldr version to 0.7.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.15`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.16`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -75,7 +75,7 @@ jobs:
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.15`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.16`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
 | `cache-key-suffix` | Optional escape hatch appended to the cache key. |
@@ -135,7 +135,7 @@ jobs:
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.15`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.16`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action keeps using the runner's existing `CARGO_HOME` unless `CARGO_HOME` is already set by the workflow. When `RUSTUP_HOME` is not explicitly set, setup-soldr prefers the runner's existing rustup home if it already satisfies the requested toolchain/components/targets; otherwise it falls back to a managed `RUSTUP_HOME` under the action cache root and rehydrates that state on later warm runs.

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,9 @@ branding:
   color: green
 inputs:
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.15.
+    description: Soldr version or tag to install. Defaults to 0.7.16.
     required: false
-    default: "0.7.15"
+    default: "0.7.16"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary
- Bumps action default from soldr `0.7.15` → `0.7.16` in `action.yml` (description + default) and updates the three matching default-version mentions in `README.md` (intro, inputs table, notes).
- 0.7.16 ships a CLI zccache session resync fix for the "unknown session:" wrapper error ([soldr#265](https://github.com/zackees/soldr/pull/267)) plus a managed zccache bump from 1.4.0 → 1.4.2. No target-cache wire-format change vs 0.7.15.
- Historical `0.7.15` references (soldr#237 shipping, single-knob profile selector) are left unchanged because that's still factually correct.

## Test plan
- [ ] Confirm the action installs `soldr v0.7.16` on a cold cache run.
- [ ] Confirm `target-cache-profile: thin-v1` (default) keeps producing the legacy slice with no downgrade warning.
- [ ] Confirm opting into `target-cache-profile: thin-v2` against managed zccache 1.4.2 still emits the silent-downgrade warning (so the README's "stay on thin-v1" guidance remains accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)