### PR TITLE
fix(tests): add token to EXPECTED_INPUTS in contract test

### DIFF
--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -18,11 +18,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 ACTION_PATH = REPO_ROOT / "action.yml"
 
 
-# Inputs preserved verbatim from the original composite action.
+# Full set of inputs the action.yml manifest exposes. Originally preserved
+# verbatim from the composite action; new inputs added since the node20 port
+# are appended here so the contract test continues to guard the public input
+# surface.
 EXPECTED_INPUTS = {
     "version",
     "repo",
     "ref",
+    "token",
     "cache",
     "cache-dir",
     "cache-key-suffix",


### PR DESCRIPTION
## Summary

PR #84 (\`feat: default setup token for GitHub API calls\`) added a \`token\` input to \`action.yml\` but did not update \`tests/test_action_target_cache_wiring.py::EXPECTED_INPUTS\`. The Contract Tests job has been red on \`main\` since e4ea85e.

Failure: https://github.com/zackees/setup-soldr/actions/runs/25820394008/job/75859808299

\`\`\`
AssertionError: assert {'build-cache...y-cache', ...} == {...}
Extra items in the left set:
'token'
\`\`\`

This PR adds \`token\` to the allowlist and updates the leading comment so future input additions know to keep the set in sync.

## Test plan

- [x] \`python -m pytest tests/test_action_target_cache_wiring.py tests/test_release_rollout_contract.py tests/test_zccache_build_demo_workflow.py\` → 9 passed locally
- [ ] CI Contract Tests job green on this PR
- [ ] All other CI jobs (JS Build and Tests, Build zccache) stay green — this change touches only the test allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)