### PR TITLE
Use released soldr in zccache demo

### DIFF
--- a/.github/workflows/zccache-build-demo.yml
+++ b/.github/workflows/zccache-build-demo.yml
@@ -112,12 +112,10 @@ jobs:
 
           requested="$REQUESTED_INTEGRATION_REF"
           zccache_ref="$(resolve_ref zackees/zccache "$requested")"
-          soldr_ref="$(resolve_ref zackees/soldr "$requested")"
 
           {
             echo "requested_ref=$requested"
             echo "zccache_ref=$zccache_ref"
-            echo "soldr_ref=$soldr_ref"
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout zccache
@@ -137,7 +135,6 @@ jobs:
           target-dir: zccache/target
           cache-key-suffix: ${{ env.DEMO_CACHE_SUFFIX }}
           repo: zackees/soldr
-          ref: ${{ steps.resolve-refs.outputs.soldr_ref }}
 
       - name: Show cache plan
         shell: bash
@@ -148,9 +145,9 @@ jobs:
             echo "| Output | Value |"
             echo "| --- | --- |"
             echo "| soldr-version | \`${{ steps.setup.outputs.soldr-version }}\` |"
+            echo "| soldr-install | \`release asset\` |"
             echo "| requested-integration-ref | \`${{ steps.resolve-refs.outputs.requested_ref }}\` |"
             echo "| zccache-ref | \`${{ steps.resolve-refs.outputs.zccache_ref }}\` |"
-            echo "| soldr-ref | \`${{ steps.resolve-refs.outputs.soldr_ref }}\` |"
             echo "| cache-restore-status | \`${{ steps.setup.outputs.cache-restore-status }}\` |"
             echo "| build-cache-restore-status | \`${{ steps.setup.outputs.build-cache-restore-status }}\` |"
             echo "| build-cache-mode | \`${{ steps.setup.outputs.build-cache-mode }}\` |"
@@ -220,12 +217,10 @@ jobs:
 
           requested="$REQUESTED_INTEGRATION_REF"
           zccache_ref="$(resolve_ref zackees/zccache "$requested")"
-          soldr_ref="$(resolve_ref zackees/soldr "$requested")"
 
           {
             echo "requested_ref=$requested"
             echo "zccache_ref=$zccache_ref"
-            echo "soldr_ref=$soldr_ref"
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout zccache
@@ -245,7 +240,6 @@ jobs:
           target-dir: zccache/target
           cache-key-suffix: ${{ env.DEMO_CACHE_SUFFIX }}
           repo: zackees/soldr
-          ref: ${{ steps.resolve-refs.outputs.soldr_ref }}
 
       - name: Show cache plan
         shell: bash
@@ -256,9 +250,9 @@ jobs:
             echo "| Output | Value |"
             echo "| --- | --- |"
             echo "| soldr-version | \`${{ steps.setup.outputs.soldr-version }}\` |"
+            echo "| soldr-install | \`release asset\` |"
             echo "| requested-integration-ref | \`${{ steps.resolve-refs.outputs.requested_ref }}\` |"
             echo "| zccache-ref | \`${{ steps.resolve-refs.outputs.zccache_ref }}\` |"
-            echo "| soldr-ref | \`${{ steps.resolve-refs.outputs.soldr_ref }}\` |"
             echo "| cache-restore-status | \`${{ steps.setup.outputs.cache-restore-status }}\` |"
             echo "| build-cache-restore-status | \`${{ steps.setup.outputs.build-cache-restore-status }}\` |"
             echo "| build-cache-mode | \`${{ steps.setup.outputs.build-cache-mode }}\` |"

--- a/tests/test_zccache_build_demo_workflow.py
+++ b/tests/test_zccache_build_demo_workflow.py
@@ -10,7 +10,7 @@ def _workflow_text() -> str:
     )
 
 
-def test_demo_workflow_resolves_upstream_refs_with_fallbacks() -> None:
+def test_demo_workflow_resolves_zccache_ref_with_fallbacks() -> None:
     workflow = _workflow_text()
 
     assert "REQUESTED_INTEGRATION_REF: ${{ github.ref_name }}" in workflow
@@ -18,16 +18,17 @@ def test_demo_workflow_resolves_upstream_refs_with_fallbacks() -> None:
     assert 'requested="$REQUESTED_INTEGRATION_REF"' in workflow
     assert 'git ls-remote --exit-code --heads "https://github.com/${repo}.git" "$requested"' in workflow
     assert "ref: ${{ steps.resolve-refs.outputs.zccache_ref }}" in workflow
-    assert "ref: ${{ steps.resolve-refs.outputs.soldr_ref }}" in workflow
+    assert "soldr_ref" not in workflow
 
 
-def test_demo_workflow_uses_checked_out_action_and_resolved_soldr_repo() -> None:
+def test_demo_workflow_uses_checked_out_action_and_released_soldr() -> None:
     workflow = _workflow_text()
 
     assert "name: Checkout setup-soldr action" in workflow
     assert "uses: ./setup-soldr" in workflow
     assert "repo: zackees/soldr" in workflow
-    assert "ref: ${{ steps.resolve-refs.outputs.soldr_ref }}" in workflow
+    assert "soldr-install | \\`release asset\\`" in workflow
+    assert "ref: ${{ steps.resolve-refs.outputs.soldr_ref }}" not in workflow
 
 
 def test_demo_workflow_preserves_cold_then_warm_rollout_path() -> None:


### PR DESCRIPTION
## Summary
- Stop resolving a soldr branch/ref for the zccache cache speed demo
- Let setup-soldr install its released default soldr binary instead of building soldr from source
- Keep the requested integration ref only for the zccache checkout

## Test Plan
- git diff --check