### PR TITLE
feat(action): add target-cache compression codec and level inputs

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -266,6 +266,48 @@ def normalize_target_cache_profile(value: str) -> str:
 _TARGET_CACHE_BOOL_TRUE = {"true", "1", "yes", "on"}
 _TARGET_CACHE_BOOL_FALSE = {"false", "0", "no", "off"}
 
+_TARGET_CACHE_COMPRESS_CODECS = ("auto", "zstd", "none")
+_TARGET_CACHE_COMPRESS_DEFAULT = "zstd"
+_TARGET_CACHE_COMPRESS_LEVEL_DEFAULT = "3"
+_TARGET_CACHE_COMPRESS_LEVEL_MIN = 1
+_TARGET_CACHE_COMPRESS_LEVEL_MAX = 22
+
+
+def normalize_target_cache_compress(value: str) -> str:
+    codec = value.strip().lower()
+    if not codec:
+        return _TARGET_CACHE_COMPRESS_DEFAULT
+    if codec not in _TARGET_CACHE_COMPRESS_CODECS:
+        expected = ", ".join(_TARGET_CACHE_COMPRESS_CODECS)
+        raise RuntimeError(
+            f"invalid target-cache-compress {value!r}; expected {expected}"
+        )
+    return codec
+
+
+def normalize_target_cache_compress_level(value: str) -> str:
+    raw = value.strip()
+    if not raw:
+        return _TARGET_CACHE_COMPRESS_LEVEL_DEFAULT
+    try:
+        level = int(raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"invalid target-cache-compress-level {value!r}; "
+            f"expected integer between {_TARGET_CACHE_COMPRESS_LEVEL_MIN} and "
+            f"{_TARGET_CACHE_COMPRESS_LEVEL_MAX}"
+        ) from exc
+    if (
+        level < _TARGET_CACHE_COMPRESS_LEVEL_MIN
+        or level > _TARGET_CACHE_COMPRESS_LEVEL_MAX
+    ):
+        raise RuntimeError(
+            f"invalid target-cache-compress-level {value!r}; "
+            f"expected integer between {_TARGET_CACHE_COMPRESS_LEVEL_MIN} and "
+            f"{_TARGET_CACHE_COMPRESS_LEVEL_MAX}"
+        )
+    return str(level)
+
 
 def normalize_target_cache_bool(input_name: str, value: str) -> str | None:
     normalized = value.strip().lower()
@@ -847,6 +889,14 @@ def main() -> None:
             "SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES",
             target_cache_include_build_script_binaries,
         )
+    target_cache_compress = normalize_target_cache_compress(
+        os.environ.get("INPUT_TARGET_CACHE_COMPRESS", "")
+    )
+    target_cache_compress_level = normalize_target_cache_compress_level(
+        os.environ.get("INPUT_TARGET_CACHE_COMPRESS_LEVEL", "")
+    )
+    _write_env("SOLDR_TARGET_CACHE_COMPRESS", target_cache_compress)
+    _write_env("SOLDR_TARGET_CACHE_COMPRESS_LEVEL", target_cache_compress_level)
     # setup-soldr already rehydrates the rust-plan bundle directory with
     # actions/cache, so the soldr/zccache layer should operate on that local
     # bundle instead of switching to zccache's separate direct GHA backend.
@@ -931,6 +981,8 @@ def main() -> None:
             "target_cache_enabled": str(target_cache_enabled).lower(),
             "target_cache_mode": target_cache_effective_mode,
             "target_cache_profile": target_cache_profile,
+            "target_cache_compress": target_cache_compress,
+            "target_cache_compress_level": target_cache_compress_level,
             "target_cache_key": target_cache_key,
             "target_cache_restore_key_parent": target_cache_parent_key,
             "target_cache_restore_key_lock": target_cache_lock_prefix,

--- a/action.yml
+++ b/action.yml
@@ -118,6 +118,23 @@ inputs:
       Default "" (unset - soldr default applies).
     required: false
     default: ""
+  target-cache-compress:
+    description: >
+      Compression codec used when packing the target-cache tar archive.
+      Values: "auto" (let soldr decide), "zstd" (force zstd), or "none"
+      (uncompressed). Default "zstd". Forward-compatible: requires a soldr
+      release that consumes SOLDR_TARGET_CACHE_COMPRESS; older soldr
+      releases ignore the setting and fall back to their built-in behavior.
+    required: false
+    default: "zstd"
+  target-cache-compress-level:
+    description: >
+      Compression level used when target-cache-compress is "zstd" (or "auto"
+      and soldr selects zstd). Accepts integers 1-22; zstd's default is 3.
+      Forward-compatible: requires a soldr release that consumes
+      SOLDR_TARGET_CACHE_COMPRESS_LEVEL.
+    required: false
+    default: "3"
   source-mtime-normalize:
     description: >
       Opt-in. When "true", rewrite the mtime of tracked Rust build-input files
@@ -193,6 +210,12 @@ outputs:
   target-cache-profile:
     description: Effective setup-soldr thin-slice pruning policy (thin-v1 or thin-v2).
     value: ${{ steps.resolve.outputs.target_cache_profile }}
+  target-cache-compress:
+    description: Effective target-cache compression codec (auto, zstd, or none).
+    value: ${{ steps.resolve.outputs.target_cache_compress }}
+  target-cache-compress-level:
+    description: Effective target-cache compression level (1-22) applied when zstd is selected.
+    value: ${{ steps.resolve.outputs.target_cache_compress_level }}
   target-cache-restore-status:
     description: Diagnostic restore status for the Rust target artifact cache state.
     value: ${{ steps.cache-meta.outputs.target_cache_restore_status }}
@@ -254,6 +277,8 @@ runs:
         INPUT_TARGET_CACHE_STRIP_DEBUGINFO: ${{ inputs.target-cache-strip-debuginfo }}
         INPUT_TARGET_CACHE_INCLUDE_INCREMENTAL: ${{ inputs.target-cache-include-incremental }}
         INPUT_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES: ${{ inputs.target-cache-include-build-script-binaries }}
+        INPUT_TARGET_CACHE_COMPRESS: ${{ inputs.target-cache-compress }}
+        INPUT_TARGET_CACHE_COMPRESS_LEVEL: ${{ inputs.target-cache-compress-level }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}

--- a/tests/test_resolve_setup_target_cache_compression.py
+++ b/tests/test_resolve_setup_target_cache_compression.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESOLVE_SETUP = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "resolve_setup.py"
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    env_exports: dict[str, str]
+    outputs: dict[str, str]
+
+
+def _parse_github_kv_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if "<<" in line:
+            key, delimiter = line.split("<<", 1)
+            index += 1
+            body: list[str] = []
+            while index < len(lines) and lines[index] != delimiter:
+                body.append(lines[index])
+                index += 1
+            values[key] = "\n".join(body)
+        elif "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+        index += 1
+    return values
+
+
+def _run_resolve_setup(
+    extra_env: dict[str, str] | None = None,
+    root_override: Path | None = None,
+) -> ResolveResult:
+    cm = (
+        tempfile.TemporaryDirectory(prefix="setup-soldr-tests-")
+        if root_override is None
+        else None
+    )
+    try:
+        if root_override is not None:
+            root = root_override
+        else:
+            assert cm is not None
+            root = Path(cm.__enter__())
+        workspace = root / "workspace"
+        runner_temp = root / "runner-temp"
+        home_dir = root / "home"
+        github_env = root / "github-env"
+        github_output = root / "github-output"
+        github_path = root / "github-path"
+        workspace.mkdir(exist_ok=True)
+        runner_temp.mkdir(exist_ok=True)
+        home_dir.mkdir(exist_ok=True)
+        (workspace / "Cargo.lock").write_text("# test lockfile\n", encoding="utf-8")
+        if github_env.exists():
+            github_env.unlink()
+        if github_output.exists():
+            github_output.unlink()
+        if github_path.exists():
+            github_path.unlink()
+
+        env = os.environ.copy()
+        for key in list(env):
+            if key.startswith(("INPUT_", "ACTION_", "GITHUB_", "SETUP_SOLDR_")):
+                env.pop(key, None)
+        for key in (
+            "CARGO_HOME",
+            "RUSTUP_HOME",
+            "NO_COLOR",
+            "CARGO_TERM_COLOR",
+            "CLICOLOR_FORCE",
+            "FORCE_COLOR",
+        ):
+            env.pop(key, None)
+
+        env.update(
+            {
+                "ACTION_WORKSPACE": str(workspace),
+                "ACTION_OS": "Linux",
+                "ACTION_ARCH": "X64",
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_ENV": str(github_env),
+                "GITHUB_OUTPUT": str(github_output),
+                "GITHUB_PATH": str(github_path),
+                "GITHUB_SHA": "0123456789abcdef",
+                "HOME": str(home_dir),
+                "USERPROFILE": str(home_dir),
+                "INPUT_VERSION": "0.7.11",
+                "INPUT_TIMESTAMPS": "false",
+                "INPUT_TOOLCHAIN_FILE": "",
+                "CARGO_HOME": str(root / "cargo-home"),
+                "RUSTUP_HOME": str(root / "rustup-home"),
+            }
+        )
+        if extra_env:
+            env.update(extra_env)
+
+        proc = subprocess.run(
+            [sys.executable, str(RESOLVE_SETUP)],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        return ResolveResult(
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            env_exports=_parse_github_kv_file(github_env),
+            outputs=_parse_github_kv_file(github_output),
+        )
+    finally:
+        if cm is not None:
+            cm.__exit__(None, None, None)
+
+
+class TargetCacheCompressionResolveTests(unittest.TestCase):
+    def test_default_compress_codec_is_zstd(self) -> None:
+        result = _run_resolve_setup()
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"resolve_setup.py failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        self.assertEqual(result.env_exports.get("SOLDR_TARGET_CACHE_COMPRESS"), "zstd")
+        self.assertEqual(result.outputs.get("target_cache_compress"), "zstd")
+
+    def test_default_compress_level_is_three(self) -> None:
+        result = _run_resolve_setup()
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            result.env_exports.get("SOLDR_TARGET_CACHE_COMPRESS_LEVEL"), "3"
+        )
+        self.assertEqual(result.outputs.get("target_cache_compress_level"), "3")
+
+    def test_explicit_compress_codecs_propagate_to_env(self) -> None:
+        for codec in ("auto", "zstd", "none"):
+            with self.subTest(codec=codec):
+                result = _run_resolve_setup({"INPUT_TARGET_CACHE_COMPRESS": codec})
+
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(
+                    result.env_exports.get("SOLDR_TARGET_CACHE_COMPRESS"), codec
+                )
+                self.assertEqual(result.outputs.get("target_cache_compress"), codec)
+
+    def test_explicit_compress_level_propagates_to_env(self) -> None:
+        for level in ("1", "3", "9", "19"):
+            with self.subTest(level=level):
+                result = _run_resolve_setup(
+                    {"INPUT_TARGET_CACHE_COMPRESS_LEVEL": level}
+                )
+
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(
+                    result.env_exports.get("SOLDR_TARGET_CACHE_COMPRESS_LEVEL"),
+                    level,
+                )
+                self.assertEqual(
+                    result.outputs.get("target_cache_compress_level"), level
+                )
+
+    def test_empty_compress_codec_falls_back_to_zstd_default(self) -> None:
+        result = _run_resolve_setup({"INPUT_TARGET_CACHE_COMPRESS": ""})
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.env_exports.get("SOLDR_TARGET_CACHE_COMPRESS"), "zstd")
+        self.assertEqual(result.outputs.get("target_cache_compress"), "zstd")
+
+    def test_empty_compress_level_falls_back_to_default_three(self) -> None:
+        result = _run_resolve_setup({"INPUT_TARGET_CACHE_COMPRESS_LEVEL": ""})
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            result.env_exports.get("SOLDR_TARGET_CACHE_COMPRESS_LEVEL"), "3"
+        )
+        self.assertEqual(result.outputs.get("target_cache_compress_level"), "3")
+
+    def test_compress_codec_case_is_normalized_to_lowercase(self) -> None:
+        result = _run_resolve_setup({"INPUT_TARGET_CACHE_COMPRESS": " ZSTD "})
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.env_exports.get("SOLDR_TARGET_CACHE_COMPRESS"), "zstd")
+        self.assertEqual(result.outputs.get("target_cache_compress"), "zstd")
+
+    def test_invalid_compress_codec_raises_clear_error(self) -> None:
+        result = _run_resolve_setup({"INPUT_TARGET_CACHE_COMPRESS": "lz4"})
+
+        self.assertNotEqual(result.returncode, 0)
+        combined_output = f"{result.stdout}\n{result.stderr}".lower()
+        self.assertIn("invalid target-cache-compress", combined_output)
+        self.assertIn("'lz4'", combined_output)
+        self.assertIn("auto", combined_output)
+        self.assertIn("zstd", combined_output)
+        self.assertIn("none", combined_output)
+
+    def test_invalid_compress_level_non_integer_raises_clear_error(self) -> None:
+        result = _run_resolve_setup({"INPUT_TARGET_CACHE_COMPRESS_LEVEL": "fast"})
+
+        self.assertNotEqual(result.returncode, 0)
+        combined_output = f"{result.stdout}\n{result.stderr}".lower()
+        self.assertIn("invalid target-cache-compress-level", combined_output)
+        self.assertIn("'fast'", combined_output)
+
+    def test_compress_level_out_of_range_raises_clear_error(self) -> None:
+        for level in ("0", "23", "-1"):
+            with self.subTest(level=level):
+                result = _run_resolve_setup(
+                    {"INPUT_TARGET_CACHE_COMPRESS_LEVEL": level}
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                combined_output = f"{result.stdout}\n{result.stderr}".lower()
+                self.assertIn(
+                    "invalid target-cache-compress-level", combined_output
+                )
+
+    def test_compression_inputs_do_not_change_cache_keys(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="setup-soldr-tests-shared-") as shared:
+            root = Path(shared)
+            baseline = _run_resolve_setup(root_override=root)
+            with_inputs = _run_resolve_setup(
+                {
+                    "INPUT_TARGET_CACHE_COMPRESS": "none",
+                    "INPUT_TARGET_CACHE_COMPRESS_LEVEL": "9",
+                },
+                root_override=root,
+            )
+
+        self.assertEqual(baseline.returncode, 0)
+        self.assertEqual(with_inputs.returncode, 0)
+        self.assertEqual(
+            baseline.outputs.get("cache_key"),
+            with_inputs.outputs.get("cache_key"),
+        )
+        self.assertEqual(
+            baseline.outputs.get("target_cache_key"),
+            with_inputs.outputs.get("target_cache_key"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `target-cache-compress` input (default `zstd`, accepts `auto | zstd | none`) and `target-cache-compress-level` input (default `3`, integer 1-22) to `action.yml`.
- Wires both into `resolve_setup.py` so they export `SOLDR_TARGET_CACHE_COMPRESS` / `SOLDR_TARGET_CACHE_COMPRESS_LEVEL` for the soldr CLI to consume.
- Both inputs are validated, surfaced as outputs, and **do not affect cache keys** — they're forward-compatible, matching the existing pattern used by `target-cache-strip-debuginfo` and friends.

Refs zackees/setup-soldr#70. The actual `tar | zstd` pipe still lives inside the soldr CLI (the natural home — composite actions can't insert work between user-build and post-job cache save). setup-soldr's responsibility here is just the input surface and env-var routing.

## Why the defaults

- `zstd` over `auto` so the inputs *mean* something out of the box.
- `3` matches zstd's own default. The issue argues for `--fast=1` on the perf merits, but level is exposed as an explicit input so consumers can tune.
- `gzip` is intentionally **not** an option — it's the codec we're trying to escape.

## Test plan

11 new TDD tests in `tests/test_resolve_setup_target_cache_compression.py` covering:
- [x] Defaults: codec=`zstd`, level=`3`
- [x] Each codec propagates to env and output
- [x] Each level (1, 3, 9, 19) propagates
- [x] Empty input falls back to default
- [x] Case/whitespace normalization (` ZSTD ` → `zstd`)
- [x] Invalid codec rejects with clear error mentioning all valid choices
- [x] Non-integer level rejects
- [x] Out-of-range levels (`0`, `23`, `-1`) reject
- [x] Compression inputs do not change `cache_key` or `target_cache_key` (forward-compat invariant)

Full suite: `python -m pytest tests/` — 111 passed (11 new + 100 existing).

## Related issues

- zackees/setup-soldr#70 — parent perf issue (codec choice)
- zackees/soldr#272 — companion parallel-tar work (consumes the env vars wired here)
- zackees/zccache#182 — Windows EBUSY blocker on the post-job tar (must land before the perf wins are observable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)