### PR TITLE
feat: linker input forwarding SOLDR_LINKER

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ preferred for new workflows.
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty; `components` and `targets` in the file are provisioned during setup. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
+| `linker` | Linker override forwarded as `SOLDR_LINKER`. One of `default`, `ld`, `mold`, `rust-lld`, `fast`. Omit (or leave empty) and `default` both mean "do not export `SOLDR_LINKER`", so soldr's config-file value (if any) stays in effect. |
 | `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
 | `lockfile` | Optional `Cargo.lock` path used for Rust artifact cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
 | `build-cache` | Restore and save Soldr/zccache build cache state across runs. Default `true`; set to `false` to opt out. |

--- a/__tests__/resolve-setup.test.ts
+++ b/__tests__/resolve-setup.test.ts
@@ -426,10 +426,42 @@ test("readRawInputs maps INPUT_* env vars by name", () => {
     INPUT_REPO: "zackees/soldr",
     INPUT_TARGET_CACHE_COMPRESS: "zstd",
     INPUT_CARGO_REGISTRY_CACHE: "true",
+    INPUT_LINKER: "fast",
   });
   assert.equal(inputs.version, "0.7.11");
   assert.equal(inputs.repo, "zackees/soldr");
   assert.equal(inputs.targetCacheCompress, "zstd");
   assert.equal(inputs.cargoRegistryCache, "true");
   assert.equal(inputs.cacheDir, "");
+  assert.equal(inputs.linker, "fast");
+});
+
+// --- linker input ---
+
+test("linker empty does not export SOLDR_LINKER", async () => {
+  const { result } = await run({}, { INPUT_LINKER: "" });
+  assert.equal(result.envExports["SOLDR_LINKER"], undefined);
+});
+
+test("linker 'default' does not export SOLDR_LINKER", async () => {
+  const { result } = await run({}, { INPUT_LINKER: "default" });
+  assert.equal(result.envExports["SOLDR_LINKER"], undefined);
+});
+
+test("linker valid non-default values export SOLDR_LINKER", async () => {
+  for (const value of ["ld", "mold", "rust-lld", "fast"]) {
+    const { result } = await run({}, { INPUT_LINKER: value });
+    assert.equal(result.envExports["SOLDR_LINKER"], value, `linker=${value}`);
+  }
+});
+
+test("linker invalid value throws with helpful message", async () => {
+  await assert.rejects(
+    () => run({}, { INPUT_LINKER: "garbage" }),
+    (err: unknown) => {
+      assert.ok(err instanceof Error);
+      assert.match(err.message, /invalid 'linker' input/);
+      return true;
+    },
+  );
 });

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,13 @@ inputs:
     description: Optional value for SOLDR_TRUST_MODE.
     required: false
     default: ""
+  linker:
+    description: |
+      Linker override forwarded as SOLDR_LINKER.
+      One of: default | ld | mold | rust-lld | fast.
+      Omit or set to empty to leave the linker unspecified.
+    required: false
+    default: ""
   timestamps:
     description: Prefix setup-soldr diagnostic and streamed command output with elapsed mm:ss timestamps.
     required: false

--- a/dist/main.js
+++ b/dist/main.js
@@ -61556,6 +61556,7 @@ const log_utils_js_1 = __nccwpck_require__(28129);
 const toolchain_js_1 = __nccwpck_require__(10260);
 const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
 const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
+const ALLOWED_LINKER_VALUES = ["default", "ld", "mold", "rust-lld", "fast"];
 // CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
 // FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
 // causes "failed to connect to jobserver" warnings in every downstream step.
@@ -61589,6 +61590,7 @@ function readRawInputs(env) {
         toolchain: get("TOOLCHAIN"),
         toolchainFile: get("TOOLCHAIN_FILE"),
         trustMode: get("TRUST_MODE"),
+        linker: get("LINKER"),
         timestamps: get("TIMESTAMPS"),
         lockfile: get("LOCKFILE"),
         buildCache: get("BUILD_CACHE"),
@@ -61962,6 +61964,15 @@ async function resolveSetup(ctx, inputs, deps) {
     }
     if (inputs.trustMode.trim()) {
         setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
+    }
+    const linkerValue = inputs.linker.trim();
+    if (linkerValue) {
+        if (!ALLOWED_LINKER_VALUES.includes(linkerValue)) {
+            throw new Error(`invalid 'linker' input: '${linkerValue}'. Allowed: default | ld | mold | rust-lld | fast`);
+        }
+        if (linkerValue !== "default") {
+            setEnv("SOLDR_LINKER", linkerValue);
+        }
     }
     // ---- path additions ----
     const pathAdditions = [binDir, path.join(cargoHome, "bin")];

--- a/src/lib/resolve-setup.ts
+++ b/src/lib/resolve-setup.ts
@@ -48,6 +48,7 @@ import type {
 
 const FALSY_VALUES: ReadonlySet<string> = new Set(["0", "false", "no", "off"]);
 const TRUTHY_VALUES: ReadonlySet<string> = new Set(["1", "true", "yes", "on"]);
+const ALLOWED_LINKER_VALUES = ["default", "ld", "mold", "rust-lld", "fast"] as const;
 
 // CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
 // FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
@@ -83,6 +84,7 @@ export function readRawInputs(env: Record<string, string | undefined>): RawInput
     toolchain: get("TOOLCHAIN"),
     toolchainFile: get("TOOLCHAIN_FILE"),
     trustMode: get("TRUST_MODE"),
+    linker: get("LINKER"),
     timestamps: get("TIMESTAMPS"),
     lockfile: get("LOCKFILE"),
     buildCache: get("BUILD_CACHE"),
@@ -537,6 +539,17 @@ export async function resolveSetup(
   }
   if (inputs.trustMode.trim()) {
     setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
+  }
+  const linkerValue = inputs.linker.trim();
+  if (linkerValue) {
+    if (!(ALLOWED_LINKER_VALUES as readonly string[]).includes(linkerValue)) {
+      throw new Error(
+        `invalid 'linker' input: '${linkerValue}'. Allowed: default | ld | mold | rust-lld | fast`,
+      );
+    }
+    if (linkerValue !== "default") {
+      setEnv("SOLDR_LINKER", linkerValue);
+    }
   }
 
   // ---- path additions ----

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,6 +27,7 @@ export interface RawInputs {
   toolchain: string;
   toolchainFile: string;
   trustMode: string;
+  linker: string;
   timestamps: string;
   lockfile: string;
   buildCache: string;

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -33,6 +33,7 @@ EXPECTED_INPUTS = {
     "toolchain",
     "toolchain-file",
     "trust-mode",
+    "linker",
     "timestamps",
     "lockfile",
     "build-cache",


### PR DESCRIPTION
## Summary

Adds a `linker:` action input that validates against an enum and forwards the value as the `SOLDR_LINKER` env var for subsequent workflow steps.

- **Enum**: `default | ld | mold | rust-lld | fast`
- **No-export semantics**: empty string AND the literal `default` both skip the export, so soldr's config-file value (if any) stays in effect. Only the four "real" overrides (`ld`, `mold`, `rust-lld`, `fast`) actually set `SOLDR_LINKER`.
- **Validation**: anything outside the enum throws with a message containing `invalid 'linker' input` before any setup work runs.

## Forward compatibility

The action change is forward-compatible with the current soldr binary: older soldr releases that don't recognize `SOLDR_LINKER` will simply ignore the env var. This PR can therefore land independently of (and before) the soldr-side env-var consumer in zackees/soldr#285.

## Test plan

- [x] `npm test` (168 tests, all pass) — covers new positive/negative/empty/`default` cases
- [x] `npm run typecheck`
- [x] `npm run build` — regenerated `dist/main.js` (only file affected; `dist/post.js` unchanged because `resolve-setup` is only imported from `main`)
- [x] `pytest tests/test_action_target_cache_wiring.py` — public-input-surface contract test updated to include `linker`

Closes #87.
See zackees/soldr#285 for the binary-side `SOLDR_LINKER` implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)