### PR TITLE
ci: auto-bump v0 floating tag on push to main

### DIFF
--- a/.github/workflows/update-v0-tag.yml
+++ b/.github/workflows/update-v0-tag.yml
@@ -1,0 +1,41 @@
+name: Update v0 tag
+
+# Keep the floating `v0` major-version tag pointing at the latest `main`.
+# Users who pin to `zackees/setup-soldr@v0` then automatically pick up the
+# newest commit on `main` without each merge requiring a manual tag move.
+#
+# Trigger: every push to `main` (including merge commits from PRs) plus a
+# manual workflow_dispatch escape hatch for one-off catch-up bumps.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-v0-tag
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Force-update v0 tag to current commit
+        env:
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          echo "Pointing v0 at ${TARGET_SHA}"
+          git tag -f v0 "${TARGET_SHA}"
+          git push origin "refs/tags/v0" --force


### PR DESCRIPTION
## Summary

- The `v0` floating major-version tag (what users pin via `uses: zackees/setup-soldr@v0`) had drifted 5 commits behind `main` because tag moves were manual.
- Adds `.github/workflows/update-v0-tag.yml`: on every push to `main` (plus `workflow_dispatch` as an escape hatch), force-update `v0` to point at the just-pushed commit. Uses the default `GITHUB_TOKEN` with `contents: write`, and a concurrency group so two pushes can't race on the tag move.
- Once this PR merges the workflow runs on its own merge commit, so `v0` will catch up to `main` automatically — no manual follow-up needed.

## Test plan

- [ ] After merge, the new workflow runs and `git ls-remote --tags origin refs/tags/v0` resolves to the merge commit's SHA.
- [ ] Subsequent merges (e.g. #80, #81) also advance `v0` without manual intervention.
- [ ] `workflow_dispatch` trigger works when invoked manually from the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)