### PR TITLE
feat(stats): add stats and debug inputs for cache diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.18`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.19`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -104,7 +104,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.18`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.19`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -112,7 +112,8 @@ preferred for new workflows.
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty; `components` and `targets` in the file are provisioned during setup. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
-| `linker` | Linker override forwarded as `SOLDR_LINKER`. One of `default`, `ld`, `mold`, `rust-lld`, `fast`. Omit (or leave empty) and `default` both mean "do not export `SOLDR_LINKER`", so soldr's config-file value (if any) stays in effect. |
+| `linker` | Linker override forwarded as `SOLDR_LINKER` (requires soldr 0.7.19+). Empty (default) selects `fast` — mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows — and emits a one-time GitHub Actions warning so the override is visible in CI logs. Soldr's native default is no injection (smaller artifact cache, slower link); pass `platform-default` (or `default`) to opt out and keep cargo/rust-toolchain.toml in charge. Other accepted values pass through verbatim: `ld`, `mold`, `rust-lld`, `fast`. Unknown values raise an error. |
+| `compile-priority` | Compiler/linker child-process priority forwarded as `ZCCACHE_COMPILE_PRIORITY` (requires zccache 1.4.6+). Defaults to `high` because CI runners are dedicated and have no foreground workload to yield to. zccache's native default is `low` (designed for interactive dev). Accepted: `normal`, `low`, `idle`, `high`. Set to empty string to opt out and let zccache pick its native default. |
 | `timestamps` | Prefix setup-soldr diagnostics and streamed command output with elapsed `mm:ss` timestamps. Default `true`; set to `false` to opt out. |
 | `lockfile` | Optional `Cargo.lock` path used for Rust artifact cache keying. Empty infers `Cargo.lock` next to `target-dir`, then workspace `Cargo.lock`. |
 | `build-cache` | Restore and save Soldr/zccache build cache state across runs. Default `true`; set to `false` to opt out. |
@@ -167,7 +168,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.18`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.19`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action keeps using the runner's existing `CARGO_HOME` unless `CARGO_HOME` is already set by the workflow. When `RUSTUP_HOME` is not explicitly set, setup-soldr prefers the runner's existing rustup home if it already satisfies the requested toolchain/components/targets; otherwise it falls back to a managed `RUSTUP_HOME` under the action cache root and rehydrates that state on later warm runs.

--- a/__tests__/resolve-setup.test.ts
+++ b/__tests__/resolve-setup.test.ts
@@ -408,6 +408,75 @@ test("layout switch alters cache key", async () => {
   assert.notEqual(r1.setupCache.key, r2.setupCache.key);
 });
 
+// --- linker ---
+
+async function runCapturingWarnings(
+  extraEnv: Record<string, string> = {},
+): Promise<{ result: ResolveResult; warnings: string[] }> {
+  const { root, workspace, runnerTemp } = makeWorkspace();
+  const ctx = makeContext(root, workspace, runnerTemp);
+  ctx.env = withInputs(ctx.env, extraEnv);
+  const warnings: string[] = [];
+  ctx.logger = {
+    info: () => {},
+    warning: (msg) => warnings.push(msg),
+    error: () => {},
+    debug: () => {},
+    log: () => {},
+  };
+  const inputs: RawInputs = readRawInputs(ctx.env);
+  const result = await resolveSetup(ctx, inputs, {
+    fetchReleaseTag: async () => "v0.7.11",
+    systemRustupOverride: async () => false,
+  });
+  return { result, warnings };
+}
+
+test("linker default exports SOLDR_LINKER=fast and warns", async () => {
+  const { result, warnings } = await runCapturingWarnings();
+  assert.equal(result.envExports["SOLDR_LINKER"], "fast");
+  assert.equal(
+    warnings.some((m) => m.includes("SOLDR_LINKER=fast") && m.includes("platform-default")),
+    true,
+    `expected linker warning, got: ${JSON.stringify(warnings)}`,
+  );
+});
+
+test("linker platform-default omits SOLDR_LINKER and does not warn", async () => {
+  const { result, warnings } = await runCapturingWarnings({ INPUT_LINKER: "platform-default" });
+  assert.equal(result.envExports["SOLDR_LINKER"], undefined);
+  assert.equal(warnings.some((m) => m.includes("SOLDR_LINKER")), false);
+});
+
+test("linker explicit value passes through verbatim without warning", async () => {
+  const { result, warnings } = await runCapturingWarnings({ INPUT_LINKER: "rust-lld" });
+  assert.equal(result.envExports["SOLDR_LINKER"], "rust-lld");
+  assert.equal(warnings.some((m) => m.includes("SOLDR_LINKER")), false);
+});
+
+test("linker explicit fast passes through without warning", async () => {
+  const { result, warnings } = await runCapturingWarnings({ INPUT_LINKER: "fast" });
+  assert.equal(result.envExports["SOLDR_LINKER"], "fast");
+  assert.equal(warnings.some((m) => m.includes("SOLDR_LINKER")), false);
+});
+
+// --- compile-priority ---
+
+test("compile-priority defaults to high via action.yml", async () => {
+  const { result } = await run({}, { INPUT_COMPILE_PRIORITY: "high" });
+  assert.equal(result.envExports["ZCCACHE_COMPILE_PRIORITY"], "high");
+});
+
+test("compile-priority explicit low passes through verbatim", async () => {
+  const { result } = await run({}, { INPUT_COMPILE_PRIORITY: "low" });
+  assert.equal(result.envExports["ZCCACHE_COMPILE_PRIORITY"], "low");
+});
+
+test("compile-priority empty string skips export so zccache uses its native default", async () => {
+  const { result } = await run({}, { INPUT_COMPILE_PRIORITY: "" });
+  assert.equal(result.envExports["ZCCACHE_COMPILE_PRIORITY"], undefined);
+});
+
 // --- jobserver env deny list ---
 
 test("CARGO_MAKEFLAGS / MAKEFLAGS are never exported", async () => {
@@ -436,19 +505,14 @@ test("readRawInputs maps INPUT_* env vars by name", () => {
   assert.equal(inputs.linker, "fast");
 });
 
-// --- linker input ---
+// --- linker input (validation + alias semantics) ---
 
-test("linker empty does not export SOLDR_LINKER", async () => {
-  const { result } = await run({}, { INPUT_LINKER: "" });
-  assert.equal(result.envExports["SOLDR_LINKER"], undefined);
-});
-
-test("linker 'default' does not export SOLDR_LINKER", async () => {
+test("linker 'default' opts out and does not export SOLDR_LINKER", async () => {
   const { result } = await run({}, { INPUT_LINKER: "default" });
   assert.equal(result.envExports["SOLDR_LINKER"], undefined);
 });
 
-test("linker valid non-default values export SOLDR_LINKER", async () => {
+test("linker valid non-opt-out values export SOLDR_LINKER", async () => {
   for (const value of ["ld", "mold", "rust-lld", "fast"]) {
     const { result } = await run({}, { INPUT_LINKER: value });
     assert.equal(result.envExports["SOLDR_LINKER"], value, `linker=${value}`);

--- a/action.yml
+++ b/action.yml
@@ -185,6 +185,25 @@ inputs:
       zccache own the registry cache via its legacy gzip path.
     required: false
     default: "true"
+  stats:
+    description: >
+      Controls diagnostic output for cache operations. "none" suppresses all
+      stats output. "summarize" (default) prints a compact hit/miss table after
+      setup showing each cache's status, matched key, archive/inflated sizes, and
+      restore time. "detailed" adds full JSON stats to the log, writes
+      $RUNNER_TEMP/setup-soldr-stats.json and $RUNNER_TEMP/setup-soldr-session.log
+      (updated by the post phase with save operations), and sets the stats-json
+      action output.
+    required: false
+    default: "summarize"
+  debug:
+    description: >
+      When "true", enables verbose per-operation diagnostics printed to the
+      workflow log regardless of runner debug mode. Includes archive magic-byte
+      detection, compressed/inflated byte counts, file counts, compression
+      ratios, and the exact decompression/compression commands run.
+    required: false
+    default: "false"
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -251,6 +270,11 @@ outputs:
     description: Cargo.lock path used for Rust artifact cache keying.
   target-lockfile-hash:
     description: Short hash of the Cargo.lock used for Rust artifact cache keying, or no-lock.
+  stats-json:
+    description: >
+      JSON string containing the full cache stats report. Only set when
+      stats is "detailed". Contains restore and save operation details
+      including byte counts, file counts, durations, and hit/miss status.
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
 runs:

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,9 @@ branding:
   color: green
 inputs:
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.18.
+    description: Soldr version or tag to install. Defaults to 0.7.19.
     required: false
-    default: "0.7.18"
+    default: "0.7.19"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false
@@ -46,12 +46,30 @@ inputs:
     required: false
     default: ""
   linker:
-    description: |
-      Linker override forwarded as SOLDR_LINKER.
-      One of: default | ld | mold | rust-lld | fast.
-      Omit or set to empty to leave the linker unspecified.
+    description: >
+      Linker override forwarded as SOLDR_LINKER for `soldr cargo ...` builds
+      (requires soldr 0.7.19+). Empty (the default) opts the workflow into
+      `fast` — mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS and
+      Windows — and emits a one-time GitHub Actions warning so the override
+      is visible in CI logs. Soldr's own native default is no injection
+      (smaller artifact cache, slower link); pass `platform-default` (or
+      `default`) to opt out and keep whatever cargo config /
+      rust-toolchain.toml specifies. Other accepted values pass through
+      verbatim to SOLDR_LINKER: `ld`, `mold`, `rust-lld`, `fast`. Unknown
+      values raise an error.
     required: false
     default: ""
+  compile-priority:
+    description: >
+      Compiler/linker child-process priority forwarded as
+      ZCCACHE_COMPILE_PRIORITY (requires zccache 1.4.6+). Setup-soldr defaults
+      to `high` because GitHub Actions runners are dedicated to CI and have
+      no foreground workload to yield to — zccache's own native default is
+      `low` (designed for interactive dev). Accepted values:
+      `normal`, `low`, `idle`, `high`. Set to empty string to opt out and
+      let zccache pick its native default.
+    required: false
+    default: "high"
   timestamps:
     description: Prefix setup-soldr diagnostic and streamed command output with elapsed mm:ss timestamps.
     required: false

--- a/dist/main.js
+++ b/dist/main.js
@@ -19909,6 +19909,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.walkDirSize = walkDirSize;
 exports.detectCompressMagic = detectCompressMagic;
 exports.decompressCache = decompressCache;
 exports.compressCache = compressCache;
@@ -19917,6 +19918,41 @@ const path = __importStar(__nccwpck_require__(76760));
 const core = __importStar(__nccwpck_require__(37484));
 const exec = __importStar(__nccwpck_require__(95236));
 const io = __importStar(__nccwpck_require__(94994));
+/**
+ * Recursively walk a directory and sum file sizes.
+ * Returns { bytes, files } for all regular files found.
+ */
+async function walkDirSize(dir) {
+    let bytes = 0;
+    let files = 0;
+    async function walk(d) {
+        let entries;
+        try {
+            entries = await fs.readdir(d, { withFileTypes: true });
+        }
+        catch {
+            return;
+        }
+        for (const entry of entries) {
+            const full = path.join(d, entry.name);
+            if (entry.isDirectory()) {
+                await walk(full);
+            }
+            else if (entry.isFile()) {
+                try {
+                    const st = await fs.stat(full);
+                    bytes += st.size;
+                    files++;
+                }
+                catch {
+                    // skip inaccessible files
+                }
+            }
+        }
+    }
+    await walk(dir);
+    return { bytes, files };
+}
 /**
  * Read the first 4 bytes of a file and identify the compression codec.
  *   zstd:  0x28 B5 2F FD
@@ -19961,46 +19997,82 @@ async function pathExists(p) {
  *
  *   zstd: `zstd -d <archive>` piped into `tar -xf - -C <targetDir>`.
  *   gzip: `tar -xzf <archive> -C <targetDir>`.
+ *
+ * Returns compressed archive size, inflated directory size, and file count.
+ * When debug=true, logs verbose byte/file diagnostics via the supplied log fn.
  */
 async function decompressCache(opts) {
-    const { archivePath, targetDir } = opts;
+    const { archivePath, targetDir, debug = false, log = () => undefined } = opts;
     await ensureDir(targetDir);
-    const magic = await detectCompressMagic(archivePath);
-    if (magic === "gzip") {
-        await exec.exec("tar", ["-xzf", archivePath, "-C", targetDir]);
-        return;
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fs.stat(archivePath)).size;
     }
-    if (magic === "zstd") {
-        // tar -xf - reads from stdin; we pipe `zstd -d -c <archive>` into it.
+    catch {
+        // archive may not exist — caller guards, but be safe
+    }
+    const magic = await detectCompressMagic(archivePath);
+    if (debug) {
+        log(`[debug] decompress ${path.basename(archivePath)}: magic=${magic} archive=${fmtBytesDebug(archiveBytes)}`);
+    }
+    if (magic === "gzip") {
+        if (debug)
+            log(`[debug] decompress cmd: tar -xzf ${archivePath} -C ${targetDir}`);
+        await exec.exec("tar", ["-xzf", archivePath, "-C", targetDir]);
+    }
+    else if (magic === "zstd") {
         const zstdPath = await io.which("zstd", false);
         if (!zstdPath) {
+            if (debug)
+                log(`[debug] decompress cmd (zstd fallback): tar --zstd -xf ${archivePath} -C ${targetDir}`);
             // Fall back: many tars know how to decode zstd themselves (--zstd).
             await exec.exec("tar", ["--zstd", "-xf", archivePath, "-C", targetDir]);
-            return;
         }
-        await runPipe([zstdPath, ["-d", "-c", archivePath]], ["tar", ["-xf", "-", "-C", targetDir]]);
-        return;
+        else {
+            if (debug)
+                log(`[debug] decompress cmd: zstd -d -c ${archivePath} | tar -xf - -C ${targetDir}`);
+            // tar -xf - reads from stdin; we pipe `zstd -d -c <archive>` into it.
+            await runPipe([zstdPath, ["-d", "-c", archivePath]], ["tar", ["-xf", "-", "-C", targetDir]]);
+        }
     }
-    throw new Error(`decompressCache: unrecognized archive magic for ${archivePath}`);
+    else {
+        throw new Error(`decompressCache: unrecognized archive magic for ${archivePath}`);
+    }
+    const { bytes: inflatedBytes, files: fileCount } = await walkDirSize(targetDir);
+    if (debug) {
+        const ratio = archiveBytes > 0 ? (archiveBytes / inflatedBytes).toFixed(2) : "n/a";
+        log(`[debug] decompress result: inflated=${fmtBytesDebug(inflatedBytes)} files=${fileCount} ratio=${ratio}`);
+    }
+    return { archiveBytes, inflatedBytes, fileCount };
 }
 /**
  * tar -cf - <cache-dir-basename> | zstd -T0 -<level> > <cache-dir>.tar.zst
  *
- * When codec=="none" or zstd is not installed, returns null and leaves the
- * caller to use the default actions/cache compression.
+ * When codec=="none" or zstd is not installed, returns archivePath=null and
+ * leaves the caller to use the default actions/cache compression.
+ * When debug=true, walks the source dir for byte/file counts and logs ratios.
  */
 async function compressCache(opts) {
-    const { cacheDir, codec, level } = opts;
+    const { cacheDir, codec, level, debug = false, log = () => undefined } = opts;
+    const nullResult = { archivePath: null, archiveBytes: 0, inflatedBytes: null, fileCount: null };
     if (codec === "none")
-        return null;
+        return nullResult;
     const zstdPath = await io.which("zstd", false);
     if (!zstdPath) {
         core.warning("setup-soldr: zstd binary not found on PATH; falling back to actions/cache default codec");
-        return null;
+        return nullResult;
     }
     if (!(await pathExists(cacheDir))) {
         core.warning(`setup-soldr: cache dir ${cacheDir} does not exist, skipping compression`);
-        return null;
+        return nullResult;
+    }
+    let inflatedBytes = null;
+    let fileCount = null;
+    if (debug) {
+        const walked = await walkDirSize(cacheDir);
+        inflatedBytes = walked.bytes;
+        fileCount = walked.files;
+        log(`[debug] compress ${path.basename(cacheDir)}: input=${fmtBytesDebug(inflatedBytes)} files=${fileCount}`);
     }
     const parent = path.dirname(cacheDir);
     const basename = path.basename(cacheDir);
@@ -20009,8 +20081,30 @@ async function compressCache(opts) {
     await fs.rm(archivePath, { force: true }).catch(() => undefined);
     const levelNumeric = parseLevel(level);
     const levelFlag = `-${levelNumeric}`;
+    if (debug)
+        log(`[debug] compress cmd: tar -cf - -C ${parent} ${basename} | zstd -T0 ${levelFlag} -o ${archivePath}`);
     await runPipe(["tar", ["-cf", "-", "-C", parent, basename]], [zstdPath, ["-T0", levelFlag, "-o", archivePath]]);
-    return archivePath;
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fs.stat(archivePath)).size;
+    }
+    catch {
+        // archive may not have been created
+    }
+    if (debug && inflatedBytes !== null && inflatedBytes > 0) {
+        const ratio = (archiveBytes / inflatedBytes).toFixed(2);
+        log(`[debug] compress result: archive=${fmtBytesDebug(archiveBytes)} ratio=${ratio}`);
+    }
+    return { archivePath, archiveBytes, inflatedBytes, fileCount };
+}
+function fmtBytesDebug(n) {
+    if (n < 1024)
+        return `${n}B`;
+    if (n < 1024 * 1024)
+        return `${(n / 1024).toFixed(1)}KB`;
+    if (n < 1024 * 1024 * 1024)
+        return `${(n / 1024 / 1024).toFixed(1)}MB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
 }
 function parseLevel(value) {
     const trimmed = (value ?? "").toString().trim();
@@ -35242,6 +35336,7 @@ const verify_soldr_js_1 = __nccwpck_require__(82947);
 const normalize_source_mtime_js_1 = __nccwpck_require__(79691);
 const detect_shared_target_warning_js_1 = __nccwpck_require__(35761);
 const cache_compress_js_1 = __nccwpck_require__(24978);
+const stats_collector_js_1 = __nccwpck_require__(51002);
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 const FALSY = new Set(["0", "false", "no", "off"]);
 function isTruthy(value) {
@@ -35314,6 +35409,10 @@ async function run() {
     // Persist resolve state for the post-job step.
     core.saveState("resolveResult", JSON.stringify(result));
     core.saveState("buildCacheMode", result.buildCache.mode);
+    const stats = result.stats;
+    const debugMode = result.debugMode;
+    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
+    const statsCollector = new stats_collector_js_1.StatsCollector();
     // ---- source-mtime-normalize ----
     if (isTruthy(inputs.sourceMtimeNormalize)) {
         await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
@@ -35324,6 +35423,7 @@ async function run() {
     await (0, phase_timing_js_1.markPhase)("setup-cache");
     let setupCacheExactHit = false;
     if (cacheEnabled && result.setupCache.paths.length > 0) {
+        const setupCacheStart = Date.now();
         const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
         setupCacheExactHit = restore.hit;
         core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
@@ -35332,6 +35432,22 @@ async function run() {
         core.saveState("setupCacheMatchedKey", restore.matchedKey);
         // Expose for ensure_rust_toolchain to read via env (the python port did this).
         process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
+        statsCollector.record({
+            label: "setup-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: result.setupCache.key,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [result.setupCache.restorePrefix],
+            archiveBytes: null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - setupCacheStart,
+            timestamp: new Date().toISOString(),
+        });
+        if (debugMode) {
+            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+        }
     }
     await (0, phase_timing_js_1.finishPhase)("setup-cache");
     // ---- target-cache ----
@@ -35342,6 +35458,7 @@ async function run() {
             .map((s) => s.trim())
             .filter((s) => s.length > 0);
         if (targetPaths.length > 0) {
+            const targetCacheStart = Date.now();
             const restoreKeys = [];
             if (result.targetCache.restoreKeyParent)
                 restoreKeys.push(result.targetCache.restoreKeyParent);
@@ -35353,6 +35470,22 @@ async function run() {
             core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
             core.setOutput("target_cache_matched_key", restore.matchedKey);
             core.saveState("targetCacheMatchedKey", restore.matchedKey);
+            statsCollector.record({
+                label: "target-cache",
+                operation: "restore",
+                hit: restore.hit,
+                key: result.targetCache.key,
+                matchedKey: restore.matchedKey,
+                restoreKeys,
+                archiveBytes: null,
+                inflatedBytes: null,
+                fileCount: null,
+                durationMs: Date.now() - targetCacheStart,
+                timestamp: new Date().toISOString(),
+            });
+            if (debugMode) {
+                debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+            }
         }
     }
     await (0, phase_timing_js_1.finishPhase)("target-cache");
@@ -35368,21 +35501,46 @@ async function run() {
             restoreKeys.push(result.buildCache.restoreKeyToolchain);
         if (result.buildCache.restoreKeyOsArch)
             restoreKeys.push(result.buildCache.restoreKeyOsArch);
+        const buildCacheStart = Date.now();
         const restore = await restoreCacheSafe([archivePath, buildCachePath], result.buildCache.key, restoreKeys, logger);
         core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
         core.setOutput("build_cache_matched_key", restore.matchedKey);
         core.saveState("buildCacheMatchedKey", restore.matchedKey);
+        let buildArchiveBytes = null;
+        let buildInflatedBytes = null;
+        let buildFileCount = null;
         if (fileExists(archivePath)) {
             const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
             if (magic === "zstd" || magic === "gzip") {
                 try {
-                    await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath });
+                    const decompResult = await (0, cache_compress_js_1.decompressCache)({
+                        archivePath,
+                        targetDir: buildCachePath,
+                        debug: debugMode,
+                        log: debugLog,
+                    });
+                    buildArchiveBytes = decompResult.archiveBytes;
+                    buildInflatedBytes = decompResult.inflatedBytes;
+                    buildFileCount = decompResult.fileCount;
                 }
                 catch (err) {
                     logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
                 }
             }
         }
+        statsCollector.record({
+            label: "build-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: result.buildCache.key,
+            matchedKey: restore.matchedKey,
+            restoreKeys,
+            archiveBytes: buildArchiveBytes,
+            inflatedBytes: buildInflatedBytes,
+            fileCount: buildFileCount,
+            durationMs: Date.now() - buildCacheStart,
+            timestamp: new Date().toISOString(),
+        });
     }
     await (0, phase_timing_js_1.finishPhase)("build-cache");
     // ---- target-tree-cache (full mode) ----
@@ -35412,22 +35570,44 @@ async function run() {
     // ---- cargo-registry restore (if requested) ----
     if (result.cargoRegistryCache.enabled) {
         const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
+        const registryCacheStart = Date.now();
         const restore = await restoreCacheSafe([registryArchive, result.cargoRegistryCache.path], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
         core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
+        let regArchiveBytes = null;
+        let regInflatedBytes = null;
+        let regFileCount = null;
         if (fileExists(registryArchive)) {
             const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
             if (magic === "zstd" || magic === "gzip") {
                 try {
-                    await (0, cache_compress_js_1.decompressCache)({
+                    const decompResult = await (0, cache_compress_js_1.decompressCache)({
                         archivePath: registryArchive,
                         targetDir: result.cargoRegistryCache.path,
+                        debug: debugMode,
+                        log: debugLog,
                     });
+                    regArchiveBytes = decompResult.archiveBytes;
+                    regInflatedBytes = decompResult.inflatedBytes;
+                    regFileCount = decompResult.fileCount;
                 }
                 catch (err) {
                     logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
                 }
             }
         }
+        statsCollector.record({
+            label: "cargo-registry",
+            operation: "restore",
+            hit: restore.hit,
+            key: result.cargoRegistryCache.key,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [result.cargoRegistryCache.restorePrefix],
+            archiveBytes: regArchiveBytes,
+            inflatedBytes: regInflatedBytes,
+            fileCount: regFileCount,
+            durationMs: Date.now() - registryCacheStart,
+            timestamp: new Date().toISOString(),
+        });
     }
     // ---- shared-target warning ----
     await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
@@ -35436,6 +35616,20 @@ async function run() {
         buildCacheMode: result.buildCache.mode,
         targetDir: result.targetCache.targetPath,
     });
+    // ---- stats report ----
+    statsCollector.report(stats, (msg) => logger.log(msg));
+    if (stats === "detailed") {
+        try {
+            await statsCollector.writeFiles(ctx.runnerTemp);
+            statsCollector.setGithubOutputs();
+        }
+        catch (err) {
+            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    core.saveState("statsCollector", statsCollector.serialize());
+    core.saveState("statsMode", stats);
+    core.saveState("runnerTemp", ctx.runnerTemp);
     await (0, phase_timing_js_1.finishPhase)("action");
     // dirHasContent is exported for tests; suppress unused warning here.
     void dirHasContent;
@@ -44649,6 +44843,203 @@ inherits(PartStream, ReadableStream)
 PartStream.prototype._read = function (n) {}
 
 module.exports = PartStream
+
+
+/***/ }),
+
+/***/ 51002:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.StatsCollector = void 0;
+const fs = __importStar(__nccwpck_require__(51455));
+const path = __importStar(__nccwpck_require__(76760));
+const core = __importStar(__nccwpck_require__(37484));
+function fmtBytes(n) {
+    if (n === null)
+        return "-";
+    if (n < 1024)
+        return `${n}B`;
+    if (n < 1024 * 1024)
+        return `${(n / 1024).toFixed(1)}KB`;
+    if (n < 1024 * 1024 * 1024)
+        return `${(n / 1024 / 1024).toFixed(1)}MB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
+}
+function fmtMs(ms) {
+    return `${(ms / 1000).toFixed(1)}s`;
+}
+function truncKey(key, maxLen) {
+    if (!key)
+        return "(no match)";
+    if (key.length <= maxLen)
+        return key;
+    return `\u2026${key.slice(-(maxLen - 1))}`;
+}
+function ratioStr(archiveBytes, inflatedBytes) {
+    if (archiveBytes === null || inflatedBytes === null || inflatedBytes === 0)
+        return "";
+    return ` ratio=${(archiveBytes / inflatedBytes).toFixed(2)}`;
+}
+class StatsCollector {
+    ops = [];
+    record(op) {
+        this.ops.push(op);
+    }
+    summaryText() {
+        const restoreOps = this.ops.filter((o) => o.operation === "restore");
+        if (restoreOps.length === 0)
+            return "";
+        const CW = { cache: 20, status: 8, matched: 42, archive: 10, inflated: 10, files: 8, time: 7 };
+        const header = [
+            "cache".padEnd(CW.cache),
+            "status".padEnd(CW.status),
+            "matched-key".padEnd(CW.matched),
+            "archive".padStart(CW.archive),
+            "inflated".padStart(CW.inflated),
+            "files".padStart(CW.files),
+            "time".padStart(CW.time),
+        ].join("  ");
+        const rule = "\u2500".repeat(header.length);
+        const rows = restoreOps.map((op) => {
+            const status = op.hit ? "HIT" : op.matchedKey ? "FALLBACK" : "MISS";
+            const matchedDisplay = op.hit
+                ? truncKey(op.matchedKey, CW.matched - 4)
+                : op.matchedKey
+                    ? `fallback: ${truncKey(op.matchedKey, CW.matched - 10)}`
+                    : "(no match)";
+            return [
+                op.label.padEnd(CW.cache),
+                status.padEnd(CW.status),
+                matchedDisplay.padEnd(CW.matched),
+                fmtBytes(op.archiveBytes).padStart(CW.archive),
+                fmtBytes(op.inflatedBytes).padStart(CW.inflated),
+                (op.fileCount !== null ? String(op.fileCount) : "-").padStart(CW.files),
+                fmtMs(op.durationMs).padStart(CW.time),
+            ].join("  ");
+        });
+        const exactHits = restoreOps.filter((o) => o.hit).length;
+        const anyHits = restoreOps.filter((o) => o.hit || Boolean(o.matchedKey)).length;
+        const totalMs = restoreOps.reduce((s, o) => s + o.durationMs, 0);
+        const footer = `${exactHits}/${restoreOps.length} exact-hit  ${anyHits}/${restoreOps.length} any-hit  total restore: ${fmtMs(totalMs)}`;
+        return [header, rule, ...rows, rule, footer].join("\n");
+    }
+    detailedJson() {
+        const restoreOps = this.ops.filter((o) => o.operation === "restore");
+        const saveOps = this.ops.filter((o) => o.operation === "save");
+        const exactHits = restoreOps.filter((o) => o.hit).length;
+        const anyHits = restoreOps.filter((o) => o.hit || Boolean(o.matchedKey)).length;
+        const totalRestoreMs = restoreOps.reduce((s, o) => s + o.durationMs, 0);
+        return {
+            summary: {
+                totalCaches: restoreOps.length,
+                exactHits,
+                anyHits,
+                misses: restoreOps.length - anyHits,
+                totalRestoreMs,
+                savedCaches: saveOps.length,
+            },
+            restores: restoreOps,
+            saves: saveOps,
+        };
+    }
+    restoreLogLine(op) {
+        const status = op.hit ? "HIT" : op.matchedKey ? "FALLBACK" : "MISS";
+        const matchStr = op.matchedKey ? ` matched=${op.matchedKey}` : "";
+        const archStr = op.archiveBytes !== null ? ` archive=${fmtBytes(op.archiveBytes)}` : "";
+        const inflStr = op.inflatedBytes !== null ? ` inflated=${fmtBytes(op.inflatedBytes)}` : "";
+        const filesStr = op.fileCount !== null ? ` files=${op.fileCount}` : "";
+        return `[restore] ${op.label.padEnd(20)} ${status.padEnd(8)} key=${op.key}${matchStr}${archStr}${inflStr}${filesStr}  ${op.timestamp}  ${fmtMs(op.durationMs)}`;
+    }
+    saveLogLine(op) {
+        const archStr = op.archiveBytes !== null ? ` archive=${fmtBytes(op.archiveBytes)}` : "";
+        const inflStr = op.inflatedBytes !== null ? ` inflated=${fmtBytes(op.inflatedBytes)}` : "";
+        const filesStr = op.fileCount !== null ? ` files=${op.fileCount}` : "";
+        const ratio = ratioStr(op.archiveBytes, op.inflatedBytes);
+        return `[save]    ${op.label.padEnd(20)}          key=${op.key}${archStr}${inflStr}${filesStr}${ratio}  ${op.timestamp}  ${fmtMs(op.durationMs)}`;
+    }
+    async writeFiles(runnerTemp) {
+        await fs.mkdir(runnerTemp, { recursive: true });
+        const jsonPath = path.join(runnerTemp, "setup-soldr-stats.json");
+        const logPath = path.join(runnerTemp, "setup-soldr-session.log");
+        await fs.writeFile(jsonPath, JSON.stringify(this.detailedJson(), null, 2), "utf8");
+        const restoreLines = this.ops
+            .filter((o) => o.operation === "restore")
+            .map((o) => this.restoreLogLine(o));
+        await fs.writeFile(logPath, restoreLines.join("\n") + "\n", "utf8");
+    }
+    async appendSavesToSessionLog(runnerTemp) {
+        const saveOps = this.ops.filter((o) => o.operation === "save");
+        if (saveOps.length === 0)
+            return;
+        const logPath = path.join(runnerTemp, "setup-soldr-session.log");
+        const lines = saveOps.map((o) => this.saveLogLine(o));
+        await fs.appendFile(logPath, lines.join("\n") + "\n", "utf8").catch(() => undefined);
+    }
+    report(mode, log) {
+        if (mode === "none")
+            return;
+        const summary = this.summaryText();
+        if (summary)
+            log(summary);
+        if (mode === "detailed") {
+            log(JSON.stringify(this.detailedJson(), null, 2));
+        }
+    }
+    setGithubOutputs() {
+        core.setOutput("stats-json", JSON.stringify(this.detailedJson()));
+    }
+    serialize() {
+        return JSON.stringify({ ops: this.ops });
+    }
+    static deserialize(s) {
+        const c = new StatsCollector();
+        try {
+            const parsed = JSON.parse(s);
+            c.ops = Array.isArray(parsed.ops) ? parsed.ops : [];
+        }
+        catch {
+            // empty collector
+        }
+        return c;
+    }
+}
+exports.StatsCollector = StatsCollector;
 
 
 /***/ }),
@@ -61614,7 +62005,15 @@ function readRawInputs(env) {
         targetCacheCompressLevel: get("TARGET_CACHE_COMPRESS_LEVEL"),
         sourceMtimeNormalize: get("SOURCE_MTIME_NORMALIZE"),
         cargoRegistryCache: get("CARGO_REGISTRY_CACHE"),
+        stats: get("STATS"),
+        debugMode: get("DEBUG"),
     };
+}
+function normalizeStatsMode(raw) {
+    const v = raw.trim().toLowerCase();
+    if (v === "none" || v === "summarize" || v === "detailed")
+        return v;
+    return "summarize";
 }
 function isFalsy(value) {
     return FALSY_VALUES.has(value.trim().toLowerCase());
@@ -62069,6 +62468,8 @@ async function resolveSetup(ctx, inputs, deps) {
     // Avoid unused warnings on alias helper.
     void toolchain_js_1.rollingToolchainAlias;
     void cache_keys_js_1.canonicalJsonStringify;
+    const stats = normalizeStatsMode(inputs.stats);
+    const debugMode = isTruthy(inputs.debugMode.trim() || "false");
     return {
         workspace,
         cacheRoot,
@@ -62094,6 +62495,8 @@ async function resolveSetup(ctx, inputs, deps) {
         pathAdditions,
         logStartEpoch: logStart,
         timestamps,
+        stats,
+        debugMode,
     };
 }
 /**

--- a/dist/main.js
+++ b/dist/main.js
@@ -61556,7 +61556,14 @@ const log_utils_js_1 = __nccwpck_require__(28129);
 const toolchain_js_1 = __nccwpck_require__(10260);
 const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
 const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
-const ALLOWED_LINKER_VALUES = ["default", "ld", "mold", "rust-lld", "fast"];
+const ALLOWED_LINKER_VALUES = [
+    "default",
+    "platform-default",
+    "ld",
+    "mold",
+    "rust-lld",
+    "fast",
+];
 // CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
 // FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
 // causes "failed to connect to jobserver" warnings in every downstream step.
@@ -61591,6 +61598,7 @@ function readRawInputs(env) {
         toolchainFile: get("TOOLCHAIN_FILE"),
         trustMode: get("TRUST_MODE"),
         linker: get("LINKER"),
+        compilePriority: get("COMPILE_PRIORITY"),
         timestamps: get("TIMESTAMPS"),
         lockfile: get("LOCKFILE"),
         buildCache: get("BUILD_CACHE"),
@@ -61965,14 +61973,20 @@ async function resolveSetup(ctx, inputs, deps) {
     if (inputs.trustMode.trim()) {
         setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
     }
-    const linkerValue = inputs.linker.trim();
-    if (linkerValue) {
-        if (!ALLOWED_LINKER_VALUES.includes(linkerValue)) {
-            throw new Error(`invalid 'linker' input: '${linkerValue}'. Allowed: default | ld | mold | rust-lld | fast`);
-        }
-        if (linkerValue !== "default") {
-            setEnv("SOLDR_LINKER", linkerValue);
-        }
+    const linkerRaw = inputs.linker.trim();
+    if (linkerRaw === "") {
+        setEnv("SOLDR_LINKER", "fast");
+        logger.warning("setup-soldr: defaulting SOLDR_LINKER=fast (mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows) for faster CI links. Soldr's native default is no injection, which produces a smaller build-cache and a slower link. Set `linker: platform-default` to opt out and keep cargo/rust-toolchain.toml in charge, or set `linker: <value>` to silence this warning.");
+    }
+    else if (!ALLOWED_LINKER_VALUES.includes(linkerRaw)) {
+        throw new Error(`invalid 'linker' input: '${linkerRaw}'. Allowed: default | platform-default | ld | mold | rust-lld | fast`);
+    }
+    else if (linkerRaw !== "default" && linkerRaw !== "platform-default") {
+        setEnv("SOLDR_LINKER", linkerRaw);
+    }
+    const compilePriorityRaw = inputs.compilePriority.trim();
+    if (compilePriorityRaw !== "") {
+        setEnv("ZCCACHE_COMPILE_PRIORITY", compilePriorityRaw);
     }
     // ---- path additions ----
     const pathAdditions = [binDir, path.join(cargoHome, "bin")];

--- a/dist/post.js
+++ b/dist/post.js
@@ -8918,6 +8918,203 @@ module.exports = Dispatcher
 
 /***/ }),
 
+/***/ 1002:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.StatsCollector = void 0;
+const fs = __importStar(__nccwpck_require__(1455));
+const path = __importStar(__nccwpck_require__(6760));
+const core = __importStar(__nccwpck_require__(7484));
+function fmtBytes(n) {
+    if (n === null)
+        return "-";
+    if (n < 1024)
+        return `${n}B`;
+    if (n < 1024 * 1024)
+        return `${(n / 1024).toFixed(1)}KB`;
+    if (n < 1024 * 1024 * 1024)
+        return `${(n / 1024 / 1024).toFixed(1)}MB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
+}
+function fmtMs(ms) {
+    return `${(ms / 1000).toFixed(1)}s`;
+}
+function truncKey(key, maxLen) {
+    if (!key)
+        return "(no match)";
+    if (key.length <= maxLen)
+        return key;
+    return `\u2026${key.slice(-(maxLen - 1))}`;
+}
+function ratioStr(archiveBytes, inflatedBytes) {
+    if (archiveBytes === null || inflatedBytes === null || inflatedBytes === 0)
+        return "";
+    return ` ratio=${(archiveBytes / inflatedBytes).toFixed(2)}`;
+}
+class StatsCollector {
+    ops = [];
+    record(op) {
+        this.ops.push(op);
+    }
+    summaryText() {
+        const restoreOps = this.ops.filter((o) => o.operation === "restore");
+        if (restoreOps.length === 0)
+            return "";
+        const CW = { cache: 20, status: 8, matched: 42, archive: 10, inflated: 10, files: 8, time: 7 };
+        const header = [
+            "cache".padEnd(CW.cache),
+            "status".padEnd(CW.status),
+            "matched-key".padEnd(CW.matched),
+            "archive".padStart(CW.archive),
+            "inflated".padStart(CW.inflated),
+            "files".padStart(CW.files),
+            "time".padStart(CW.time),
+        ].join("  ");
+        const rule = "\u2500".repeat(header.length);
+        const rows = restoreOps.map((op) => {
+            const status = op.hit ? "HIT" : op.matchedKey ? "FALLBACK" : "MISS";
+            const matchedDisplay = op.hit
+                ? truncKey(op.matchedKey, CW.matched - 4)
+                : op.matchedKey
+                    ? `fallback: ${truncKey(op.matchedKey, CW.matched - 10)}`
+                    : "(no match)";
+            return [
+                op.label.padEnd(CW.cache),
+                status.padEnd(CW.status),
+                matchedDisplay.padEnd(CW.matched),
+                fmtBytes(op.archiveBytes).padStart(CW.archive),
+                fmtBytes(op.inflatedBytes).padStart(CW.inflated),
+                (op.fileCount !== null ? String(op.fileCount) : "-").padStart(CW.files),
+                fmtMs(op.durationMs).padStart(CW.time),
+            ].join("  ");
+        });
+        const exactHits = restoreOps.filter((o) => o.hit).length;
+        const anyHits = restoreOps.filter((o) => o.hit || Boolean(o.matchedKey)).length;
+        const totalMs = restoreOps.reduce((s, o) => s + o.durationMs, 0);
+        const footer = `${exactHits}/${restoreOps.length} exact-hit  ${anyHits}/${restoreOps.length} any-hit  total restore: ${fmtMs(totalMs)}`;
+        return [header, rule, ...rows, rule, footer].join("\n");
+    }
+    detailedJson() {
+        const restoreOps = this.ops.filter((o) => o.operation === "restore");
+        const saveOps = this.ops.filter((o) => o.operation === "save");
+        const exactHits = restoreOps.filter((o) => o.hit).length;
+        const anyHits = restoreOps.filter((o) => o.hit || Boolean(o.matchedKey)).length;
+        const totalRestoreMs = restoreOps.reduce((s, o) => s + o.durationMs, 0);
+        return {
+            summary: {
+                totalCaches: restoreOps.length,
+                exactHits,
+                anyHits,
+                misses: restoreOps.length - anyHits,
+                totalRestoreMs,
+                savedCaches: saveOps.length,
+            },
+            restores: restoreOps,
+            saves: saveOps,
+        };
+    }
+    restoreLogLine(op) {
+        const status = op.hit ? "HIT" : op.matchedKey ? "FALLBACK" : "MISS";
+        const matchStr = op.matchedKey ? ` matched=${op.matchedKey}` : "";
+        const archStr = op.archiveBytes !== null ? ` archive=${fmtBytes(op.archiveBytes)}` : "";
+        const inflStr = op.inflatedBytes !== null ? ` inflated=${fmtBytes(op.inflatedBytes)}` : "";
+        const filesStr = op.fileCount !== null ? ` files=${op.fileCount}` : "";
+        return `[restore] ${op.label.padEnd(20)} ${status.padEnd(8)} key=${op.key}${matchStr}${archStr}${inflStr}${filesStr}  ${op.timestamp}  ${fmtMs(op.durationMs)}`;
+    }
+    saveLogLine(op) {
+        const archStr = op.archiveBytes !== null ? ` archive=${fmtBytes(op.archiveBytes)}` : "";
+        const inflStr = op.inflatedBytes !== null ? ` inflated=${fmtBytes(op.inflatedBytes)}` : "";
+        const filesStr = op.fileCount !== null ? ` files=${op.fileCount}` : "";
+        const ratio = ratioStr(op.archiveBytes, op.inflatedBytes);
+        return `[save]    ${op.label.padEnd(20)}          key=${op.key}${archStr}${inflStr}${filesStr}${ratio}  ${op.timestamp}  ${fmtMs(op.durationMs)}`;
+    }
+    async writeFiles(runnerTemp) {
+        await fs.mkdir(runnerTemp, { recursive: true });
+        const jsonPath = path.join(runnerTemp, "setup-soldr-stats.json");
+        const logPath = path.join(runnerTemp, "setup-soldr-session.log");
+        await fs.writeFile(jsonPath, JSON.stringify(this.detailedJson(), null, 2), "utf8");
+        const restoreLines = this.ops
+            .filter((o) => o.operation === "restore")
+            .map((o) => this.restoreLogLine(o));
+        await fs.writeFile(logPath, restoreLines.join("\n") + "\n", "utf8");
+    }
+    async appendSavesToSessionLog(runnerTemp) {
+        const saveOps = this.ops.filter((o) => o.operation === "save");
+        if (saveOps.length === 0)
+            return;
+        const logPath = path.join(runnerTemp, "setup-soldr-session.log");
+        const lines = saveOps.map((o) => this.saveLogLine(o));
+        await fs.appendFile(logPath, lines.join("\n") + "\n", "utf8").catch(() => undefined);
+    }
+    report(mode, log) {
+        if (mode === "none")
+            return;
+        const summary = this.summaryText();
+        if (summary)
+            log(summary);
+        if (mode === "detailed") {
+            log(JSON.stringify(this.detailedJson(), null, 2));
+        }
+    }
+    setGithubOutputs() {
+        core.setOutput("stats-json", JSON.stringify(this.detailedJson()));
+    }
+    serialize() {
+        return JSON.stringify({ ops: this.ops });
+    }
+    static deserialize(s) {
+        const c = new StatsCollector();
+        try {
+            const parsed = JSON.parse(s);
+            c.ops = Array.isArray(parsed.ops) ? parsed.ops : [];
+        }
+        catch {
+            // empty collector
+        }
+        return c;
+    }
+}
+exports.StatsCollector = StatsCollector;
+
+
+/***/ }),
+
 /***/ 1093:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -45346,6 +45543,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.walkDirSize = walkDirSize;
 exports.detectCompressMagic = detectCompressMagic;
 exports.decompressCache = decompressCache;
 exports.compressCache = compressCache;
@@ -45354,6 +45552,41 @@ const path = __importStar(__nccwpck_require__(6760));
 const core = __importStar(__nccwpck_require__(7484));
 const exec = __importStar(__nccwpck_require__(5236));
 const io = __importStar(__nccwpck_require__(4994));
+/**
+ * Recursively walk a directory and sum file sizes.
+ * Returns { bytes, files } for all regular files found.
+ */
+async function walkDirSize(dir) {
+    let bytes = 0;
+    let files = 0;
+    async function walk(d) {
+        let entries;
+        try {
+            entries = await fs.readdir(d, { withFileTypes: true });
+        }
+        catch {
+            return;
+        }
+        for (const entry of entries) {
+            const full = path.join(d, entry.name);
+            if (entry.isDirectory()) {
+                await walk(full);
+            }
+            else if (entry.isFile()) {
+                try {
+                    const st = await fs.stat(full);
+                    bytes += st.size;
+                    files++;
+                }
+                catch {
+                    // skip inaccessible files
+                }
+            }
+        }
+    }
+    await walk(dir);
+    return { bytes, files };
+}
 /**
  * Read the first 4 bytes of a file and identify the compression codec.
  *   zstd:  0x28 B5 2F FD
@@ -45398,46 +45631,82 @@ async function pathExists(p) {
  *
  *   zstd: `zstd -d <archive>` piped into `tar -xf - -C <targetDir>`.
  *   gzip: `tar -xzf <archive> -C <targetDir>`.
+ *
+ * Returns compressed archive size, inflated directory size, and file count.
+ * When debug=true, logs verbose byte/file diagnostics via the supplied log fn.
  */
 async function decompressCache(opts) {
-    const { archivePath, targetDir } = opts;
+    const { archivePath, targetDir, debug = false, log = () => undefined } = opts;
     await ensureDir(targetDir);
-    const magic = await detectCompressMagic(archivePath);
-    if (magic === "gzip") {
-        await exec.exec("tar", ["-xzf", archivePath, "-C", targetDir]);
-        return;
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fs.stat(archivePath)).size;
     }
-    if (magic === "zstd") {
-        // tar -xf - reads from stdin; we pipe `zstd -d -c <archive>` into it.
+    catch {
+        // archive may not exist — caller guards, but be safe
+    }
+    const magic = await detectCompressMagic(archivePath);
+    if (debug) {
+        log(`[debug] decompress ${path.basename(archivePath)}: magic=${magic} archive=${fmtBytesDebug(archiveBytes)}`);
+    }
+    if (magic === "gzip") {
+        if (debug)
+            log(`[debug] decompress cmd: tar -xzf ${archivePath} -C ${targetDir}`);
+        await exec.exec("tar", ["-xzf", archivePath, "-C", targetDir]);
+    }
+    else if (magic === "zstd") {
         const zstdPath = await io.which("zstd", false);
         if (!zstdPath) {
+            if (debug)
+                log(`[debug] decompress cmd (zstd fallback): tar --zstd -xf ${archivePath} -C ${targetDir}`);
             // Fall back: many tars know how to decode zstd themselves (--zstd).
             await exec.exec("tar", ["--zstd", "-xf", archivePath, "-C", targetDir]);
-            return;
         }
-        await runPipe([zstdPath, ["-d", "-c", archivePath]], ["tar", ["-xf", "-", "-C", targetDir]]);
-        return;
+        else {
+            if (debug)
+                log(`[debug] decompress cmd: zstd -d -c ${archivePath} | tar -xf - -C ${targetDir}`);
+            // tar -xf - reads from stdin; we pipe `zstd -d -c <archive>` into it.
+            await runPipe([zstdPath, ["-d", "-c", archivePath]], ["tar", ["-xf", "-", "-C", targetDir]]);
+        }
     }
-    throw new Error(`decompressCache: unrecognized archive magic for ${archivePath}`);
+    else {
+        throw new Error(`decompressCache: unrecognized archive magic for ${archivePath}`);
+    }
+    const { bytes: inflatedBytes, files: fileCount } = await walkDirSize(targetDir);
+    if (debug) {
+        const ratio = archiveBytes > 0 ? (archiveBytes / inflatedBytes).toFixed(2) : "n/a";
+        log(`[debug] decompress result: inflated=${fmtBytesDebug(inflatedBytes)} files=${fileCount} ratio=${ratio}`);
+    }
+    return { archiveBytes, inflatedBytes, fileCount };
 }
 /**
  * tar -cf - <cache-dir-basename> | zstd -T0 -<level> > <cache-dir>.tar.zst
  *
- * When codec=="none" or zstd is not installed, returns null and leaves the
- * caller to use the default actions/cache compression.
+ * When codec=="none" or zstd is not installed, returns archivePath=null and
+ * leaves the caller to use the default actions/cache compression.
+ * When debug=true, walks the source dir for byte/file counts and logs ratios.
  */
 async function compressCache(opts) {
-    const { cacheDir, codec, level } = opts;
+    const { cacheDir, codec, level, debug = false, log = () => undefined } = opts;
+    const nullResult = { archivePath: null, archiveBytes: 0, inflatedBytes: null, fileCount: null };
     if (codec === "none")
-        return null;
+        return nullResult;
     const zstdPath = await io.which("zstd", false);
     if (!zstdPath) {
         core.warning("setup-soldr: zstd binary not found on PATH; falling back to actions/cache default codec");
-        return null;
+        return nullResult;
     }
     if (!(await pathExists(cacheDir))) {
         core.warning(`setup-soldr: cache dir ${cacheDir} does not exist, skipping compression`);
-        return null;
+        return nullResult;
+    }
+    let inflatedBytes = null;
+    let fileCount = null;
+    if (debug) {
+        const walked = await walkDirSize(cacheDir);
+        inflatedBytes = walked.bytes;
+        fileCount = walked.files;
+        log(`[debug] compress ${path.basename(cacheDir)}: input=${fmtBytesDebug(inflatedBytes)} files=${fileCount}`);
     }
     const parent = path.dirname(cacheDir);
     const basename = path.basename(cacheDir);
@@ -45446,8 +45715,30 @@ async function compressCache(opts) {
     await fs.rm(archivePath, { force: true }).catch(() => undefined);
     const levelNumeric = parseLevel(level);
     const levelFlag = `-${levelNumeric}`;
+    if (debug)
+        log(`[debug] compress cmd: tar -cf - -C ${parent} ${basename} | zstd -T0 ${levelFlag} -o ${archivePath}`);
     await runPipe(["tar", ["-cf", "-", "-C", parent, basename]], [zstdPath, ["-T0", levelFlag, "-o", archivePath]]);
-    return archivePath;
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fs.stat(archivePath)).size;
+    }
+    catch {
+        // archive may not have been created
+    }
+    if (debug && inflatedBytes !== null && inflatedBytes > 0) {
+        const ratio = (archiveBytes / inflatedBytes).toFixed(2);
+        log(`[debug] compress result: archive=${fmtBytesDebug(archiveBytes)} ratio=${ratio}`);
+    }
+    return { archivePath, archiveBytes, inflatedBytes, fileCount };
+}
+function fmtBytesDebug(n) {
+    if (n < 1024)
+        return `${n}B`;
+    if (n < 1024 * 1024)
+        return `${(n / 1024).toFixed(1)}KB`;
+    if (n < 1024 * 1024 * 1024)
+        return `${(n / 1024 / 1024).toFixed(1)}MB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
 }
 function parseLevel(value) {
     const trimmed = (value ?? "").toString().trim();
@@ -63376,6 +63667,7 @@ const core = __importStar(__nccwpck_require__(7484));
 const cache = __importStar(__nccwpck_require__(5116));
 const cache_compress_js_1 = __nccwpck_require__(4978);
 const log_utils_js_1 = __nccwpck_require__(8129);
+const stats_collector_js_1 = __nccwpck_require__(1002);
 function dirExists(p) {
     try {
         return fs.statSync(p).isDirectory();
@@ -63385,24 +63677,32 @@ function dirExists(p) {
     }
 }
 async function saveOne(opts) {
-    const { cacheDir, codec, level, key, matchedKey, label, log } = opts;
+    const { cacheDir, codec, level, key, matchedKey, label, debug, log } = opts;
+    const nullResult = { archiveBytes: null, inflatedBytes: null, fileCount: null, skipped: true };
     if (!dirExists(cacheDir)) {
         log(`${label}: cache dir ${cacheDir} does not exist, skipping save`);
-        return;
+        return nullResult;
     }
     if (matchedKey === key) {
         log(`${label}: exact cache hit on ${key}, skipping save`);
-        return;
+        return nullResult;
     }
-    const archive = await (0, cache_compress_js_1.compressCache)({ cacheDir, codec, level });
-    const pathsToSave = archive ? [archive] : [cacheDir];
+    const { archivePath, archiveBytes, inflatedBytes, fileCount } = await (0, cache_compress_js_1.compressCache)({
+        cacheDir,
+        codec,
+        level,
+        debug,
+        log,
+    });
+    const pathsToSave = archivePath ? [archivePath] : [cacheDir];
     try {
         const id = await cache.saveCache(pathsToSave, key);
-        log(`${label}: saved cache id=${id} key=${key} via ${archive ? "tar.zst" : "default"}`);
+        log(`${label}: saved cache id=${id} key=${key} via ${archivePath ? "tar.zst" : "default"}`);
     }
     catch (err) {
         log(`${label}: save failed: ${err instanceof Error ? err.message : String(err)}`);
     }
+    return { archiveBytes, inflatedBytes, fileCount, skipped: false };
 }
 async function run() {
     const logger = (0, log_utils_js_1.createLogger)(process.env);
@@ -63422,27 +63722,75 @@ async function run() {
     }
     const buildCacheMatched = core.getState("buildCacheMatchedKey");
     const registryMatched = core.getState("cargoRegistryCacheMatchedKey");
+    const statsMode = (core.getState("statsMode") || "summarize");
+    const runnerTemp = core.getState("runnerTemp") || "";
+    const debugMode = result.debugMode ?? false;
+    const debugLog = debugMode ? log : () => undefined;
+    const postCollector = new stats_collector_js_1.StatsCollector();
     // Build cache
-    await saveOne({
+    const buildSaveStart = Date.now();
+    const buildSaveResult = await saveOne({
         cacheDir: result.buildCache.path,
         codec: result.targetCacheCompress,
         level: result.targetCacheCompressLevel,
         key: result.buildCache.key,
         matchedKey: buildCacheMatched,
         label: "build-cache",
-        log,
+        debug: debugMode,
+        log: debugLog,
     });
+    if (!buildSaveResult.skipped) {
+        postCollector.record({
+            label: "build-cache",
+            operation: "save",
+            hit: false,
+            key: result.buildCache.key,
+            matchedKey: buildCacheMatched,
+            restoreKeys: [],
+            archiveBytes: buildSaveResult.archiveBytes,
+            inflatedBytes: buildSaveResult.inflatedBytes,
+            fileCount: buildSaveResult.fileCount,
+            durationMs: Date.now() - buildSaveStart,
+            timestamp: new Date().toISOString(),
+        });
+    }
     // Cargo registry cache (only when enabled)
     if (result.cargoRegistryCache.enabled) {
-        await saveOne({
+        const regSaveStart = Date.now();
+        const regSaveResult = await saveOne({
             cacheDir: result.cargoRegistryCache.path,
             codec: result.targetCacheCompress,
             level: result.targetCacheCompressLevel,
             key: result.cargoRegistryCache.key,
             matchedKey: registryMatched,
             label: "cargo-registry-cache",
-            log,
+            debug: debugMode,
+            log: debugLog,
         });
+        if (!regSaveResult.skipped) {
+            postCollector.record({
+                label: "cargo-registry",
+                operation: "save",
+                hit: false,
+                key: result.cargoRegistryCache.key,
+                matchedKey: registryMatched,
+                restoreKeys: [],
+                archiveBytes: regSaveResult.archiveBytes,
+                inflatedBytes: regSaveResult.inflatedBytes,
+                fileCount: regSaveResult.fileCount,
+                durationMs: Date.now() - regSaveStart,
+                timestamp: new Date().toISOString(),
+            });
+        }
+    }
+    // Append save ops to session log when detailed stats are enabled
+    if (statsMode === "detailed" && runnerTemp) {
+        try {
+            await postCollector.appendSavesToSessionLog(runnerTemp);
+        }
+        catch (err) {
+            log(`post: stats log append failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
     }
 }
 // See main.ts for the rationale behind the test-import escape hatch.

--- a/src/lib/cache-compress.ts
+++ b/src/lib/cache-compress.ts
@@ -8,10 +8,44 @@
 // zstd vs gzip magic bytes for back-compat.
 
 import * as fs from "node:fs/promises";
+import type { Dirent } from "node:fs";
 import * as path from "node:path";
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import * as io from "@actions/io";
+
+/**
+ * Recursively walk a directory and sum file sizes.
+ * Returns { bytes, files } for all regular files found.
+ */
+export async function walkDirSize(dir: string): Promise<{ bytes: number; files: number }> {
+  let bytes = 0;
+  let files = 0;
+  async function walk(d: string): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        try {
+          const st = await fs.stat(full);
+          bytes += st.size;
+          files++;
+        } catch {
+          // skip inaccessible files
+        }
+      }
+    }
+  }
+  await walk(dir);
+  return { bytes, files };
+}
 
 export type CompressMagic = "zstd" | "gzip" | "unknown";
 
@@ -53,62 +87,118 @@ async function pathExists(p: string): Promise<boolean> {
   }
 }
 
+export interface DecompressResult {
+  archiveBytes: number;
+  inflatedBytes: number;
+  fileCount: number;
+}
+
 /**
  * Decompress <cache-dir>.tar.zst (or .tar.gz) into <cache-dir>.
  *
  *   zstd: `zstd -d <archive>` piped into `tar -xf - -C <targetDir>`.
  *   gzip: `tar -xzf <archive> -C <targetDir>`.
+ *
+ * Returns compressed archive size, inflated directory size, and file count.
+ * When debug=true, logs verbose byte/file diagnostics via the supplied log fn.
  */
-export async function decompressCache(opts: { archivePath: string; targetDir: string }): Promise<void> {
-  const { archivePath, targetDir } = opts;
+export async function decompressCache(opts: {
+  archivePath: string;
+  targetDir: string;
+  debug?: boolean;
+  log?: (msg: string) => void;
+}): Promise<DecompressResult> {
+  const { archivePath, targetDir, debug = false, log = (): void => undefined } = opts;
   await ensureDir(targetDir);
-  const magic = await detectCompressMagic(archivePath);
-  if (magic === "gzip") {
-    await exec.exec("tar", ["-xzf", archivePath, "-C", targetDir]);
-    return;
+
+  let archiveBytes = 0;
+  try {
+    archiveBytes = (await fs.stat(archivePath)).size;
+  } catch {
+    // archive may not exist — caller guards, but be safe
   }
-  if (magic === "zstd") {
-    // tar -xf - reads from stdin; we pipe `zstd -d -c <archive>` into it.
+
+  const magic = await detectCompressMagic(archivePath);
+  if (debug) {
+    log(`[debug] decompress ${path.basename(archivePath)}: magic=${magic} archive=${fmtBytesDebug(archiveBytes)}`);
+  }
+
+  if (magic === "gzip") {
+    if (debug) log(`[debug] decompress cmd: tar -xzf ${archivePath} -C ${targetDir}`);
+    await exec.exec("tar", ["-xzf", archivePath, "-C", targetDir]);
+  } else if (magic === "zstd") {
     const zstdPath = await io.which("zstd", false);
     if (!zstdPath) {
+      if (debug) log(`[debug] decompress cmd (zstd fallback): tar --zstd -xf ${archivePath} -C ${targetDir}`);
       // Fall back: many tars know how to decode zstd themselves (--zstd).
       await exec.exec("tar", ["--zstd", "-xf", archivePath, "-C", targetDir]);
-      return;
+    } else {
+      if (debug) log(`[debug] decompress cmd: zstd -d -c ${archivePath} | tar -xf - -C ${targetDir}`);
+      // tar -xf - reads from stdin; we pipe `zstd -d -c <archive>` into it.
+      await runPipe(
+        [zstdPath, ["-d", "-c", archivePath]],
+        ["tar", ["-xf", "-", "-C", targetDir]],
+      );
     }
-    await runPipe(
-      [zstdPath, ["-d", "-c", archivePath]],
-      ["tar", ["-xf", "-", "-C", targetDir]],
-    );
-    return;
+  } else {
+    throw new Error(`decompressCache: unrecognized archive magic for ${archivePath}`);
   }
-  throw new Error(`decompressCache: unrecognized archive magic for ${archivePath}`);
+
+  const { bytes: inflatedBytes, files: fileCount } = await walkDirSize(targetDir);
+  if (debug) {
+    const ratio = archiveBytes > 0 ? (archiveBytes / inflatedBytes).toFixed(2) : "n/a";
+    log(`[debug] decompress result: inflated=${fmtBytesDebug(inflatedBytes)} files=${fileCount} ratio=${ratio}`);
+  }
+
+  return { archiveBytes, inflatedBytes, fileCount };
+}
+
+export interface CompressResult {
+  archivePath: string | null;
+  archiveBytes: number;
+  inflatedBytes: number | null;
+  fileCount: number | null;
 }
 
 /**
  * tar -cf - <cache-dir-basename> | zstd -T0 -<level> > <cache-dir>.tar.zst
  *
- * When codec=="none" or zstd is not installed, returns null and leaves the
- * caller to use the default actions/cache compression.
+ * When codec=="none" or zstd is not installed, returns archivePath=null and
+ * leaves the caller to use the default actions/cache compression.
+ * When debug=true, walks the source dir for byte/file counts and logs ratios.
  */
 export async function compressCache(opts: {
   cacheDir: string;
   codec: "auto" | "zstd" | "none";
   level: string;
-}): Promise<string | null> {
-  const { cacheDir, codec, level } = opts;
-  if (codec === "none") return null;
+  debug?: boolean;
+  log?: (msg: string) => void;
+}): Promise<CompressResult> {
+  const { cacheDir, codec, level, debug = false, log = (): void => undefined } = opts;
+  const nullResult: CompressResult = { archivePath: null, archiveBytes: 0, inflatedBytes: null, fileCount: null };
+
+  if (codec === "none") return nullResult;
 
   const zstdPath = await io.which("zstd", false);
   if (!zstdPath) {
     core.warning(
       "setup-soldr: zstd binary not found on PATH; falling back to actions/cache default codec",
     );
-    return null;
+    return nullResult;
   }
 
   if (!(await pathExists(cacheDir))) {
     core.warning(`setup-soldr: cache dir ${cacheDir} does not exist, skipping compression`);
-    return null;
+    return nullResult;
+  }
+
+  let inflatedBytes: number | null = null;
+  let fileCount: number | null = null;
+  if (debug) {
+    const walked = await walkDirSize(cacheDir);
+    inflatedBytes = walked.bytes;
+    fileCount = walked.files;
+    log(`[debug] compress ${path.basename(cacheDir)}: input=${fmtBytesDebug(inflatedBytes)} files=${fileCount}`);
   }
 
   const parent = path.dirname(cacheDir);
@@ -120,12 +210,32 @@ export async function compressCache(opts: {
   const levelNumeric = parseLevel(level);
   const levelFlag = `-${levelNumeric}`;
 
+  if (debug) log(`[debug] compress cmd: tar -cf - -C ${parent} ${basename} | zstd -T0 ${levelFlag} -o ${archivePath}`);
   await runPipe(
     ["tar", ["-cf", "-", "-C", parent, basename]],
     [zstdPath, ["-T0", levelFlag, "-o", archivePath]],
   );
 
-  return archivePath;
+  let archiveBytes = 0;
+  try {
+    archiveBytes = (await fs.stat(archivePath)).size;
+  } catch {
+    // archive may not have been created
+  }
+
+  if (debug && inflatedBytes !== null && inflatedBytes > 0) {
+    const ratio = (archiveBytes / inflatedBytes).toFixed(2);
+    log(`[debug] compress result: archive=${fmtBytesDebug(archiveBytes)} ratio=${ratio}`);
+  }
+
+  return { archivePath, archiveBytes, inflatedBytes, fileCount };
+}
+
+function fmtBytesDebug(n: number): string {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)}MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
 }
 
 function parseLevel(value: string): number {

--- a/src/lib/resolve-setup.ts
+++ b/src/lib/resolve-setup.ts
@@ -48,7 +48,14 @@ import type {
 
 const FALSY_VALUES: ReadonlySet<string> = new Set(["0", "false", "no", "off"]);
 const TRUTHY_VALUES: ReadonlySet<string> = new Set(["1", "true", "yes", "on"]);
-const ALLOWED_LINKER_VALUES = ["default", "ld", "mold", "rust-lld", "fast"] as const;
+const ALLOWED_LINKER_VALUES = [
+  "default",
+  "platform-default",
+  "ld",
+  "mold",
+  "rust-lld",
+  "fast",
+] as const;
 
 // CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
 // FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
@@ -85,6 +92,7 @@ export function readRawInputs(env: Record<string, string | undefined>): RawInput
     toolchainFile: get("TOOLCHAIN_FILE"),
     trustMode: get("TRUST_MODE"),
     linker: get("LINKER"),
+    compilePriority: get("COMPILE_PRIORITY"),
     timestamps: get("TIMESTAMPS"),
     lockfile: get("LOCKFILE"),
     buildCache: get("BUILD_CACHE"),
@@ -540,16 +548,22 @@ export async function resolveSetup(
   if (inputs.trustMode.trim()) {
     setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
   }
-  const linkerValue = inputs.linker.trim();
-  if (linkerValue) {
-    if (!(ALLOWED_LINKER_VALUES as readonly string[]).includes(linkerValue)) {
-      throw new Error(
-        `invalid 'linker' input: '${linkerValue}'. Allowed: default | ld | mold | rust-lld | fast`,
-      );
-    }
-    if (linkerValue !== "default") {
-      setEnv("SOLDR_LINKER", linkerValue);
-    }
+  const linkerRaw = inputs.linker.trim();
+  if (linkerRaw === "") {
+    setEnv("SOLDR_LINKER", "fast");
+    logger.warning(
+      "setup-soldr: defaulting SOLDR_LINKER=fast (mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows) for faster CI links. Soldr's native default is no injection, which produces a smaller build-cache and a slower link. Set `linker: platform-default` to opt out and keep cargo/rust-toolchain.toml in charge, or set `linker: <value>` to silence this warning.",
+    );
+  } else if (!(ALLOWED_LINKER_VALUES as readonly string[]).includes(linkerRaw)) {
+    throw new Error(
+      `invalid 'linker' input: '${linkerRaw}'. Allowed: default | platform-default | ld | mold | rust-lld | fast`,
+    );
+  } else if (linkerRaw !== "default" && linkerRaw !== "platform-default") {
+    setEnv("SOLDR_LINKER", linkerRaw);
+  }
+  const compilePriorityRaw = inputs.compilePriority.trim();
+  if (compilePriorityRaw !== "") {
+    setEnv("ZCCACHE_COMPILE_PRIORITY", compilePriorityRaw);
   }
 
   // ---- path additions ----

--- a/src/lib/resolve-setup.ts
+++ b/src/lib/resolve-setup.ts
@@ -42,6 +42,7 @@ import type {
   RawInputs,
   ResolveResult,
   SetupCachePlan,
+  StatsMode,
   TargetCachePlan,
   ToolchainSpec,
 } from "./types.js";
@@ -108,7 +109,15 @@ export function readRawInputs(env: Record<string, string | undefined>): RawInput
     targetCacheCompressLevel: get("TARGET_CACHE_COMPRESS_LEVEL"),
     sourceMtimeNormalize: get("SOURCE_MTIME_NORMALIZE"),
     cargoRegistryCache: get("CARGO_REGISTRY_CACHE"),
+    stats: get("STATS"),
+    debugMode: get("DEBUG"),
   };
+}
+
+function normalizeStatsMode(raw: string): StatsMode {
+  const v = raw.trim().toLowerCase();
+  if (v === "none" || v === "summarize" || v === "detailed") return v;
+  return "summarize";
 }
 
 function isFalsy(value: string): boolean {
@@ -651,6 +660,9 @@ export async function resolveSetup(
   void rollingToolchainAlias;
   void canonicalJsonStringify;
 
+  const stats = normalizeStatsMode(inputs.stats);
+  const debugMode = isTruthy(inputs.debugMode.trim() || "false");
+
   return {
     workspace,
     cacheRoot,
@@ -676,6 +688,8 @@ export async function resolveSetup(
     pathAdditions,
     logStartEpoch: logStart,
     timestamps,
+    stats,
+    debugMode,
   };
 }
 

--- a/src/lib/stats-collector.ts
+++ b/src/lib/stats-collector.ts
@@ -1,0 +1,161 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as core from "@actions/core";
+import type { CacheOpStats, StatsMode } from "./types.js";
+
+function fmtBytes(n: number | null): string {
+  if (n === null) return "-";
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)}MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
+}
+
+function fmtMs(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function truncKey(key: string, maxLen: number): string {
+  if (!key) return "(no match)";
+  if (key.length <= maxLen) return key;
+  return `\u2026${key.slice(-(maxLen - 1))}`;
+}
+
+function ratioStr(archiveBytes: number | null, inflatedBytes: number | null): string {
+  if (archiveBytes === null || inflatedBytes === null || inflatedBytes === 0) return "";
+  return ` ratio=${(archiveBytes / inflatedBytes).toFixed(2)}`;
+}
+
+export class StatsCollector {
+  private ops: CacheOpStats[] = [];
+
+  record(op: CacheOpStats): void {
+    this.ops.push(op);
+  }
+
+  summaryText(): string {
+    const restoreOps = this.ops.filter((o) => o.operation === "restore");
+    if (restoreOps.length === 0) return "";
+
+    const CW = { cache: 20, status: 8, matched: 42, archive: 10, inflated: 10, files: 8, time: 7 };
+    const header = [
+      "cache".padEnd(CW.cache),
+      "status".padEnd(CW.status),
+      "matched-key".padEnd(CW.matched),
+      "archive".padStart(CW.archive),
+      "inflated".padStart(CW.inflated),
+      "files".padStart(CW.files),
+      "time".padStart(CW.time),
+    ].join("  ");
+    const rule = "\u2500".repeat(header.length);
+
+    const rows = restoreOps.map((op) => {
+      const status = op.hit ? "HIT" : op.matchedKey ? "FALLBACK" : "MISS";
+      const matchedDisplay = op.hit
+        ? truncKey(op.matchedKey, CW.matched - 4)
+        : op.matchedKey
+          ? `fallback: ${truncKey(op.matchedKey, CW.matched - 10)}`
+          : "(no match)";
+      return [
+        op.label.padEnd(CW.cache),
+        status.padEnd(CW.status),
+        matchedDisplay.padEnd(CW.matched),
+        fmtBytes(op.archiveBytes).padStart(CW.archive),
+        fmtBytes(op.inflatedBytes).padStart(CW.inflated),
+        (op.fileCount !== null ? String(op.fileCount) : "-").padStart(CW.files),
+        fmtMs(op.durationMs).padStart(CW.time),
+      ].join("  ");
+    });
+
+    const exactHits = restoreOps.filter((o) => o.hit).length;
+    const anyHits = restoreOps.filter((o) => o.hit || Boolean(o.matchedKey)).length;
+    const totalMs = restoreOps.reduce((s, o) => s + o.durationMs, 0);
+    const footer = `${exactHits}/${restoreOps.length} exact-hit  ${anyHits}/${restoreOps.length} any-hit  total restore: ${fmtMs(totalMs)}`;
+
+    return [header, rule, ...rows, rule, footer].join("\n");
+  }
+
+  detailedJson(): object {
+    const restoreOps = this.ops.filter((o) => o.operation === "restore");
+    const saveOps = this.ops.filter((o) => o.operation === "save");
+    const exactHits = restoreOps.filter((o) => o.hit).length;
+    const anyHits = restoreOps.filter((o) => o.hit || Boolean(o.matchedKey)).length;
+    const totalRestoreMs = restoreOps.reduce((s, o) => s + o.durationMs, 0);
+    return {
+      summary: {
+        totalCaches: restoreOps.length,
+        exactHits,
+        anyHits,
+        misses: restoreOps.length - anyHits,
+        totalRestoreMs,
+        savedCaches: saveOps.length,
+      },
+      restores: restoreOps,
+      saves: saveOps,
+    };
+  }
+
+  private restoreLogLine(op: CacheOpStats): string {
+    const status = op.hit ? "HIT" : op.matchedKey ? "FALLBACK" : "MISS";
+    const matchStr = op.matchedKey ? ` matched=${op.matchedKey}` : "";
+    const archStr = op.archiveBytes !== null ? ` archive=${fmtBytes(op.archiveBytes)}` : "";
+    const inflStr = op.inflatedBytes !== null ? ` inflated=${fmtBytes(op.inflatedBytes)}` : "";
+    const filesStr = op.fileCount !== null ? ` files=${op.fileCount}` : "";
+    return `[restore] ${op.label.padEnd(20)} ${status.padEnd(8)} key=${op.key}${matchStr}${archStr}${inflStr}${filesStr}  ${op.timestamp}  ${fmtMs(op.durationMs)}`;
+  }
+
+  private saveLogLine(op: CacheOpStats): string {
+    const archStr = op.archiveBytes !== null ? ` archive=${fmtBytes(op.archiveBytes)}` : "";
+    const inflStr = op.inflatedBytes !== null ? ` inflated=${fmtBytes(op.inflatedBytes)}` : "";
+    const filesStr = op.fileCount !== null ? ` files=${op.fileCount}` : "";
+    const ratio = ratioStr(op.archiveBytes, op.inflatedBytes);
+    return `[save]    ${op.label.padEnd(20)}          key=${op.key}${archStr}${inflStr}${filesStr}${ratio}  ${op.timestamp}  ${fmtMs(op.durationMs)}`;
+  }
+
+  async writeFiles(runnerTemp: string): Promise<void> {
+    await fs.mkdir(runnerTemp, { recursive: true });
+    const jsonPath = path.join(runnerTemp, "setup-soldr-stats.json");
+    const logPath = path.join(runnerTemp, "setup-soldr-session.log");
+    await fs.writeFile(jsonPath, JSON.stringify(this.detailedJson(), null, 2), "utf8");
+    const restoreLines = this.ops
+      .filter((o) => o.operation === "restore")
+      .map((o) => this.restoreLogLine(o));
+    await fs.writeFile(logPath, restoreLines.join("\n") + "\n", "utf8");
+  }
+
+  async appendSavesToSessionLog(runnerTemp: string): Promise<void> {
+    const saveOps = this.ops.filter((o) => o.operation === "save");
+    if (saveOps.length === 0) return;
+    const logPath = path.join(runnerTemp, "setup-soldr-session.log");
+    const lines = saveOps.map((o) => this.saveLogLine(o));
+    await fs.appendFile(logPath, lines.join("\n") + "\n", "utf8").catch(() => undefined);
+  }
+
+  report(mode: StatsMode, log: (msg: string) => void): void {
+    if (mode === "none") return;
+    const summary = this.summaryText();
+    if (summary) log(summary);
+    if (mode === "detailed") {
+      log(JSON.stringify(this.detailedJson(), null, 2));
+    }
+  }
+
+  setGithubOutputs(): void {
+    core.setOutput("stats-json", JSON.stringify(this.detailedJson()));
+  }
+
+  serialize(): string {
+    return JSON.stringify({ ops: this.ops });
+  }
+
+  static deserialize(s: string): StatsCollector {
+    const c = new StatsCollector();
+    try {
+      const parsed = JSON.parse(s) as { ops: CacheOpStats[] };
+      c.ops = Array.isArray(parsed.ops) ? parsed.ops : [];
+    } catch {
+      // empty collector
+    }
+    return c;
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,24 @@ export type CompressCodec = "auto" | "zstd" | "none";
 export type BuildCacheMode = "" | "once" | "thin" | "full";
 export type TargetCacheMode = "" | "thin" | "full" | "off" | "hot";
 export type TargetCacheProfile = "thin-v1" | "thin-v2";
+export type StatsMode = "none" | "summarize" | "detailed";
+
+/**
+ * Per-cache-operation stats record collected during main and post phases.
+ */
+export interface CacheOpStats {
+  label: string;
+  operation: "restore" | "save";
+  hit: boolean;
+  key: string;
+  matchedKey: string;
+  restoreKeys: string[];
+  archiveBytes: number | null;
+  inflatedBytes: number | null;
+  fileCount: number | null;
+  durationMs: number;
+  timestamp: string;
+}
 
 /**
  * Raw INPUT_* env vars read at process start. Mirrors `inputs:` in action.yml.
@@ -44,6 +62,8 @@ export interface RawInputs {
   targetCacheCompressLevel: string;
   sourceMtimeNormalize: string;
   cargoRegistryCache: string;
+  stats: string;
+  debugMode: string;
 }
 
 /**
@@ -160,6 +180,10 @@ export interface ResolveResult {
   // Timing
   logStartEpoch: string;
   timestamps: string;
+
+  // Stats and debug
+  stats: StatsMode;
+  debugMode: boolean;
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface RawInputs {
   toolchainFile: string;
   trustMode: string;
   linker: string;
+  compilePriority: string;
   timestamps: string;
   lockfile: string;
   buildCache: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { verifySoldr } from "./lib/verify-soldr.js";
 import { normalizeSourceMtime } from "./lib/normalize-source-mtime.js";
 import { detectSharedTargetWarning } from "./lib/detect-shared-target-warning.js";
 import { detectCompressMagic, decompressCache } from "./lib/cache-compress.js";
+import { StatsCollector } from "./lib/stats-collector.js";
 import type { ActionContext } from "./lib/types.js";
 
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
@@ -104,6 +105,11 @@ export async function run(): Promise<void> {
   core.saveState("resolveResult", JSON.stringify(result));
   core.saveState("buildCacheMode", result.buildCache.mode);
 
+  const stats = result.stats;
+  const debugMode = result.debugMode;
+  const debugLog = debugMode ? (msg: string): void => logger.log(msg) : (): void => undefined;
+  const statsCollector = new StatsCollector();
+
   // ---- source-mtime-normalize ----
   if (isTruthy(inputs.sourceMtimeNormalize)) {
     await normalizeSourceMtime({ workspace: ctx.workspace, enabled: true });
@@ -116,6 +122,7 @@ export async function run(): Promise<void> {
   await markPhase("setup-cache");
   let setupCacheExactHit = false;
   if (cacheEnabled && result.setupCache.paths.length > 0) {
+    const setupCacheStart = Date.now();
     const restore = await restoreCacheSafe(
       result.setupCache.paths,
       result.setupCache.key,
@@ -129,6 +136,22 @@ export async function run(): Promise<void> {
     core.saveState("setupCacheMatchedKey", restore.matchedKey);
     // Expose for ensure_rust_toolchain to read via env (the python port did this).
     process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
+    statsCollector.record({
+      label: "setup-cache",
+      operation: "restore",
+      hit: restore.hit,
+      key: result.setupCache.key,
+      matchedKey: restore.matchedKey,
+      restoreKeys: [result.setupCache.restorePrefix],
+      archiveBytes: null,
+      inflatedBytes: null,
+      fileCount: null,
+      durationMs: Date.now() - setupCacheStart,
+      timestamp: new Date().toISOString(),
+    });
+    if (debugMode) {
+      debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    }
   }
   await finishPhase("setup-cache");
 
@@ -140,6 +163,7 @@ export async function run(): Promise<void> {
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
     if (targetPaths.length > 0) {
+      const targetCacheStart = Date.now();
       const restoreKeys: string[] = [];
       if (result.targetCache.restoreKeyParent) restoreKeys.push(result.targetCache.restoreKeyParent);
       if (result.targetCache.restoreKeyLock) restoreKeys.push(result.targetCache.restoreKeyLock);
@@ -148,6 +172,22 @@ export async function run(): Promise<void> {
       core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
       core.setOutput("target_cache_matched_key", restore.matchedKey);
       core.saveState("targetCacheMatchedKey", restore.matchedKey);
+      statsCollector.record({
+        label: "target-cache",
+        operation: "restore",
+        hit: restore.hit,
+        key: result.targetCache.key,
+        matchedKey: restore.matchedKey,
+        restoreKeys,
+        archiveBytes: null,
+        inflatedBytes: null,
+        fileCount: null,
+        durationMs: Date.now() - targetCacheStart,
+        timestamp: new Date().toISOString(),
+      });
+      if (debugMode) {
+        debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+      }
     }
   }
   await finishPhase("target-cache");
@@ -161,6 +201,7 @@ export async function run(): Promise<void> {
     if (result.buildCache.restoreKeyParent) restoreKeys.push(result.buildCache.restoreKeyParent);
     if (result.buildCache.restoreKeyToolchain) restoreKeys.push(result.buildCache.restoreKeyToolchain);
     if (result.buildCache.restoreKeyOsArch) restoreKeys.push(result.buildCache.restoreKeyOsArch);
+    const buildCacheStart = Date.now();
     const restore = await restoreCacheSafe(
       [archivePath, buildCachePath],
       result.buildCache.key,
@@ -170,11 +211,22 @@ export async function run(): Promise<void> {
     core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
     core.setOutput("build_cache_matched_key", restore.matchedKey);
     core.saveState("buildCacheMatchedKey", restore.matchedKey);
+    let buildArchiveBytes: number | null = null;
+    let buildInflatedBytes: number | null = null;
+    let buildFileCount: number | null = null;
     if (fileExists(archivePath)) {
       const magic = await detectCompressMagic(archivePath);
       if (magic === "zstd" || magic === "gzip") {
         try {
-          await decompressCache({ archivePath, targetDir: buildCachePath });
+          const decompResult = await decompressCache({
+            archivePath,
+            targetDir: buildCachePath,
+            debug: debugMode,
+            log: debugLog,
+          });
+          buildArchiveBytes = decompResult.archiveBytes;
+          buildInflatedBytes = decompResult.inflatedBytes;
+          buildFileCount = decompResult.fileCount;
         } catch (err) {
           logger.log(
             `build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -182,6 +234,19 @@ export async function run(): Promise<void> {
         }
       }
     }
+    statsCollector.record({
+      label: "build-cache",
+      operation: "restore",
+      hit: restore.hit,
+      key: result.buildCache.key,
+      matchedKey: restore.matchedKey,
+      restoreKeys,
+      archiveBytes: buildArchiveBytes,
+      inflatedBytes: buildInflatedBytes,
+      fileCount: buildFileCount,
+      durationMs: Date.now() - buildCacheStart,
+      timestamp: new Date().toISOString(),
+    });
   }
   await finishPhase("build-cache");
 
@@ -216,6 +281,7 @@ export async function run(): Promise<void> {
   // ---- cargo-registry restore (if requested) ----
   if (result.cargoRegistryCache.enabled) {
     const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
+    const registryCacheStart = Date.now();
     const restore = await restoreCacheSafe(
       [registryArchive, result.cargoRegistryCache.path],
       result.cargoRegistryCache.key,
@@ -223,14 +289,22 @@ export async function run(): Promise<void> {
       logger,
     );
     core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
+    let regArchiveBytes: number | null = null;
+    let regInflatedBytes: number | null = null;
+    let regFileCount: number | null = null;
     if (fileExists(registryArchive)) {
       const magic = await detectCompressMagic(registryArchive);
       if (magic === "zstd" || magic === "gzip") {
         try {
-          await decompressCache({
+          const decompResult = await decompressCache({
             archivePath: registryArchive,
             targetDir: result.cargoRegistryCache.path,
+            debug: debugMode,
+            log: debugLog,
           });
+          regArchiveBytes = decompResult.archiveBytes;
+          regInflatedBytes = decompResult.inflatedBytes;
+          regFileCount = decompResult.fileCount;
         } catch (err) {
           logger.log(
             `cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -238,6 +312,19 @@ export async function run(): Promise<void> {
         }
       }
     }
+    statsCollector.record({
+      label: "cargo-registry",
+      operation: "restore",
+      hit: restore.hit,
+      key: result.cargoRegistryCache.key,
+      matchedKey: restore.matchedKey,
+      restoreKeys: [result.cargoRegistryCache.restorePrefix],
+      archiveBytes: regArchiveBytes,
+      inflatedBytes: regInflatedBytes,
+      fileCount: regFileCount,
+      durationMs: Date.now() - registryCacheStart,
+      timestamp: new Date().toISOString(),
+    });
   }
 
   // ---- shared-target warning ----
@@ -247,6 +334,20 @@ export async function run(): Promise<void> {
     buildCacheMode: result.buildCache.mode,
     targetDir: result.targetCache.targetPath,
   });
+
+  // ---- stats report ----
+  statsCollector.report(stats, (msg) => logger.log(msg));
+  if (stats === "detailed") {
+    try {
+      await statsCollector.writeFiles(ctx.runnerTemp);
+      statsCollector.setGithubOutputs();
+    } catch (err) {
+      logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  core.saveState("statsCollector", statsCollector.serialize());
+  core.saveState("statsMode", stats);
+  core.saveState("runnerTemp", ctx.runnerTemp);
 
   await finishPhase("action");
 

--- a/src/post.ts
+++ b/src/post.ts
@@ -12,7 +12,8 @@ import * as core from "@actions/core";
 import * as cache from "@actions/cache";
 import { compressCache } from "./lib/cache-compress.js";
 import { createLogger } from "./lib/log-utils.js";
-import type { ResolveResult } from "./lib/types.js";
+import { StatsCollector } from "./lib/stats-collector.js";
+import type { ResolveResult, StatsMode } from "./lib/types.js";
 
 function dirExists(p: string): boolean {
   try {
@@ -22,6 +23,13 @@ function dirExists(p: string): boolean {
   }
 }
 
+interface SaveOneResult {
+  archiveBytes: number | null;
+  inflatedBytes: number | null;
+  fileCount: number | null;
+  skipped: boolean;
+}
+
 async function saveOne(opts: {
   cacheDir: string;
   codec: "auto" | "zstd" | "none";
@@ -29,25 +37,34 @@ async function saveOne(opts: {
   key: string;
   matchedKey: string;
   label: string;
+  debug: boolean;
   log: (msg: string) => void;
-}): Promise<void> {
-  const { cacheDir, codec, level, key, matchedKey, label, log } = opts;
+}): Promise<SaveOneResult> {
+  const { cacheDir, codec, level, key, matchedKey, label, debug, log } = opts;
+  const nullResult: SaveOneResult = { archiveBytes: null, inflatedBytes: null, fileCount: null, skipped: true };
   if (!dirExists(cacheDir)) {
     log(`${label}: cache dir ${cacheDir} does not exist, skipping save`);
-    return;
+    return nullResult;
   }
   if (matchedKey === key) {
     log(`${label}: exact cache hit on ${key}, skipping save`);
-    return;
+    return nullResult;
   }
-  const archive = await compressCache({ cacheDir, codec, level });
-  const pathsToSave = archive ? [archive] : [cacheDir];
+  const { archivePath, archiveBytes, inflatedBytes, fileCount } = await compressCache({
+    cacheDir,
+    codec,
+    level,
+    debug,
+    log,
+  });
+  const pathsToSave = archivePath ? [archivePath] : [cacheDir];
   try {
     const id = await cache.saveCache(pathsToSave, key);
-    log(`${label}: saved cache id=${id} key=${key} via ${archive ? "tar.zst" : "default"}`);
+    log(`${label}: saved cache id=${id} key=${key} via ${archivePath ? "tar.zst" : "default"}`);
   } catch (err) {
     log(`${label}: save failed: ${err instanceof Error ? err.message : String(err)}`);
   }
+  return { archiveBytes, inflatedBytes, fileCount, skipped: false };
 }
 
 export async function run(): Promise<void> {
@@ -68,29 +85,78 @@ export async function run(): Promise<void> {
 
   const buildCacheMatched = core.getState("buildCacheMatchedKey");
   const registryMatched = core.getState("cargoRegistryCacheMatchedKey");
+  const statsMode = (core.getState("statsMode") || "summarize") as StatsMode;
+  const runnerTemp = core.getState("runnerTemp") || "";
+  const debugMode = result.debugMode ?? false;
+  const debugLog = debugMode ? log : (): void => undefined;
+
+  const postCollector = new StatsCollector();
 
   // Build cache
-  await saveOne({
+  const buildSaveStart = Date.now();
+  const buildSaveResult = await saveOne({
     cacheDir: result.buildCache.path,
     codec: result.targetCacheCompress,
     level: result.targetCacheCompressLevel,
     key: result.buildCache.key,
     matchedKey: buildCacheMatched,
     label: "build-cache",
-    log,
+    debug: debugMode,
+    log: debugLog,
   });
+  if (!buildSaveResult.skipped) {
+    postCollector.record({
+      label: "build-cache",
+      operation: "save",
+      hit: false,
+      key: result.buildCache.key,
+      matchedKey: buildCacheMatched,
+      restoreKeys: [],
+      archiveBytes: buildSaveResult.archiveBytes,
+      inflatedBytes: buildSaveResult.inflatedBytes,
+      fileCount: buildSaveResult.fileCount,
+      durationMs: Date.now() - buildSaveStart,
+      timestamp: new Date().toISOString(),
+    });
+  }
 
   // Cargo registry cache (only when enabled)
   if (result.cargoRegistryCache.enabled) {
-    await saveOne({
+    const regSaveStart = Date.now();
+    const regSaveResult = await saveOne({
       cacheDir: result.cargoRegistryCache.path,
       codec: result.targetCacheCompress,
       level: result.targetCacheCompressLevel,
       key: result.cargoRegistryCache.key,
       matchedKey: registryMatched,
       label: "cargo-registry-cache",
-      log,
+      debug: debugMode,
+      log: debugLog,
     });
+    if (!regSaveResult.skipped) {
+      postCollector.record({
+        label: "cargo-registry",
+        operation: "save",
+        hit: false,
+        key: result.cargoRegistryCache.key,
+        matchedKey: registryMatched,
+        restoreKeys: [],
+        archiveBytes: regSaveResult.archiveBytes,
+        inflatedBytes: regSaveResult.inflatedBytes,
+        fileCount: regSaveResult.fileCount,
+        durationMs: Date.now() - regSaveStart,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  // Append save ops to session log when detailed stats are enabled
+  if (statsMode === "detailed" && runnerTemp) {
+    try {
+      await postCollector.appendSavesToSessionLog(runnerTemp);
+    } catch (err) {
+      log(`post: stats log append failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 }
 

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -34,6 +34,7 @@ EXPECTED_INPUTS = {
     "toolchain-file",
     "trust-mode",
     "linker",
+    "compile-priority",
     "timestamps",
     "lockfile",
     "build-cache",

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -50,6 +50,8 @@ EXPECTED_INPUTS = {
     "target-cache-compress-level",
     "source-mtime-normalize",
     "cargo-registry-cache",
+    "stats",
+    "debug",
 }
 
 
@@ -85,6 +87,7 @@ EXPECTED_OUTPUTS = {
     "target-lockfile",
     "target-lockfile-hash",
     "toolchain",
+    "stats-json",
 }
 
 


### PR DESCRIPTION
## Summary

- Adds `stats` input (`none` / `summarize` / `detailed`, default `summarize`) — prints a compact hit/miss table after every setup, or full JSON + session log files in detailed mode
- Adds `debug` input (`true`/`false`, default `false`) — always-visible per-operation diagnostics: archive magic bytes, compressed/inflated byte counts, file counts, compression ratios, exact tar/zstd commands
- Adds `stats-json` output (set when `stats: detailed`) — JSON string of the full cache report
- `decompressCache` now returns `{ archiveBytes, inflatedBytes, fileCount }` and accepts optional debug opts
- `compressCache` now returns `{ archivePath, archiveBytes, inflatedBytes, fileCount }` and accepts optional debug opts
- New `src/lib/stats-collector.ts`: `StatsCollector` class with serialize/deserialize for main→post state handoff; post phase appends save ops to `setup-soldr-session.log`

## Motivation

Diagnosed from run https://github.com/zackees/setup-soldr/actions/runs/25883958721 where a warm build showed ~half the caches missing with no visibility into which caches hit/missed, what the archive sizes were, or what keys were tried.

## Test plan

- [x] `npm run build` succeeds (TypeScript compiles, dist/ updated)
- [x] `npm test` — 174 tests pass
- [x] Python contract tests pass (`test_action_target_cache_wiring.py`, `test_release_rollout_contract.py`)
- [ ] In a real workflow: set `stats: detailed` and `debug: true`, verify summary table in step log, `setup-soldr-stats.json` artifact, `setup-soldr-session.log` artifact, and `stats-json` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)