### PR TITLE
feat(action): bump default soldr to 0.7.19, add linker + compile-priority inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.18`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.19`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -104,7 +104,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.18`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.19`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -112,7 +112,8 @@ preferred for new workflows.
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty; `components` and `targets` in the file are provisioned during setup. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
-| `linker` | Linker override forwarded as `SOLDR_LINKER`. One of `default`, `ld`, `mold`, `rust-lld`, `fast`. Omit (or leave empty) and `default` both mean "do not export `SOLDR_LINKER`", so soldr's config-file value (if any) stays in effect. |
+| `linker` | Linker override forwarded as `SOLDR_LINKER` (requires soldr 0.7.19+). Empty (default) selects `fast` — mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows — and emits a one-time GitHub Actions warning so the override is visible in CI logs. Soldr's native default is no injection (smaller artifact cache, slower link); pass `platform-default` (or `default`) to opt out and keep cargo/rust-toolchain.toml in charge. Other accepted values pass through verbatim: `ld`, `mold`, `rust-lld`, `fast`. Unknown values raise an error. |
+| `compile-priority` | Compiler/linker child-process priority forwarded as `ZCCACHE_COMPILE_PRIORITY` (requires zccache 1.4.6+). Defaults to `high` because CI runners are dedicated and have no foreground workload to yield to. zccache's native default is `low` (designed for interactive dev). Accepted: `normal`, `low`, `idle`, `high`. Set to empty string to opt out and let zccache pick its native default. |
 | `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
 | `lockfile` | Optional `Cargo.lock` path used for Rust artifact cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
 | `build-cache` | Restore and save Soldr/zccache build cache state across runs. Default `true`; set to `false` to opt out. |
@@ -167,7 +168,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.18`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.19`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action keeps using the runner's existing `CARGO_HOME` unless `CARGO_HOME` is already set by the workflow. When `RUSTUP_HOME` is not explicitly set, setup-soldr prefers the runner's existing rustup home if it already satisfies the requested toolchain/components/targets; otherwise it falls back to a managed `RUSTUP_HOME` under the action cache root and rehydrates that state on later warm runs.

--- a/__tests__/resolve-setup.test.ts
+++ b/__tests__/resolve-setup.test.ts
@@ -408,6 +408,75 @@ test("layout switch alters cache key", async () => {
   assert.notEqual(r1.setupCache.key, r2.setupCache.key);
 });
 
+// --- linker ---
+
+async function runCapturingWarnings(
+  extraEnv: Record<string, string> = {},
+): Promise<{ result: ResolveResult; warnings: string[] }> {
+  const { root, workspace, runnerTemp } = makeWorkspace();
+  const ctx = makeContext(root, workspace, runnerTemp);
+  ctx.env = withInputs(ctx.env, extraEnv);
+  const warnings: string[] = [];
+  ctx.logger = {
+    info: () => {},
+    warning: (msg) => warnings.push(msg),
+    error: () => {},
+    debug: () => {},
+    log: () => {},
+  };
+  const inputs: RawInputs = readRawInputs(ctx.env);
+  const result = await resolveSetup(ctx, inputs, {
+    fetchReleaseTag: async () => "v0.7.11",
+    systemRustupOverride: async () => false,
+  });
+  return { result, warnings };
+}
+
+test("linker default exports SOLDR_LINKER=fast and warns", async () => {
+  const { result, warnings } = await runCapturingWarnings();
+  assert.equal(result.envExports["SOLDR_LINKER"], "fast");
+  assert.equal(
+    warnings.some((m) => m.includes("SOLDR_LINKER=fast") && m.includes("platform-default")),
+    true,
+    `expected linker warning, got: ${JSON.stringify(warnings)}`,
+  );
+});
+
+test("linker platform-default omits SOLDR_LINKER and does not warn", async () => {
+  const { result, warnings } = await runCapturingWarnings({ INPUT_LINKER: "platform-default" });
+  assert.equal(result.envExports["SOLDR_LINKER"], undefined);
+  assert.equal(warnings.some((m) => m.includes("SOLDR_LINKER")), false);
+});
+
+test("linker explicit value passes through verbatim without warning", async () => {
+  const { result, warnings } = await runCapturingWarnings({ INPUT_LINKER: "rust-lld" });
+  assert.equal(result.envExports["SOLDR_LINKER"], "rust-lld");
+  assert.equal(warnings.some((m) => m.includes("SOLDR_LINKER")), false);
+});
+
+test("linker explicit fast passes through without warning", async () => {
+  const { result, warnings } = await runCapturingWarnings({ INPUT_LINKER: "fast" });
+  assert.equal(result.envExports["SOLDR_LINKER"], "fast");
+  assert.equal(warnings.some((m) => m.includes("SOLDR_LINKER")), false);
+});
+
+// --- compile-priority ---
+
+test("compile-priority defaults to high via action.yml", async () => {
+  const { result } = await run({}, { INPUT_COMPILE_PRIORITY: "high" });
+  assert.equal(result.envExports["ZCCACHE_COMPILE_PRIORITY"], "high");
+});
+
+test("compile-priority explicit low passes through verbatim", async () => {
+  const { result } = await run({}, { INPUT_COMPILE_PRIORITY: "low" });
+  assert.equal(result.envExports["ZCCACHE_COMPILE_PRIORITY"], "low");
+});
+
+test("compile-priority empty string skips export so zccache uses its native default", async () => {
+  const { result } = await run({}, { INPUT_COMPILE_PRIORITY: "" });
+  assert.equal(result.envExports["ZCCACHE_COMPILE_PRIORITY"], undefined);
+});
+
 // --- jobserver env deny list ---
 
 test("CARGO_MAKEFLAGS / MAKEFLAGS are never exported", async () => {
@@ -436,19 +505,14 @@ test("readRawInputs maps INPUT_* env vars by name", () => {
   assert.equal(inputs.linker, "fast");
 });
 
-// --- linker input ---
+// --- linker input (validation + alias semantics) ---
 
-test("linker empty does not export SOLDR_LINKER", async () => {
-  const { result } = await run({}, { INPUT_LINKER: "" });
-  assert.equal(result.envExports["SOLDR_LINKER"], undefined);
-});
-
-test("linker 'default' does not export SOLDR_LINKER", async () => {
+test("linker 'default' opts out and does not export SOLDR_LINKER", async () => {
   const { result } = await run({}, { INPUT_LINKER: "default" });
   assert.equal(result.envExports["SOLDR_LINKER"], undefined);
 });
 
-test("linker valid non-default values export SOLDR_LINKER", async () => {
+test("linker valid non-opt-out values export SOLDR_LINKER", async () => {
   for (const value of ["ld", "mold", "rust-lld", "fast"]) {
     const { result } = await run({}, { INPUT_LINKER: value });
     assert.equal(result.envExports["SOLDR_LINKER"], value, `linker=${value}`);

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,9 @@ branding:
   color: green
 inputs:
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.18.
+    description: Soldr version or tag to install. Defaults to 0.7.19.
     required: false
-    default: "0.7.18"
+    default: "0.7.19"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false
@@ -46,12 +46,30 @@ inputs:
     required: false
     default: ""
   linker:
-    description: |
-      Linker override forwarded as SOLDR_LINKER.
-      One of: default | ld | mold | rust-lld | fast.
-      Omit or set to empty to leave the linker unspecified.
+    description: >
+      Linker override forwarded as SOLDR_LINKER for `soldr cargo ...` builds
+      (requires soldr 0.7.19+). Empty (the default) opts the workflow into
+      `fast` — mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS and
+      Windows — and emits a one-time GitHub Actions warning so the override
+      is visible in CI logs. Soldr's own native default is no injection
+      (smaller artifact cache, slower link); pass `platform-default` (or
+      `default`) to opt out and keep whatever cargo config /
+      rust-toolchain.toml specifies. Other accepted values pass through
+      verbatim to SOLDR_LINKER: `ld`, `mold`, `rust-lld`, `fast`. Unknown
+      values raise an error.
     required: false
     default: ""
+  compile-priority:
+    description: >
+      Compiler/linker child-process priority forwarded as
+      ZCCACHE_COMPILE_PRIORITY (requires zccache 1.4.6+). Setup-soldr defaults
+      to `high` because GitHub Actions runners are dedicated to CI and have
+      no foreground workload to yield to — zccache's own native default is
+      `low` (designed for interactive dev). Accepted values:
+      `normal`, `low`, `idle`, `high`. Set to empty string to opt out and
+      let zccache pick its native default.
+    required: false
+    default: "high"
   timestamps:
     description: Prefix setup-soldr diagnostic and streamed command output with elapsed mm:ss timestamps.
     required: false

--- a/dist/main.js
+++ b/dist/main.js
@@ -61556,7 +61556,14 @@ const log_utils_js_1 = __nccwpck_require__(28129);
 const toolchain_js_1 = __nccwpck_require__(10260);
 const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
 const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
-const ALLOWED_LINKER_VALUES = ["default", "ld", "mold", "rust-lld", "fast"];
+const ALLOWED_LINKER_VALUES = [
+    "default",
+    "platform-default",
+    "ld",
+    "mold",
+    "rust-lld",
+    "fast",
+];
 // CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
 // FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
 // causes "failed to connect to jobserver" warnings in every downstream step.
@@ -61591,6 +61598,7 @@ function readRawInputs(env) {
         toolchainFile: get("TOOLCHAIN_FILE"),
         trustMode: get("TRUST_MODE"),
         linker: get("LINKER"),
+        compilePriority: get("COMPILE_PRIORITY"),
         timestamps: get("TIMESTAMPS"),
         lockfile: get("LOCKFILE"),
         buildCache: get("BUILD_CACHE"),
@@ -61965,14 +61973,20 @@ async function resolveSetup(ctx, inputs, deps) {
     if (inputs.trustMode.trim()) {
         setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
     }
-    const linkerValue = inputs.linker.trim();
-    if (linkerValue) {
-        if (!ALLOWED_LINKER_VALUES.includes(linkerValue)) {
-            throw new Error(`invalid 'linker' input: '${linkerValue}'. Allowed: default | ld | mold | rust-lld | fast`);
-        }
-        if (linkerValue !== "default") {
-            setEnv("SOLDR_LINKER", linkerValue);
-        }
+    const linkerRaw = inputs.linker.trim();
+    if (linkerRaw === "") {
+        setEnv("SOLDR_LINKER", "fast");
+        logger.warning("setup-soldr: defaulting SOLDR_LINKER=fast (mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows) for faster CI links. Soldr's native default is no injection, which produces a smaller build-cache and a slower link. Set `linker: platform-default` to opt out and keep cargo/rust-toolchain.toml in charge, or set `linker: <value>` to silence this warning.");
+    }
+    else if (!ALLOWED_LINKER_VALUES.includes(linkerRaw)) {
+        throw new Error(`invalid 'linker' input: '${linkerRaw}'. Allowed: default | platform-default | ld | mold | rust-lld | fast`);
+    }
+    else if (linkerRaw !== "default" && linkerRaw !== "platform-default") {
+        setEnv("SOLDR_LINKER", linkerRaw);
+    }
+    const compilePriorityRaw = inputs.compilePriority.trim();
+    if (compilePriorityRaw !== "") {
+        setEnv("ZCCACHE_COMPILE_PRIORITY", compilePriorityRaw);
     }
     // ---- path additions ----
     const pathAdditions = [binDir, path.join(cargoHome, "bin")];

--- a/src/lib/resolve-setup.ts
+++ b/src/lib/resolve-setup.ts
@@ -48,7 +48,14 @@ import type {
 
 const FALSY_VALUES: ReadonlySet<string> = new Set(["0", "false", "no", "off"]);
 const TRUTHY_VALUES: ReadonlySet<string> = new Set(["1", "true", "yes", "on"]);
-const ALLOWED_LINKER_VALUES = ["default", "ld", "mold", "rust-lld", "fast"] as const;
+const ALLOWED_LINKER_VALUES = [
+  "default",
+  "platform-default",
+  "ld",
+  "mold",
+  "rust-lld",
+  "fast",
+] as const;
 
 // CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
 // FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
@@ -85,6 +92,7 @@ export function readRawInputs(env: Record<string, string | undefined>): RawInput
     toolchainFile: get("TOOLCHAIN_FILE"),
     trustMode: get("TRUST_MODE"),
     linker: get("LINKER"),
+    compilePriority: get("COMPILE_PRIORITY"),
     timestamps: get("TIMESTAMPS"),
     lockfile: get("LOCKFILE"),
     buildCache: get("BUILD_CACHE"),
@@ -540,16 +548,22 @@ export async function resolveSetup(
   if (inputs.trustMode.trim()) {
     setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
   }
-  const linkerValue = inputs.linker.trim();
-  if (linkerValue) {
-    if (!(ALLOWED_LINKER_VALUES as readonly string[]).includes(linkerValue)) {
-      throw new Error(
-        `invalid 'linker' input: '${linkerValue}'. Allowed: default | ld | mold | rust-lld | fast`,
-      );
-    }
-    if (linkerValue !== "default") {
-      setEnv("SOLDR_LINKER", linkerValue);
-    }
+  const linkerRaw = inputs.linker.trim();
+  if (linkerRaw === "") {
+    setEnv("SOLDR_LINKER", "fast");
+    logger.warning(
+      "setup-soldr: defaulting SOLDR_LINKER=fast (mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows) for faster CI links. Soldr's native default is no injection, which produces a smaller build-cache and a slower link. Set `linker: platform-default` to opt out and keep cargo/rust-toolchain.toml in charge, or set `linker: <value>` to silence this warning.",
+    );
+  } else if (!(ALLOWED_LINKER_VALUES as readonly string[]).includes(linkerRaw)) {
+    throw new Error(
+      `invalid 'linker' input: '${linkerRaw}'. Allowed: default | platform-default | ld | mold | rust-lld | fast`,
+    );
+  } else if (linkerRaw !== "default" && linkerRaw !== "platform-default") {
+    setEnv("SOLDR_LINKER", linkerRaw);
+  }
+  const compilePriorityRaw = inputs.compilePriority.trim();
+  if (compilePriorityRaw !== "") {
+    setEnv("ZCCACHE_COMPILE_PRIORITY", compilePriorityRaw);
   }
 
   // ---- path additions ----

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface RawInputs {
   toolchainFile: string;
   trustMode: string;
   linker: string;
+  compilePriority: string;
   timestamps: string;
   lockfile: string;
   buildCache: string;

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -34,6 +34,7 @@ EXPECTED_INPUTS = {
     "toolchain-file",
     "trust-mode",
     "linker",
+    "compile-priority",
     "timestamps",
     "lockfile",
     "build-cache",


### PR DESCRIPTION
## Summary

- Default soldr version bumped `0.7.18` → `0.7.19` in `action.yml` + README (4 mentions).
- New `linker` input forwarded as `SOLDR_LINKER` (soldr#287). Empty default → `fast` with a one-time `core.warning` so the override is visible in CI logs; `platform-default` opts out; explicit values pass through verbatim.
- New `compile-priority` input forwarded as `ZCCACHE_COMPILE_PRIORITY` (zccache#225). Defaults to `high` since GitHub Actions runners are dedicated to CI and have no foreground workload to yield to (zccache's own default is `low`, designed for interactive dev).
- Contract test `EXPECTED_INPUTS` extended; 7 new resolve-setup unit tests cover default-with-warning, opt-out, explicit passthrough, no-warning-when-explicit.

## Why these defaults

**`linker: fast`** — On a clean CI checkout the linker step dominates incremental rebuilds. `fast` (mold→rust-lld) measurably trims link time. We warn (and document) that this enlarges the build cache vs. soldr's native no-inject default, so users who hit cache-size budgets can opt back with `linker: platform-default`.

**`compile-priority: high`** — GHA runners aren't shared. zccache defaults to `low` to coexist with interactive workloads; that's a pessimization for CI. Pushing to `high` reclaims that headroom.

## Sqlite

Investigated whether sqlite still lives anywhere after soldr#298's redb migration. Upstream soldr 0.7.19 `crates/soldr-cache/Cargo.toml` is redb-only; zccache only mentions sqlite in `DESIGN_DECISIONS.md` documenting its rejection. The vendored `soldr/` submodule in this repo is pinned at 0.7.14 (pre-#298) but only serves as a local dev clone — it doesn't ship in `dist/`. No issue filed; nothing to fix.

## Test plan

- [x] `npm run build` (rebuilt `dist/main.js`)
- [x] `npm test` — 171/171 passing (7 new tests for linker + compile-priority wiring)
- [x] `python -m pytest tests/test_action_target_cache_wiring.py` — 3/3 passing
- [ ] CI green on this PR
- [ ] Smoke a downstream workflow with `linker: platform-default` to confirm opt-out path is silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)