### PR TITLE
fix(ci): make dist bundle deterministic on Windows + update node-version test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "Setup-soldr GitHub Action: installs soldr, provisions Rust toolchain, manages caches. TypeScript port of the composite action.",
   "main": "dist/main.js",
   "scripts": {
-    "build:main": "ncc build src/main.ts -o dist-main --license licenses.txt --no-source-map-register && node -e \"require('fs').copyFileSync('dist-main/index.js','dist/main.js')\"",
-    "build:post": "ncc build src/post.ts -o dist-post --license licenses.txt --no-source-map-register && node -e \"require('fs').copyFileSync('dist-post/index.js','dist/post.js')\"",
+    "build:main": "ncc build src/main.ts -o dist-main --license licenses.txt --no-source-map-register && node scripts/bundle-entrypoint.mjs main",
+    "build:post": "ncc build src/post.ts -o dist-post --license licenses.txt --no-source-map-register && node scripts/bundle-entrypoint.mjs post",
     "build": "npm run build:main && npm run build:post",
     "typecheck": "tsc --noEmit",
     "test": "node --test --experimental-strip-types --import ./__tests__/register-loader.mjs __tests__/log-utils.test.ts __tests__/cache-keys.test.ts __tests__/toolchain.test.ts __tests__/resolve-setup.test.ts __tests__/phase-timing.test.ts __tests__/normalize-source-mtime.test.ts __tests__/detect-shared-target-warning.test.ts __tests__/cache-compress.test.ts __tests__/verify-soldr.test.ts __tests__/ensure-rust-toolchain.test.ts __tests__/ensure-soldr.test.ts __tests__/main.test.ts __tests__/post.test.ts"

--- a/scripts/bundle-entrypoint.mjs
+++ b/scripts/bundle-entrypoint.mjs
@@ -1,0 +1,36 @@
+// Post-process an ncc bundle into dist/<name>.js with LF line endings.
+//
+// Why: ncc inlines tslib.js verbatim into the bundle. On Windows,
+// `node_modules/tslib/tslib.js` is extracted with CRLF line endings by npm,
+// so the bundled output has a CRLF block where tslib lives. On Linux/macOS
+// the same file is LF. That produces non-deterministic dist/ across
+// platforms and trips `Verify dist/ is up to date` in CI.
+//
+// This script copies dist-<name>/index.js to dist/<name>.js and rewrites
+// any CRLF to LF so the result is byte-identical regardless of build host.
+//
+// Usage: node scripts/bundle-entrypoint.mjs main
+//        node scripts/bundle-entrypoint.mjs post
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+
+const name = process.argv[2];
+if (!name) {
+  console.error("usage: node scripts/bundle-entrypoint.mjs <main|post>");
+  process.exit(1);
+}
+
+const sourcePath = `dist-${name}/index.js`;
+const targetPath = `dist/${name}.js`;
+mkdirSync("dist", { recursive: true });
+
+const buf = readFileSync(sourcePath);
+// Normalize CRLF -> LF. Standalone CR (without LF) is left alone — ncc bundles
+// don't emit lone CRs in practice and we want to fail loudly if they appear
+// rather than silently transform.
+const normalized = Buffer.from(buf.toString("utf8").replace(/\r\n/g, "\n"), "utf8");
+writeFileSync(targetPath, normalized);
+
+console.log(
+  `wrote ${targetPath} (${normalized.length} bytes; normalized from ${buf.length} bytes)`,
+);

--- a/tests/test_release_rollout_contract.py
+++ b/tests/test_release_rollout_contract.py
@@ -24,7 +24,10 @@ def test_rollout_contract_workflow_builds_and_tests_the_js_action() -> None:
     )
 
     assert "actions/setup-node@" in workflow
-    assert "node-version: 20" in workflow
+    # Node 22+ is required for --experimental-strip-types used by `npm test`
+    # to run our TypeScript test files via `node --test`. The action runtime
+    # in action.yml (`using: node20`) is independent of this CI Node version.
+    assert "node-version: 22" in workflow
     assert "npm ci" in workflow
     assert "npm run typecheck" in workflow
     assert "npm test" in workflow


### PR DESCRIPTION
## Two failures still on main after #77

CI run: https://github.com/zackees/setup-soldr/actions/runs/25777648889

### 1. `JS Build and Tests` — \`Verify dist/ is up to date\` fails

The committed \`dist/main.js\` and \`dist/post.js\` were built on Linux (LF line endings). When a developer rebuilds them on Windows, ncc inlines \`node_modules/tslib/tslib.js\` verbatim into the bundle — and on Windows, npm extracts tslib's tarball with **CRLF line endings**. That produces a 451-byte-longer bundle (one extra byte per line in the tslib block, ~451 lines), and the dist-up-to-date check fails on every Windows-built rebuild.

The CI failure log showed exactly this pattern in the tslib section:

\`\`\`
-        function fail(e) {
-                        if (r.async) return s |= 2, Promise.resolve(result)...
+        function fail(e) {
+                        if (r.async) return s |= 2, Promise.resolve(result)...
\`\`\`

The \`-\` and \`+\` lines look identical because \`git diff\` doesn't render the trailing CR. Byte-level inspection (`cmp` finds first differing byte at 742715 inside the Microsoft TSLib copyright header) confirmed CRLF vs LF in tslib.

**Fix:** \`scripts/bundle-entrypoint.mjs\` post-processes ncc's output to normalize all CRLF → LF before writing \`dist/<name>.js\`. Build scripts in \`package.json\` now invoke this normalizer in place of the old one-line \`copyFileSync\`. Verified byte-identical output to the previously-committed dist on a Windows rebuild (3,331,443 bytes for main.js, 3,108,576 bytes for post.js).

### 2. \`Contract Tests\` — assertion still expects Node 20

\`tests/test_release_rollout_contract.py\` line 27 asserts \`"node-version: 20" in workflow\`. PR #77 bumped the workflow to Node 22 but didn't update this string match.

**Fix:** assertion updated to \`"node-version: 22"\` with a comment explaining the Node 22.6+ requirement for \`--experimental-strip-types\`.

## Test plan

- [x] Local \`npm run build\` produces byte-identical \`dist/main.js\` + \`dist/post.js\` to what's already committed on main (Windows host).
- [x] \`git diff --exit-code -- dist/\` is clean after rebuild.
- [x] \`npx tsc --noEmit\` clean.
- [x] \`npm test\` — 163/163 passing.
- [x] \`python -m pytest tests/\` — 9/9 passing (including the corrected rollout-contract assertion).

## Why this isn't broader scope

This PR avoids invasive changes:
- No dependency churn (tslib stays as-is; npm's CRLF-on-Windows is a known platform quirk we can't reasonably fix upstream).
- No \`.gitattributes\` shenanigans (tried mentally; would mask the underlying non-determinism rather than fix it).
- No switch to a different bundler.

The normalizer is the minimal, portable fix: post-process the bundler output once, deterministic byte-for-byte across all build hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)