### PR TITLE
chore(action): post-if always() so daemon shutdown fires on failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -359,4 +359,8 @@ runs:
   using: node20
   main: dist/main.js
   post: dist/post.js
-  post-if: success()
+  # always() so the post step (and its unconditional cache-daemon
+  # shutdown) fires on job failure too. saveOne is already best-effort
+  # — missing dirs and save errors are logged, not raised — so running
+  # the full post pipeline on failure cannot brick the run.
+  post-if: always()

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -117,7 +117,7 @@ def test_action_runs_as_node20_with_main_and_post_entrypoints() -> None:
     assert runs["using"] == "node20"
     assert runs["main"] == "dist/main.js"
     assert runs["post"] == "dist/post.js"
-    assert runs.get("post-if") == "success()"
+    assert runs.get("post-if") == "always()"
 
 
 def test_action_preserves_all_original_inputs() -> None:


### PR DESCRIPTION
## Summary
Flip `post-if: success()` → `post-if: always()` so the unconditional `zccache --stop-server` / `<soldrPath> stop` sweep (added in #114) fires on job failure too. GitHub Actions doesn't expose job status to the post step, so this is the only way to make the shutdown run regardless of outcome.

Side effect: cache save also runs on failure. `saveOne` is already best-effort (missing-dir-skip, errors logged not raised), and zccache validates per-entry, so caching deps from a failed compile is safe and frequently useful.

Contract test updated to expect `always()`.

## Test plan
- [x] Full suite: 201 pass / 4 skipped / 0 fail
- [x] Contract test now asserts `post-if: always()`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)