### PR TITLE
chore: add CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!soldr/**"
+    - "!zccache/**"
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary
- Adds `.coderabbit.yaml` with a `chill` review profile, auto-review on non-draft PRs, and path filters excluding the vendored `soldr/**` and `zccache/**` trees.
- Config only takes effect once the CodeRabbit GitHub App is installed on the repo: https://github.com/apps/coderabbitai/installations/new

## Why these defaults
- `profile: chill` — small Action repo, less noisy than the default `assertive`.
- `drafts: false` — don't review work-in-progress PRs.
- `path_filters: !soldr/**, !zccache/**` — those are vendored upstream source mirrors, not ours to review here.
- `poem: false` — skip the auto-generated PR poem.
- `request_changes_workflow: false` — comments only, no blocking review state.

## Test plan
- [ ] Install the CodeRabbit GitHub App on `zackees/setup-soldr`.
- [ ] Confirm CodeRabbit posts a review on this PR using the chill profile.
- [ ] Confirm it ignores changes under `soldr/**` and `zccache/**` on a future PR that touches those paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)