### PR TITLE
feat: default setup token for GitHub API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,41 @@ jobs:
       - run: soldr cargo test --locked
 ```
 
+## GitHub API Authentication
+
+`setup-soldr` calls the GitHub Releases API to resolve the requested
+`soldr` release and download its platform asset. The action authenticates those
+requests by default with the workflow's `${{ github.token }}` through its
+`token` input. This avoids anonymous API rate limits and transient HTTP 403
+failures on busy CI matrices.
+
+Most workflows do not need to configure anything:
+
+```yaml
+- uses: zackees/setup-soldr@v0
+  with:
+    cache: true
+```
+
+To override the token, pass a token with read access to the release repository:
+
+```yaml
+- uses: zackees/setup-soldr@v0
+  with:
+    token: ${{ secrets.SOLDR_RELEASE_TOKEN }}
+    cache: true
+```
+
+For compatibility with older workflows, `setup-soldr` also honors a
+`GITHUB_TOKEN` environment variable on the step. The explicit `token` input is
+preferred for new workflows.
+
 ## Inputs
 
 | Input | Meaning |
 |---|---|
 | `version` | Soldr release tag or version to install. Defaults to `0.7.18`. |
+| `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
 | `cache-key-suffix` | Optional escape hatch appended to the cache key. |

--- a/__tests__/resolve-setup.test.ts
+++ b/__tests__/resolve-setup.test.ts
@@ -261,6 +261,37 @@ test("explicit version is normalized for cache keying", async () => {
   assert.equal(a["cache_key"], b["cache_key"]);
 });
 
+test("latest release lookup uses token input for GitHub API auth", async () => {
+  const originalFetch = globalThis.fetch;
+  let authorization = "";
+  globalThis.fetch = (async (_url: unknown, init?: { headers?: unknown }) => {
+    const headers = init?.headers as Record<string, string> | undefined;
+    authorization = headers?.["Authorization"] ?? "";
+    return new Response(JSON.stringify({ tag_name: "v0.7.12" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const { root, workspace, runnerTemp } = makeWorkspace({});
+    const ctx = makeContext(root, workspace, runnerTemp);
+    ctx.env = withInputs(ctx.env, {
+      INPUT_VERSION: "latest",
+      INPUT_TOKEN: "input-token",
+    });
+    const inputs = readRawInputs(ctx.env);
+    const result = await resolveSetup(ctx, inputs, {
+      systemRustupOverride: async () => false,
+    });
+
+    assert.equal(result.soldrVersionResolved, "v0.7.12");
+    assert.equal(authorization, "Bearer input-token");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("source ref changes setup cache key", async () => {
   const { outputs: base } = await run({}, { INPUT_REPO: "zackees/soldr" });
   const { outputs: branch } = await run({}, {

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Internal override that builds Soldr from a Git ref instead of downloading a release asset.
     required: false
     default: ""
+  token:
+    description: GitHub token used for authenticated release metadata and asset download requests.
+    required: false
+    default: ${{ github.token }}
   cache:
     description: Restore and save the action-managed cache/state root across workflow runs.
     required: false

--- a/dist/main.js
+++ b/dist/main.js
@@ -61632,7 +61632,7 @@ async function fetchReleaseTagDefault(repo, version, env) {
         "X-GitHub-Api-Version": "2022-11-28",
         "User-Agent": "setup-soldr-action",
     };
-    const token = (env["GITHUB_TOKEN"] ?? "").trim();
+    const token = (env["GITHUB_TOKEN"] ?? "").trim() || (env["INPUT_TOKEN"] ?? "").trim();
     if (token) {
         headers["Authorization"] = `Bearer ${token}`;
     }

--- a/src/lib/resolve-setup.ts
+++ b/src/lib/resolve-setup.ts
@@ -148,7 +148,7 @@ async function fetchReleaseTagDefault(
     "X-GitHub-Api-Version": "2022-11-28",
     "User-Agent": "setup-soldr-action",
   };
-  const token = (env["GITHUB_TOKEN"] ?? "").trim();
+  const token = (env["GITHUB_TOKEN"] ?? "").trim() || (env["INPUT_TOKEN"] ?? "").trim();
   if (token) {
     headers["Authorization"] = `Bearer ${token}`;
   }


### PR DESCRIPTION
## Summary
- add a documented 	oken input that defaults to ${{ github.token }}
- use INPUT_TOKEN for the latest-release lookup path, matching the existing release download path
- document authenticated GitHub API requests and token override behavior in the README

## Verification
- npm run typecheck
- npm test
- npm run build
- git diff --check