### PR TITLE
feat: flip cargo-registry-cache default to true (closes #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ preferred for new workflows.
 | `target-cache-include-incremental` | Forward-compatible pass-through. When `false`, requests that soldr exclude `target/*/incremental/` directories from the target-cache. Requires soldr#237 to take effect. Default unset (soldr default applies). See "Forward-compatible target-cache pruning inputs" below. |
 | `target-cache-include-build-script-binaries` | Forward-compatible pass-through. When `false`, requests that soldr exclude `target/*/build/*-{hash}/build-script-build` binaries from the target-cache. Requires soldr#237 to take effect. Default unset (soldr default applies). See "Forward-compatible target-cache pruning inputs" below. |
 | `source-mtime-normalize` | Opt-in. When `true`, rewrite the mtime of tracked Rust build-input files under `${{ github.workspace }}` to each file's last-commit timestamp before the target-cache restore. Default `false`. See "Source mtime normalization" below. |
+| `cargo-registry-cache` | When `true` (default), setup-soldr caches `~/.cargo/registry` directly as a fast-zstd `.tar.zst` and exports `SOLDR_SKIP_CARGO_REGISTRY_SAVE=1` so zccache CLI's built-in registry save no-ops. Requires zccache `>=1.4.4` (skip-flag support). Set to `false` to opt out and let zccache own the registry cache via its legacy gzip path. |
 
 ### Legacy Compatibility Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -151,15 +151,15 @@ inputs:
     default: "false"
   cargo-registry-cache:
     description: >
-      Opt-in. When "true", setup-soldr manages a separate actions/cache step
+      When "true" (default), setup-soldr manages a separate actions/cache step
       for ~/.cargo/registry that pre-compresses the directory into a single
       .tar.zst via the embedded setup-soldr-cache-compress sub-action. Also
       exports SOLDR_SKIP_CARGO_REGISTRY_SAVE=1 so the zccache CLI's built-in
-      cargo-registry save no-ops and the payload is not double-saved.
-      Default "false" until the zccache release that honors the skip flag
-      lands; flip to "true" in a follow-up once it does.
+      cargo-registry save (honored in zccache >=1.4.4) no-ops and the
+      payload is not double-saved. Set to "false" to opt out and let
+      zccache own the registry cache via its legacy gzip path.
     required: false
-    default: "false"
+    default: "true"
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.

--- a/dist/main.js
+++ b/dist/main.js
@@ -61896,7 +61896,7 @@ async function resolveSetup(ctx, inputs, deps) {
         }
     }
     // ---- cargo registry cache ----
-    const cargoRegistryCacheRequested = isTruthy(inputs.cargoRegistryCache.trim() || "false");
+    const cargoRegistryCacheRequested = isTruthy(inputs.cargoRegistryCache.trim() || "true");
     const cargoRegistryCachePath = path.join(cargoHome, "registry");
     const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-v1-${runnerOs}-${runnerArch}`;
     const cargoRegistryCacheRestorePrefix = `${cargoRegistryCachePrefix}-${cargoLockHash}-`;

--- a/src/lib/resolve-setup.ts
+++ b/src/lib/resolve-setup.ts
@@ -458,7 +458,7 @@ export async function resolveSetup(
   }
 
   // ---- cargo registry cache ----
-  const cargoRegistryCacheRequested = isTruthy(inputs.cargoRegistryCache.trim() || "false");
+  const cargoRegistryCacheRequested = isTruthy(inputs.cargoRegistryCache.trim() || "true");
   const cargoRegistryCachePath = path.join(cargoHome, "registry");
   const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-v1-${runnerOs}-${runnerArch}`;
   const cargoRegistryCacheRestorePrefix = `${cargoRegistryCachePrefix}-${cargoLockHash}-`;


### PR DESCRIPTION
## Summary

Executes the one-line follow-up tracked in #74. The prerequisite — zccache CLI honoring \`SOLDR_SKIP_CARGO_REGISTRY_SAVE\` — landed in zccache 1.4.4 ([zackees/zccache#184](https://github.com/zackees/zccache/issues/184), released 2026-05-13). With that in place, the action's \`cargo-registry-cache\` input now defaults to \`\"true\"\` so workflows opt **in** to the fast-zstd registry cache (managed by setup-soldr's embedded post-action) without explicit configuration. The exported \`SOLDR_SKIP_CARGO_REGISTRY_SAVE=1\` prevents zccache's legacy gzip save path from double-saving the same payload.

## Changes

- **\`action.yml\`** — default \`\"false\"\` → \`\"true\"\`; rewrote the description to reflect default-on behavior, call out the zccache \`>=1.4.4\` requirement, and document the opt-out path.
- **\`src/lib/resolve-setup.ts\`** — align the in-code fallback used when \`INPUT_CARGO_REGISTRY_CACHE\` is missing/empty (e.g., direct invocation outside GitHub Actions) with the new manifest default.
- **\`README.md\`** — add a row for \`cargo-registry-cache\` in the Inputs table.
- **\`dist/main.js\`** — rebuild via \`npm run build\` so the action.yml-referenced bundle matches.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 164/164 pass
- [x] Python contract tests — 9/9 pass
- [x] \`npm run build\` — dist rebuilt; \`dist/post.js\` unchanged (registry-cache code path lives in main)
- [ ] CI green on this PR
- [ ] On a workflow consuming \`zackees/setup-soldr@v0\` without specifying \`cargo-registry-cache\`, observe that registry cache save runs via setup-soldr's post-action and zccache logs \`cargo-registry save: skipping (SOLDR_SKIP_CARGO_REGISTRY_SAVE=1)\`

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)