### PR TITLE
chore(action): bump default soldr 0.7.16 -> 0.7.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.16`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.18`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -75,7 +75,7 @@ jobs:
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.16`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.18`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
 | `cache-key-suffix` | Optional escape hatch appended to the cache key. |
@@ -135,7 +135,7 @@ jobs:
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.16`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.18`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action keeps using the runner's existing `CARGO_HOME` unless `CARGO_HOME` is already set by the workflow. When `RUSTUP_HOME` is not explicitly set, setup-soldr prefers the runner's existing rustup home if it already satisfies the requested toolchain/components/targets; otherwise it falls back to a managed `RUSTUP_HOME` under the action cache root and rehydrates that state on later warm runs.

--- a/__tests__/ensure-soldr.test.ts
+++ b/__tests__/ensure-soldr.test.ts
@@ -22,7 +22,7 @@ test("ensureSoldr rejects with a clear message for unknown arch (mocked)", async
       soldrRepo: "zackees/soldr",
       soldrRef: "",
       soldrVersionRequested: "",
-      soldrVersionResolved: "v0.7.16",
+      soldrVersionResolved: "v0.7.18",
     } as Parameters<typeof ensureSoldr>[0]["resolveResult"];
     await assert.rejects(
       ensureSoldr({ resolveResult, githubToken: "" }),

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,9 @@ branding:
   color: green
 inputs:
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.16.
+    description: Soldr version or tag to install. Defaults to 0.7.18.
     required: false
-    default: "0.7.16"
+    default: "0.7.18"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary

- Soldr shipped v0.7.17 and v0.7.18. Bumps the action's default `version` input from `0.7.16` to `0.7.18`.
- Updates the three README mentions of the default and the `soldrVersionResolved` fixture string in `__tests__/ensure-soldr.test.ts` so the test tracks the new default.
- `dist/` is intentionally unchanged: the default is read from `action.yml` at runtime, not bundled into the JS output.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 163/163 pass locally
- [ ] CI green on this PR (in particular `Verify dist/ is up to date` should still pass since `dist/` is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)