### PR TITLE
refactor(lib): split detect-musl-cc and build-outputs out of resolve-setup

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -14,15 +14,15 @@
 //  * support limits.fieldNameSize
 //     -- this will require modifications to utils.parseParams
 
-const { Readable } = __nccwpck_require__(422)
-const { inherits } = __nccwpck_require__(368)
+const { Readable } = __nccwpck_require__(423)
+const { inherits } = __nccwpck_require__(369)
 
 const Dicer = __nccwpck_require__(12)
 
 const parseParams = __nccwpck_require__(187)
 const decodeText = __nccwpck_require__(268)
-const basename = __nccwpck_require__(467)
-const getLimit = __nccwpck_require__(473)
+const basename = __nccwpck_require__(468)
+const getLimit = __nccwpck_require__(474)
 
 const RE_BOUNDARY = /^boundary$/i
 const RE_FIELD = /^form-data$/i
@@ -340,7 +340,7 @@ __export(inspect_exports, {
   custom: () => custom
 });
 module.exports = __toCommonJS(inspect_exports);
-var import_node_util = __nccwpck_require__(368);
+var import_node_util = __nccwpck_require__(369);
 const custom = import_node_util.inspect.custom;
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -469,13 +469,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = exports.downloadCacheHttpClient = exports.DownloadProgress = void 0;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 const http_client_1 = __nccwpck_require__(278);
-const storage_blob_1 = __nccwpck_require__(439);
-const buffer = __importStar(__nccwpck_require__(115));
-const fs = __importStar(__nccwpck_require__(520));
-const stream = __importStar(__nccwpck_require__(127));
-const util = __importStar(__nccwpck_require__(120));
+const storage_blob_1 = __nccwpck_require__(440);
+const buffer = __importStar(__nccwpck_require__(116));
+const fs = __importStar(__nccwpck_require__(522));
+const stream = __importStar(__nccwpck_require__(128));
+const util = __importStar(__nccwpck_require__(121));
 const utils = __importStar(__nccwpck_require__(74));
 const constants_1 = __nccwpck_require__(44);
 const requestUtils_1 = __nccwpck_require__(254);
@@ -839,14 +839,14 @@ exports.SearchState = SearchState;
 "use strict";
 
 
-const { InvalidArgumentError } = __nccwpck_require__(478)
+const { InvalidArgumentError } = __nccwpck_require__(479)
 const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(190)
 const DispatcherBase = __nccwpck_require__(61)
-const Pool = __nccwpck_require__(330)
-const Client = __nccwpck_require__(85)
+const Pool = __nccwpck_require__(331)
+const Client = __nccwpck_require__(86)
 const util = __nccwpck_require__(68)
 const createRedirectInterceptor = __nccwpck_require__(248)
-const { WeakRef, FinalizationRegistry } = __nccwpck_require__(406)()
+const { WeakRef, FinalizationRegistry } = __nccwpck_require__(407)()
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -1078,14 +1078,14 @@ const {
   kOriginalDispatch,
   kOrigin,
   kGetNetConnect
-} = __nccwpck_require__(461)
+} = __nccwpck_require__(462)
 const { buildURL, nop } = __nccwpck_require__(68)
-const { STATUS_CODES } = __nccwpck_require__(321)
+const { STATUS_CODES } = __nccwpck_require__(322)
 const {
   types: {
     isPromise
   }
-} = __nccwpck_require__(120)
+} = __nccwpck_require__(121)
 
 function matchValue (match, value) {
   if (typeof match === 'string') {
@@ -1510,7 +1510,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetryHelper = void 0;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 /**
  * Internal class for retries
  */
@@ -1613,14 +1613,14 @@ const { kConstruct } = __nccwpck_require__(153)
 const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(77)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(68)
 const { kHeadersList } = __nccwpck_require__(190)
-const { webidl } = __nccwpck_require__(448)
+const { webidl } = __nccwpck_require__(449)
 const { Response, cloneResponse } = __nccwpck_require__(40)
 const { Request } = __nccwpck_require__(81)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(14)
-const { fetching } = __nccwpck_require__(442)
-const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(506)
-const assert = __nccwpck_require__(515)
-const { getGlobalDispatcher } = __nccwpck_require__(369)
+const { fetching } = __nccwpck_require__(443)
+const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(507)
+const assert = __nccwpck_require__(517)
+const { getGlobalDispatcher } = __nccwpck_require__(370)
 
 /**
  * @see https://w3c.github.io/ServiceWorker/#dfn-cache-batch-operation
@@ -2455,13 +2455,13 @@ module.exports = {
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(422).Writable)
-const inherits = (__nccwpck_require__(368).inherits)
+const WritableStream = (__nccwpck_require__(423).Writable)
+const inherits = (__nccwpck_require__(369).inherits)
 
-const StreamSearch = __nccwpck_require__(110)
+const StreamSearch = __nccwpck_require__(111)
 
 const PartStream = __nccwpck_require__(65)
-const HeaderParser = __nccwpck_require__(104)
+const HeaderParser = __nccwpck_require__(105)
 
 const DASH = 45
 const B_ONEDASH = Buffer.from('-')
@@ -2690,15 +2690,15 @@ exports.uint8ArrayToString = uint8ArrayToString;
 exports.stringToUint8Array = stringToUint8Array;
 const tslib_1 = __nccwpck_require__(210);
 const tspRuntime = tslib_1.__importStar(__nccwpck_require__(143));
-var aborterUtils_js_1 = __nccwpck_require__(97);
+var aborterUtils_js_1 = __nccwpck_require__(98);
 Object.defineProperty(exports, "cancelablePromiseRace", ({ enumerable: true, get: function () { return aborterUtils_js_1.cancelablePromiseRace; } }));
 var createAbortablePromise_js_1 = __nccwpck_require__(253);
 Object.defineProperty(exports, "createAbortablePromise", ({ enumerable: true, get: function () { return createAbortablePromise_js_1.createAbortablePromise; } }));
-var delay_js_1 = __nccwpck_require__(109);
+var delay_js_1 = __nccwpck_require__(110);
 Object.defineProperty(exports, "delay", ({ enumerable: true, get: function () { return delay_js_1.delay; } }));
 var error_js_1 = __nccwpck_require__(207);
 Object.defineProperty(exports, "getErrorMessage", ({ enumerable: true, get: function () { return error_js_1.getErrorMessage; } }));
-var typeGuards_js_1 = __nccwpck_require__(107);
+var typeGuards_js_1 = __nccwpck_require__(108);
 Object.defineProperty(exports, "isDefined", ({ enumerable: true, get: function () { return typeGuards_js_1.isDefined; } }));
 Object.defineProperty(exports, "isObjectWithProperties", ({ enumerable: true, get: function () { return typeGuards_js_1.isObjectWithProperties; } }));
 Object.defineProperty(exports, "objectHasProperty", ({ enumerable: true, get: function () { return typeGuards_js_1.objectHasProperty; } }));
@@ -2871,8 +2871,8 @@ __export(retryPolicy_exports, {
   retryPolicy: () => retryPolicy
 });
 module.exports = __toCommonJS(retryPolicy_exports);
-var import_helpers = __nccwpck_require__(447);
-var import_restError = __nccwpck_require__(436);
+var import_helpers = __nccwpck_require__(448);
+var import_restError = __nccwpck_require__(437);
 var import_AbortError = __nccwpck_require__(10);
 var import_logger = __nccwpck_require__(239);
 var import_constants = __nccwpck_require__(47);
@@ -3032,7 +3032,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
 const string_decoder_1 = __nccwpck_require__(146);
-const tr = __importStar(__nccwpck_require__(122));
+const tr = __importStar(__nccwpck_require__(123));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -3116,7 +3116,7 @@ exports.getExecOutput = getExecOutput;
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Convenience JSON typings and corresponding type guards
-var json_typings_1 = __nccwpck_require__(387);
+var json_typings_1 = __nccwpck_require__(388);
 Object.defineProperty(exports, "typeofJsonValue", ({ enumerable: true, get: function () { return json_typings_1.typeofJsonValue; } }));
 Object.defineProperty(exports, "isJsonObject", ({ enumerable: true, get: function () { return json_typings_1.isJsonObject; } }));
 // Base 64 encoding
@@ -3124,15 +3124,15 @@ var base64_1 = __nccwpck_require__(295);
 Object.defineProperty(exports, "base64decode", ({ enumerable: true, get: function () { return base64_1.base64decode; } }));
 Object.defineProperty(exports, "base64encode", ({ enumerable: true, get: function () { return base64_1.base64encode; } }));
 // UTF8 encoding
-var protobufjs_utf8_1 = __nccwpck_require__(338);
+var protobufjs_utf8_1 = __nccwpck_require__(339);
 Object.defineProperty(exports, "utf8read", ({ enumerable: true, get: function () { return protobufjs_utf8_1.utf8read; } }));
 // Binary format contracts, options for reading and writing, for example
-var binary_format_contract_1 = __nccwpck_require__(325);
+var binary_format_contract_1 = __nccwpck_require__(326);
 Object.defineProperty(exports, "WireType", ({ enumerable: true, get: function () { return binary_format_contract_1.WireType; } }));
 Object.defineProperty(exports, "mergeBinaryOptions", ({ enumerable: true, get: function () { return binary_format_contract_1.mergeBinaryOptions; } }));
 Object.defineProperty(exports, "UnknownFieldHandler", ({ enumerable: true, get: function () { return binary_format_contract_1.UnknownFieldHandler; } }));
 // Standard IBinaryReader implementation
-var binary_reader_1 = __nccwpck_require__(131);
+var binary_reader_1 = __nccwpck_require__(132);
 Object.defineProperty(exports, "BinaryReader", ({ enumerable: true, get: function () { return binary_reader_1.BinaryReader; } }));
 Object.defineProperty(exports, "binaryReadOptions", ({ enumerable: true, get: function () { return binary_reader_1.binaryReadOptions; } }));
 // Standard IBinaryWriter implementation
@@ -3140,7 +3140,7 @@ var binary_writer_1 = __nccwpck_require__(244);
 Object.defineProperty(exports, "BinaryWriter", ({ enumerable: true, get: function () { return binary_writer_1.BinaryWriter; } }));
 Object.defineProperty(exports, "binaryWriteOptions", ({ enumerable: true, get: function () { return binary_writer_1.binaryWriteOptions; } }));
 // Int64 and UInt64 implementations required for the binary format
-var pb_long_1 = __nccwpck_require__(113);
+var pb_long_1 = __nccwpck_require__(114);
 Object.defineProperty(exports, "PbLong", ({ enumerable: true, get: function () { return pb_long_1.PbLong; } }));
 Object.defineProperty(exports, "PbULong", ({ enumerable: true, get: function () { return pb_long_1.PbULong; } }));
 // JSON format contracts, options for reading and writing, for example
@@ -3149,13 +3149,13 @@ Object.defineProperty(exports, "jsonReadOptions", ({ enumerable: true, get: func
 Object.defineProperty(exports, "jsonWriteOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonWriteOptions; } }));
 Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: function () { return json_format_contract_1.mergeJsonOptions; } }));
 // Message type contract
-var message_type_contract_1 = __nccwpck_require__(398);
+var message_type_contract_1 = __nccwpck_require__(399);
 Object.defineProperty(exports, "MESSAGE_TYPE", ({ enumerable: true, get: function () { return message_type_contract_1.MESSAGE_TYPE; } }));
 // Message type implementation via reflection
-var message_type_1 = __nccwpck_require__(519);
+var message_type_1 = __nccwpck_require__(521);
 Object.defineProperty(exports, "MessageType", ({ enumerable: true, get: function () { return message_type_1.MessageType; } }));
 // Reflection info, generated by the plugin, exposed to the user, used by reflection ops
-var reflection_info_1 = __nccwpck_require__(444);
+var reflection_info_1 = __nccwpck_require__(445);
 Object.defineProperty(exports, "ScalarType", ({ enumerable: true, get: function () { return reflection_info_1.ScalarType; } }));
 Object.defineProperty(exports, "LongType", ({ enumerable: true, get: function () { return reflection_info_1.LongType; } }));
 Object.defineProperty(exports, "RepeatType", ({ enumerable: true, get: function () { return reflection_info_1.RepeatType; } }));
@@ -3168,19 +3168,19 @@ var reflection_type_check_1 = __nccwpck_require__(283);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
 var reflection_create_1 = __nccwpck_require__(200);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
-var reflection_scalar_default_1 = __nccwpck_require__(453);
+var reflection_scalar_default_1 = __nccwpck_require__(454);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
-var reflection_merge_partial_1 = __nccwpck_require__(133);
+var reflection_merge_partial_1 = __nccwpck_require__(134);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
-var reflection_equals_1 = __nccwpck_require__(452);
+var reflection_equals_1 = __nccwpck_require__(453);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
-var reflection_binary_reader_1 = __nccwpck_require__(400);
+var reflection_binary_reader_1 = __nccwpck_require__(401);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
 var reflection_binary_writer_1 = __nccwpck_require__(181);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
-var reflection_json_reader_1 = __nccwpck_require__(336);
+var reflection_json_reader_1 = __nccwpck_require__(337);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
-var reflection_json_writer_1 = __nccwpck_require__(87);
+var reflection_json_writer_1 = __nccwpck_require__(88);
 Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get: function () { return reflection_json_writer_1.ReflectionJsonWriter; } }));
 var reflection_contains_message_type_1 = __nccwpck_require__(49);
 Object.defineProperty(exports, "containsMessageType", ({ enumerable: true, get: function () { return reflection_contains_message_type_1.containsMessageType; } }));
@@ -3198,10 +3198,10 @@ Object.defineProperty(exports, "listEnumNames", ({ enumerable: true, get: functi
 Object.defineProperty(exports, "listEnumNumbers", ({ enumerable: true, get: function () { return enum_object_1.listEnumNumbers; } }));
 Object.defineProperty(exports, "isEnumObject", ({ enumerable: true, get: function () { return enum_object_1.isEnumObject; } }));
 // lowerCamelCase() is exported for plugin, rpc-runtime and other rpc packages
-var lower_camel_case_1 = __nccwpck_require__(445);
+var lower_camel_case_1 = __nccwpck_require__(446);
 Object.defineProperty(exports, "lowerCamelCase", ({ enumerable: true, get: function () { return lower_camel_case_1.lowerCamelCase; } }));
 // assertion functions are exported for plugin, may also be useful to user
-var assert_1 = __nccwpck_require__(474);
+var assert_1 = __nccwpck_require__(475);
 Object.defineProperty(exports, "assert", ({ enumerable: true, get: function () { return assert_1.assert; } }));
 Object.defineProperty(exports, "assertNever", ({ enumerable: true, get: function () { return assert_1.assertNever; } }));
 Object.defineProperty(exports, "assertInt32", ({ enumerable: true, get: function () { return assert_1.assertInt32; } }));
@@ -3236,7 +3236,7 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_ts_http_runtime = __nccwpck_require__(86);
+var import_ts_http_runtime = __nccwpck_require__(87);
 function createPipelineRequest(options) {
   return (0, import_ts_http_runtime.createPipelineRequest)(options);
 }
@@ -3365,7 +3365,7 @@ function throttlingRetryPolicy(options = {}) {
 "use strict";
 
 
-const Busboy = __nccwpck_require__(408)
+const Busboy = __nccwpck_require__(409)
 const util = __nccwpck_require__(68)
 const {
   ReadableStreamFrom,
@@ -3374,17 +3374,17 @@ const {
   readableStreamClose,
   createDeferredPromise,
   fullyReadBody
-} = __nccwpck_require__(506)
+} = __nccwpck_require__(507)
 const { FormData } = __nccwpck_require__(202)
 const { kState } = __nccwpck_require__(14)
-const { webidl } = __nccwpck_require__(448)
+const { webidl } = __nccwpck_require__(449)
 const { DOMException, structuredClone } = __nccwpck_require__(29)
-const { Blob, File: NativeFile } = __nccwpck_require__(115)
+const { Blob, File: NativeFile } = __nccwpck_require__(116)
 const { kBodyUsed } = __nccwpck_require__(190)
-const assert = __nccwpck_require__(515)
+const assert = __nccwpck_require__(517)
 const { isErrored } = __nccwpck_require__(68)
 const { isUint8Array, isArrayBuffer } = __nccwpck_require__(193)
-const { File: UndiciFile } = __nccwpck_require__(356)
+const { File: UndiciFile } = __nccwpck_require__(357)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(24)
 
 let random
@@ -3983,9 +3983,9 @@ module.exports = {
 /***/ 24:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const assert = __nccwpck_require__(515)
-const { atob } = __nccwpck_require__(115)
-const { isomorphicDecode } = __nccwpck_require__(506)
+const assert = __nccwpck_require__(517)
+const { atob } = __nccwpck_require__(116)
+const { isomorphicDecode } = __nccwpck_require__(507)
 
 const encoder = new TextEncoder()
 
@@ -4629,7 +4629,7 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
 const tslib_1 = __nccwpck_require__(210);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(431));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(432));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(64));
 /** Class containing AppendBlob operations. */
@@ -4963,7 +4963,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(388);
+var import_exponentialRetryStrategy = __nccwpck_require__(389);
 var import_retryPolicy = __nccwpck_require__(15);
 var import_constants = __nccwpck_require__(47);
 const systemErrorRetryPolicyName = "systemErrorRetryPolicy";
@@ -5324,10 +5324,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.reserveCache = exports.downloadCache = exports.getCacheEntry = void 0;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 const http_client_1 = __nccwpck_require__(278);
 const auth_1 = __nccwpck_require__(26);
-const fs = __importStar(__nccwpck_require__(520));
+const fs = __importStar(__nccwpck_require__(522));
 const url_1 = __nccwpck_require__(82);
 const utils = __importStar(__nccwpck_require__(74));
 const uploadUtils_1 = __nccwpck_require__(156);
@@ -5335,7 +5335,7 @@ const downloadUtils_1 = __nccwpck_require__(3);
 const options_1 = __nccwpck_require__(258);
 const requestUtils_1 = __nccwpck_require__(254);
 const config_1 = __nccwpck_require__(36);
-const user_agent_1 = __nccwpck_require__(354);
+const user_agent_1 = __nccwpck_require__(355);
 function getCacheApiUrl(resource) {
     const baseUrl = (0, config_1.getCacheServiceURL)();
     if (!baseUrl) {
@@ -5574,7 +5574,7 @@ __export(throttlingRetryStrategy_exports, {
   throttlingRetryStrategy: () => throttlingRetryStrategy
 });
 module.exports = __toCommonJS(throttlingRetryStrategy_exports);
-var import_helpers = __nccwpck_require__(447);
+var import_helpers = __nccwpck_require__(448);
 const RetryAfterHeader = "Retry-After";
 const AllRetryAfterHeaders = ["retry-after-ms", "x-ms-retry-after-ms", RetryAfterHeader];
 function getRetryAfterInMs(response) {
@@ -5789,7 +5789,7 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_https_proxy_agent = __nccwpck_require__(129);
+var import_https_proxy_agent = __nccwpck_require__(130);
 var import_http_proxy_agent = __nccwpck_require__(218);
 var import_log = __nccwpck_require__(148);
 const HTTPS_PROXY = "HTTPS_PROXY";
@@ -5964,7 +5964,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 "use strict";
 
 
-const { Headers, HeadersList, fill } = __nccwpck_require__(505)
+const { Headers, HeadersList, fill } = __nccwpck_require__(506)
 const { extractBody, cloneBody, mixinBody } = __nccwpck_require__(23)
 const util = __nccwpck_require__(68)
 const { kEnumerableProperty } = util
@@ -5976,20 +5976,20 @@ const {
   serializeJavascriptValueToJSONString,
   isErrorLike,
   isomorphicEncode
-} = __nccwpck_require__(506)
+} = __nccwpck_require__(507)
 const {
   redirectStatusSet,
   nullBodyStatus,
   DOMException
 } = __nccwpck_require__(29)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(14)
-const { webidl } = __nccwpck_require__(448)
+const { webidl } = __nccwpck_require__(449)
 const { FormData } = __nccwpck_require__(202)
-const { getGlobalOrigin } = __nccwpck_require__(136)
+const { getGlobalOrigin } = __nccwpck_require__(137)
 const { URLSerializer } = __nccwpck_require__(24)
 const { kHeadersList, kConstruct } = __nccwpck_require__(190)
-const assert = __nccwpck_require__(515)
-const { types } = __nccwpck_require__(120)
+const assert = __nccwpck_require__(517)
+const { types } = __nccwpck_require__(121)
 
 const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(250).ReadableStream)
 const textEncoder = new TextEncoder('utf-8')
@@ -6626,7 +6626,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
 const pathHelper = __importStar(__nccwpck_require__(216));
-const internal_match_kind_1 = __nccwpck_require__(517);
+const internal_match_kind_1 = __nccwpck_require__(519);
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Given an array of patterns, returns an array of paths to search.
@@ -6865,7 +6865,7 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
 const tslib_1 = __nccwpck_require__(210);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(431));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(432));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(64));
 /** Class containing Blob operations. */
@@ -7939,7 +7939,7 @@ exports.StorageBrowserPolicy = void 0;
 const RequestPolicy_js_1 = __nccwpck_require__(45);
 const core_util_1 = __nccwpck_require__(13);
 const constants_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(464);
+const utils_common_js_1 = __nccwpck_require__(465);
 /**
  * StorageBrowserPolicy will handle differences between Node.js and browser runtime, including:
  *
@@ -7992,7 +7992,7 @@ exports.StorageBrowserPolicy = StorageBrowserPolicy;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.containsMessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(398);
+const message_type_contract_1 = __nccwpck_require__(399);
 /**
  * Check if the provided object is a proto message.
  *
@@ -8415,14 +8415,14 @@ const {
   kResult,
   kAborted,
   kLastProgressEventFired
-} = __nccwpck_require__(451)
-const { ProgressEvent } = __nccwpck_require__(434)
-const { getEncoding } = __nccwpck_require__(94)
+} = __nccwpck_require__(452)
+const { ProgressEvent } = __nccwpck_require__(435)
+const { getEncoding } = __nccwpck_require__(95)
 const { DOMException } = __nccwpck_require__(29)
 const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(24)
-const { types } = __nccwpck_require__(120)
+const { types } = __nccwpck_require__(121)
 const { StringDecoder } = __nccwpck_require__(146)
-const { btoa } = __nccwpck_require__(115)
+const { btoa } = __nccwpck_require__(116)
 
 /** @type {PropertyDescriptor} */
 const staticPropertyDescriptors = {
@@ -8808,7 +8808,7 @@ module.exports = {
 
 "use strict";
 
-const f = __nccwpck_require__(396)
+const f = __nccwpck_require__(397)
 const DateTime = global.Date
 
 class Date extends DateTime {
@@ -8934,8 +8934,8 @@ exports.UnaryCall = UnaryCall;
 "use strict";
 
 
-const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(95)
-const { states, opcodes } = __nccwpck_require__(456)
+const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(96)
+const { states, opcodes } = __nccwpck_require__(457)
 const { MessageEvent, ErrorEvent } = __nccwpck_require__(243)
 
 /* globals Blob */
@@ -9417,14 +9417,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.internalCacheTwirpClient = void 0;
-const core_1 = __nccwpck_require__(450);
-const user_agent_1 = __nccwpck_require__(354);
+const core_1 = __nccwpck_require__(451);
+const user_agent_1 = __nccwpck_require__(355);
 const errors_1 = __nccwpck_require__(297);
 const config_1 = __nccwpck_require__(36);
 const cacheUtils_1 = __nccwpck_require__(74);
 const auth_1 = __nccwpck_require__(26);
 const http_client_1 = __nccwpck_require__(278);
-const cache_twirp_client_1 = __nccwpck_require__(428);
+const cache_twirp_client_1 = __nccwpck_require__(429);
 const util_1 = __nccwpck_require__(288);
 /**
  * This class is a wrapper around the CacheServiceClientJSON class generated by Twirp.
@@ -9576,12 +9576,12 @@ exports.internalCacheTwirpClient = internalCacheTwirpClient;
 "use strict";
 
 
-const Dispatcher = __nccwpck_require__(468)
+const Dispatcher = __nccwpck_require__(469)
 const {
   ClientDestroyedError,
   ClientClosedError,
   InvalidArgumentError
-} = __nccwpck_require__(478)
+} = __nccwpck_require__(479)
 const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(190)
 
 const kDestroyed = Symbol('destroyed')
@@ -9797,8 +9797,8 @@ __export(requestPolicyFactoryPolicy_exports, {
   requestPolicyFactoryPolicyName: () => requestPolicyFactoryPolicyName
 });
 module.exports = __toCommonJS(requestPolicyFactoryPolicy_exports);
-var import_util = __nccwpck_require__(106);
-var import_response = __nccwpck_require__(404);
+var import_util = __nccwpck_require__(107);
+var import_response = __nccwpck_require__(405);
 var HttpPipelineLogLevel = /* @__PURE__ */ ((HttpPipelineLogLevel2) => {
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["ERROR"] = 1] = "ERROR";
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["INFO"] = 3] = "INFO";
@@ -9848,18 +9848,18 @@ function createRequestPolicyFactoryPolicy(factories) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 const core_util_1 = __nccwpck_require__(13);
-const core_auth_1 = __nccwpck_require__(503);
+const core_auth_1 = __nccwpck_require__(504);
 const storage_common_1 = __nccwpck_require__(269);
 const Pipeline_js_1 = __nccwpck_require__(178);
-const StorageClient_js_1 = __nccwpck_require__(446);
+const StorageClient_js_1 = __nccwpck_require__(447);
 const tracing_js_1 = __nccwpck_require__(30);
 const utils_common_js_1 = __nccwpck_require__(151);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(67);
 const BlobLeaseClient_js_1 = __nccwpck_require__(199);
 const Clients_js_1 = __nccwpck_require__(180);
-const BlobBatchClient_js_1 = __nccwpck_require__(395);
+const BlobBatchClient_js_1 = __nccwpck_require__(396);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
  */
@@ -12837,8 +12837,8 @@ exports.listType = {
 "use strict";
 
 
-const inherits = (__nccwpck_require__(368).inherits)
-const ReadableStream = (__nccwpck_require__(422).Readable)
+const inherits = (__nccwpck_require__(369).inherits)
+const ReadableStream = (__nccwpck_require__(423).Readable)
 
 function PartStream (opts) {
   ReadableStream.call(this, opts)
@@ -12873,8 +12873,8 @@ exports.generateBlobSASQueryParametersInternal = generateBlobSASQueryParametersI
 const BlobSASPermissions_js_1 = __nccwpck_require__(493);
 const ContainerSASPermissions_js_1 = __nccwpck_require__(272);
 const storage_common_1 = __nccwpck_require__(269);
-const SasIPRange_js_1 = __nccwpck_require__(352);
-const SASQueryParameters_js_1 = __nccwpck_require__(514);
+const SasIPRange_js_1 = __nccwpck_require__(353);
+const SASQueryParameters_js_1 = __nccwpck_require__(515);
 const constants_js_1 = __nccwpck_require__(145);
 const utils_common_js_1 = __nccwpck_require__(151);
 const storage_common_2 = __nccwpck_require__(269);
@@ -13543,15 +13543,15 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 "use strict";
 
 
-const assert = __nccwpck_require__(515)
+const assert = __nccwpck_require__(517)
 const { kDestroyed, kBodyUsed } = __nccwpck_require__(190)
-const { IncomingMessage } = __nccwpck_require__(321)
-const stream = __nccwpck_require__(127)
-const net = __nccwpck_require__(498)
-const { InvalidArgumentError } = __nccwpck_require__(478)
-const { Blob } = __nccwpck_require__(115)
-const nodeUtil = __nccwpck_require__(120)
-const { stringify } = __nccwpck_require__(126)
+const { IncomingMessage } = __nccwpck_require__(322)
+const stream = __nccwpck_require__(128)
+const net = __nccwpck_require__(499)
+const { InvalidArgumentError } = __nccwpck_require__(479)
+const { Blob } = __nccwpck_require__(116)
+const nodeUtil = __nccwpck_require__(121)
+const { stringify } = __nccwpck_require__(127)
 const { headerNameLowerCasedRecord } = __nccwpck_require__(72)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
@@ -14149,11 +14149,11 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 var import_extendedClient = __nccwpck_require__(209);
-var import_response = __nccwpck_require__(404);
+var import_response = __nccwpck_require__(405);
 var import_requestPolicyFactoryPolicy = __nccwpck_require__(62);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
 var import_httpClientAdapter = __nccwpck_require__(205);
-var import_util = __nccwpck_require__(106);
+var import_util = __nccwpck_require__(107);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -14743,15 +14743,15 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 const exec = __importStar(__nccwpck_require__(17));
 const glob = __importStar(__nccwpck_require__(164));
 const io = __importStar(__nccwpck_require__(287));
 const crypto = __importStar(__nccwpck_require__(284));
-const fs = __importStar(__nccwpck_require__(520));
+const fs = __importStar(__nccwpck_require__(522));
 const path = __importStar(__nccwpck_require__(241));
 const semver = __importStar(__nccwpck_require__(174));
-const util = __importStar(__nccwpck_require__(120));
+const util = __importStar(__nccwpck_require__(121));
 const constants_1 = __nccwpck_require__(44);
 const versionSalt = '1.0';
 // From https://github.com/actions/toolkit/blob/main/packages/tool-cache/src/tool-cache.ts#L23
@@ -14940,7 +14940,7 @@ exports.storageSharedKeyCredentialPolicyName = void 0;
 exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
 const node_crypto_1 = __nccwpck_require__(267);
 const constants_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(464);
+const utils_common_js_1 = __nccwpck_require__(465);
 const SharedKeyComparator_js_1 = __nccwpck_require__(172);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
@@ -15077,9 +15077,9 @@ function storageSharedKeyCredentialPolicy(options) {
 "use strict";
 
 
-const assert = __nccwpck_require__(515)
+const assert = __nccwpck_require__(517)
 const { URLSerializer } = __nccwpck_require__(24)
-const { isValidHeaderName } = __nccwpck_require__(506)
+const { isValidHeaderName } = __nccwpck_require__(507)
 
 /**
  * @see https://url.spec.whatwg.org/#concept-url-equals
@@ -15138,12 +15138,12 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageRetryPolicy = void 0;
 exports.NewRetryPolicyFactory = NewRetryPolicyFactory;
-const abort_controller_1 = __nccwpck_require__(484);
+const abort_controller_1 = __nccwpck_require__(485);
 const RequestPolicy_js_1 = __nccwpck_require__(45);
 const constants_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(464);
+const utils_common_js_1 = __nccwpck_require__(465);
 const log_js_1 = __nccwpck_require__(16);
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(409);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(410);
 /**
  * A factory method used to generated a RetryPolicy factory.
  *
@@ -15368,9 +15368,9 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = exports.useInstrumenter = void 0;
-var instrumenter_js_1 = __nccwpck_require__(399);
+var instrumenter_js_1 = __nccwpck_require__(400);
 Object.defineProperty(exports, "useInstrumenter", ({ enumerable: true, get: function () { return instrumenter_js_1.useInstrumenter; } }));
-var tracingClient_js_1 = __nccwpck_require__(340);
+var tracingClient_js_1 = __nccwpck_require__(341);
 Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: function () { return tracingClient_js_1.createTracingClient; } }));
 //# sourceMappingURL=index.js.map
 
@@ -15397,8 +15397,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 
 const { extractBody, mixinBody, cloneBody } = __nccwpck_require__(23)
-const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(505)
-const { FinalizationRegistry } = __nccwpck_require__(406)()
+const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(506)
+const { FinalizationRegistry } = __nccwpck_require__(407)()
 const util = __nccwpck_require__(68)
 const {
   isValidHTTPToken,
@@ -15406,7 +15406,7 @@ const {
   normalizeMethod,
   makePolicyContainer,
   normalizeMethodRecord
-} = __nccwpck_require__(506)
+} = __nccwpck_require__(507)
 const {
   forbiddenMethodsSet,
   corsSafeListedMethodsSet,
@@ -15419,12 +15419,12 @@ const {
 } = __nccwpck_require__(29)
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(14)
-const { webidl } = __nccwpck_require__(448)
-const { getGlobalOrigin } = __nccwpck_require__(136)
+const { webidl } = __nccwpck_require__(449)
+const { getGlobalOrigin } = __nccwpck_require__(137)
 const { URLSerializer } = __nccwpck_require__(24)
 const { kHeadersList, kConstruct } = __nccwpck_require__(190)
-const assert = __nccwpck_require__(515)
-const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(460)
+const assert = __nccwpck_require__(517)
+const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(461)
 
 let TransformStream = globalThis.TransformStream
 
@@ -16360,10 +16360,10 @@ module.exports = require("url");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.deserializationPolicyName = void 0;
 exports.deserializationPolicy = deserializationPolicy;
-const interfaces_js_1 = __nccwpck_require__(96);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
-const serializer_js_1 = __nccwpck_require__(470);
-const operationHelpers_js_1 = __nccwpck_require__(424);
+const interfaces_js_1 = __nccwpck_require__(97);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
+const serializer_js_1 = __nccwpck_require__(471);
+const operationHelpers_js_1 = __nccwpck_require__(425);
 const defaultJsonContentTypes = ["application/json", "text/json"];
 const defaultXmlContentTypes = ["application/xml", "application/atom+xml"];
 /**
@@ -16592,6 +16592,403 @@ async function parse(jsonContentTypes, xmlContentTypes, operationResponse, opts,
 /***/ }),
 
 /***/ 84:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr entry point. Owned by Agent 2.
+//
+// Replaces the composite action's main-phase steps with a single JS
+// orchestrator. Calls the helpers in src/lib/* in the same order the
+// composite's steps fire.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(242));
+const os = __importStar(__nccwpck_require__(376));
+const path = __importStar(__nccwpck_require__(498));
+const core = __importStar(__nccwpck_require__(451));
+const cache = __importStar(__nccwpck_require__(208));
+const log_utils_js_1 = __nccwpck_require__(346);
+const resolve_setup_js_1 = __nccwpck_require__(516);
+const phase_timing_js_1 = __nccwpck_require__(330);
+const ensure_rust_toolchain_js_1 = __nccwpck_require__(502);
+const ensure_soldr_js_1 = __nccwpck_require__(333);
+const verify_soldr_js_1 = __nccwpck_require__(352);
+const install_passthrough_js_1 = __nccwpck_require__(117);
+const normalize_source_mtime_js_1 = __nccwpck_require__(365);
+const detect_shared_target_warning_js_1 = __nccwpck_require__(212);
+const ensure_shims_js_1 = __nccwpck_require__(520);
+const cache_compress_js_1 = __nccwpck_require__(276);
+const stats_collector_js_1 = __nccwpck_require__(305);
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+function isTruthy(value) {
+    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
+}
+function isFalsy(value) {
+    return FALSY.has(((value ?? "").trim().toLowerCase()));
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+function dirHasContent(p) {
+    try {
+        return fs.readdirSync(p).length > 0;
+    }
+    catch {
+        return false;
+    }
+}
+function buildActionContext() {
+    const env = process.env;
+    const logger = (0, log_utils_js_1.createLogger)(env);
+    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
+    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
+    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
+    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
+    const githubSha = env["GITHUB_SHA"]?.trim() || "";
+    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
+    const parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
+    return {
+        env: { ...env },
+        workspace,
+        runnerTemp,
+        runnerOs,
+        runnerArch,
+        githubSha,
+        githubToken,
+        parentSha,
+        logger,
+    };
+}
+async function restoreCacheSafe(paths, key, restoreKeys, logger) {
+    if (paths.length === 0 || !key) {
+        return { hit: false, matchedKey: "" };
+    }
+    try {
+        const matched = await cache.restoreCache(paths, key, restoreKeys);
+        return { hit: matched === key, matchedKey: matched ?? "" };
+    }
+    catch (err) {
+        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "" };
+    }
+}
+async function run() {
+    const ctx = buildActionContext();
+    const logger = ctx.logger;
+    await (0, phase_timing_js_1.markPhase)("action");
+    // ---- resolve ----
+    await (0, phase_timing_js_1.markPhase)("resolve");
+    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
+    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
+    await (0, resolve_setup_js_1.applyResolveResult)(result);
+    await (0, phase_timing_js_1.finishPhase)("resolve");
+    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
+    if (dryRun) {
+        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
+        await (0, phase_timing_js_1.finishPhase)("action");
+        return;
+    }
+    // Persist resolve state for the post-job step.
+    core.saveState("resolveResult", JSON.stringify(result));
+    core.saveState("buildCacheMode", result.buildCache.mode);
+    const statsMode = result.stats;
+    const debugMode = result.debugMode;
+    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
+    const statsCollector = new stats_collector_js_1.StatsCollector();
+    // ---- source-mtime-normalize ----
+    if (isTruthy(inputs.sourceMtimeNormalize)) {
+        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
+    }
+    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
+    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
+    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
+    core.saveState("setupCacheExactHit", "false");
+    core.saveState("setupCacheMatchedKey", "");
+    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
+    core.saveState("targetCacheExactHit", "false");
+    core.saveState("targetCacheMatchedKey", "");
+    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
+    core.saveState("buildCacheExactHit", "false");
+    core.saveState("buildCacheMatchedKey", "");
+    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
+    core.saveState("cargoRegistryCacheExactHit", "false");
+    core.saveState("cargoRegistryCacheMatchedKey", "");
+    // ---- setup-cache ----
+    await (0, phase_timing_js_1.markPhase)("setup-cache");
+    let setupCacheExactHit = false;
+    if (cacheEnabled && result.setupCache.paths.length > 0) {
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
+        setupCacheExactHit = restore.hit;
+        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("setup_cache_matched_key", restore.matchedKey);
+        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("setupCacheMatchedKey", restore.matchedKey);
+        // Expose for ensure_rust_toolchain to read via env (the python port did this).
+        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
+        statsCollector.record({
+            label: "setup-cache", operation: "restore", hit: restore.hit,
+            key: result.setupCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.setupCache.restorePrefix],
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    }
+    await (0, phase_timing_js_1.finishPhase)("setup-cache");
+    // ---- target-cache ----
+    await (0, phase_timing_js_1.markPhase)("target-cache");
+    if (result.targetCache.enabled) {
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (targetPaths.length > 0) {
+            const restoreKeys = [];
+            if (result.targetCache.restoreKeyParent)
+                restoreKeys.push(result.targetCache.restoreKeyParent);
+            if (result.targetCache.restoreKeyLock)
+                restoreKeys.push(result.targetCache.restoreKeyLock);
+            if (result.targetCache.restoreKeyLockfile)
+                restoreKeys.push(result.targetCache.restoreKeyLockfile);
+            const t0 = Date.now();
+            const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
+            core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
+            core.setOutput("target_cache_matched_key", restore.matchedKey);
+            core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
+            core.saveState("targetCacheMatchedKey", restore.matchedKey);
+            statsCollector.record({
+                label: "target-cache", operation: "restore", hit: restore.hit,
+                key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
+                archiveBytes: null, inflatedBytes: null, fileCount: null,
+                durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+            });
+            if (debugMode)
+                debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+        }
+    }
+    await (0, phase_timing_js_1.finishPhase)("target-cache");
+    // ---- build-cache ----
+    await (0, phase_timing_js_1.markPhase)("build-cache");
+    if (buildCacheEnabled) {
+        const buildCachePath = result.buildCache.path;
+        const archivePath = `${buildCachePath}.tar.zst`;
+        const restoreKeys = [];
+        if (result.buildCache.restoreKeyParent)
+            restoreKeys.push(result.buildCache.restoreKeyParent);
+        if (result.buildCache.restoreKeyToolchain)
+            restoreKeys.push(result.buildCache.restoreKeyToolchain);
+        if (result.buildCache.restoreKeyOsArch)
+            restoreKeys.push(result.buildCache.restoreKeyOsArch);
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe([archivePath, buildCachePath], result.buildCache.key, restoreKeys, logger);
+        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("build_cache_matched_key", restore.matchedKey);
+        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("buildCacheMatchedKey", restore.matchedKey);
+        let buildArchiveBytes = null;
+        let buildInflatedBytes = null;
+        let buildFileCount = null;
+        if (fileExists(archivePath)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+            if (magic === "zstd" || magic === "gzip") {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath, debug: debugMode, log: debugLog });
+                    buildArchiveBytes = dr.archiveBytes;
+                    buildInflatedBytes = dr.inflatedBytes;
+                    buildFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        statsCollector.record({
+            label: "build-cache", operation: "restore", hit: restore.hit,
+            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    }
+    await (0, phase_timing_js_1.finishPhase)("build-cache");
+    // ---- target-tree-cache (full mode) ----
+    await (0, phase_timing_js_1.markPhase)("target-tree");
+    // The bundle path is included in target-cache restore paths above when full
+    // mode is requested, so there's no separate restore here. We keep the phase
+    // marker for parity with the composite step ordering.
+    await (0, phase_timing_js_1.finishPhase)("target-tree");
+    // ---- toolchain ----
+    await (0, phase_timing_js_1.markPhase)("toolchain");
+    await (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({ resolveResult: result, setupCacheExactHit });
+    await (0, phase_timing_js_1.finishPhase)("toolchain");
+    // ---- install soldr ----
+    await (0, phase_timing_js_1.markPhase)("install");
+    if (result.enabled) {
+        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
+    }
+    else {
+        (0, install_passthrough_js_1.installPassthrough)({
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
+            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
+            "verbatim, and soldr-aware caching/observability is disabled.");
+    }
+    await (0, phase_timing_js_1.finishPhase)("install");
+    // Export SOLDR_BINARY so shims can exec it directly
+    core.exportVariable("SOLDR_BINARY", result.soldrPath);
+    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
+    // ---- shims ----
+    if (result.shimsEnabled) {
+        await (0, ensure_shims_js_1.ensureShims)({
+            shimsDir: result.shimsDir,
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+    }
+    // ---- verify ----
+    await (0, phase_timing_js_1.markPhase)("verify");
+    if (result.enabled) {
+        const verify = await (0, verify_soldr_js_1.verifySoldr)({
+            soldrPath: result.soldrPath,
+            buildCacheMode: result.buildCache.mode,
+            requireRustPlan: result.targetCache.enabled,
+        });
+        core.setOutput("soldr-version", verify.soldrVersion);
+        core.setOutput("soldr_version", verify.soldrVersion);
+    }
+    else {
+        core.setOutput("soldr-version", "passthrough");
+        core.setOutput("soldr_version", "passthrough");
+    }
+    await (0, phase_timing_js_1.finishPhase)("verify");
+    // ---- cargo-registry restore (if requested) ----
+    if (result.cargoRegistryCache.enabled) {
+        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe([registryArchive, result.cargoRegistryCache.path], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
+        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
+        let regArchiveBytes = null;
+        let regInflatedBytes = null;
+        let regFileCount = null;
+        if (fileExists(registryArchive)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
+            if (magic === "zstd" || magic === "gzip") {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({
+                        archivePath: registryArchive,
+                        targetDir: result.cargoRegistryCache.path,
+                        debug: debugMode, log: debugLog,
+                    });
+                    regArchiveBytes = dr.archiveBytes;
+                    regInflatedBytes = dr.inflatedBytes;
+                    regFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        statsCollector.record({
+            label: "cargo-registry", operation: "restore", hit: restore.hit,
+            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.cargoRegistryCache.restorePrefix],
+            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    }
+    // ---- shared-target warning ----
+    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
+        buildCacheEnabled,
+        effectiveTargetCacheEnabled: result.targetCache.enabled,
+        buildCacheMode: result.buildCache.mode,
+        targetDir: result.targetCache.targetPath,
+    });
+    // ---- stats report ----
+    statsCollector.report(statsMode, (msg) => logger.log(msg));
+    if (statsMode === "detailed") {
+        try {
+            await statsCollector.writeFiles(ctx.runnerTemp);
+            statsCollector.setGithubOutputs();
+        }
+        catch (err) {
+            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    core.saveState("statsCollector", statsCollector.serialize());
+    core.saveState("statsMode", statsMode);
+    core.saveState("compileCacheStats", result.compileCacheStats);
+    core.saveState("runnerTemp", ctx.runnerTemp);
+    await (0, phase_timing_js_1.finishPhase)("action");
+    // dirHasContent is exported for tests; suppress unused warning here.
+    void dirHasContent;
+}
+// Auto-invoke only when this module is run as the main entry point. This lets
+// tests import `run` (and helpers) without triggering the side-effectful
+// orchestration. The dist/main.js produced by ncc is invoked directly by the
+// Actions runtime so the check trips and the action executes normally.
+if (typeof process !== "undefined" &&
+    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
+    // import.meta.url is the file URL of this module; argv[1] is the runner
+    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
+    // the dev path — we rely on the env-var opt-out for tests instead.
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    run().catch((err) => {
+        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        core.setFailed(`setup-soldr failed: ${message}`);
+    });
+}
+
+
+/***/ }),
+
+/***/ 85:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -16617,7 +17014,7 @@ __export(apiKeyAuthenticationPolicy_exports, {
   apiKeyAuthenticationPolicyName: () => apiKeyAuthenticationPolicyName
 });
 module.exports = __toCommonJS(apiKeyAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(427);
+var import_checkInsecureConnection = __nccwpck_require__(428);
 const apiKeyAuthenticationPolicyName = "apiKeyAuthenticationPolicy";
 function apiKeyAuthenticationPolicy(options) {
   return {
@@ -16643,7 +17040,7 @@ function apiKeyAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 85:
+/***/ 86:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16653,12 +17050,12 @@ function apiKeyAuthenticationPolicy(options) {
 
 /* global WebAssembly */
 
-const assert = __nccwpck_require__(515)
-const net = __nccwpck_require__(498)
-const http = __nccwpck_require__(321)
-const { pipeline } = __nccwpck_require__(127)
+const assert = __nccwpck_require__(517)
+const net = __nccwpck_require__(499)
+const http = __nccwpck_require__(322)
+const { pipeline } = __nccwpck_require__(128)
 const util = __nccwpck_require__(68)
-const timers = __nccwpck_require__(320)
+const timers = __nccwpck_require__(321)
 const Request = __nccwpck_require__(291)
 const DispatcherBase = __nccwpck_require__(61)
 const {
@@ -16674,7 +17071,7 @@ const {
   HTTPParserError,
   ResponseExceededMaxSizeError,
   ClientDestroyedError
-} = __nccwpck_require__(478)
+} = __nccwpck_require__(479)
 const buildConnector = __nccwpck_require__(259)
 const {
   kUrl,
@@ -17133,7 +17530,7 @@ function onHTTP2GoAway (code) {
   resume(client)
 }
 
-const constants = __nccwpck_require__(440)
+const constants = __nccwpck_require__(441)
 const createRedirectInterceptor = __nccwpck_require__(248)
 const EMPTY_BUF = Buffer.alloc(0)
 
@@ -18934,7 +19331,7 @@ module.exports = Client
 
 /***/ }),
 
-/***/ 86:
+/***/ 87:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -18976,15 +19373,15 @@ __export(src_exports, {
 module.exports = __toCommonJS(src_exports);
 var import_AbortError = __nccwpck_require__(10);
 var import_logger = __nccwpck_require__(239);
-var import_httpHeaders = __nccwpck_require__(475);
-var import_pipelineRequest = __nccwpck_require__(111);
-var import_pipeline = __nccwpck_require__(513);
-var import_restError = __nccwpck_require__(436);
+var import_httpHeaders = __nccwpck_require__(476);
+var import_pipelineRequest = __nccwpck_require__(112);
+var import_pipeline = __nccwpck_require__(514);
+var import_restError = __nccwpck_require__(437);
 var import_bytesEncoding = __nccwpck_require__(280);
-var import_defaultHttpClient = __nccwpck_require__(365);
+var import_defaultHttpClient = __nccwpck_require__(366);
 var import_getClient = __nccwpck_require__(204);
-var import_operationOptionHelpers = __nccwpck_require__(376);
-var import_restError2 = __nccwpck_require__(360);
+var import_operationOptionHelpers = __nccwpck_require__(377);
+var import_restError2 = __nccwpck_require__(361);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -18992,7 +19389,7 @@ var import_restError2 = __nccwpck_require__(360);
 
 /***/ }),
 
-/***/ 87:
+/***/ 88:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19000,9 +19397,9 @@ var import_restError2 = __nccwpck_require__(360);
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
 const base64_1 = __nccwpck_require__(295);
-const pb_long_1 = __nccwpck_require__(113);
-const reflection_info_1 = __nccwpck_require__(444);
-const assert_1 = __nccwpck_require__(474);
+const pb_long_1 = __nccwpck_require__(114);
+const reflection_info_1 = __nccwpck_require__(445);
+const assert_1 = __nccwpck_require__(475);
 /**
  * Writes proto3 messages in canonical JSON format using reflection
  * information.
@@ -19230,7 +19627,7 @@ exports.ReflectionJsonWriter = ReflectionJsonWriter;
 
 /***/ }),
 
-/***/ 88:
+/***/ 89:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19241,7 +19638,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Batch = void 0;
 // In browser, during webpack or browserify bundling, this module will be replaced by 'events'
 // https://github.com/Gozala/events
-const events_1 = __nccwpck_require__(460);
+const events_1 = __nccwpck_require__(461);
 /**
  * States for Batch.
  */
@@ -19371,7 +19768,7 @@ exports.Batch = Batch;
 
 /***/ }),
 
-/***/ 89:
+/***/ 90:
 /***/ ((module) => {
 
 "use strict";
@@ -19379,7 +19776,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 90:
+/***/ 91:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19410,7 +19807,7 @@ exports.AnonymousCredentialPolicy = AnonymousCredentialPolicy;
 
 /***/ }),
 
-/***/ 91:
+/***/ 92:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19427,8 +19824,8 @@ const {
   kResult,
   kEvents,
   kAborted
-} = __nccwpck_require__(451)
-const { webidl } = __nccwpck_require__(448)
+} = __nccwpck_require__(452)
+const { webidl } = __nccwpck_require__(449)
 const { kEnumerableProperty } = __nccwpck_require__(68)
 
 class FileReader extends EventTarget {
@@ -19762,7 +20159,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 92:
+/***/ 93:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -19791,7 +20188,7 @@ exports.Credential = Credential;
 
 /***/ }),
 
-/***/ 93:
+/***/ 94:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -19812,7 +20209,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 94:
+/***/ 95:
 /***/ ((module) => {
 
 "use strict";
@@ -20110,7 +20507,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 95:
+/***/ 96:
 /***/ ((module) => {
 
 "use strict";
@@ -20130,7 +20527,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 96:
+/***/ 97:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20151,7 +20548,7 @@ exports.XML_CHARKEY = "_";
 
 /***/ }),
 
-/***/ 97:
+/***/ 98:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20181,7 +20578,7 @@ async function cancelablePromiseRace(abortablePromiseBuilders, options) {
 
 /***/ }),
 
-/***/ 98:
+/***/ 99:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -20256,34 +20653,34 @@ var import_createPipelineFromOptions = __nccwpck_require__(273);
 var import_defaultHttpClient = __nccwpck_require__(229);
 var import_httpHeaders = __nccwpck_require__(236);
 var import_pipelineRequest = __nccwpck_require__(19);
-var import_restError = __nccwpck_require__(346);
+var import_restError = __nccwpck_require__(347);
 var import_decompressResponsePolicy = __nccwpck_require__(232);
-var import_exponentialRetryPolicy = __nccwpck_require__(385);
+var import_exponentialRetryPolicy = __nccwpck_require__(386);
 var import_setClientRequestIdPolicy = __nccwpck_require__(147);
 var import_logPolicy = __nccwpck_require__(70);
 var import_multipartPolicy = __nccwpck_require__(264);
-var import_proxyPolicy = __nccwpck_require__(463);
-var import_redirectPolicy = __nccwpck_require__(334);
+var import_proxyPolicy = __nccwpck_require__(464);
+var import_redirectPolicy = __nccwpck_require__(335);
 var import_systemErrorRetryPolicy = __nccwpck_require__(213);
 var import_throttlingRetryPolicy = __nccwpck_require__(22);
 var import_retryPolicy = __nccwpck_require__(206);
-var import_tracingPolicy = __nccwpck_require__(328);
+var import_tracingPolicy = __nccwpck_require__(329);
 var import_defaultRetryPolicy = __nccwpck_require__(54);
-var import_userAgentPolicy = __nccwpck_require__(382);
-var import_tlsPolicy = __nccwpck_require__(371);
+var import_userAgentPolicy = __nccwpck_require__(383);
+var import_tlsPolicy = __nccwpck_require__(372);
 var import_formDataPolicy = __nccwpck_require__(261);
 var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(211);
 var import_ndJsonPolicy = __nccwpck_require__(233);
 var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(188);
 var import_agentPolicy = __nccwpck_require__(225);
-var import_file = __nccwpck_require__(319);
+var import_file = __nccwpck_require__(320);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 
 
 /***/ }),
 
-/***/ 99:
+/***/ 100:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -20310,7 +20707,7 @@ __export(logPolicy_exports, {
 });
 module.exports = __toCommonJS(logPolicy_exports);
 var import_log = __nccwpck_require__(148);
-var import_sanitizer = __nccwpck_require__(118);
+var import_sanitizer = __nccwpck_require__(119);
 const logPolicyName = "logPolicy";
 function logPolicy(options = {}) {
   const logger = options.logger ?? import_log.logger.info;
@@ -20339,11 +20736,11 @@ function logPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 100:
+/***/ 101:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const { addAbortListener } = __nccwpck_require__(68)
-const { RequestAbortedError } = __nccwpck_require__(478)
+const { RequestAbortedError } = __nccwpck_require__(479)
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')
@@ -20400,7 +20797,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 101:
+/***/ 102:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20431,7 +20828,7 @@ function rangeToString(iRange) {
 
 /***/ }),
 
-/***/ 102:
+/***/ 103:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20441,16 +20838,16 @@ const {
   Readable,
   Duplex,
   PassThrough
-} = __nccwpck_require__(127)
+} = __nccwpck_require__(128)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(478)
+} = __nccwpck_require__(479)
 const util = __nccwpck_require__(68)
-const { AsyncResource } = __nccwpck_require__(421)
-const { addSignal, removeSignal } = __nccwpck_require__(100)
-const assert = __nccwpck_require__(515)
+const { AsyncResource } = __nccwpck_require__(422)
+const { addSignal, removeSignal } = __nccwpck_require__(101)
+const assert = __nccwpck_require__(517)
 
 const kResume = Symbol('resume')
 
@@ -20688,7 +21085,7 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 103:
+/***/ 104:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20706,17 +21103,17 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 
 /***/ }),
 
-/***/ 104:
+/***/ 105:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const EventEmitter = (__nccwpck_require__(141).EventEmitter)
-const inherits = (__nccwpck_require__(368).inherits)
-const getLimit = __nccwpck_require__(473)
+const inherits = (__nccwpck_require__(369).inherits)
+const getLimit = __nccwpck_require__(474)
 
-const StreamSearch = __nccwpck_require__(110)
+const StreamSearch = __nccwpck_require__(111)
 
 const B_DCRLF = Buffer.from('\r\n\r\n')
 const RE_CRLF = /\r\n/g
@@ -20814,7 +21211,7 @@ module.exports = HeaderParser
 
 /***/ }),
 
-/***/ 105:
+/***/ 106:
 /***/ ((module) => {
 
 "use strict";
@@ -20822,7 +21219,7 @@ module.exports = require("node:fs/promises");
 
 /***/ }),
 
-/***/ 106:
+/***/ 107:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -20850,7 +21247,7 @@ __export(util_exports, {
   toWebResourceLike: () => toWebResourceLike
 });
 module.exports = __toCommonJS(util_exports);
-var import_core_rest_pipeline = __nccwpck_require__(98);
+var import_core_rest_pipeline = __nccwpck_require__(99);
 const originalRequestSymbol = /* @__PURE__ */ Symbol("Original PipelineRequest");
 const originalClientRequestSymbol = /* @__PURE__ */ Symbol.for("@azure/core-client original request");
 function toPipelineRequest(webResource, options = {}) {
@@ -21092,7 +21489,7 @@ class HttpHeaders {
 
 /***/ }),
 
-/***/ 107:
+/***/ 108:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21138,7 +21535,7 @@ function objectHasProperty(thing, property) {
 
 /***/ }),
 
-/***/ 108:
+/***/ 109:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21148,8 +21545,8 @@ function objectHasProperty(thing, property) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseCAEChallenge = parseCAEChallenge;
 exports.authorizeRequestOnClaimChallenge = authorizeRequestOnClaimChallenge;
-const log_js_1 = __nccwpck_require__(471);
-const base64_js_1 = __nccwpck_require__(429);
+const log_js_1 = __nccwpck_require__(472);
+const base64_js_1 = __nccwpck_require__(430);
 /**
  * Converts: `Bearer a="b", c="d", Bearer d="e", f="g"`.
  * Into: `[ { a: 'b', c: 'd' }, { d: 'e', f: 'g' } ]`.
@@ -21221,7 +21618,7 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 
 /***/ }),
 
-/***/ 109:
+/***/ 110:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21271,7 +21668,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 110:
+/***/ 111:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21304,7 +21701,7 @@ function calculateRetryDelay(retryAttempt, config) {
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
 const EventEmitter = (__nccwpck_require__(141).EventEmitter)
-const inherits = (__nccwpck_require__(368).inherits)
+const inherits = (__nccwpck_require__(369).inherits)
 
 function SBMH (needle) {
   if (typeof needle === 'string') {
@@ -21507,7 +21904,7 @@ module.exports = SBMH
 
 /***/ }),
 
-/***/ 111:
+/***/ 112:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -21532,8 +21929,8 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_httpHeaders = __nccwpck_require__(475);
-var import_uuidUtils = __nccwpck_require__(386);
+var import_httpHeaders = __nccwpck_require__(476);
+var import_uuidUtils = __nccwpck_require__(387);
 class PipelineRequestImpl {
   url;
   method;
@@ -21586,7 +21983,7 @@ function createPipelineRequest(options) {
 
 /***/ }),
 
-/***/ 112:
+/***/ 113:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -21622,7 +22019,7 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(375));
+var import_node_os = __toESM(__nccwpck_require__(376));
 var import_node_process = __toESM(__nccwpck_require__(230));
 function getHeaderName() {
   return "User-Agent";
@@ -21646,7 +22043,7 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 113:
+/***/ 114:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21892,7 +22289,7 @@ PbLong.ZERO = new PbLong(0, 0);
 
 /***/ }),
 
-/***/ 114:
+/***/ 115:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21909,7 +22306,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 115:
+/***/ 116:
 /***/ ((module) => {
 
 "use strict";
@@ -21917,7 +22314,7 @@ module.exports = require("buffer");
 
 /***/ }),
 
-/***/ 116:
+/***/ 117:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -21966,7 +22363,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._internal = void 0;
 exports.installPassthrough = installPassthrough;
 const fs = __importStar(__nccwpck_require__(242));
-const path = __importStar(__nccwpck_require__(497));
+const path = __importStar(__nccwpck_require__(498));
 const STUB_VERSION = "passthrough";
 function bashStub() {
     return `#!/usr/bin/env bash
@@ -22056,7 +22453,7 @@ exports._internal = { bashStub, cmdStub, STUB_VERSION };
 
 /***/ }),
 
-/***/ 117:
+/***/ 118:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -22087,7 +22484,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
 const path = __importStar(__nccwpck_require__(241));
 const pathHelper = __importStar(__nccwpck_require__(216));
-const assert_1 = __importDefault(__nccwpck_require__(515));
+const assert_1 = __importDefault(__nccwpck_require__(517));
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Helper class for parsing paths into segments
@@ -22176,7 +22573,7 @@ exports.Path = Path;
 
 /***/ }),
 
-/***/ 118:
+/***/ 119:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -22350,7 +22747,7 @@ class Sanitizer {
 
 /***/ }),
 
-/***/ 119:
+/***/ 120:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22367,7 +22764,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 120:
+/***/ 121:
 /***/ ((module) => {
 
 "use strict";
@@ -22375,7 +22772,7 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 121:
+/***/ 122:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
@@ -22387,7 +22784,7 @@ var path = (function () { try { return __nccwpck_require__(241) } catch (e) {}}(
 minimatch.sep = path.sep
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __nccwpck_require__(476)
+var expand = __nccwpck_require__(477)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -23387,7 +23784,7 @@ function regExpEscape (s) {
 
 /***/ }),
 
-/***/ 122:
+/***/ 123:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -23422,13 +23819,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
-const os = __importStar(__nccwpck_require__(89));
-const events = __importStar(__nccwpck_require__(460));
+const os = __importStar(__nccwpck_require__(90));
+const events = __importStar(__nccwpck_require__(461));
 const child = __importStar(__nccwpck_require__(160));
 const path = __importStar(__nccwpck_require__(241));
 const io = __importStar(__nccwpck_require__(287));
 const ioUtil = __importStar(__nccwpck_require__(219));
-const timers_1 = __nccwpck_require__(499);
+const timers_1 = __nccwpck_require__(500);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -24012,7 +24409,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 123:
+/***/ 124:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24022,7 +24419,7 @@ class ExecState extends events.EventEmitter {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredentialPolicy = void 0;
 const constants_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(464);
+const utils_common_js_1 = __nccwpck_require__(465);
 const CredentialPolicy_js_1 = __nccwpck_require__(301);
 const SharedKeyComparator_js_1 = __nccwpck_require__(172);
 /**
@@ -24168,7 +24565,7 @@ exports.StorageSharedKeyCredentialPolicy = StorageSharedKeyCredentialPolicy;
 
 /***/ }),
 
-/***/ 124:
+/***/ 125:
 /***/ ((module) => {
 
 "use strict";
@@ -24188,7 +24585,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 125:
+/***/ 126:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24196,9 +24593,9 @@ module.exports = {
 
 
 
-const assert = __nccwpck_require__(515)
-const { Readable } = __nccwpck_require__(127)
-const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(478)
+const assert = __nccwpck_require__(517)
+const { Readable } = __nccwpck_require__(128)
+const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(479)
 const util = __nccwpck_require__(68)
 const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(68)
 
@@ -24480,7 +24877,7 @@ function consumeEnd (consume) {
       resolve(dst.buffer)
     } else if (type === 'blob') {
       if (!Blob) {
-        Blob = (__nccwpck_require__(115).Blob)
+        Blob = (__nccwpck_require__(116).Blob)
       }
       resolve(new Blob(body, { type: stream[kContentType] }))
     }
@@ -24518,7 +24915,7 @@ function consumeFinish (consume, err) {
 
 /***/ }),
 
-/***/ 126:
+/***/ 127:
 /***/ ((module) => {
 
 "use strict";
@@ -24526,7 +24923,7 @@ module.exports = require("querystring");
 
 /***/ }),
 
-/***/ 127:
+/***/ 128:
 /***/ ((module) => {
 
 "use strict";
@@ -24534,7 +24931,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 128:
+/***/ 129:
 /***/ ((module) => {
 
 "use strict";
@@ -24604,7 +25001,7 @@ function range(a, b, str) {
 
 /***/ }),
 
-/***/ 129:
+/***/ 130:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -24637,13 +25034,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpsProxyAgent = void 0;
-const net = __importStar(__nccwpck_require__(498));
-const tls = __importStar(__nccwpck_require__(495));
-const assert_1 = __importDefault(__nccwpck_require__(515));
-const debug_1 = __importDefault(__nccwpck_require__(504));
+const net = __importStar(__nccwpck_require__(499));
+const tls = __importStar(__nccwpck_require__(496));
+const assert_1 = __importDefault(__nccwpck_require__(517));
+const debug_1 = __importDefault(__nccwpck_require__(505));
 const agent_base_1 = __nccwpck_require__(234);
 const url_1 = __nccwpck_require__(82);
-const parse_proxy_response_1 = __nccwpck_require__(411);
+const parse_proxy_response_1 = __nccwpck_require__(412);
 const debug = (0, debug_1.default)('https-proxy-agent');
 const setServernameFromNonIpHost = (options) => {
     if (options.servername === undefined &&
@@ -24791,7 +25188,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 130:
+/***/ 131:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -24809,7 +25206,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
 const http_client_1 = __nccwpck_require__(278);
 const auth_1 = __nccwpck_require__(26);
-const core_1 = __nccwpck_require__(450);
+const core_1 = __nccwpck_require__(451);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -24875,15 +25272,15 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 131:
+/***/ 132:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
-const binary_format_contract_1 = __nccwpck_require__(325);
-const pb_long_1 = __nccwpck_require__(113);
+const binary_format_contract_1 = __nccwpck_require__(326);
+const pb_long_1 = __nccwpck_require__(114);
 const goog_varint_1 = __nccwpck_require__(198);
 const defaultsRead = {
     readUnknownField: true,
@@ -25066,7 +25463,7 @@ exports.BinaryReader = BinaryReader;
 
 /***/ }),
 
-/***/ 132:
+/***/ 133:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25080,8 +25477,8 @@ const {
   kDefaultTrailers,
   kContentLength,
   kMockDispatch
-} = __nccwpck_require__(461)
-const { InvalidArgumentError } = __nccwpck_require__(478)
+} = __nccwpck_require__(462)
+const { InvalidArgumentError } = __nccwpck_require__(479)
 const { buildURL } = __nccwpck_require__(68)
 
 /**
@@ -25280,7 +25677,7 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 133:
+/***/ 134:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -25378,7 +25775,7 @@ exports.reflectionMergePartial = reflectionMergePartial;
 
 /***/ }),
 
-/***/ 134:
+/***/ 135:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -25471,22 +25868,22 @@ async function parseXML(str, opts = {}) {
 
 /***/ }),
 
-/***/ 135:
+/***/ 136:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-module.exports.request = __nccwpck_require__(500)
-module.exports.stream = __nccwpck_require__(347)
-module.exports.pipeline = __nccwpck_require__(102)
-module.exports.upgrade = __nccwpck_require__(425)
-module.exports.connect = __nccwpck_require__(366)
+module.exports.request = __nccwpck_require__(501)
+module.exports.stream = __nccwpck_require__(348)
+module.exports.pipeline = __nccwpck_require__(103)
+module.exports.upgrade = __nccwpck_require__(426)
+module.exports.connect = __nccwpck_require__(367)
 
 
 /***/ }),
 
-/***/ 136:
+/***/ 137:
 /***/ ((module) => {
 
 "use strict";
@@ -25529,980 +25926,6 @@ function setGlobalOrigin (newOrigin) {
 module.exports = {
   getGlobalOrigin,
   setGlobalOrigin
-}
-
-
-/***/ }),
-
-/***/ 137:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Top-level resolve-setup entry point. Owned by Agent 1.
-//
-// Full port of resolve_setup.py::main(). Reads INPUT_* / GITHUB_* env vars,
-// resolves the toolchain spec, derives all cache keys, computes the env
-// exports + outputs the orchestrator needs.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.readRawInputs = readRawInputs;
-exports.parseCacheShutdownOnIdleSeconds = parseCacheShutdownOnIdleSeconds;
-exports.detectUserLinkerEnv = detectUserLinkerEnv;
-exports.detectMuslCcEnv = detectMuslCcEnv;
-exports.resolveSetup = resolveSetup;
-exports.applyResolveResult = applyResolveResult;
-exports.buildOutputs = buildOutputs;
-exports.pythonDefaultJson = pythonDefaultJson;
-const os = __importStar(__nccwpck_require__(375));
-const path = __importStar(__nccwpck_require__(497));
-const fs = __importStar(__nccwpck_require__(242));
-const core = __importStar(__nccwpck_require__(450));
-const cache_keys_js_1 = __nccwpck_require__(161);
-const log_utils_js_1 = __nccwpck_require__(345);
-const toolchain_js_1 = __nccwpck_require__(359);
-const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
-const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
-const ALLOWED_LINKER_VALUES = [
-    "default",
-    "platform-default",
-    "ld",
-    "mold",
-    "rust-lld",
-    "fast",
-];
-// CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
-// FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
-// causes "failed to connect to jobserver" warnings in every downstream step.
-// See setup-soldr#71.
-const GITHUB_ENV_DENY_LIST = new Set(["CARGO_MAKEFLAGS", "MAKEFLAGS"]);
-function expanduser(p, env) {
-    if (!p)
-        return p;
-    if (p.startsWith("~")) {
-        const home = env["HOME"] || env["USERPROFILE"] || "";
-        if (p === "~")
-            return home;
-        if (p.startsWith("~/") || p.startsWith("~\\")) {
-            return path.join(home, p.slice(2));
-        }
-    }
-    return p;
-}
-function resolveAbsolute(p, env) {
-    return path.resolve(expanduser(p, env));
-}
-function readRawInputs(env) {
-    const get = (name) => env[`INPUT_${name}`] ?? "";
-    return {
-        enable: get("ENABLE"),
-        version: get("VERSION"),
-        repo: get("REPO"),
-        ref: get("REF"),
-        cache: get("CACHE"),
-        cacheDir: get("CACHE_DIR"),
-        cacheKeySuffix: get("CACHE_KEY_SUFFIX"),
-        toolchain: get("TOOLCHAIN"),
-        toolchainFile: get("TOOLCHAIN_FILE"),
-        trustMode: get("TRUST_MODE"),
-        linker: get("LINKER"),
-        compilePriority: get("COMPILE_PRIORITY"),
-        timestamps: get("TIMESTAMPS"),
-        lockfile: get("LOCKFILE"),
-        buildCache: get("BUILD_CACHE"),
-        buildCacheMode: get("BUILD_CACHE_MODE"),
-        targetCache: get("TARGET_CACHE"),
-        targetCacheMode: get("TARGET_CACHE_MODE"),
-        targetDir: get("TARGET_DIR"),
-        targetCacheProfile: get("TARGET_CACHE_PROFILE"),
-        targetCacheStripDebuginfo: get("TARGET_CACHE_STRIP_DEBUGINFO"),
-        targetCacheIncludeIncremental: get("TARGET_CACHE_INCLUDE_INCREMENTAL"),
-        targetCacheIncludeBuildScriptBinaries: get("TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES"),
-        targetCacheCompress: get("TARGET_CACHE_COMPRESS"),
-        targetCacheCompressLevel: get("TARGET_CACHE_COMPRESS_LEVEL"),
-        sourceMtimeNormalize: get("SOURCE_MTIME_NORMALIZE"),
-        cargoRegistryCache: get("CARGO_REGISTRY_CACHE"),
-        compileCacheStats: get("COMPILE_CACHE_STATS"),
-        shims: get("SHIMS"),
-        stats: get("STATS"),
-        debugMode: get("DEBUG"),
-        cacheShutdownOnIdle: get("CACHE_SHUTDOWN_ON_IDLE"),
-    };
-}
-/**
- * Parse the `cache-shutdown-on-idle` input into a seconds count.
- *
- * Accepts:
- *   - "" / "0" / "off" / "false" / "no" → null (disabled)
- *   - bare integer ("30")               → that many seconds
- *   - "<N>s" / "<N>m" / "<N>h"          → seconds / minutes / hours
- *
- * Throws on any other value so misspellings ("30sec", "thirty") surface
- * loudly at action start rather than silently being treated as "off".
- */
-function parseCacheShutdownOnIdleSeconds(raw) {
-    const value = raw.trim().toLowerCase();
-    if (value === "" || value === "0" || value === "off" || value === "false" || value === "no") {
-        return null;
-    }
-    const m = value.match(/^(\d+)\s*(s|m|h)?$/);
-    if (!m) {
-        throw new Error(`invalid 'cache-shutdown-on-idle' input: '${raw}'. ` +
-            "Expected <seconds>, <N>s, <N>m, <N>h, or empty/off/false to disable.");
-    }
-    const n = parseInt(m[1], 10);
-    if (!Number.isFinite(n) || n < 0) {
-        throw new Error(`invalid 'cache-shutdown-on-idle' input: '${raw}'.`);
-    }
-    const unit = m[2] ?? "s";
-    if (unit === "s")
-        return n;
-    if (unit === "m")
-        return n * 60;
-    return n * 3600;
-}
-/**
- * Detect cross-compile env vars the user has already set that soldr's
- * `linker: fast` default would silently overwrite (CARGO_TARGET_<TRIPLE>_LINKER
- * and CARGO_TARGET_<TRIPLE>_RUSTFLAGS). Returns the list of `NAME=value`
- * strings to surface in the deferral log. See issue #108.
- */
-function detectUserLinkerEnv(env) {
-    const hits = [];
-    for (const [name, raw] of Object.entries(env)) {
-        if (raw === undefined || raw === "")
-            continue;
-        if (!name.startsWith("CARGO_TARGET_"))
-            continue;
-        if (name.endsWith("_LINKER") || name.endsWith("_RUSTFLAGS")) {
-            hits.push(`${name}=${raw}`);
-        }
-    }
-    hits.sort();
-    return hits;
-}
-const MUSL_TRIPLE_RE = /^[a-z0-9_]+-unknown-linux-musl$/;
-function tripleToCcRsSuffix(triple) {
-    return triple.replace(/-/g, "_");
-}
-function findOnPathSync(env, cmd) {
-    const pathRaw = env["PATH"] ?? env["Path"] ?? "";
-    if (!pathRaw)
-        return null;
-    const sep = process.platform === "win32" ? ";" : ":";
-    const exts = process.platform === "win32" ? ["", ".exe"] : [""];
-    for (const dir of pathRaw.split(sep)) {
-        if (!dir)
-            continue;
-        for (const ext of exts) {
-            const candidate = path.join(dir, `${cmd}${ext}`);
-            try {
-                if (fs.statSync(candidate).isFile())
-                    return candidate;
-            }
-            catch {
-                // not present; continue
-            }
-        }
-    }
-    return null;
-}
-function scanPathForMuslTriples(env, readDir) {
-    const triples = new Set();
-    const pathRaw = env["PATH"] ?? env["Path"] ?? "";
-    if (!pathRaw)
-        return triples;
-    const sep = process.platform === "win32" ? ";" : ":";
-    const isWin = process.platform === "win32";
-    const tail = isWin ? /-unknown-linux-musl-gcc(?:\.exe)?$/i : /-unknown-linux-musl-gcc$/;
-    for (const dir of pathRaw.split(sep)) {
-        if (!dir)
-            continue;
-        let entries;
-        try {
-            entries = readDir(dir);
-        }
-        catch {
-            continue;
-        }
-        for (const entry of entries) {
-            const m = entry.match(tail);
-            if (!m)
-                continue;
-            const triple = entry.slice(0, entry.length - m[0].length) + "-unknown-linux-musl";
-            if (MUSL_TRIPLE_RE.test(triple))
-                triples.add(triple);
-        }
-    }
-    return triples;
-}
-/**
- * Detect *-unknown-linux-musl cross compilers on PATH and return the
- * cc-rs env-var exports needed to make cc-rs find them. cc-rs strips the
- * "-unknown-" segment from the Rust target triple when searching for a
- * cross compiler, so the cross-tools archives (which ship binaries named
- * with the full triple, e.g. aarch64-unknown-linux-musl-gcc) are missed
- * and cc-rs falls back to the host gcc. Auto-exporting CC_<triple>,
- * CXX_<triple>, and AR_<triple> in snake-case fixes the build without
- * any workflow edits.
- *
- * Triples are sourced from: CARGO_BUILD_TARGET, any CARGO_TARGET_<T>_*
- * env vars the user has already set, and PATH-scanning for
- * `*-unknown-linux-musl-gcc` binaries. A triple is skipped when the user
- * has already set any of CC_/CXX_/AR_<snake_triple>.
- */
-function detectMuslCcEnv(env, deps) {
-    const find = deps?.findOnPath ?? ((cmd) => findOnPathSync(env, cmd));
-    const readDir = deps?.readDir ?? ((dir) => fs.readdirSync(dir));
-    const triples = new Set();
-    const cbt = (env["CARGO_BUILD_TARGET"] ?? "").trim();
-    if (cbt && MUSL_TRIPLE_RE.test(cbt))
-        triples.add(cbt);
-    // Cargo encodes triples by uppercasing and replacing `-` with `_`, so
-    // `x86_64-unknown-linux-musl` becomes `X86_64_UNKNOWN_LINUX_MUSL` — the
-    // reverse is ambiguous (the arch may contain a real underscore). Match on
-    // the fixed `_UNKNOWN_LINUX_MUSL_` suffix and treat the prefix as the
-    // verbatim arch name to round-trip safely.
-    for (const name of Object.keys(env)) {
-        const m = name.match(/^CARGO_TARGET_(.+?)_UNKNOWN_LINUX_MUSL_(LINKER|RUSTFLAGS|RUNNER)$/);
-        if (!m)
-            continue;
-        const arch = m[1].toLowerCase();
-        if (!/^[a-z0-9_]+$/.test(arch))
-            continue;
-        const triple = `${arch}-unknown-linux-musl`;
-        if (MUSL_TRIPLE_RE.test(triple))
-            triples.add(triple);
-    }
-    for (const t of scanPathForMuslTriples(env, readDir)) {
-        triples.add(t);
-    }
-    const out = [];
-    for (const triple of [...triples].sort()) {
-        const suffix = tripleToCcRsSuffix(triple);
-        const ccVar = `CC_${suffix}`;
-        const cxxVar = `CXX_${suffix}`;
-        const arVar = `AR_${suffix}`;
-        if ((env[ccVar] ?? "").trim() !== "")
-            continue;
-        if ((env[cxxVar] ?? "").trim() !== "")
-            continue;
-        if ((env[arVar] ?? "").trim() !== "")
-            continue;
-        const ccPath = find(`${triple}-gcc`);
-        const cxxPath = find(`${triple}-g++`);
-        const arPath = find(`${triple}-ar`);
-        if (!ccPath || !cxxPath || !arPath)
-            continue;
-        out.push({
-            triple,
-            exports: {
-                [ccVar]: `${triple}-gcc`,
-                [cxxVar]: `${triple}-g++`,
-                [arVar]: `${triple}-ar`,
-            },
-            resolvedPaths: { cc: ccPath, cxx: cxxPath, ar: arPath },
-        });
-    }
-    return out;
-}
-function normalizeStatsMode(raw) {
-    const v = raw.trim().toLowerCase();
-    if (v === "none" || v === "summarize" || v === "detailed")
-        return v;
-    return "summarize";
-}
-function normalizeCompileCacheStats(raw) {
-    const v = raw.trim().toLowerCase();
-    if (v === "none")
-        return "none";
-    if (v === "detailed" || v === "insights")
-        return "detailed";
-    return "summarize";
-}
-function isFalsy(value) {
-    return FALSY_VALUES.has(value.trim().toLowerCase());
-}
-function isTruthy(value) {
-    return TRUTHY_VALUES.has(value.trim().toLowerCase());
-}
-function defaultHomeDir(env, name) {
-    const home = env["HOME"] || env["USERPROFILE"] || os.homedir();
-    return path.resolve(path.join(home, name));
-}
-function makeDirs(...paths) {
-    for (const p of paths) {
-        fs.mkdirSync(p, { recursive: true });
-    }
-}
-async function fetchReleaseTagDefault(repo, version, env) {
-    if (version) {
-        // For explicit (non-latest) versions, return as-is. Caller normalizes.
-        return "";
-    }
-    const url = `https://api.github.com/repos/${repo}/releases/latest`;
-    const headers = {
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "setup-soldr-action",
-    };
-    const token = (env["GITHUB_TOKEN"] ?? "").trim() || (env["INPUT_TOKEN"] ?? "").trim();
-    if (token) {
-        headers["Authorization"] = `Bearer ${token}`;
-    }
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 10_000);
-    try {
-        const response = await fetch(url, { headers, signal: controller.signal });
-        if (!response.ok) {
-            throw new Error(`GitHub API returned HTTP ${response.status} for ${repo}`);
-        }
-        const payload = (await response.json());
-        if (typeof payload !== "object" || payload === null) {
-            throw new Error(`unexpected GitHub release payload for ${repo}`);
-        }
-        const tag = payload["tag_name"];
-        const tagName = typeof tag === "string" ? tag.trim() : "";
-        if (!tagName) {
-            throw new Error(`failed to resolve latest soldr release tag from ${repo}`);
-        }
-        return tagName;
-    }
-    finally {
-        clearTimeout(timer);
-    }
-}
-async function resolveSoldrReleaseVersion(repo, version, ref, env, deps) {
-    if (ref.trim()) {
-        return "";
-    }
-    const requested = version.trim();
-    if (requested && requested.toLowerCase() !== "latest") {
-        return requested.startsWith("v") ? requested : `v${requested}`;
-    }
-    const fetcher = deps?.fetchReleaseTag ?? fetchReleaseTagDefault;
-    const tagName = await fetcher(repo, "", env);
-    if (!tagName) {
-        throw new Error(`failed to resolve latest soldr release tag from ${repo}`);
-    }
-    return tagName;
-}
-/**
- * Resolve setup state. The orchestrator calls this once at the start of the
- * action and uses the returned ResolveResult to drive every subsequent step.
- */
-async function resolveSetup(ctx, inputs, deps) {
-    const env = { ...ctx.env };
-    // ---- timing seed ----
-    const logStart = String(Math.floor(Date.now() / 1000));
-    const timestamps = (inputs.timestamps && inputs.timestamps.trim()) || "true";
-    env["SETUP_SOLDR_LOG_START_EPOCH"] = logStart;
-    env["SETUP_SOLDR_TIMESTAMPS"] = timestamps;
-    const logger = ctx.logger ?? (0, log_utils_js_1.createLogger)(env);
-    const log = (msg) => logger.log(msg);
-    if (!ctx.workspace) {
-        throw new Error("ACTION_WORKSPACE / ctx.workspace must be set");
-    }
-    const workspace = path.resolve(ctx.workspace);
-    const runnerTemp = ctx.runnerTemp
-        ? path.resolve(ctx.runnerTemp)
-        : path.resolve(path.join(workspace, ".tmp"));
-    // ---- cache roots ----
-    const requestedCacheDir = inputs.cacheDir.trim();
-    const cacheRoot = requestedCacheDir
-        ? resolveAbsolute(requestedCacheDir, env)
-        : path.resolve(path.join(runnerTemp, "setup-soldr"));
-    const soldrRoot = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-soldr`);
-    const cargoHomeInput = (env["CARGO_HOME"] ?? "").trim();
-    const cargoHome = cargoHomeInput
-        ? resolveAbsolute(cargoHomeInput, env)
-        : defaultHomeDir(env, ".cargo");
-    const binDir = path.join(cacheRoot, "bin");
-    const setupCachePath = cacheRoot;
-    const soldrBinCachePath = path.join(soldrRoot, "bin");
-    const zccacheCacheDir = path.join(soldrRoot, "cache", "zccache");
-    const thinTargetCacheBundlePath = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-target-thin`);
-    // When the action is disabled (`enable: false`), we write a script-based
-    // passthrough stub at soldrPath instead of installing the real binary.
-    // The stub is a bash script on Unix and a .cmd shim on Windows — Windows
-    // cannot spawn a script via the .exe extension without a real PE, so
-    // soldrPath must end in .cmd in passthrough mode.
-    const enableRaw = inputs.enable.trim() || "true";
-    if (!TRUTHY_VALUES.has(enableRaw.toLowerCase()) && !FALSY_VALUES.has(enableRaw.toLowerCase())) {
-        throw new Error(`invalid 'enable' input: '${enableRaw}'. Allowed: true | false`);
-    }
-    const enabled = !FALSY_VALUES.has(enableRaw.toLowerCase());
-    const soldrBinary = enabled
-        ? process.platform === "win32"
-            ? "soldr.exe"
-            : "soldr"
-        : process.platform === "win32"
-            ? "soldr.cmd"
-            : "soldr";
-    const soldrPath = path.join(binDir, soldrBinary);
-    // ---- toolchain ----
-    const toolchain = await (0, toolchain_js_1.loadToolchainSpec)({
-        workspace,
-        toolchainFile: inputs.toolchainFile || "rust-toolchain.toml",
-        toolchainOverride: inputs.toolchain,
-        log,
-    });
-    // ---- rustup home selection ----
-    const explicitRustupHome = (env["RUSTUP_HOME"] ?? "").trim();
-    let rustupHome;
-    let rustupStrategy;
-    if (explicitRustupHome) {
-        rustupHome = resolveAbsolute(explicitRustupHome, env);
-        rustupStrategy = "explicit";
-    }
-    else {
-        const runnerRustupHome = defaultHomeDir(env, ".rustup");
-        let satisfied = false;
-        if (deps?.systemRustupOverride) {
-            satisfied = await deps.systemRustupOverride(cargoHome, runnerRustupHome, toolchain);
-        }
-        else {
-            satisfied = await (0, toolchain_js_1.systemRustupSatisfiesRequest)({
-                cargoHome,
-                rustupHome: runnerRustupHome,
-                toolchain,
-                env,
-                logger,
-                deps: deps?.systemRustup,
-            });
-        }
-        if (satisfied) {
-            rustupHome = runnerRustupHome;
-            rustupStrategy = "system";
-        }
-        else {
-            rustupHome = path.join(cacheRoot, "rustup-home");
-            rustupStrategy = "managed";
-        }
-    }
-    const setupCachePathsList = (0, cache_keys_js_1.setupCachePaths)(setupCachePath, binDir, soldrBinCachePath, rustupHome);
-    const setupCacheLayoutValue = (0, cache_keys_js_1.setupCacheLayout)(setupCachePath, rustupHome);
-    for (const dir of [
-        cacheRoot,
-        soldrRoot,
-        path.join(soldrRoot, "cache"),
-        soldrBinCachePath,
-        cargoHome,
-        path.join(cargoHome, "bin"),
-        rustupHome,
-        binDir,
-        zccacheCacheDir,
-        thinTargetCacheBundlePath,
-    ]) {
-        makeDirs(dir);
-    }
-    const soldrRepo = inputs.repo.trim() || "zackees/soldr";
-    const soldrRef = inputs.ref.trim();
-    const soldrVersionRequested = inputs.version.trim();
-    const soldrVersionResolved = await resolveSoldrReleaseVersion(soldrRepo, soldrVersionRequested, soldrRef, env, deps);
-    const toolchainSignature = {
-        channel: toolchain.cacheChannel,
-        profile: toolchain.profile,
-        components: toolchain.components,
-        targets: toolchain.targets,
-        source: toolchain.source,
-        file_hash: toolchain.fileHash,
-        setup_cache_layout: setupCacheLayoutValue,
-        soldr_repo: soldrRepo,
-        soldr_ref: soldrRef || "release",
-        soldr_version: soldrVersionResolved || soldrRef || "source-ref",
-    };
-    // Python uses json.dumps(sort_keys=True) without compact separators here,
-    // so canonical_json_stringify is wrong; mirror Python's default separators
-    // (", " and ": ") to match byte-for-byte.
-    const signatureString = pythonDefaultJson(toolchainSignature);
-    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 267, 23));
-    const digest = createHash("sha256").update(signatureString, "utf8").digest("hex").slice(0, 16);
-    const runnerOs = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_OS"] ?? process.platform).toLowerCase());
-    const runnerArch = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_ARCH"] ?? "unknown").toLowerCase());
-    const cachePrefix = `setup-soldr-v4-${runnerOs}-${runnerArch}`;
-    let cacheKey = `${cachePrefix}-${digest}`;
-    const wsManifestHash = await (0, cache_keys_js_1.workspaceManifestHash)(workspace);
-    const cargoConfigHashValue = await (0, cache_keys_js_1.cargoConfigHash)(workspace);
-    const suffix = inputs.cacheKeySuffix.trim();
-    const sanitizedSuffix = suffix ? (0, cache_keys_js_1.sanitizeFragment)(suffix) : "";
-    if (suffix) {
-        cacheKey = `${cacheKey}-${sanitizedSuffix}`;
-    }
-    // ---- build cache ----
-    const githubSha = (env["GITHUB_SHA"] ?? "").trim() || "nosha";
-    let parentSha = (env["ACTION_PARENT_SHA"] ?? "").trim();
-    if (parentSha === githubSha) {
-        parentSha = "";
-    }
-    const buildCachePrefix = `setup-soldr-buildcache-v2-${runnerOs}-${runnerArch}`;
-    const buildCacheToolchainPrefix = `${buildCachePrefix}-${digest}-`;
-    let buildCacheKey = `${buildCacheToolchainPrefix}${githubSha}`;
-    let buildCacheParentKey = parentSha ? `${buildCacheToolchainPrefix}${parentSha}` : "";
-    // ---- target cache ----
-    const targetDirInput = inputs.targetDir.trim() || "target";
-    let targetCachePath = expanduser(targetDirInput, env);
-    if (!path.isAbsolute(targetCachePath)) {
-        targetCachePath = path.join(workspace, targetCachePath);
-    }
-    targetCachePath = path.resolve(targetCachePath);
-    makeDirs(targetCachePath);
-    const lockfilePath = (0, cache_keys_js_1.resolveLockfilePath)(workspace, targetCachePath, inputs.lockfile);
-    const cargoLockHash = lockfilePath ? await (0, cache_keys_js_1.shortFileHash)(lockfilePath, "no-lock") : "no-lock";
-    const legacyTargetCacheModeInput = inputs.targetCacheMode;
-    const legacyTargetCacheMode = (0, cache_keys_js_1.normalizeLegacyTargetCacheMode)(legacyTargetCacheModeInput, log);
-    const targetCacheProfile = (0, cache_keys_js_1.normalizeTargetCacheProfile)(inputs.targetCacheProfile);
-    const targetCacheInputRaw = inputs.targetCache.trim() || "true";
-    const targetCacheRequested = !isFalsy(targetCacheInputRaw) && legacyTargetCacheMode !== "off";
-    const explicitBuildCacheMode = inputs.buildCacheMode.trim();
-    const buildCacheMode = (0, cache_keys_js_1.normalizeBuildCacheMode)(inputs.buildCacheMode, legacyTargetCacheModeInput, !explicitBuildCacheMode && targetCacheRequested, log);
-    const buildCacheInputRaw = inputs.buildCache.trim() || "true";
-    const buildCacheEnabled = !isFalsy(buildCacheInputRaw);
-    const buildCacheRuntimeMode = buildCacheMode === "once" ? "full" : buildCacheMode;
-    let targetCacheEnabled = buildCacheEnabled && targetCacheRequested;
-    if (buildCacheMode === "thin" && cargoLockHash === "no-lock") {
-        log("build-cache-mode 'thin' requires Cargo.lock; target artifact cache disabled.");
-        targetCacheEnabled = false;
-    }
-    const [targetCacheBudgetBytes, targetCacheBudgetFiles] = (0, cache_keys_js_1.targetCacheSoftBudget)(targetCacheEnabled, buildCacheMode);
-    const targetShapeHash = (0, cache_keys_js_1.shortJsonHash)({
-        target_dir: targetCachePath,
-        target_dir_input: targetDirInput,
-        target_env: (0, cache_keys_js_1.targetEnvHash)(env),
-    });
-    const targetInputsHash = (0, cache_keys_js_1.shortJsonHash)({
-        cargo_config: cargoConfigHashValue,
-        cargo_lock: cargoLockHash,
-        manifest: wsManifestHash,
-        target_shape: targetShapeHash,
-        toolchain: digest,
-    });
-    const lockfileOnlyHash = (0, cache_keys_js_1.shortJsonHash)({
-        cargo_lock: cargoLockHash,
-        toolchain: digest,
-    });
-    const targetCacheBundlePath = thinTargetCacheBundlePath;
-    const targetTreeCacheEnabled = targetCacheEnabled && buildCacheMode === "full";
-    let targetCachePaths;
-    let targetCacheEffectiveMode;
-    let targetCachePrefix;
-    let targetCacheLockPrefix;
-    let targetCacheLockfilePrefix;
-    let targetCacheKey;
-    let targetCacheParentKey;
-    if (!targetCacheEnabled) {
-        targetCachePaths = "";
-        targetCacheEffectiveMode = "off";
-        targetCachePrefix = `setup-soldr-targetcache-off-v1-${runnerOs}-${runnerArch}`;
-        targetCacheLockPrefix = "";
-        targetCacheLockfilePrefix = "";
-        targetCacheKey = `${targetCachePrefix}-${targetInputsHash}`;
-        targetCacheParentKey = "";
-    }
-    else if (targetTreeCacheEnabled) {
-        targetCachePaths = [targetCachePath, targetCacheBundlePath].join("\n");
-        targetCacheEffectiveMode = buildCacheMode;
-        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v1-${runnerOs}-${runnerArch}`;
-        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
-        targetCacheLockPrefix = `${targetCachePrefix}-${digest}-${cargoLockHash}-${targetShapeHash}-${sf}`;
-        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
-        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
-        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
-    }
-    else {
-        targetCachePaths = targetCacheBundlePath;
-        targetCacheEffectiveMode = buildCacheMode;
-        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v1-${runnerOs}-${runnerArch}`;
-        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
-        targetCacheLockPrefix = `${targetCachePrefix}-${targetInputsHash}-${sf}`;
-        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
-        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
-        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
-    }
-    if (suffix) {
-        buildCacheKey = `${buildCacheKey}-${sanitizedSuffix}`;
-        if (buildCacheParentKey) {
-            buildCacheParentKey = `${buildCacheParentKey}-${sanitizedSuffix}`;
-        }
-    }
-    // ---- cargo registry cache ----
-    const cargoRegistryCacheRequested = isTruthy(inputs.cargoRegistryCache.trim() || "true");
-    const cargoRegistryCachePath = path.join(cargoHome, "registry");
-    const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-v1-${runnerOs}-${runnerArch}`;
-    const cargoRegistryCacheRestorePrefix = `${cargoRegistryCachePrefix}-${cargoLockHash}-`;
-    let cargoRegistryCacheKey = `${cargoRegistryCacheRestorePrefix}${digest}-${githubSha}`;
-    if (suffix) {
-        cargoRegistryCacheKey = `${cargoRegistryCacheKey}-${sanitizedSuffix}`;
-    }
-    const cargoRegistryCacheEnabled = cargoRegistryCacheRequested;
-    if (cargoRegistryCacheEnabled) {
-        makeDirs(cargoRegistryCachePath);
-    }
-    // ---- env exports ----
-    const cacheShutdownOnIdleSeconds = parseCacheShutdownOnIdleSeconds(inputs.cacheShutdownOnIdle);
-    const envExports = {};
-    const setEnv = (name, value) => {
-        if (GITHUB_ENV_DENY_LIST.has(name))
-            return;
-        envExports[name] = value;
-    };
-    setEnv("SOLDR_CACHE_DIR", soldrRoot);
-    setEnv("CARGO_HOME", cargoHome);
-    setEnv("RUSTUP_HOME", rustupHome);
-    setEnv("ZCCACHE_CACHE_DIR", zccacheCacheDir);
-    setEnv("SETUP_SOLDR_BUILD_CACHE_MODE", buildCacheMode);
-    setEnv("SOLDR_BUILD_CACHE_MODE", buildCacheRuntimeMode);
-    setEnv("SOLDR_TARGET_CACHE_MODE", targetCacheEnabled ? buildCacheRuntimeMode : "off");
-    setEnv("SOLDR_TARGET_CACHE_DIR", targetCachePath);
-    setEnv("SOLDR_TARGET_CACHE_BUNDLE_DIR", targetCacheBundlePath);
-    setEnv("SOLDR_TARGET_CACHE_PROFILE", targetCacheProfile);
-    const stripDebug = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-strip-debuginfo", inputs.targetCacheStripDebuginfo);
-    if (stripDebug !== null) {
-        setEnv("SOLDR_TARGET_CACHE_STRIP_DEBUGINFO", stripDebug);
-    }
-    const includeIncremental = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-incremental", inputs.targetCacheIncludeIncremental);
-    if (includeIncremental !== null) {
-        setEnv("SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL", includeIncremental);
-    }
-    const includeBuildScripts = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-build-script-binaries", inputs.targetCacheIncludeBuildScriptBinaries);
-    if (includeBuildScripts !== null) {
-        setEnv("SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES", includeBuildScripts);
-    }
-    const targetCacheCompress = (0, cache_keys_js_1.normalizeTargetCacheCompress)(inputs.targetCacheCompress);
-    const targetCacheCompressLevel = (0, cache_keys_js_1.normalizeTargetCacheCompressLevel)(inputs.targetCacheCompressLevel);
-    setEnv("SOLDR_TARGET_CACHE_COMPRESS", targetCacheCompress);
-    setEnv("SOLDR_TARGET_CACHE_COMPRESS_LEVEL", targetCacheCompressLevel);
-    if (cargoRegistryCacheEnabled) {
-        setEnv("SOLDR_SKIP_CARGO_REGISTRY_SAVE", "1");
-    }
-    setEnv("SOLDR_TARGET_CACHE_BACKEND", "local");
-    setEnv("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain.channel);
-    setEnv("SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL", toolchain.cacheChannel);
-    setEnv("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain.profile);
-    setEnv("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", JSON.stringify(toolchain.components));
-    setEnv("SETUP_SOLDR_TOOLCHAIN_TARGETS", JSON.stringify(toolchain.targets));
-    setEnv("SETUP_SOLDR_LOG_START_EPOCH", logStart);
-    setEnv("SETUP_SOLDR_TIMESTAMPS", timestamps);
-    if (!FALSY_VALUES.has(timestamps.toLowerCase()) && env["NO_COLOR"] === undefined) {
-        if (!env["CARGO_TERM_COLOR"])
-            setEnv("CARGO_TERM_COLOR", "always");
-        if (!env["CLICOLOR_FORCE"])
-            setEnv("CLICOLOR_FORCE", "1");
-        if (!env["FORCE_COLOR"])
-            setEnv("FORCE_COLOR", "1");
-    }
-    if (inputs.trustMode.trim()) {
-        setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
-    }
-    const linkerRaw = inputs.linker.trim();
-    if (linkerRaw === "") {
-        const preset = detectUserLinkerEnv(env);
-        if (preset.length > 0) {
-            logger.info(`setup-soldr: deferring to user-set ${preset.join(", ")}; skipping default SOLDR_LINKER=fast injection. See https://github.com/zackees/setup-soldr/issues/108`);
-        }
-        else {
-            setEnv("SOLDR_LINKER", "fast");
-            logger.warning("setup-soldr: defaulting SOLDR_LINKER=fast (mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows) for faster CI links. Soldr's native default is no injection, which produces a smaller build-cache and a slower link. Set `linker: platform-default` to opt out and keep cargo/rust-toolchain.toml in charge, or set `linker: <value>` to silence this warning.");
-        }
-    }
-    else if (!ALLOWED_LINKER_VALUES.includes(linkerRaw)) {
-        throw new Error(`invalid 'linker' input: '${linkerRaw}'. Allowed: default | platform-default | ld | mold | rust-lld | fast`);
-    }
-    else if (linkerRaw !== "default" && linkerRaw !== "platform-default") {
-        setEnv("SOLDR_LINKER", linkerRaw);
-    }
-    const compilePriorityRaw = inputs.compilePriority.trim();
-    if (compilePriorityRaw !== "") {
-        setEnv("ZCCACHE_COMPILE_PRIORITY", compilePriorityRaw);
-    }
-    if (cacheShutdownOnIdleSeconds !== null) {
-        // Set both env vars. zccache reads its own, sccache reads the
-        // SCCACHE_-prefixed one; exporting both means a zccache fork that
-        // still honors only the sccache name keeps working, and a vanilla
-        // sccache invoked via this action would too.
-        const seconds = String(cacheShutdownOnIdleSeconds);
-        setEnv("ZCCACHE_IDLE_TIMEOUT", seconds);
-        setEnv("SCCACHE_IDLE_TIMEOUT", seconds);
-    }
-    // Auto-export cc-rs cross-compile env for *-unknown-linux-musl triples
-    // when the matching `<triple>-gcc/g++/ar` binaries are on PATH. cc-rs
-    // strips the "-unknown-" segment when looking up cross compilers, so
-    // archives that ship binaries with the full triple are missed without
-    // these per-target overrides. See setup-soldr#... and the cc-rs docs.
-    const muslCcHits = detectMuslCcEnv(env);
-    for (const hit of muslCcHits) {
-        const suffix = tripleToCcRsSuffix(hit.triple);
-        for (const [name, value] of Object.entries(hit.exports)) {
-            setEnv(name, value);
-        }
-        logger.warning(`setup-soldr: auto-exporting cc-rs cross-compile env for ${hit.triple} ` +
-            `(CC_${suffix}=${hit.exports[`CC_${suffix}`]}, ` +
-            `CXX_${suffix}=${hit.exports[`CXX_${suffix}`]}, ` +
-            `AR_${suffix}=${hit.exports[`AR_${suffix}`]}) ` +
-            "because cc-rs strips \"-unknown-\" from the triple when probing for a " +
-            "cross compiler and would otherwise fall back to the host gcc. " +
-            `Resolved: cc=${hit.resolvedPaths.cc}, cxx=${hit.resolvedPaths.cxx}, ar=${hit.resolvedPaths.ar}. ` +
-            `Pre-set CC_${suffix} yourself to opt out.`);
-    }
-    // ---- path additions ----
-    const pathAdditions = [binDir, path.join(cargoHome, "bin")];
-    // ---- logging summary ----
-    log("setup-soldr cache plan");
-    log(`cache key=${cacheKey}`);
-    log(`cache restore-key=${cachePrefix}-`);
-    log(`build-cache key=${buildCacheKey}`);
-    log(`build-cache mode=${buildCacheMode}`);
-    log(`build-cache soldr-mode=${buildCacheRuntimeMode}`);
-    if (buildCacheParentKey) {
-        log(`build-cache restore-key-parent=${buildCacheParentKey}`);
-    }
-    log(`build-cache restore-key-toolchain=${buildCacheToolchainPrefix}`);
-    log(`build-cache restore-key-os-arch=${buildCachePrefix}-`);
-    log(`target-cache key=${targetCacheKey}`);
-    log(`target-cache enabled=${targetCacheEnabled ? "true" : "false"}`);
-    log(`target-cache mode=${targetCacheEffectiveMode}`);
-    log("target-cache backend=local");
-    if (targetCacheEnabled) {
-        log(`target-cache soft-budget-bytes=${targetCacheBudgetBytes}`);
-        log(`target-cache soft-budget-files=${targetCacheBudgetFiles}`);
-    }
-    log(`soldr repo=${soldrRepo}`);
-    log(`soldr ref=${soldrRef || "release"}`);
-    if (soldrVersionResolved) {
-        log(`soldr version=${soldrVersionResolved}`);
-    }
-    log(`toolchain channel=${toolchain.channel}`);
-    log(`toolchain cache-channel=${toolchain.cacheChannel}`);
-    log(`rustup strategy=${rustupStrategy}`);
-    log(`setup-cache layout=${setupCacheLayoutValue}`);
-    if (targetCacheParentKey) {
-        log(`target-cache restore-key-parent=${targetCacheParentKey}`);
-    }
-    log(`target-cache restore-key-lock=${targetCacheLockPrefix}`);
-    log(`target-cache restore-key-lockfile=${targetCacheLockfilePrefix}`);
-    log(`target-cache paths=${targetCachePaths}`);
-    log(`target-cache bundle-dir=${targetCacheBundlePath}`);
-    log(`target-cache lockfile=${(0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath)}`);
-    log(`target-cache lockfile-hash=${cargoLockHash}`);
-    // ---- assemble plans ----
-    const setupCache = {
-        key: cacheKey,
-        restorePrefix: `${cachePrefix}-`,
-        paths: setupCachePathsList ? setupCachePathsList.split("\n") : [],
-        setupCachePath,
-        layout: setupCacheLayoutValue,
-    };
-    const buildCache = {
-        key: buildCacheKey,
-        restoreKeyParent: buildCacheParentKey,
-        restoreKeyToolchain: buildCacheToolchainPrefix,
-        restoreKeyOsArch: `${buildCachePrefix}-`,
-        path: zccacheCacheDir,
-        mode: buildCacheMode,
-    };
-    const targetCache = {
-        enabled: targetCacheEnabled,
-        key: targetCacheKey,
-        restoreKeyParent: targetCacheParentKey,
-        restoreKeyLock: targetCacheLockPrefix,
-        restoreKeyLockfile: targetCacheLockfilePrefix,
-        paths: targetCachePaths,
-        bundlePath: targetCacheBundlePath,
-        targetPath: targetCachePath,
-        effectiveMode: targetCacheEffectiveMode,
-        profile: targetCacheProfile,
-        budgetBytes: targetCacheBudgetBytes,
-        budgetFiles: targetCacheBudgetFiles,
-        lockfilePath: (0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath),
-        lockfileHash: cargoLockHash,
-    };
-    const cargoRegistryCachePlan = {
-        enabled: cargoRegistryCacheEnabled,
-        key: cargoRegistryCacheKey,
-        restorePrefix: cargoRegistryCacheRestorePrefix,
-        path: cargoRegistryCachePath,
-    };
-    // Avoid unused warnings on alias helper.
-    void toolchain_js_1.rollingToolchainAlias;
-    void cache_keys_js_1.canonicalJsonStringify;
-    const compileCacheStats = normalizeCompileCacheStats(inputs.compileCacheStats);
-    const stats = normalizeStatsMode(inputs.stats);
-    const debugMode = isTruthy(inputs.debugMode.trim() || "false");
-    // ---- shims ----
-    const shimsRaw = inputs.shims.trim() || "false";
-    const shimsEnabled = !isFalsy(shimsRaw);
-    const shimsDir = path.join(cacheRoot, "shims");
-    return {
-        enabled,
-        workspace,
-        cacheRoot,
-        soldrRoot,
-        binDir,
-        cargoHome,
-        rustupHome,
-        soldrPath,
-        soldrBinCachePath,
-        toolchain,
-        rustupStrategy,
-        soldrRepo,
-        soldrRef,
-        soldrVersionRequested,
-        soldrVersionResolved,
-        setupCache,
-        buildCache,
-        targetCache,
-        cargoRegistryCache: cargoRegistryCachePlan,
-        targetCacheCompress,
-        targetCacheCompressLevel,
-        envExports,
-        pathAdditions,
-        logStartEpoch: logStart,
-        timestamps,
-        shimsEnabled,
-        shimsDir,
-        compileCacheStats,
-        stats,
-        debugMode,
-        cacheShutdownOnIdleSeconds,
-    };
-}
-/**
- * Apply ResolveResult to the runner: write $GITHUB_ENV, $GITHUB_PATH, and
- * $GITHUB_OUTPUT keys.
- */
-async function applyResolveResult(result) {
-    for (const [name, value] of Object.entries(result.envExports)) {
-        if (GITHUB_ENV_DENY_LIST.has(name))
-            continue;
-        core.exportVariable(name, value);
-    }
-    for (const p of result.pathAdditions) {
-        core.addPath(p);
-    }
-    const outputs = buildOutputs(result);
-    for (const [key, value] of Object.entries(outputs)) {
-        core.setOutput(key, value);
-    }
-}
-/**
- * Build the $GITHUB_OUTPUT key/value map mirroring resolve_setup.py's
- * `_write_outputs()` call. Exposed for tests so they can assert byte-for-byte.
- */
-function buildOutputs(result) {
-    return {
-        cache_root: result.cacheRoot,
-        setup_cache_path: result.setupCache.setupCachePath,
-        setup_cache_paths: result.setupCache.paths.join("\n"),
-        cache_key: result.setupCache.key,
-        cache_restore_prefix: result.setupCache.restorePrefix,
-        build_cache_key: result.buildCache.key,
-        build_cache_restore_key_parent: result.buildCache.restoreKeyParent,
-        build_cache_restore_key_toolchain: result.buildCache.restoreKeyToolchain,
-        build_cache_restore_key_os_arch: result.buildCache.restoreKeyOsArch,
-        build_cache_path: result.buildCache.path,
-        build_cache_mode: result.buildCache.mode,
-        target_cache_path: result.targetCache.targetPath,
-        target_cache_bundle_path: result.targetCache.bundlePath,
-        target_cache_paths: result.targetCache.paths,
-        target_cache_enabled: result.targetCache.enabled ? "true" : "false",
-        target_cache_mode: result.targetCache.effectiveMode,
-        target_cache_profile: result.targetCache.profile,
-        target_cache_compress: result.targetCacheCompress,
-        target_cache_compress_level: result.targetCacheCompressLevel,
-        target_cache_key: result.targetCache.key,
-        target_cache_restore_key_parent: result.targetCache.restoreKeyParent,
-        target_cache_restore_key_lock: result.targetCache.restoreKeyLock,
-        target_cache_restore_key_lockfile: result.targetCache.restoreKeyLockfile,
-        target_cache_budget_bytes: result.targetCache.budgetBytes,
-        target_cache_budget_files: result.targetCache.budgetFiles,
-        target_lockfile_path: result.targetCache.lockfilePath,
-        target_lockfile_hash: result.targetCache.lockfileHash,
-        cargo_registry_cache_enabled: result.cargoRegistryCache.enabled ? "true" : "false",
-        cargo_registry_cache_path: result.cargoRegistryCache.path,
-        cargo_registry_cache_key: result.cargoRegistryCache.key,
-        cargo_registry_cache_restore_prefix: result.cargoRegistryCache.restorePrefix,
-        soldr_root: result.soldrRoot,
-        soldr_bin_cache_path: result.soldrBinCachePath,
-        cargo_home: result.cargoHome,
-        rustup_home: result.rustupHome,
-        setup_cache_layout: result.setupCache.layout,
-        bin_dir: result.binDir,
-        shims_dir: result.shimsDir,
-        soldr_path: result.soldrPath,
-        soldr_repo: result.soldrRepo,
-        soldr_ref: result.soldrRef,
-        soldr_version_requested: result.soldrVersionRequested,
-        soldr_version_resolved: result.soldrVersionResolved,
-        toolchain_channel: result.toolchain.channel,
-        toolchain_cache_channel: result.toolchain.cacheChannel,
-        toolchain_profile: result.toolchain.profile,
-        toolchain_source: result.toolchain.source,
-        toolchain: result.toolchain.channel,
-        enabled: result.enabled ? "true" : "false",
-    };
-}
-// --------------------- Python-default JSON serialization ---------------------
-/**
- * Mirror Python's `json.dumps(value, sort_keys=True)` with default separators
- * (", " between items, ": " between key/value). Used for the toolchain
- * signature digest where Python does NOT pass compact separators.
- */
-function pythonDefaultJson(value) {
-    return formatDefaultJson(value);
-}
-function formatDefaultJson(value) {
-    if (value === null || value === undefined)
-        return "null";
-    if (typeof value === "string")
-        return JSON.stringify(value);
-    if (typeof value === "number") {
-        return Number.isFinite(value) ? JSON.stringify(value) : "null";
-    }
-    if (typeof value === "boolean")
-        return value ? "true" : "false";
-    if (Array.isArray(value)) {
-        const parts = value.map((item) => formatDefaultJson(item));
-        return `[${parts.join(", ")}]`;
-    }
-    if (typeof value === "object") {
-        const obj = value;
-        const keys = Object.keys(obj).sort();
-        const parts = keys.map((key) => `${JSON.stringify(key)}: ${formatDefaultJson(obj[key])}`);
-        return `{${parts.join(", ")}}`;
-    }
-    return JSON.stringify(value);
 }
 
 
@@ -26711,7 +26134,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(367);
+	createDebug.humanize = __nccwpck_require__(368);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -27078,15 +26501,15 @@ __export(internal_exports, {
   uint8ArrayToString: () => import_bytesEncoding.uint8ArrayToString
 });
 module.exports = __toCommonJS(internal_exports);
-var import_delay = __nccwpck_require__(465);
-var import_random = __nccwpck_require__(496);
+var import_delay = __nccwpck_require__(466);
+var import_random = __nccwpck_require__(497);
 var import_object = __nccwpck_require__(142);
 var import_error = __nccwpck_require__(150);
 var import_sha256 = __nccwpck_require__(195);
-var import_uuidUtils = __nccwpck_require__(386);
-var import_checkEnvironment = __nccwpck_require__(430);
+var import_uuidUtils = __nccwpck_require__(387);
+var import_checkEnvironment = __nccwpck_require__(431);
 var import_bytesEncoding = __nccwpck_require__(280);
-var import_sanitizer = __nccwpck_require__(118);
+var import_sanitizer = __nccwpck_require__(119);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -27476,7 +26899,7 @@ __export(basicAuthenticationPolicy_exports, {
 });
 module.exports = __toCommonJS(basicAuthenticationPolicy_exports);
 var import_bytesEncoding = __nccwpck_require__(280);
-var import_checkInsecureConnection = __nccwpck_require__(427);
+var import_checkInsecureConnection = __nccwpck_require__(428);
 const basicAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function basicAuthenticationPolicy(options) {
   return {
@@ -27591,7 +27014,7 @@ exports.ConvertInternalResponseOfListBlobHierarchy = ConvertInternalResponseOfLi
 exports.ExtractPageRangeInfoItems = ExtractPageRangeInfoItems;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 const core_util_1 = __nccwpck_require__(13);
 const constants_js_1 = __nccwpck_require__(145);
 /**
@@ -28411,7 +27834,7 @@ module.exports = {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionLongConvert = void 0;
-const reflection_info_1 = __nccwpck_require__(444);
+const reflection_info_1 = __nccwpck_require__(445);
 /**
  * Utility method to convert a PbLong or PbUlong to a JavaScript
  * representation during runtime.
@@ -28509,8 +27932,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.uploadCacheArchiveSDK = exports.UploadProgress = void 0;
-const core = __importStar(__nccwpck_require__(450));
-const storage_blob_1 = __nccwpck_require__(439);
+const core = __importStar(__nccwpck_require__(451));
+const storage_blob_1 = __nccwpck_require__(440);
 const errors_1 = __nccwpck_require__(297);
 /**
  * Class for tracking the upload state and displaying stats.
@@ -28674,7 +28097,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.req = exports.json = exports.toBuffer = void 0;
-const http = __importStar(__nccwpck_require__(321));
+const http = __importStar(__nccwpck_require__(322));
 const https = __importStar(__nccwpck_require__(69));
 async function toBuffer(stream) {
     let length = 0;
@@ -28861,25 +28284,25 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 "use strict";
 
 
-const Client = __nccwpck_require__(85)
-const Dispatcher = __nccwpck_require__(468)
-const errors = __nccwpck_require__(478)
-const Pool = __nccwpck_require__(330)
-const BalancedPool = __nccwpck_require__(374)
+const Client = __nccwpck_require__(86)
+const Dispatcher = __nccwpck_require__(469)
+const errors = __nccwpck_require__(479)
+const Pool = __nccwpck_require__(331)
+const BalancedPool = __nccwpck_require__(375)
 const Agent = __nccwpck_require__(5)
 const util = __nccwpck_require__(68)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(135)
+const api = __nccwpck_require__(136)
 const buildConnector = __nccwpck_require__(259)
 const MockClient = __nccwpck_require__(194)
-const MockAgent = __nccwpck_require__(370)
-const MockPool = __nccwpck_require__(342)
+const MockAgent = __nccwpck_require__(371)
+const MockPool = __nccwpck_require__(343)
 const mockErrors = __nccwpck_require__(226)
-const ProxyAgent = __nccwpck_require__(335)
+const ProxyAgent = __nccwpck_require__(336)
 const RetryHandler = __nccwpck_require__(266)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(369)
-const DecoratorHandler = __nccwpck_require__(466)
-const RedirectHandler = __nccwpck_require__(383)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(370)
+const DecoratorHandler = __nccwpck_require__(467)
+const RedirectHandler = __nccwpck_require__(384)
 const createRedirectInterceptor = __nccwpck_require__(248)
 
 let hasCrypto
@@ -28963,7 +28386,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   let fetchImpl = null
   module.exports.fetch = async function fetch (resource) {
     if (!fetchImpl) {
-      fetchImpl = (__nccwpck_require__(442).fetch)
+      fetchImpl = (__nccwpck_require__(443).fetch)
     }
 
     try {
@@ -28976,14 +28399,14 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
       throw err
     }
   }
-  module.exports.Headers = __nccwpck_require__(505).Headers
+  module.exports.Headers = __nccwpck_require__(506).Headers
   module.exports.Response = __nccwpck_require__(40).Response
   module.exports.Request = __nccwpck_require__(81).Request
   module.exports.FormData = __nccwpck_require__(202).FormData
-  module.exports.File = __nccwpck_require__(356).File
-  module.exports.FileReader = __nccwpck_require__(91).FileReader
+  module.exports.File = __nccwpck_require__(357).File
+  module.exports.FileReader = __nccwpck_require__(92).FileReader
 
-  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(136)
+  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(137)
 
   module.exports.setGlobalOrigin = setGlobalOrigin
   module.exports.getGlobalOrigin = getGlobalOrigin
@@ -28997,7 +28420,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
 }
 
 if (util.nodeMajor >= 16) {
-  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(379)
+  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(380)
 
   module.exports.deleteCookie = deleteCookie
   module.exports.getCookies = getCookies
@@ -29118,7 +28541,7 @@ exports.setupCacheLayout = setupCacheLayout;
 exports.pathForOutput = pathForOutput;
 const node_crypto_1 = __nccwpck_require__(267);
 const fs = __importStar(__nccwpck_require__(242));
-const path = __importStar(__nccwpck_require__(497));
+const path = __importStar(__nccwpck_require__(498));
 const TARGET_CACHE_PROFILES = ["thin-v1", "thin-v2"];
 const TARGET_CACHE_BOOL_TRUE = new Set(["true", "1", "yes", "on"]);
 const TARGET_CACHE_BOOL_FALSE = new Set(["false", "0", "no", "off"]);
@@ -29508,9 +28931,9 @@ function pathForOutput(workspace, p) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const tslib_1 = __nccwpck_require__(210);
-tslib_1.__exportStar(__nccwpck_require__(114), exports);
+tslib_1.__exportStar(__nccwpck_require__(115), exports);
 tslib_1.__exportStar(__nccwpck_require__(176), exports);
-tslib_1.__exportStar(__nccwpck_require__(119), exports);
+tslib_1.__exportStar(__nccwpck_require__(120), exports);
 tslib_1.__exportStar(__nccwpck_require__(309), exports);
 tslib_1.__exportStar(__nccwpck_require__(203), exports);
 tslib_1.__exportStar(__nccwpck_require__(263), exports);
@@ -29528,12 +28951,12 @@ tslib_1.__exportStar(__nccwpck_require__(263), exports);
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageRetryPolicyName = void 0;
 exports.storageRetryPolicy = storageRetryPolicy;
-const abort_controller_1 = __nccwpck_require__(484);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const abort_controller_1 = __nccwpck_require__(485);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 const core_util_1 = __nccwpck_require__(13);
 const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(318);
 const constants_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(464);
+const utils_common_js_1 = __nccwpck_require__(465);
 const log_js_1 = __nccwpck_require__(16);
 /**
  * Name of the {@link storageRetryPolicy}
@@ -29709,7 +29132,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.create = void 0;
-const internal_globber_1 = __nccwpck_require__(423);
+const internal_globber_1 = __nccwpck_require__(424);
 /**
  * Constructs a globber
  *
@@ -29807,8 +29230,8 @@ __export(multipartPolicy_exports, {
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
 var import_bytesEncoding = __nccwpck_require__(280);
-var import_typeGuards = __nccwpck_require__(486);
-var import_uuidUtils = __nccwpck_require__(386);
+var import_typeGuards = __nccwpck_require__(487);
+var import_uuidUtils = __nccwpck_require__(387);
 var import_concat = __nccwpck_require__(296);
 function generateBoundary() {
   return `----AzSDKFormBoundary${(0, import_uuidUtils.randomUUID)()}`;
@@ -29923,7 +29346,7 @@ function multipartPolicy() {
 
 "use strict";
 
-const f = __nccwpck_require__(396)
+const f = __nccwpck_require__(397)
 
 class FloatingDateTime extends Date {
   constructor (value) {
@@ -30098,9 +29521,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Note: we do not use `export * from ...` to help tree shakers,
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-var service_type_1 = __nccwpck_require__(469);
+var service_type_1 = __nccwpck_require__(470);
 Object.defineProperty(exports, "ServiceType", ({ enumerable: true, get: function () { return service_type_1.ServiceType; } }));
-var reflection_info_1 = __nccwpck_require__(516);
+var reflection_info_1 = __nccwpck_require__(518);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
 Object.defineProperty(exports, "readMethodOption", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOption; } }));
 Object.defineProperty(exports, "readServiceOption", ({ enumerable: true, get: function () { return reflection_info_1.readServiceOption; } }));
@@ -30110,26 +29533,26 @@ var rpc_options_1 = __nccwpck_require__(286);
 Object.defineProperty(exports, "mergeRpcOptions", ({ enumerable: true, get: function () { return rpc_options_1.mergeRpcOptions; } }));
 var rpc_output_stream_1 = __nccwpck_require__(299);
 Object.defineProperty(exports, "RpcOutputStreamController", ({ enumerable: true, get: function () { return rpc_output_stream_1.RpcOutputStreamController; } }));
-var test_transport_1 = __nccwpck_require__(502);
+var test_transport_1 = __nccwpck_require__(503);
 Object.defineProperty(exports, "TestTransport", ({ enumerable: true, get: function () { return test_transport_1.TestTransport; } }));
 var deferred_1 = __nccwpck_require__(51);
 Object.defineProperty(exports, "Deferred", ({ enumerable: true, get: function () { return deferred_1.Deferred; } }));
 Object.defineProperty(exports, "DeferredState", ({ enumerable: true, get: function () { return deferred_1.DeferredState; } }));
 var duplex_streaming_call_1 = __nccwpck_require__(298);
 Object.defineProperty(exports, "DuplexStreamingCall", ({ enumerable: true, get: function () { return duplex_streaming_call_1.DuplexStreamingCall; } }));
-var client_streaming_call_1 = __nccwpck_require__(343);
+var client_streaming_call_1 = __nccwpck_require__(344);
 Object.defineProperty(exports, "ClientStreamingCall", ({ enumerable: true, get: function () { return client_streaming_call_1.ClientStreamingCall; } }));
-var server_streaming_call_1 = __nccwpck_require__(443);
+var server_streaming_call_1 = __nccwpck_require__(444);
 Object.defineProperty(exports, "ServerStreamingCall", ({ enumerable: true, get: function () { return server_streaming_call_1.ServerStreamingCall; } }));
 var unary_call_1 = __nccwpck_require__(55);
 Object.defineProperty(exports, "UnaryCall", ({ enumerable: true, get: function () { return unary_call_1.UnaryCall; } }));
-var rpc_interceptor_1 = __nccwpck_require__(521);
+var rpc_interceptor_1 = __nccwpck_require__(523);
 Object.defineProperty(exports, "stackIntercept", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackIntercept; } }));
 Object.defineProperty(exports, "stackDuplexStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackDuplexStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackClientStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackClientStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackServerStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackServerStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackUnaryInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackUnaryInterceptors; } }));
-var server_call_context_1 = __nccwpck_require__(416);
+var server_call_context_1 = __nccwpck_require__(417);
 Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: true, get: function () { return server_call_context_1.ServerCallContextController; } }));
 
 
@@ -30271,7 +29694,7 @@ function isLessThan(lhs, rhs) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-const operation_js_1 = __nccwpck_require__(350);
+const operation_js_1 = __nccwpck_require__(351);
 const constants_js_1 = __nccwpck_require__(59);
 const poller_js_1 = __nccwpck_require__(73);
 const operation_js_2 = __nccwpck_require__(138);
@@ -40334,11 +39757,11 @@ exports.newPipeline = newPipeline;
 exports.getCoreClientOptions = getCoreClientOptions;
 exports.getCredentialFromPipeline = getCredentialFromPipeline;
 const core_http_compat_1 = __nccwpck_require__(71);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
-const core_client_1 = __nccwpck_require__(431);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
+const core_client_1 = __nccwpck_require__(432);
 const core_xml_1 = __nccwpck_require__(189);
-const core_auth_1 = __nccwpck_require__(503);
-const log_js_1 = __nccwpck_require__(103);
+const core_auth_1 = __nccwpck_require__(504);
+const log_js_1 = __nccwpck_require__(104);
 const storage_common_1 = __nccwpck_require__(269);
 const constants_js_1 = __nccwpck_require__(145);
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return constants_js_1.StorageOAuthScopes; } }));
@@ -40646,20 +40069,20 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobClient = exports.BlockBlobClient = exports.AppendBlobClient = exports.BlobClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
-const core_auth_1 = __nccwpck_require__(503);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
+const core_auth_1 = __nccwpck_require__(504);
 const core_util_1 = __nccwpck_require__(13);
 const core_util_2 = __nccwpck_require__(13);
-const BlobDownloadResponse_js_1 = __nccwpck_require__(418);
+const BlobDownloadResponse_js_1 = __nccwpck_require__(419);
 const BlobQueryResponse_js_1 = __nccwpck_require__(196);
 const storage_common_1 = __nccwpck_require__(269);
-const models_js_1 = __nccwpck_require__(407);
+const models_js_1 = __nccwpck_require__(408);
 const PageBlobRangeResponse_js_1 = __nccwpck_require__(28);
 const Pipeline_js_1 = __nccwpck_require__(178);
-const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(523);
-const Range_js_1 = __nccwpck_require__(101);
-const StorageClient_js_1 = __nccwpck_require__(446);
-const Batch_js_1 = __nccwpck_require__(88);
+const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(525);
+const Range_js_1 = __nccwpck_require__(102);
+const StorageClient_js_1 = __nccwpck_require__(447);
+const Batch_js_1 = __nccwpck_require__(89);
 const storage_common_2 = __nccwpck_require__(269);
 const constants_js_1 = __nccwpck_require__(145);
 const tracing_js_1 = __nccwpck_require__(30);
@@ -43503,10 +42926,10 @@ exports.PageBlobClient = PageBlobClient;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryWriter = void 0;
-const binary_format_contract_1 = __nccwpck_require__(325);
-const reflection_info_1 = __nccwpck_require__(444);
-const assert_1 = __nccwpck_require__(474);
-const pb_long_1 = __nccwpck_require__(113);
+const binary_format_contract_1 = __nccwpck_require__(326);
+const reflection_info_1 = __nccwpck_require__(445);
+const assert_1 = __nccwpck_require__(475);
+const pb_long_1 = __nccwpck_require__(114);
 /**
  * Writes proto3 messages in binary format using reflection information.
  *
@@ -43743,7 +43166,7 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 "use strict";
 
 
-const { maxUnsigned16Bit } = __nccwpck_require__(456)
+const { maxUnsigned16Bit } = __nccwpck_require__(457)
 
 /** @type {import('crypto')} */
 let crypto
@@ -43868,10 +43291,10 @@ function isApiKeyCredential(credential) {
 /***/ 184:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const assert = __nccwpck_require__(515)
+const assert = __nccwpck_require__(517)
 const {
   ResponseStatusCodeError
-} = __nccwpck_require__(478)
+} = __nccwpck_require__(479)
 const { toUSVString } = __nccwpck_require__(68)
 
 async function getResolveErrorBodyCallback ({ callback, body, contentType, statusCode, statusMessage, headers }) {
@@ -44384,7 +43807,7 @@ __export(src_exports, {
   stringifyXML: () => import_xml.stringifyXML
 });
 module.exports = __toCommonJS(src_exports);
-var import_xml = __nccwpck_require__(134);
+var import_xml = __nccwpck_require__(135);
 var import_xml_common = __nccwpck_require__(20);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -44610,8 +44033,8 @@ module.exports = require("util/types");
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(120)
-const Client = __nccwpck_require__(85)
+const { promisify } = __nccwpck_require__(121)
+const Client = __nccwpck_require__(86)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
   kDispatches,
@@ -44621,10 +44044,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(461)
-const { MockInterceptor } = __nccwpck_require__(132)
+} = __nccwpck_require__(462)
+const { MockInterceptor } = __nccwpck_require__(133)
 const Symbols = __nccwpck_require__(190)
-const { InvalidArgumentError } = __nccwpck_require__(478)
+const { InvalidArgumentError } = __nccwpck_require__(479)
 
 /**
  * MockClient provides an API that extends the Client to influence the mockDispatches.
@@ -45107,7 +44530,7 @@ exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
 const tslib_1 = __nccwpck_require__(210);
 const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(242));
-const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(368));
+const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(369));
 const constants_js_1 = __nccwpck_require__(145);
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
@@ -45740,8 +45163,8 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionCreate = void 0;
-const reflection_scalar_default_1 = __nccwpck_require__(453);
-const message_type_contract_1 = __nccwpck_require__(398);
+const reflection_scalar_default_1 = __nccwpck_require__(454);
+const message_type_contract_1 = __nccwpck_require__(399);
 /**
  * Creates an instance of the generic message, using the field
  * information.
@@ -45801,7 +45224,7 @@ exports.storageBrowserPolicyName = void 0;
 exports.storageBrowserPolicy = storageBrowserPolicy;
 const core_util_1 = __nccwpck_require__(13);
 const constants_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(464);
+const utils_common_js_1 = __nccwpck_require__(465);
 /**
  * The programmatic identifier of the StorageBrowserPolicy.
  */
@@ -45837,11 +45260,11 @@ function storageBrowserPolicy() {
 "use strict";
 
 
-const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(506)
+const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(507)
 const { kState } = __nccwpck_require__(14)
-const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(356)
-const { webidl } = __nccwpck_require__(448)
-const { Blob, File: NativeFile } = __nccwpck_require__(115)
+const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(357)
+const { webidl } = __nccwpck_require__(449)
+const { Blob, File: NativeFile } = __nccwpck_require__(116)
 
 /** @type {globalThis['File']} */
 const File = NativeFile ?? UndiciFile
@@ -46146,10 +45569,10 @@ __export(getClient_exports, {
   getClient: () => getClient
 });
 module.exports = __toCommonJS(getClient_exports);
-var import_clientHelpers = __nccwpck_require__(481);
-var import_sendRequest = __nccwpck_require__(441);
+var import_clientHelpers = __nccwpck_require__(482);
+var import_sendRequest = __nccwpck_require__(442);
 var import_urlHelpers = __nccwpck_require__(316);
-var import_checkEnvironment = __nccwpck_require__(430);
+var import_checkEnvironment = __nccwpck_require__(431);
 function getClient(endpoint, clientOptions = {}) {
   const pipeline = clientOptions.pipeline ?? (0, import_clientHelpers.createDefaultPipeline)(clientOptions);
   if (clientOptions.additionalPolicies?.length) {
@@ -46329,8 +45752,8 @@ __export(httpClientAdapter_exports, {
   convertHttpClient: () => convertHttpClient
 });
 module.exports = __toCommonJS(httpClientAdapter_exports);
-var import_response = __nccwpck_require__(404);
-var import_util = __nccwpck_require__(106);
+var import_response = __nccwpck_require__(405);
+var import_util = __nccwpck_require__(107);
 function convertHttpClient(requestPolicyClient) {
   return {
     sendRequest: async (request) => {
@@ -46468,13 +45891,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.restoreCache = exports.isFeatureAvailable = exports.FinalizeCacheError = exports.ReserveCacheError = exports.ValidationError = void 0;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 const path = __importStar(__nccwpck_require__(241));
 const utils = __importStar(__nccwpck_require__(74));
 const cacheHttpClient = __importStar(__nccwpck_require__(33));
 const cacheTwirpClient = __importStar(__nccwpck_require__(60));
 const config_1 = __nccwpck_require__(36);
-const tar_1 = __nccwpck_require__(432);
+const tar_1 = __nccwpck_require__(433);
 const http_client_1 = __nccwpck_require__(278);
 class ValidationError extends Error {
     constructor(message) {
@@ -46981,9 +46404,9 @@ __export(extendedClient_exports, {
 });
 module.exports = __toCommonJS(extendedClient_exports);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_core_rest_pipeline = __nccwpck_require__(98);
-var import_core_client = __nccwpck_require__(431);
-var import_response = __nccwpck_require__(404);
+var import_core_rest_pipeline = __nccwpck_require__(99);
+var import_core_client = __nccwpck_require__(432);
+var import_response = __nccwpck_require__(405);
 class ExtendedServiceClient extends import_core_client.ServiceClient {
   constructor(options) {
     super(options);
@@ -47519,7 +46942,7 @@ __export(bearerTokenAuthenticationPolicy_exports, {
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
 var import_tokenCycler = __nccwpck_require__(158);
 var import_log = __nccwpck_require__(179);
-var import_restError = __nccwpck_require__(346);
+var import_restError = __nccwpck_require__(347);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
   try {
@@ -47759,9 +47182,9 @@ exports.targetDirHasCompiledArtifacts = targetDirHasCompiledArtifacts;
 exports.shouldEmitSharedTargetWarning = shouldEmitSharedTargetWarning;
 exports.detectSharedTargetWarning = detectSharedTargetWarning;
 const fs = __importStar(__nccwpck_require__(242));
-const path = __importStar(__nccwpck_require__(497));
-const core = __importStar(__nccwpck_require__(450));
-const log_utils_js_1 = __nccwpck_require__(345);
+const path = __importStar(__nccwpck_require__(498));
+const core = __importStar(__nccwpck_require__(451));
+const log_utils_js_1 = __nccwpck_require__(346);
 const WARNING_MESSAGE = "setup-soldr detected a pre-populated shared target directory; a " +
     "subsequent `soldr cargo build` using the same `--target-dir` may fail " +
     "with a missing .rmeta error - see README 'Known limitations'.";
@@ -47907,7 +47330,7 @@ function systemErrorRetryPolicy(options = {}) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
 const tslib_1 = __nccwpck_require__(210);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(431));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(432));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(64));
 /** Class containing Container operations. */
@@ -48695,7 +48118,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.safeTrimTrailingSeparator = exports.normalizeSeparators = exports.hasRoot = exports.hasAbsoluteRoot = exports.ensureAbsoluteRoot = exports.dirname = void 0;
 const path = __importStar(__nccwpck_require__(241));
-const assert_1 = __importDefault(__nccwpck_require__(515));
+const assert_1 = __importDefault(__nccwpck_require__(517));
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Similar to path.dirname except normalizes the path separators and slightly better handling for Windows UNC paths.
@@ -48876,8 +48299,8 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 "use strict";
 
 module.exports = __nccwpck_require__(281)
-module.exports.async = __nccwpck_require__(403)
-module.exports.stream = __nccwpck_require__(412)
+module.exports.async = __nccwpck_require__(404)
+module.exports.stream = __nccwpck_require__(413)
 module.exports.prettyError = __nccwpck_require__(271)
 
 
@@ -48916,10 +48339,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpProxyAgent = void 0;
-const net = __importStar(__nccwpck_require__(498));
-const tls = __importStar(__nccwpck_require__(495));
-const debug_1 = __importDefault(__nccwpck_require__(504));
-const events_1 = __nccwpck_require__(460);
+const net = __importStar(__nccwpck_require__(499));
+const tls = __importStar(__nccwpck_require__(496));
+const debug_1 = __importDefault(__nccwpck_require__(505));
+const events_1 = __nccwpck_require__(461);
 const agent_base_1 = __nccwpck_require__(234);
 const url_1 = __nccwpck_require__(82);
 const debug = (0, debug_1.default)('http-proxy-agent');
@@ -49074,7 +48497,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
-const fs = __importStar(__nccwpck_require__(520));
+const fs = __importStar(__nccwpck_require__(522));
 const path = __importStar(__nccwpck_require__(241));
 _a = fs.promises
 // export const {open} = 'fs'
@@ -49584,7 +49007,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
 const tslib_1 = __nccwpck_require__(210);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(431));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(432));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(64));
 /** Class containing Service operations. */
@@ -49948,7 +49371,7 @@ function agentPolicy(agent) {
 "use strict";
 
 
-const { UndiciError } = __nccwpck_require__(478)
+const { UndiciError } = __nccwpck_require__(479)
 
 class MockNotMatchedError extends UndiciError {
   constructor (message) {
@@ -49973,7 +49396,7 @@ module.exports = {
 "use strict";
 
 
-const { Transform } = __nccwpck_require__(127)
+const { Transform } = __nccwpck_require__(128)
 const { Console } = __nccwpck_require__(31)
 
 /**
@@ -50027,7 +49450,7 @@ const runtime_2 = __nccwpck_require__(18);
 const runtime_3 = __nccwpck_require__(18);
 const runtime_4 = __nccwpck_require__(18);
 const runtime_5 = __nccwpck_require__(18);
-const cachescope_1 = __nccwpck_require__(389);
+const cachescope_1 = __nccwpck_require__(390);
 // @generated message type with reflection information, may provide speed optimized methods
 class CacheMetadata$Type extends runtime_5.MessageType {
     constructor() {
@@ -50111,8 +49534,8 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_ts_http_runtime = __nccwpck_require__(86);
-var import_wrapAbortSignal = __nccwpck_require__(437);
+var import_ts_http_runtime = __nccwpck_require__(87);
+var import_wrapAbortSignal = __nccwpck_require__(438);
 function createDefaultHttpClient() {
   const client = (0, import_ts_http_runtime.createDefaultHttpClient)();
   return {
@@ -50151,8 +49574,8 @@ module.exports = require("node:process");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRequestUrl = getRequestUrl;
 exports.appendQueryParams = appendQueryParams;
-const operationHelpers_js_1 = __nccwpck_require__(424);
-const interfaceHelpers_js_1 = __nccwpck_require__(392);
+const operationHelpers_js_1 = __nccwpck_require__(425);
+const interfaceHelpers_js_1 = __nccwpck_require__(393);
 const CollectionFormatToDelimiterMap = {
     CSV: ",",
     SSV: " ",
@@ -50502,8 +49925,8 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Agent = void 0;
-const net = __importStar(__nccwpck_require__(498));
-const http = __importStar(__nccwpck_require__(321));
+const net = __importStar(__nccwpck_require__(499));
+const http = __importStar(__nccwpck_require__(322));
 const https_1 = __nccwpck_require__(69);
 __exportStar(__nccwpck_require__(157), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
@@ -50722,7 +50145,7 @@ __export(httpHeaders_exports, {
   createHttpHeaders: () => createHttpHeaders
 });
 module.exports = __toCommonJS(httpHeaders_exports);
-var import_ts_http_runtime = __nccwpck_require__(86);
+var import_ts_http_runtime = __nccwpck_require__(87);
 function createHttpHeaders(rawHeaders) {
   return (0, import_ts_http_runtime.createHttpHeaders)(rawHeaders);
 }
@@ -50772,7 +50195,7 @@ __export(pipeline_exports, {
   createEmptyPipeline: () => createEmptyPipeline
 });
 module.exports = __toCommonJS(pipeline_exports);
-var import_ts_http_runtime = __nccwpck_require__(86);
+var import_ts_http_runtime = __nccwpck_require__(87);
 function createEmptyPipeline() {
   return (0, import_ts_http_runtime.createEmptyPipeline)();
 }
@@ -50821,7 +50244,7 @@ __export(logger_exports, {
   setLogLevel: () => setLogLevel
 });
 module.exports = __toCommonJS(logger_exports);
-var import_debug = __toESM(__nccwpck_require__(457));
+var import_debug = __toESM(__nccwpck_require__(458));
 const TYPESPEC_RUNTIME_LOG_LEVELS = ["verbose", "info", "warning", "error"];
 const levelMap = {
   verbose: 400,
@@ -50996,7 +50419,7 @@ module.exports = require("node:fs");
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(448)
+const { webidl } = __nccwpck_require__(449)
 const { kEnumerableProperty } = __nccwpck_require__(68)
 const { MessagePort } = __nccwpck_require__(311)
 
@@ -51308,9 +50731,9 @@ module.exports = {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryWriter = exports.binaryWriteOptions = void 0;
-const pb_long_1 = __nccwpck_require__(113);
+const pb_long_1 = __nccwpck_require__(114);
 const goog_varint_1 = __nccwpck_require__(198);
-const assert_1 = __nccwpck_require__(474);
+const assert_1 = __nccwpck_require__(475);
 const defaultsWrite = {
     writeUnknownFields: true,
     writerFactory: () => new BinaryWriter(),
@@ -51550,9 +50973,9 @@ exports.BinaryWriter = BinaryWriter;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
-const AvroReadable_js_1 = __nccwpck_require__(380);
-const abort_controller_1 = __nccwpck_require__(485);
-const buffer_1 = __nccwpck_require__(115);
+const AvroReadable_js_1 = __nccwpck_require__(381);
+const abort_controller_1 = __nccwpck_require__(486);
+const buffer_1 = __nccwpck_require__(116);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
 class AvroReadableFromStream extends AvroReadable_js_1.AvroReadable {
     _position;
@@ -51647,7 +51070,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 let _defaultHttpClient;
 function getCachedDefaultHttpClient() {
     if (!_defaultHttpClient) {
@@ -51702,7 +51125,7 @@ module.exports = class Pluralizer {
 "use strict";
 
 
-const RedirectHandler = __nccwpck_require__(383)
+const RedirectHandler = __nccwpck_require__(384)
 
 function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections }) {
   return (dispatch) => {
@@ -51751,7 +51174,7 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(420);
+var import_userAgentPlatform = __nccwpck_require__(421);
 var import_constants = __nccwpck_require__(47);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
@@ -51839,7 +51262,7 @@ __export(wrapAbortSignalLikePolicy_exports, {
   wrapAbortSignalLikePolicyName: () => wrapAbortSignalLikePolicyName
 });
 module.exports = __toCommonJS(wrapAbortSignalLikePolicy_exports);
-var import_wrapAbortSignal = __nccwpck_require__(437);
+var import_wrapAbortSignal = __nccwpck_require__(438);
 const wrapAbortSignalLikePolicyName = "wrapAbortSignalLikePolicy";
 function wrapAbortSignalLikePolicy() {
   return {
@@ -51873,7 +51296,7 @@ function wrapAbortSignalLikePolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createAbortablePromise = createAbortablePromise;
-const abort_controller_1 = __nccwpck_require__(483);
+const abort_controller_1 = __nccwpck_require__(484);
 /**
  * Creates an abortable promise.
  * @param buildPromise - A function that takes the resolve and reject functions as parameters.
@@ -51955,7 +51378,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.retryHttpClientResponse = exports.retryTypedResponse = exports.retry = exports.isRetryableStatusCode = exports.isServerErrorStatusCode = exports.isSuccessStatusCode = void 0;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 const http_client_1 = __nccwpck_require__(278);
 const constants_1 = __nccwpck_require__(44);
 function isSuccessStatusCode(statusCode) {
@@ -52070,8 +51493,8 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredential = void 0;
 const node_crypto_1 = __nccwpck_require__(267);
-const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(123);
-const Credential_js_1 = __nccwpck_require__(92);
+const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(124);
+const Credential_js_1 = __nccwpck_require__(93);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -52165,7 +51588,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDownloadOptions = exports.getUploadOptions = void 0;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 /**
  * Returns a copy of the upload options with defaults filled in.
  *
@@ -52265,10 +51688,10 @@ exports.getDownloadOptions = getDownloadOptions;
 "use strict";
 
 
-const net = __nccwpck_require__(498)
-const assert = __nccwpck_require__(515)
+const net = __nccwpck_require__(499)
+const assert = __nccwpck_require__(517)
 const util = __nccwpck_require__(68)
-const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(478)
+const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(479)
 
 let tls // include tls conditionally since it is not always available
 
@@ -52351,7 +51774,7 @@ function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, ...o
     let socket
     if (protocol === 'https:') {
       if (!tls) {
-        tls = __nccwpck_require__(495)
+        tls = __nccwpck_require__(496)
       }
       servername = servername || options.servername || util.getServerName(host) || null
 
@@ -52547,10 +51970,10 @@ __export(multipart_exports, {
   buildMultipartBody: () => buildMultipartBody
 });
 module.exports = __toCommonJS(multipart_exports);
-var import_restError = __nccwpck_require__(436);
-var import_httpHeaders = __nccwpck_require__(475);
+var import_restError = __nccwpck_require__(437);
+var import_httpHeaders = __nccwpck_require__(476);
 var import_bytesEncoding = __nccwpck_require__(280);
-var import_typeGuards = __nccwpck_require__(486);
+var import_typeGuards = __nccwpck_require__(487);
 function getHeaderValue(descriptor, headerName) {
   if (descriptor.headers) {
     const actualHeaderName = Object.keys(descriptor.headers).find(
@@ -52703,7 +52126,7 @@ __export(multipartPolicy_exports, {
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
 var import_policies = __nccwpck_require__(279);
-var import_file = __nccwpck_require__(319);
+var import_file = __nccwpck_require__(320);
 const multipartPolicyName = import_policies.multipartPolicyName;
 function multipartPolicy() {
   const tspPolicy = (0, import_policies.multipartPolicy)();
@@ -52825,10 +52248,10 @@ exports.listEnumNumbers = listEnumNumbers;
 /***/ 266:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const assert = __nccwpck_require__(515)
+const assert = __nccwpck_require__(517)
 
 const { kRetryHandlerDefaultRetry } = __nccwpck_require__(190)
-const { RequestRetryError } = __nccwpck_require__(478)
+const { RequestRetryError } = __nccwpck_require__(479)
 const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(68)
 
 function calculateRetryAfterHeader (retryAfter) {
@@ -53305,25 +52728,25 @@ module.exports = decodeText
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
 const tslib_1 = __nccwpck_require__(210);
-tslib_1.__exportStar(__nccwpck_require__(355), exports);
+tslib_1.__exportStar(__nccwpck_require__(356), exports);
 var cache_js_1 = __nccwpck_require__(246);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
 tslib_1.__exportStar(__nccwpck_require__(80), exports);
 tslib_1.__exportStar(__nccwpck_require__(152), exports);
-tslib_1.__exportStar(__nccwpck_require__(390), exports);
-tslib_1.__exportStar(__nccwpck_require__(92), exports);
+tslib_1.__exportStar(__nccwpck_require__(391), exports);
+tslib_1.__exportStar(__nccwpck_require__(93), exports);
 tslib_1.__exportStar(__nccwpck_require__(255), exports);
 tslib_1.__exportStar(__nccwpck_require__(318), exports);
 var RequestPolicy_js_1 = __nccwpck_require__(45);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
-tslib_1.__exportStar(__nccwpck_require__(90), exports);
+tslib_1.__exportStar(__nccwpck_require__(91), exports);
 tslib_1.__exportStar(__nccwpck_require__(301), exports);
 tslib_1.__exportStar(__nccwpck_require__(201), exports);
-tslib_1.__exportStar(__nccwpck_require__(454), exports);
+tslib_1.__exportStar(__nccwpck_require__(455), exports);
 tslib_1.__exportStar(__nccwpck_require__(163), exports);
-tslib_1.__exportStar(__nccwpck_require__(123), exports);
+tslib_1.__exportStar(__nccwpck_require__(124), exports);
 tslib_1.__exportStar(__nccwpck_require__(76), exports);
-tslib_1.__exportStar(__nccwpck_require__(419), exports);
+tslib_1.__exportStar(__nccwpck_require__(420), exports);
 tslib_1.__exportStar(__nccwpck_require__(165), exports);
 //# sourceMappingURL=index.js.map
 
@@ -53348,7 +52771,7 @@ tslib_1.__exportStar(__nccwpck_require__(214), exports);
 tslib_1.__exportStar(__nccwpck_require__(46), exports);
 tslib_1.__exportStar(__nccwpck_require__(274), exports);
 tslib_1.__exportStar(__nccwpck_require__(25), exports);
-tslib_1.__exportStar(__nccwpck_require__(348), exports);
+tslib_1.__exportStar(__nccwpck_require__(349), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -53651,18 +53074,18 @@ __export(createPipelineFromOptions_exports, {
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(70);
 var import_pipeline = __nccwpck_require__(238);
-var import_redirectPolicy = __nccwpck_require__(334);
-var import_userAgentPolicy = __nccwpck_require__(382);
+var import_redirectPolicy = __nccwpck_require__(335);
+var import_userAgentPolicy = __nccwpck_require__(383);
 var import_multipartPolicy = __nccwpck_require__(264);
 var import_decompressResponsePolicy = __nccwpck_require__(232);
 var import_defaultRetryPolicy = __nccwpck_require__(54);
 var import_formDataPolicy = __nccwpck_require__(261);
 var import_core_util = __nccwpck_require__(13);
-var import_proxyPolicy = __nccwpck_require__(463);
+var import_proxyPolicy = __nccwpck_require__(464);
 var import_setClientRequestIdPolicy = __nccwpck_require__(147);
 var import_agentPolicy = __nccwpck_require__(225);
-var import_tlsPolicy = __nccwpck_require__(371);
-var import_tracingPolicy = __nccwpck_require__(328);
+var import_tlsPolicy = __nccwpck_require__(372);
+var import_tracingPolicy = __nccwpck_require__(329);
 var import_wrapAbortSignalLikePolicy = __nccwpck_require__(252);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
@@ -53712,7 +53135,7 @@ function createPipelineFromOptions(options) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
 const tslib_1 = __nccwpck_require__(210);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(431));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(432));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(64));
 /** Class containing PageBlob operations. */
@@ -54175,7 +53598,7 @@ const copyIncrementalOperationSpec = {
 
 const { kConstruct } = __nccwpck_require__(153)
 const { Cache } = __nccwpck_require__(11)
-const { webidl } = __nccwpck_require__(448)
+const { webidl } = __nccwpck_require__(449)
 const { kEnumerableProperty } = __nccwpck_require__(68)
 
 class CacheStorage {
@@ -54370,9 +53793,9 @@ exports.walkDirSize = walkDirSize;
 exports.detectCompressMagic = detectCompressMagic;
 exports.decompressCache = decompressCache;
 exports.compressCache = compressCache;
-const fs = __importStar(__nccwpck_require__(105));
-const path = __importStar(__nccwpck_require__(497));
-const core = __importStar(__nccwpck_require__(450));
+const fs = __importStar(__nccwpck_require__(106));
+const path = __importStar(__nccwpck_require__(498));
+const core = __importStar(__nccwpck_require__(451));
 const exec = __importStar(__nccwpck_require__(17));
 const io = __importStar(__nccwpck_require__(287));
 /**
@@ -54621,8 +54044,8 @@ async function runPipe(producer, consumer) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createClientPipeline = createClientPipeline;
 const deserializationPolicy_js_1 = __nccwpck_require__(83);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
-const serializationPolicy_js_1 = __nccwpck_require__(479);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
+const serializationPolicy_js_1 = __nccwpck_require__(480);
 /**
  * Creates a new Pipeline for use with a Service Client.
  * Adds in deserializationPolicy by default.
@@ -54687,10 +54110,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
-const http = __importStar(__nccwpck_require__(321));
+const http = __importStar(__nccwpck_require__(322));
 const https = __importStar(__nccwpck_require__(69));
 const pm = __importStar(__nccwpck_require__(303));
-const tunnel = __importStar(__nccwpck_require__(509));
+const tunnel = __importStar(__nccwpck_require__(510));
 const undici_1 = __nccwpck_require__(159);
 var HttpCodes;
 (function (HttpCodes) {
@@ -55358,20 +54781,20 @@ __export(internal_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(internal_exports);
-var import_agentPolicy = __nccwpck_require__(455);
-var import_decompressResponsePolicy = __nccwpck_require__(349);
+var import_agentPolicy = __nccwpck_require__(456);
+var import_decompressResponsePolicy = __nccwpck_require__(350);
 var import_defaultRetryPolicy = __nccwpck_require__(317);
-var import_exponentialRetryPolicy = __nccwpck_require__(512);
+var import_exponentialRetryPolicy = __nccwpck_require__(513);
 var import_retryPolicy = __nccwpck_require__(15);
 var import_systemErrorRetryPolicy = __nccwpck_require__(27);
-var import_throttlingRetryPolicy = __nccwpck_require__(510);
-var import_formDataPolicy = __nccwpck_require__(333);
-var import_logPolicy = __nccwpck_require__(99);
+var import_throttlingRetryPolicy = __nccwpck_require__(511);
+var import_formDataPolicy = __nccwpck_require__(334);
+var import_logPolicy = __nccwpck_require__(100);
 var import_multipartPolicy = __nccwpck_require__(166);
 var import_proxyPolicy = __nccwpck_require__(38);
 var import_redirectPolicy = __nccwpck_require__(310);
 var import_tlsPolicy = __nccwpck_require__(215);
-var import_userAgentPolicy = __nccwpck_require__(353);
+var import_userAgentPolicy = __nccwpck_require__(354);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -55425,7 +54848,7 @@ function stringToUint8Array(value, format) {
 
 module.exports = parseString
 
-const TOMLParser = __nccwpck_require__(339)
+const TOMLParser = __nccwpck_require__(340)
 const prettyError = __nccwpck_require__(271)
 
 function parseString (str) {
@@ -55456,9 +54879,9 @@ exports.generateAccountSASQueryParameters = generateAccountSASQueryParameters;
 exports.generateAccountSASQueryParametersInternal = generateAccountSASQueryParametersInternal;
 const AccountSASPermissions_js_1 = __nccwpck_require__(57);
 const AccountSASResourceTypes_js_1 = __nccwpck_require__(2);
-const AccountSASServices_js_1 = __nccwpck_require__(372);
-const SasIPRange_js_1 = __nccwpck_require__(352);
-const SASQueryParameters_js_1 = __nccwpck_require__(514);
+const AccountSASServices_js_1 = __nccwpck_require__(373);
+const SasIPRange_js_1 = __nccwpck_require__(353);
+const SASQueryParameters_js_1 = __nccwpck_require__(515);
 const constants_js_1 = __nccwpck_require__(145);
 const utils_common_js_1 = __nccwpck_require__(151);
 /**
@@ -55562,7 +54985,7 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
-const reflection_info_1 = __nccwpck_require__(444);
+const reflection_info_1 = __nccwpck_require__(445);
 const oneof_1 = __nccwpck_require__(185);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
@@ -55827,7 +55250,7 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(112);
+var import_userAgentPlatform = __nccwpck_require__(113);
 var import_constants = __nccwpck_require__(155);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
@@ -55963,7 +55386,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
-const assert_1 = __nccwpck_require__(515);
+const assert_1 = __nccwpck_require__(517);
 const path = __importStar(__nccwpck_require__(241));
 const ioUtil = __importStar(__nccwpck_require__(219));
 /**
@@ -56241,7 +55664,7 @@ function copyFile(srcFile, destFile, force) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.maskSecretUrls = exports.maskSigUrl = void 0;
-const core_1 = __nccwpck_require__(450);
+const core_1 = __nccwpck_require__(451);
 /**
  * Masks the `sig` parameter in a URL and sets it as a secret.
  *
@@ -56330,8 +55753,8 @@ exports.maskSecretUrls = maskSecretUrls;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
 const tslib_1 = __nccwpck_require__(210);
-tslib_1.__exportStar(__nccwpck_require__(462), exports);
-var storageClient_js_1 = __nccwpck_require__(438);
+tslib_1.__exportStar(__nccwpck_require__(463), exports);
+var storageClient_js_1 = __nccwpck_require__(439);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
 tslib_1.__exportStar(__nccwpck_require__(162), exports);
 //# sourceMappingURL=index.js.map
@@ -56397,8 +55820,8 @@ exports.AzureKeyCredential = AzureKeyCredential;
 const {
   InvalidArgumentError,
   NotSupportedError
-} = __nccwpck_require__(478)
-const assert = __nccwpck_require__(515)
+} = __nccwpck_require__(479)
+const assert = __nccwpck_require__(517)
 const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(190)
 const util = __nccwpck_require__(68)
 
@@ -57205,11 +56628,11 @@ function stringifyComplexTable (prefix, indent, key, value) {
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(448)
+const { webidl } = __nccwpck_require__(449)
 const { DOMException } = __nccwpck_require__(29)
 const { URLSerializer } = __nccwpck_require__(24)
-const { getGlobalOrigin } = __nccwpck_require__(136)
-const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(456)
+const { getGlobalOrigin } = __nccwpck_require__(137)
+const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(457)
 const {
   kWebSocketURL,
   kReadyState,
@@ -57218,14 +56641,14 @@ const {
   kResponse,
   kSentClose,
   kByteParser
-} = __nccwpck_require__(95)
+} = __nccwpck_require__(96)
 const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(56)
-const { establishWebSocketConnection } = __nccwpck_require__(357)
+const { establishWebSocketConnection } = __nccwpck_require__(358)
 const { WebsocketFrameSend } = __nccwpck_require__(182)
-const { ByteParser } = __nccwpck_require__(472)
+const { ByteParser } = __nccwpck_require__(473)
 const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(68)
-const { getGlobalDispatcher } = __nccwpck_require__(369)
-const { types } = __nccwpck_require__(120)
+const { getGlobalDispatcher } = __nccwpck_require__(370)
+const { types } = __nccwpck_require__(121)
 
 let experimentalWarned = false
 
@@ -58334,8 +57757,8 @@ __export(concat_exports, {
   concat: () => concat
 });
 module.exports = __toCommonJS(concat_exports);
-var import_stream = __nccwpck_require__(127);
-var import_typeGuards = __nccwpck_require__(486);
+var import_stream = __nccwpck_require__(128);
+var import_typeGuards = __nccwpck_require__(487);
 async function* streamAsyncIterator() {
   const reader = this.getReader();
   try {
@@ -58779,11 +58202,11 @@ exports.CredentialPolicy = CredentialPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BatchResponseParser = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 const core_http_compat_1 = __nccwpck_require__(71);
 const constants_js_1 = __nccwpck_require__(145);
 const BatchUtils_js_1 = __nccwpck_require__(251);
-const log_js_1 = __nccwpck_require__(103);
+const log_js_1 = __nccwpck_require__(104);
 const HTTP_HEADER_DELIMITER = ": ";
 const SPACE_DELIMITER = " ";
 const NOT_FOUND = -1;
@@ -59206,9 +58629,9 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StatsCollector = void 0;
-const fs = __importStar(__nccwpck_require__(105));
-const path = __importStar(__nccwpck_require__(497));
-const core = __importStar(__nccwpck_require__(450));
+const fs = __importStar(__nccwpck_require__(106));
+const path = __importStar(__nccwpck_require__(498));
+const core = __importStar(__nccwpck_require__(451));
 function fmtBytes(n) {
     if (n === null)
         return "-";
@@ -59553,14 +58976,14 @@ exports.buildCreatePoller = buildCreatePoller;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 const pipeline_js_1 = __nccwpck_require__(277);
 const utils_js_1 = __nccwpck_require__(304);
-const httpClientCache_js_1 = __nccwpck_require__(391);
-const operationHelpers_js_1 = __nccwpck_require__(424);
+const httpClientCache_js_1 = __nccwpck_require__(392);
+const operationHelpers_js_1 = __nccwpck_require__(425);
 const urlHelpers_js_1 = __nccwpck_require__(231);
-const interfaceHelpers_js_1 = __nccwpck_require__(392);
-const log_js_1 = __nccwpck_require__(471);
+const interfaceHelpers_js_1 = __nccwpck_require__(393);
+const log_js_1 = __nccwpck_require__(472);
 /**
  * Initializes a new instance of the ServiceClient.
  */
@@ -59752,16 +59175,16 @@ __export(createPipelineFromOptions_exports, {
   createPipelineFromOptions: () => createPipelineFromOptions
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
-var import_logPolicy = __nccwpck_require__(99);
-var import_pipeline = __nccwpck_require__(513);
+var import_logPolicy = __nccwpck_require__(100);
+var import_pipeline = __nccwpck_require__(514);
 var import_redirectPolicy = __nccwpck_require__(310);
-var import_userAgentPolicy = __nccwpck_require__(353);
-var import_decompressResponsePolicy = __nccwpck_require__(349);
+var import_userAgentPolicy = __nccwpck_require__(354);
+var import_decompressResponsePolicy = __nccwpck_require__(350);
 var import_defaultRetryPolicy = __nccwpck_require__(317);
-var import_formDataPolicy = __nccwpck_require__(333);
-var import_checkEnvironment = __nccwpck_require__(430);
+var import_formDataPolicy = __nccwpck_require__(334);
+var import_checkEnvironment = __nccwpck_require__(431);
 var import_proxyPolicy = __nccwpck_require__(38);
-var import_agentPolicy = __nccwpck_require__(455);
+var import_agentPolicy = __nccwpck_require__(456);
 var import_tlsPolicy = __nccwpck_require__(215);
 var import_multipartPolicy = __nccwpck_require__(166);
 function createPipelineFromOptions(options) {
@@ -60233,7 +59656,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(388);
+var import_exponentialRetryStrategy = __nccwpck_require__(389);
 var import_throttlingRetryStrategy = __nccwpck_require__(34);
 var import_retryPolicy = __nccwpck_require__(15);
 var import_constants = __nccwpck_require__(47);
@@ -60265,7 +59688,7 @@ exports.StorageRetryPolicyFactory = exports.NewRetryPolicyFactory = exports.Stor
 const StorageRetryPolicy_js_1 = __nccwpck_require__(78);
 Object.defineProperty(exports, "StorageRetryPolicy", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.StorageRetryPolicy; } }));
 Object.defineProperty(exports, "NewRetryPolicyFactory", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.NewRetryPolicyFactory; } }));
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(409);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(410);
 Object.defineProperty(exports, "StorageRetryPolicyType", ({ enumerable: true, get: function () { return StorageRetryPolicyType_js_1.StorageRetryPolicyType; } }));
 /**
  * StorageRetryPolicyFactory is a factory class helping generating {@link StorageRetryPolicy} objects.
@@ -60295,6 +59718,80 @@ exports.StorageRetryPolicyFactory = StorageRetryPolicyFactory;
 /***/ }),
 
 /***/ 319:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+// $GITHUB_OUTPUT key/value mapping for setup-soldr. Pure function of
+// the resolved state — split out of resolve-setup.ts to keep the
+// orchestration module focused on input parsing / cache-key derivation.
+// Mirrors resolve_setup.py's `_write_outputs()` call so tests can
+// assert byte-for-byte.
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.buildOutputs = buildOutputs;
+/**
+ * Build the $GITHUB_OUTPUT key/value map. Exposed for tests so they
+ * can assert byte-for-byte parity with the legacy Python action's
+ * `_write_outputs()` call.
+ */
+function buildOutputs(result) {
+    return {
+        cache_root: result.cacheRoot,
+        setup_cache_path: result.setupCache.setupCachePath,
+        setup_cache_paths: result.setupCache.paths.join("\n"),
+        cache_key: result.setupCache.key,
+        cache_restore_prefix: result.setupCache.restorePrefix,
+        build_cache_key: result.buildCache.key,
+        build_cache_restore_key_parent: result.buildCache.restoreKeyParent,
+        build_cache_restore_key_toolchain: result.buildCache.restoreKeyToolchain,
+        build_cache_restore_key_os_arch: result.buildCache.restoreKeyOsArch,
+        build_cache_path: result.buildCache.path,
+        build_cache_mode: result.buildCache.mode,
+        target_cache_path: result.targetCache.targetPath,
+        target_cache_bundle_path: result.targetCache.bundlePath,
+        target_cache_paths: result.targetCache.paths,
+        target_cache_enabled: result.targetCache.enabled ? "true" : "false",
+        target_cache_mode: result.targetCache.effectiveMode,
+        target_cache_profile: result.targetCache.profile,
+        target_cache_compress: result.targetCacheCompress,
+        target_cache_compress_level: result.targetCacheCompressLevel,
+        target_cache_key: result.targetCache.key,
+        target_cache_restore_key_parent: result.targetCache.restoreKeyParent,
+        target_cache_restore_key_lock: result.targetCache.restoreKeyLock,
+        target_cache_restore_key_lockfile: result.targetCache.restoreKeyLockfile,
+        target_cache_budget_bytes: result.targetCache.budgetBytes,
+        target_cache_budget_files: result.targetCache.budgetFiles,
+        target_lockfile_path: result.targetCache.lockfilePath,
+        target_lockfile_hash: result.targetCache.lockfileHash,
+        cargo_registry_cache_enabled: result.cargoRegistryCache.enabled ? "true" : "false",
+        cargo_registry_cache_path: result.cargoRegistryCache.path,
+        cargo_registry_cache_key: result.cargoRegistryCache.key,
+        cargo_registry_cache_restore_prefix: result.cargoRegistryCache.restorePrefix,
+        soldr_root: result.soldrRoot,
+        soldr_bin_cache_path: result.soldrBinCachePath,
+        cargo_home: result.cargoHome,
+        rustup_home: result.rustupHome,
+        setup_cache_layout: result.setupCache.layout,
+        bin_dir: result.binDir,
+        shims_dir: result.shimsDir,
+        soldr_path: result.soldrPath,
+        soldr_repo: result.soldrRepo,
+        soldr_ref: result.soldrRef,
+        soldr_version_requested: result.soldrVersionRequested,
+        soldr_version_resolved: result.soldrVersionResolved,
+        toolchain_channel: result.toolchain.channel,
+        toolchain_cache_channel: result.toolchain.cacheChannel,
+        toolchain_profile: result.toolchain.profile,
+        toolchain_source: result.toolchain.source,
+        toolchain: result.toolchain.channel,
+        enabled: result.enabled ? "true" : "false",
+    };
+}
+
+
+/***/ }),
+
+/***/ 320:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60400,7 +59897,7 @@ function toArrayBuffer(source) {
 
 /***/ }),
 
-/***/ 320:
+/***/ 321:
 /***/ ((module) => {
 
 "use strict";
@@ -60505,7 +60002,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 321:
+/***/ 322:
 /***/ ((module) => {
 
 "use strict";
@@ -60513,7 +60010,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 322:
+/***/ 323:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -60532,7 +60029,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 323:
+/***/ 324:
 /***/ (function(module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -60572,12 +60069,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._readLinuxVersionFile = exports._getOsVersion = exports._findMatch = void 0;
 const semver = __importStar(__nccwpck_require__(174));
-const core_1 = __nccwpck_require__(450);
+const core_1 = __nccwpck_require__(451);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
-const os = __nccwpck_require__(89);
+const os = __nccwpck_require__(90);
 const cp = __nccwpck_require__(160);
-const fs = __nccwpck_require__(520);
+const fs = __nccwpck_require__(522);
 function _findMatch(versionSpec, stable, candidates, archFilter) {
     return __awaiter(this, void 0, void 0, function* () {
         const platFilter = os.platform();
@@ -60668,7 +60165,7 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
-/***/ 324:
+/***/ 325:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -60737,7 +60234,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 325:
+/***/ 326:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -60845,7 +60342,7 @@ var WireType;
 
 /***/ }),
 
-/***/ 326:
+/***/ 327:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60855,18 +60352,18 @@ var WireType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatch = void 0;
 const core_util_1 = __nccwpck_require__(13);
-const core_auth_1 = __nccwpck_require__(503);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_auth_1 = __nccwpck_require__(504);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 const core_util_2 = __nccwpck_require__(13);
 const storage_common_1 = __nccwpck_require__(269);
 const Clients_js_1 = __nccwpck_require__(180);
-const Mutex_js_1 = __nccwpck_require__(507);
+const Mutex_js_1 = __nccwpck_require__(508);
 const Pipeline_js_1 = __nccwpck_require__(178);
 const utils_common_js_1 = __nccwpck_require__(151);
 const core_xml_1 = __nccwpck_require__(189);
 const constants_js_1 = __nccwpck_require__(145);
 const tracing_js_1 = __nccwpck_require__(30);
-const core_client_1 = __nccwpck_require__(431);
+const core_client_1 = __nccwpck_require__(432);
 /**
  * A BlobBatch represents an aggregated set of operations on blobs.
  * Currently, only `delete` and `setAccessTier` are supported.
@@ -61130,7 +60627,7 @@ function batchHeaderFilterPolicy() {
 
 /***/ }),
 
-/***/ 327:
+/***/ 328:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61139,9 +60636,9 @@ function batchHeaderFilterPolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = exports.AvroReadable = exports.AvroReader = void 0;
-var AvroReader_js_1 = __nccwpck_require__(413);
+var AvroReader_js_1 = __nccwpck_require__(414);
 Object.defineProperty(exports, "AvroReader", ({ enumerable: true, get: function () { return AvroReader_js_1.AvroReader; } }));
-var AvroReadable_js_1 = __nccwpck_require__(380);
+var AvroReadable_js_1 = __nccwpck_require__(381);
 Object.defineProperty(exports, "AvroReadable", ({ enumerable: true, get: function () { return AvroReadable_js_1.AvroReadable; } }));
 var AvroReadableFromStream_js_1 = __nccwpck_require__(245);
 Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, get: function () { return AvroReadableFromStream_js_1.AvroReadableFromStream; } }));
@@ -61149,7 +60646,7 @@ Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, ge
 
 /***/ }),
 
-/***/ 328:
+/***/ 329:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61180,7 +60677,7 @@ var import_constants = __nccwpck_require__(155);
 var import_userAgent = __nccwpck_require__(285);
 var import_log = __nccwpck_require__(179);
 var import_core_util = __nccwpck_require__(13);
-var import_restError = __nccwpck_require__(346);
+var import_restError = __nccwpck_require__(347);
 var import_util = __nccwpck_require__(143);
 const tracingPolicyName = "tracingPolicy";
 function tracingPolicy(options = {}) {
@@ -61295,7 +60792,7 @@ function tryProcessResponse(span, response) {
 
 /***/ }),
 
-/***/ 329:
+/***/ 330:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61341,7 +60838,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.markPhase = markPhase;
 exports.finishPhase = finishPhase;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 function phaseEnvName(name) {
     const cleaned = name.replace(/[^A-Za-z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase() || "PHASE";
     return `SETUP_SOLDR_PHASE_${cleaned}_START_MS`;
@@ -61385,7 +60882,7 @@ async function finishPhase(phase) {
 
 /***/ }),
 
-/***/ 330:
+/***/ 331:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61397,11 +60894,11 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher
-} = __nccwpck_require__(361)
-const Client = __nccwpck_require__(85)
+} = __nccwpck_require__(362)
+const Client = __nccwpck_require__(86)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(478)
+} = __nccwpck_require__(479)
 const util = __nccwpck_require__(68)
 const { kUrl, kInterceptors } = __nccwpck_require__(190)
 const buildConnector = __nccwpck_require__(259)
@@ -61501,7 +60998,7 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 331:
+/***/ 332:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61527,7 +61024,7 @@ __export(oauth2AuthenticationPolicy_exports, {
   oauth2AuthenticationPolicyName: () => oauth2AuthenticationPolicyName
 });
 module.exports = __toCommonJS(oauth2AuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(427);
+var import_checkInsecureConnection = __nccwpck_require__(428);
 const oauth2AuthenticationPolicyName = "oauth2AuthenticationPolicy";
 function oauth2AuthenticationPolicy(options) {
   return {
@@ -61553,7 +61050,7 @@ function oauth2AuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 332:
+/***/ 333:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61599,12 +61096,12 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureSoldr = ensureSoldr;
 const fs = __importStar(__nccwpck_require__(242));
-const os = __importStar(__nccwpck_require__(375));
-const path = __importStar(__nccwpck_require__(497));
-const core = __importStar(__nccwpck_require__(450));
+const os = __importStar(__nccwpck_require__(376));
+const path = __importStar(__nccwpck_require__(498));
+const core = __importStar(__nccwpck_require__(451));
 const exec = __importStar(__nccwpck_require__(17));
-const tc = __importStar(__nccwpck_require__(511));
-const log_utils_js_1 = __nccwpck_require__(345);
+const tc = __importStar(__nccwpck_require__(512));
+const log_utils_js_1 = __nccwpck_require__(346);
 function detectTarget() {
     const machine = process.arch;
     let arch;
@@ -61927,7 +61424,7 @@ async function ensureSoldr(opts) {
 
 /***/ }),
 
-/***/ 333:
+/***/ 334:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61954,8 +61451,8 @@ __export(formDataPolicy_exports, {
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
 var import_bytesEncoding = __nccwpck_require__(280);
-var import_checkEnvironment = __nccwpck_require__(430);
-var import_httpHeaders = __nccwpck_require__(475);
+var import_checkEnvironment = __nccwpck_require__(431);
+var import_httpHeaders = __nccwpck_require__(476);
 const formDataPolicyName = "formDataPolicy";
 function formDataToFormDataMap(formData) {
   const formDataMap = {};
@@ -62043,7 +61540,7 @@ async function prepareFormData(formData, request) {
 
 /***/ }),
 
-/***/ 334:
+/***/ 335:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62080,7 +61577,7 @@ function redirectPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 335:
+/***/ 336:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62089,9 +61586,9 @@ function redirectPolicy(options = {}) {
 const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(190)
 const { URL } = __nccwpck_require__(82)
 const Agent = __nccwpck_require__(5)
-const Pool = __nccwpck_require__(330)
+const Pool = __nccwpck_require__(331)
 const DispatcherBase = __nccwpck_require__(61)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(478)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(479)
 const buildConnector = __nccwpck_require__(259)
 
 const kAgent = Symbol('proxy agent')
@@ -62277,18 +61774,18 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 336:
+/***/ 337:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonReader = void 0;
-const json_typings_1 = __nccwpck_require__(387);
+const json_typings_1 = __nccwpck_require__(388);
 const base64_1 = __nccwpck_require__(295);
-const reflection_info_1 = __nccwpck_require__(444);
-const pb_long_1 = __nccwpck_require__(113);
-const assert_1 = __nccwpck_require__(474);
+const reflection_info_1 = __nccwpck_require__(445);
+const pb_long_1 = __nccwpck_require__(114);
+const assert_1 = __nccwpck_require__(475);
 const reflection_long_convert_1 = __nccwpck_require__(154);
 /**
  * Reads proto3 messages in canonical JSON format using reflection information.
@@ -62602,7 +62099,7 @@ exports.ReflectionJsonReader = ReflectionJsonReader;
 
 /***/ }),
 
-/***/ 337:
+/***/ 338:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -62618,8 +62115,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
-const os_1 = __nccwpck_require__(89);
-const fs_1 = __nccwpck_require__(520);
+const os_1 = __nccwpck_require__(90);
+const fs_1 = __nccwpck_require__(522);
 const { access, appendFile, writeFile } = fs_1.promises;
 exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
 exports.SUMMARY_DOCS_URL = 'https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary';
@@ -62892,7 +62389,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 338:
+/***/ 339:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -62975,13 +62472,13 @@ exports.utf8read = utf8read;
 
 /***/ }),
 
-/***/ 339:
+/***/ 340:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 /* eslint-disable no-new-wrappers, no-eval, camelcase, operator-linebreak */
-module.exports = makeParserClass(__nccwpck_require__(417))
+module.exports = makeParserClass(__nccwpck_require__(418))
 module.exports.makeParserClass = makeParserClass
 
 class TomlError extends Error {
@@ -63002,10 +62499,10 @@ TomlError.wrap = err => {
 }
 module.exports.TomlError = TomlError
 
-const createDateTime = __nccwpck_require__(377)
+const createDateTime = __nccwpck_require__(378)
 const createDateTimeFloat = __nccwpck_require__(167)
 const createDate = __nccwpck_require__(53)
-const createTime = __nccwpck_require__(341)
+const createTime = __nccwpck_require__(342)
 
 const CTRL_I = 0x09
 const CTRL_J = 0x0A
@@ -64362,7 +63859,7 @@ function makeParserClass (Parser) {
 
 /***/ }),
 
-/***/ 340:
+/***/ 341:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -64371,8 +63868,8 @@ function makeParserClass (Parser) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = createTracingClient;
-const instrumenter_js_1 = __nccwpck_require__(399);
-const tracingContext_js_1 = __nccwpck_require__(362);
+const instrumenter_js_1 = __nccwpck_require__(400);
+const tracingContext_js_1 = __nccwpck_require__(363);
 /**
  * Creates a new tracing client.
  *
@@ -64450,12 +63947,12 @@ function createTracingClient(options) {
 
 /***/ }),
 
-/***/ 341:
+/***/ 342:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(396)
+const f = __nccwpck_require__(397)
 
 class Time extends Date {
   constructor (value) {
@@ -64480,14 +63977,14 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 342:
+/***/ 343:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(120)
-const Pool = __nccwpck_require__(330)
+const { promisify } = __nccwpck_require__(121)
+const Pool = __nccwpck_require__(331)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
   kDispatches,
@@ -64497,10 +63994,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(461)
-const { MockInterceptor } = __nccwpck_require__(132)
+} = __nccwpck_require__(462)
+const { MockInterceptor } = __nccwpck_require__(133)
 const Symbols = __nccwpck_require__(190)
-const { InvalidArgumentError } = __nccwpck_require__(478)
+const { InvalidArgumentError } = __nccwpck_require__(479)
 
 /**
  * MockPool provides an API that extends the Pool to influence the mockDispatches.
@@ -64547,7 +64044,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 343:
+/***/ 344:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -64605,7 +64102,7 @@ exports.ClientStreamingCall = ClientStreamingCall;
 
 /***/ }),
 
-/***/ 344:
+/***/ 345:
 /***/ ((module) => {
 
 module.exports = function (xs, fn) {
@@ -64625,7 +64122,7 @@ var isArray = Array.isArray || function (xs) {
 
 /***/ }),
 
-/***/ 345:
+/***/ 346:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -64673,7 +64170,7 @@ exports.createLogger = createLogger;
 exports.colorForceEnvironment = colorForceEnvironment;
 exports.formatLogLine = formatLogLine;
 exports.isTimestampsEnabled = isTimestampsEnabled;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 const fs = __importStar(__nccwpck_require__(242));
 function makeFileLogger(env) {
     const logPath = (env["SETUP_SOLDR_LOG"] ?? "").trim();
@@ -64796,7 +64293,7 @@ function isTimestampsEnabled(env) {
 
 /***/ }),
 
-/***/ 346:
+/***/ 347:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -64822,7 +64319,7 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_ts_http_runtime = __nccwpck_require__(86);
+var import_ts_http_runtime = __nccwpck_require__(87);
 const RestError = import_ts_http_runtime.RestError;
 function isRestError(e) {
   return (0, import_ts_http_runtime.isRestError)(e);
@@ -64833,22 +64330,22 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 347:
+/***/ 348:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { finished, PassThrough } = __nccwpck_require__(127)
+const { finished, PassThrough } = __nccwpck_require__(128)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(478)
+} = __nccwpck_require__(479)
 const util = __nccwpck_require__(68)
 const { getResolveErrorBodyCallback } = __nccwpck_require__(184)
-const { AsyncResource } = __nccwpck_require__(421)
-const { addSignal, removeSignal } = __nccwpck_require__(100)
+const { AsyncResource } = __nccwpck_require__(422)
+const { addSignal, removeSignal } = __nccwpck_require__(101)
 
 class StreamHandler extends AsyncResource {
   constructor (opts, factory, callback) {
@@ -65061,7 +64558,7 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 348:
+/***/ 349:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65076,7 +64573,7 @@ module.exports = stream
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
 const tslib_1 = __nccwpck_require__(210);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(431));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(432));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(64));
 /** Class containing BlockBlob operations. */
@@ -65441,7 +64938,7 @@ const getBlockListOperationSpec = {
 
 /***/ }),
 
-/***/ 349:
+/***/ 350:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -65486,7 +64983,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 350:
+/***/ 351:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65581,7 +65078,7 @@ exports.GenericPollOperation = GenericPollOperation;
 
 /***/ }),
 
-/***/ 351:
+/***/ 352:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -65628,7 +65125,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.versionTuple = versionTuple;
 exports.verifySoldr = verifySoldr;
 const exec = __importStar(__nccwpck_require__(17));
-const log_utils_js_1 = __nccwpck_require__(345);
+const log_utils_js_1 = __nccwpck_require__(346);
 function versionTuple(value) {
     const cleaned = value.trim().replace(/^v/, "");
     const parts = cleaned.split(".");
@@ -65724,7 +65221,7 @@ async function verifySoldr(opts) {
 
 /***/ }),
 
-/***/ 352:
+/***/ 353:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65747,7 +65244,7 @@ function ipRangeToString(ipRange) {
 
 /***/ }),
 
-/***/ 353:
+/***/ 354:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65795,7 +65292,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 354:
+/***/ 355:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65803,7 +65300,7 @@ function userAgentPolicy(options = {}) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getUserAgentString = void 0;
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const packageJson = __nccwpck_require__(459);
+const packageJson = __nccwpck_require__(460);
 /**
  * Ensure that this User Agent String is used in all HTTP calls so that we can monitor telemetry between different versions of this package
  */
@@ -65815,7 +65312,7 @@ exports.getUserAgentString = getUserAgentString;
 
 /***/ }),
 
-/***/ 355:
+/***/ 356:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65824,8 +65321,8 @@ exports.getUserAgentString = getUserAgentString;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BufferScheduler = void 0;
-const events_1 = __nccwpck_require__(460);
-const PooledBuffer_js_1 = __nccwpck_require__(363);
+const events_1 = __nccwpck_require__(461);
+const PooledBuffer_js_1 = __nccwpck_require__(364);
 /**
  * This class accepts a Node.js Readable stream as input, and keeps reading data
  * from the stream into the internal buffer structure, until it reaches maxBuffers.
@@ -66104,17 +65601,17 @@ exports.BufferScheduler = BufferScheduler;
 
 /***/ }),
 
-/***/ 356:
+/***/ 357:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Blob, File: NativeFile } = __nccwpck_require__(115)
-const { types } = __nccwpck_require__(120)
+const { Blob, File: NativeFile } = __nccwpck_require__(116)
+const { types } = __nccwpck_require__(121)
 const { kState } = __nccwpck_require__(14)
-const { isBlobLike } = __nccwpck_require__(506)
-const { webidl } = __nccwpck_require__(448)
+const { isBlobLike } = __nccwpck_require__(507)
+const { webidl } = __nccwpck_require__(449)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(24)
 const { kEnumerableProperty } = __nccwpck_require__(68)
 const encoder = new TextEncoder()
@@ -66456,26 +65953,26 @@ module.exports = { File, FileLike, isFileLike }
 
 /***/ }),
 
-/***/ 357:
+/***/ 358:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const diagnosticsChannel = __nccwpck_require__(139)
-const { uid, states } = __nccwpck_require__(456)
+const { uid, states } = __nccwpck_require__(457)
 const {
   kReadyState,
   kSentClose,
   kByteParser,
   kReceivedClose
-} = __nccwpck_require__(95)
+} = __nccwpck_require__(96)
 const { fireEvent, failWebsocketConnection } = __nccwpck_require__(56)
 const { CloseEvent } = __nccwpck_require__(243)
 const { makeRequest } = __nccwpck_require__(81)
-const { fetching } = __nccwpck_require__(442)
-const { Headers } = __nccwpck_require__(505)
-const { getGlobalDispatcher } = __nccwpck_require__(369)
+const { fetching } = __nccwpck_require__(443)
+const { Headers } = __nccwpck_require__(506)
+const { getGlobalDispatcher } = __nccwpck_require__(370)
 const { kHeadersList } = __nccwpck_require__(190)
 
 const channels = {}
@@ -66755,7 +66252,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 358:
+/***/ 359:
 /***/ ((module) => {
 
 "use strict";
@@ -66771,7 +66268,7 @@ module.exports = (flag, argv = process.argv) => {
 
 /***/ }),
 
-/***/ 359:
+/***/ 360:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -66825,8 +66322,8 @@ exports.loadToolchainSpec = loadToolchainSpec;
 exports.systemRustupSatisfiesRequest = systemRustupSatisfiesRequest;
 const node_crypto_1 = __nccwpck_require__(267);
 const fs = __importStar(__nccwpck_require__(242));
-const path = __importStar(__nccwpck_require__(497));
-const toml = __importStar(__nccwpck_require__(393));
+const path = __importStar(__nccwpck_require__(498));
+const toml = __importStar(__nccwpck_require__(394));
 const io = __importStar(__nccwpck_require__(287));
 const exec = __importStar(__nccwpck_require__(17));
 const ROLLING_TOOLCHAIN_ALIASES = ["stable", "beta", "nightly"];
@@ -67113,7 +66610,7 @@ async function defaultWhich(cmd) {
 
 /***/ }),
 
-/***/ 360:
+/***/ 361:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67138,8 +66635,8 @@ __export(restError_exports, {
   createRestError: () => createRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_restError = __nccwpck_require__(436);
-var import_httpHeaders = __nccwpck_require__(475);
+var import_restError = __nccwpck_require__(437);
+var import_httpHeaders = __nccwpck_require__(476);
 function createRestError(messageOrResponse, response) {
   const resp = typeof messageOrResponse === "string" ? response : messageOrResponse;
   const internalError = resp.body?.error ?? resp.body;
@@ -67169,7 +66666,7 @@ function statusCodeToNumber(statusCode) {
 
 /***/ }),
 
-/***/ 361:
+/***/ 362:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67371,7 +66868,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 362:
+/***/ 363:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67431,7 +66928,7 @@ exports.TracingContextImpl = TracingContextImpl;
 
 /***/ }),
 
-/***/ 363:
+/***/ 364:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67441,7 +66938,7 @@ exports.TracingContextImpl = TracingContextImpl;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
 const tslib_1 = __nccwpck_require__(210);
-const BuffersStream_js_1 = __nccwpck_require__(378);
+const BuffersStream_js_1 = __nccwpck_require__(379);
 const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(257));
 /**
  * maxBufferLength is max size of each buffer in the pooled buffers.
@@ -67538,7 +67035,7 @@ exports.PooledBuffer = PooledBuffer;
 
 /***/ }),
 
-/***/ 364:
+/***/ 365:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -67588,9 +67085,9 @@ exports.selectCandidateFiles = selectCandidateFiles;
 exports.normalizeWorkspace = normalizeWorkspace;
 exports.normalizeSourceMtime = normalizeSourceMtime;
 const fs = __importStar(__nccwpck_require__(242));
-const path = __importStar(__nccwpck_require__(497));
+const path = __importStar(__nccwpck_require__(498));
 const exec = __importStar(__nccwpck_require__(17));
-const log_utils_js_1 = __nccwpck_require__(345);
+const log_utils_js_1 = __nccwpck_require__(346);
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 // Globs evaluated against the repo-relative POSIX path of each tracked file.
 const INCLUDE_GLOBS = [
@@ -67822,7 +67319,7 @@ exports._internal = {
 
 /***/ }),
 
-/***/ 365:
+/***/ 366:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67847,7 +67344,7 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_nodeHttpClient = __nccwpck_require__(433);
+var import_nodeHttpClient = __nccwpck_require__(434);
 function createDefaultHttpClient() {
   return (0, import_nodeHttpClient.createNodeHttpClient)();
 }
@@ -67858,16 +67355,16 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 366:
+/***/ 367:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { AsyncResource } = __nccwpck_require__(421)
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(478)
+const { AsyncResource } = __nccwpck_require__(422)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(479)
 const util = __nccwpck_require__(68)
-const { addSignal, removeSignal } = __nccwpck_require__(100)
+const { addSignal, removeSignal } = __nccwpck_require__(101)
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -67970,7 +67467,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 367:
+/***/ 368:
 /***/ ((module) => {
 
 /**
@@ -68139,7 +67636,7 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 368:
+/***/ 369:
 /***/ ((module) => {
 
 "use strict";
@@ -68147,7 +67644,7 @@ module.exports = require("node:util");
 
 /***/ }),
 
-/***/ 369:
+/***/ 370:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68156,7 +67653,7 @@ module.exports = require("node:util");
 // We include a version number for the Dispatcher API. In case of breaking changes,
 // this version number must be increased to avoid conflicts.
 const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
-const { InvalidArgumentError } = __nccwpck_require__(478)
+const { InvalidArgumentError } = __nccwpck_require__(479)
 const Agent = __nccwpck_require__(5)
 
 if (getGlobalDispatcher() === undefined) {
@@ -68187,7 +67684,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 370:
+/***/ 371:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68205,12 +67702,12 @@ const {
   kGetNetConnect,
   kOptions,
   kFactory
-} = __nccwpck_require__(461)
+} = __nccwpck_require__(462)
 const MockClient = __nccwpck_require__(194)
-const MockPool = __nccwpck_require__(342)
+const MockPool = __nccwpck_require__(343)
 const { matchValue, buildMockOptions } = __nccwpck_require__(7)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(478)
-const Dispatcher = __nccwpck_require__(468)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(479)
+const Dispatcher = __nccwpck_require__(469)
 const Pluralizer = __nccwpck_require__(247)
 const PendingInterceptorsFormatter = __nccwpck_require__(227)
 
@@ -68366,7 +67863,7 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 371:
+/***/ 372:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68403,7 +67900,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 372:
+/***/ 373:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -68492,7 +67989,7 @@ exports.AccountSASServices = AccountSASServices;
 
 /***/ }),
 
-/***/ 373:
+/***/ 374:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68518,7 +68015,7 @@ __export(bearerAuthenticationPolicy_exports, {
   bearerAuthenticationPolicyName: () => bearerAuthenticationPolicyName
 });
 module.exports = __toCommonJS(bearerAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(427);
+var import_checkInsecureConnection = __nccwpck_require__(428);
 const bearerAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function bearerAuthenticationPolicy(options) {
   return {
@@ -68546,7 +68043,7 @@ function bearerAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 374:
+/***/ 375:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68555,7 +68052,7 @@ function bearerAuthenticationPolicy(options) {
 const {
   BalancedPoolMissingUpstreamError,
   InvalidArgumentError
-} = __nccwpck_require__(478)
+} = __nccwpck_require__(479)
 const {
   PoolBase,
   kClients,
@@ -68563,8 +68060,8 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(361)
-const Pool = __nccwpck_require__(330)
+} = __nccwpck_require__(362)
+const Pool = __nccwpck_require__(331)
 const { kUrl, kInterceptors } = __nccwpck_require__(190)
 const { parseOrigin } = __nccwpck_require__(68)
 const kFactory = Symbol('factory')
@@ -68744,7 +68241,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 375:
+/***/ 376:
 /***/ ((module) => {
 
 "use strict";
@@ -68752,7 +68249,7 @@ module.exports = require("node:os");
 
 /***/ }),
 
-/***/ 376:
+/***/ 377:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -68796,7 +68293,7 @@ function operationOptionsToRequestParameters(options) {
 
 /***/ }),
 
-/***/ 377:
+/***/ 378:
 /***/ ((module) => {
 
 "use strict";
@@ -68814,7 +68311,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 378:
+/***/ 379:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68823,7 +68320,7 @@ module.exports = value => {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BuffersStream = void 0;
-const node_stream_1 = __nccwpck_require__(422);
+const node_stream_1 = __nccwpck_require__(423);
 /**
  * This class generates a readable stream from the data in an array of buffers.
  */
@@ -68922,16 +68419,16 @@ exports.BuffersStream = BuffersStream;
 
 /***/ }),
 
-/***/ 379:
+/***/ 380:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { parseSetCookie } = __nccwpck_require__(415)
-const { stringify } = __nccwpck_require__(401)
-const { webidl } = __nccwpck_require__(448)
-const { Headers } = __nccwpck_require__(505)
+const { parseSetCookie } = __nccwpck_require__(416)
+const { stringify } = __nccwpck_require__(402)
+const { webidl } = __nccwpck_require__(449)
+const { Headers } = __nccwpck_require__(506)
 
 /**
  * @typedef {Object} Cookie
@@ -69113,7 +68610,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 380:
+/***/ 381:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69129,7 +68626,7 @@ exports.AvroReadable = AvroReadable;
 
 /***/ }),
 
-/***/ 381:
+/***/ 382:
 /***/ ((module) => {
 
 "use strict";
@@ -69137,7 +68634,7 @@ module.exports = require("node:https");
 
 /***/ }),
 
-/***/ 382:
+/***/ 383:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69184,7 +68681,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 383:
+/***/ 384:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69192,9 +68689,9 @@ function userAgentPolicy(options = {}) {
 
 const util = __nccwpck_require__(68)
 const { kBodyUsed } = __nccwpck_require__(190)
-const assert = __nccwpck_require__(515)
-const { InvalidArgumentError } = __nccwpck_require__(478)
-const EE = __nccwpck_require__(460)
+const assert = __nccwpck_require__(517)
+const { InvalidArgumentError } = __nccwpck_require__(479)
+const EE = __nccwpck_require__(461)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
 
@@ -69413,7 +68910,7 @@ module.exports = RedirectHandler
 
 /***/ }),
 
-/***/ 384:
+/***/ 385:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69439,7 +68936,7 @@ function arraysEqual(a, b) {
 
 /***/ }),
 
-/***/ 385:
+/***/ 386:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69476,7 +68973,7 @@ function exponentialRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 386:
+/***/ 387:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -69511,7 +69008,7 @@ function randomUUID() {
 
 /***/ }),
 
-/***/ 387:
+/***/ 388:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69544,7 +69041,7 @@ exports.isJsonObject = isJsonObject;
 
 /***/ }),
 
-/***/ 388:
+/***/ 389:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69571,7 +69068,7 @@ __export(exponentialRetryStrategy_exports, {
   isSystemError: () => isSystemError
 });
 module.exports = __toCommonJS(exponentialRetryStrategy_exports);
-var import_delay = __nccwpck_require__(465);
+var import_delay = __nccwpck_require__(466);
 var import_throttlingRetryStrategy = __nccwpck_require__(34);
 const DEFAULT_CLIENT_RETRY_INTERVAL = 1e3;
 const DEFAULT_CLIENT_MAX_RETRY_INTERVAL = 1e3 * 64;
@@ -69617,7 +69114,7 @@ function isSystemError(err) {
 
 /***/ }),
 
-/***/ 389:
+/***/ 390:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69687,7 +69184,7 @@ exports.CacheScope = new CacheScope$Type();
 
 /***/ }),
 
-/***/ 390:
+/***/ 391:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69696,8 +69193,8 @@ exports.CacheScope = new CacheScope$Type();
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredential = void 0;
-const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(90);
-const Credential_js_1 = __nccwpck_require__(92);
+const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(91);
+const Credential_js_1 = __nccwpck_require__(93);
 /**
  * AnonymousCredential provides a credentialPolicyCreator member used to create
  * AnonymousCredentialPolicy objects. AnonymousCredentialPolicy is used with
@@ -69720,7 +69217,7 @@ exports.AnonymousCredential = AnonymousCredential;
 
 /***/ }),
 
-/***/ 391:
+/***/ 392:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69729,7 +69226,7 @@ exports.AnonymousCredential = AnonymousCredential;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 let cachedHttpClient;
 function getCachedDefaultHttpClient() {
     if (!cachedHttpClient) {
@@ -69741,7 +69238,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 392:
+/***/ 393:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69751,7 +69248,7 @@ function getCachedDefaultHttpClient() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getStreamingResponseStatusCodes = getStreamingResponseStatusCodes;
 exports.getPathStringFromParameter = getPathStringFromParameter;
-const serializer_js_1 = __nccwpck_require__(470);
+const serializer_js_1 = __nccwpck_require__(471);
 /**
  * Gets the list of status codes for streaming responses.
  * @internal
@@ -69791,7 +69288,7 @@ function getPathStringFromParameter(parameter) {
 
 /***/ }),
 
-/***/ 393:
+/***/ 394:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69802,15 +69299,15 @@ exports.stringify = __nccwpck_require__(292)
 
 /***/ }),
 
-/***/ 394:
+/***/ 395:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobServiceClient = void 0;
-const core_auth_1 = __nccwpck_require__(503);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_auth_1 = __nccwpck_require__(504);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 const core_util_1 = __nccwpck_require__(13);
 const Pipeline_js_1 = __nccwpck_require__(178);
 const ContainerClient_js_1 = __nccwpck_require__(63);
@@ -69818,11 +69315,11 @@ const utils_common_js_1 = __nccwpck_require__(151);
 const storage_common_1 = __nccwpck_require__(269);
 const utils_common_js_2 = __nccwpck_require__(151);
 const tracing_js_1 = __nccwpck_require__(30);
-const BlobBatchClient_js_1 = __nccwpck_require__(395);
-const StorageClient_js_1 = __nccwpck_require__(446);
+const BlobBatchClient_js_1 = __nccwpck_require__(396);
+const StorageClient_js_1 = __nccwpck_require__(447);
 const AccountSASPermissions_js_1 = __nccwpck_require__(57);
 const AccountSASSignatureValues_js_1 = __nccwpck_require__(282);
-const AccountSASServices_js_1 = __nccwpck_require__(372);
+const AccountSASServices_js_1 = __nccwpck_require__(373);
 /**
  * A BlobServiceClient represents a Client to the Azure Storage Blob service allowing you
  * to manipulate blob containers.
@@ -70515,7 +70012,7 @@ exports.BlobServiceClient = BlobServiceClient;
 
 /***/ }),
 
-/***/ 395:
+/***/ 396:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70526,7 +70023,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatchClient = void 0;
 const BatchResponseParser_js_1 = __nccwpck_require__(302);
 const BatchUtils_js_1 = __nccwpck_require__(251);
-const BlobBatch_js_1 = __nccwpck_require__(326);
+const BlobBatch_js_1 = __nccwpck_require__(327);
 const tracing_js_1 = __nccwpck_require__(30);
 const storage_common_1 = __nccwpck_require__(269);
 const StorageContextClient_js_1 = __nccwpck_require__(260);
@@ -70698,7 +70195,7 @@ exports.BlobBatchClient = BlobBatchClient;
 
 /***/ }),
 
-/***/ 396:
+/***/ 397:
 /***/ ((module) => {
 
 "use strict";
@@ -70712,7 +70209,7 @@ module.exports = (d, num) => {
 
 /***/ }),
 
-/***/ 397:
+/***/ 398:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70720,7 +70217,7 @@ module.exports = (d, num) => {
 
 const Decoder = __nccwpck_require__(41)
 const decodeText = __nccwpck_require__(268)
-const getLimit = __nccwpck_require__(473)
+const getLimit = __nccwpck_require__(474)
 
 const RE_CHARSET = /^charset$/i
 
@@ -70910,7 +70407,7 @@ module.exports = UrlEncoded
 
 /***/ }),
 
-/***/ 398:
+/***/ 399:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -70928,7 +70425,7 @@ exports.MESSAGE_TYPE = Symbol.for("protobuf-ts/message-type");
 
 /***/ }),
 
-/***/ 399:
+/***/ 400:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70940,8 +70437,8 @@ exports.createDefaultTracingSpan = createDefaultTracingSpan;
 exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
-const tracingContext_js_1 = __nccwpck_require__(362);
-const state_js_1 = __nccwpck_require__(93);
+const tracingContext_js_1 = __nccwpck_require__(363);
+const state_js_1 = __nccwpck_require__(94);
 function createDefaultTracingSpan() {
     return {
         end: () => {
@@ -71004,17 +70501,17 @@ function getInstrumenter() {
 
 /***/ }),
 
-/***/ 400:
+/***/ 401:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
-const binary_format_contract_1 = __nccwpck_require__(325);
-const reflection_info_1 = __nccwpck_require__(444);
+const binary_format_contract_1 = __nccwpck_require__(326);
+const reflection_info_1 = __nccwpck_require__(445);
 const reflection_long_convert_1 = __nccwpck_require__(154);
-const reflection_scalar_default_1 = __nccwpck_require__(453);
+const reflection_scalar_default_1 = __nccwpck_require__(454);
 /**
  * Reads proto3 messages in binary format using reflection information.
  *
@@ -71195,7 +70692,7 @@ exports.ReflectionBinaryReader = ReflectionBinaryReader;
 
 /***/ }),
 
-/***/ 401:
+/***/ 402:
 /***/ ((module) => {
 
 "use strict";
@@ -71477,7 +70974,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 402:
+/***/ 403:
 /***/ ((module) => {
 
 "use strict";
@@ -71485,14 +70982,14 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 403:
+/***/ 404:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseAsync
 
-const TOMLParser = __nccwpck_require__(339)
+const TOMLParser = __nccwpck_require__(340)
 const prettyError = __nccwpck_require__(271)
 
 function parseAsync (str, opts) {
@@ -71523,7 +71020,7 @@ function parseAsync (str, opts) {
 
 /***/ }),
 
-/***/ 404:
+/***/ 405:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -71549,8 +71046,8 @@ __export(response_exports, {
   toPipelineResponse: () => toPipelineResponse
 });
 module.exports = __toCommonJS(response_exports);
-var import_core_rest_pipeline = __nccwpck_require__(98);
-var import_util = __nccwpck_require__(106);
+var import_core_rest_pipeline = __nccwpck_require__(99);
+var import_util = __nccwpck_require__(107);
 const originalResponse = /* @__PURE__ */ Symbol("Original FullOperationResponse");
 function toCompatResponse(response, options) {
   let request = (0, import_util.toWebResourceLike)(response.request);
@@ -71606,7 +71103,7 @@ function toPipelineResponse(compatResponse) {
 
 /***/ }),
 
-/***/ 405:
+/***/ 406:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -71632,7 +71129,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOptions = void 0;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 /**
  * Returns a copy with defaults filled in.
  */
@@ -71663,7 +71160,7 @@ exports.getOptions = getOptions;
 
 /***/ }),
 
-/***/ 406:
+/***/ 407:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71719,7 +71216,7 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 407:
+/***/ 408:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71847,18 +71344,18 @@ function getBlobServiceAccountAudience(storageAccountName) {
 
 /***/ }),
 
-/***/ 408:
+/***/ 409:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(422).Writable)
-const { inherits } = __nccwpck_require__(368)
+const WritableStream = (__nccwpck_require__(423).Writable)
+const { inherits } = __nccwpck_require__(369)
 const Dicer = __nccwpck_require__(12)
 
 const MultipartParser = __nccwpck_require__(0)
-const UrlencodedParser = __nccwpck_require__(397)
+const UrlencodedParser = __nccwpck_require__(398)
 const parseParams = __nccwpck_require__(187)
 
 function Busboy (opts) {
@@ -71940,7 +71437,7 @@ module.exports.Dicer = Dicer
 
 /***/ }),
 
-/***/ 409:
+/***/ 410:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -71967,7 +71464,7 @@ var StorageRetryPolicyType;
 
 /***/ }),
 
-/***/ 410:
+/***/ 411:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -72009,7 +71506,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDetails = exports.isLinux = exports.isMacOS = exports.isWindows = exports.arch = exports.platform = void 0;
-const os_1 = __importDefault(__nccwpck_require__(89));
+const os_1 = __importDefault(__nccwpck_require__(90));
 const exec = __importStar(__nccwpck_require__(17));
 const getWindowsInfo = () => __awaiter(void 0, void 0, void 0, function* () {
     const { stdout: version } = yield exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Version"', undefined, {
@@ -72068,7 +71565,7 @@ exports.getDetails = getDetails;
 
 /***/ }),
 
-/***/ 411:
+/***/ 412:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -72078,7 +71575,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseProxyResponse = void 0;
-const debug_1 = __importDefault(__nccwpck_require__(504));
+const debug_1 = __importDefault(__nccwpck_require__(505));
 const debug = (0, debug_1.default)('https-proxy-agent:parse-proxy-response');
 function parseProxyResponse(socket) {
     return new Promise((resolve, reject) => {
@@ -72176,15 +71673,15 @@ exports.parseProxyResponse = parseProxyResponse;
 
 /***/ }),
 
-/***/ 412:
+/***/ 413:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseStream
 
-const stream = __nccwpck_require__(127)
-const TOMLParser = __nccwpck_require__(339)
+const stream = __nccwpck_require__(128)
+const TOMLParser = __nccwpck_require__(340)
 
 function parseStream (stm) {
   if (stm) {
@@ -72264,7 +71761,7 @@ function parseTransform () {
 
 /***/ }),
 
-/***/ 413:
+/***/ 414:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72277,7 +71774,7 @@ exports.AvroReader = void 0;
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
 const AvroConstants_js_1 = __nccwpck_require__(223);
 const AvroParser_js_1 = __nccwpck_require__(294);
-const utils_common_js_1 = __nccwpck_require__(384);
+const utils_common_js_1 = __nccwpck_require__(385);
 class AvroReader {
     _dataStream;
     _headerStream;
@@ -72391,7 +71888,7 @@ exports.AvroReader = AvroReader;
 
 /***/ }),
 
-/***/ 414:
+/***/ 415:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72800,16 +72297,16 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 
 /***/ }),
 
-/***/ 415:
+/***/ 416:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(124)
-const { isCTLExcludingHtab } = __nccwpck_require__(401)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(125)
+const { isCTLExcludingHtab } = __nccwpck_require__(402)
 const { collectASequenceOfCodePointsFast } = __nccwpck_require__(24)
-const assert = __nccwpck_require__(515)
+const assert = __nccwpck_require__(517)
 
 /**
  * @description Parses the field-value attributes of a set-cookie header string.
@@ -73125,7 +72622,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 416:
+/***/ 417:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -73193,7 +72690,7 @@ exports.ServerCallContextController = ServerCallContextController;
 
 /***/ }),
 
-/***/ 417:
+/***/ 418:
 /***/ ((module) => {
 
 "use strict";
@@ -73328,7 +72825,7 @@ module.exports = Parser
 
 /***/ }),
 
-/***/ 418:
+/***/ 419:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73338,7 +72835,7 @@ exports.BlobDownloadResponse = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core_util_1 = __nccwpck_require__(13);
-const RetriableReadableStream_js_1 = __nccwpck_require__(482);
+const RetriableReadableStream_js_1 = __nccwpck_require__(483);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -73804,7 +73301,7 @@ exports.BlobDownloadResponse = BlobDownloadResponse;
 
 /***/ }),
 
-/***/ 419:
+/***/ 420:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -73849,7 +73346,7 @@ function storageRequestFailureDetailsParserPolicy() {
 
 /***/ }),
 
-/***/ 420:
+/***/ 421:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -73885,7 +73382,7 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(375));
+var import_node_os = __toESM(__nccwpck_require__(376));
 var import_node_process = __toESM(__nccwpck_require__(230));
 function getHeaderName() {
   return "User-Agent";
@@ -73909,7 +73406,7 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 421:
+/***/ 422:
 /***/ ((module) => {
 
 "use strict";
@@ -73917,7 +73414,7 @@ module.exports = require("async_hooks");
 
 /***/ }),
 
-/***/ 422:
+/***/ 423:
 /***/ ((module) => {
 
 "use strict";
@@ -73925,7 +73422,7 @@ module.exports = require("node:stream");
 
 /***/ }),
 
-/***/ 423:
+/***/ 424:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -73979,12 +73476,12 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DefaultGlobber = void 0;
-const core = __importStar(__nccwpck_require__(450));
-const fs = __importStar(__nccwpck_require__(520));
-const globOptionsHelper = __importStar(__nccwpck_require__(405));
+const core = __importStar(__nccwpck_require__(451));
+const fs = __importStar(__nccwpck_require__(522));
+const globOptionsHelper = __importStar(__nccwpck_require__(406));
 const path = __importStar(__nccwpck_require__(241));
 const patternHelper = __importStar(__nccwpck_require__(42));
-const internal_match_kind_1 = __nccwpck_require__(517);
+const internal_match_kind_1 = __nccwpck_require__(519);
 const internal_pattern_1 = __nccwpck_require__(492);
 const internal_search_state_1 = __nccwpck_require__(4);
 const IS_WINDOWS = process.platform === 'win32';
@@ -74167,7 +73664,7 @@ exports.DefaultGlobber = DefaultGlobber;
 
 /***/ }),
 
-/***/ 424:
+/***/ 425:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74177,7 +73674,7 @@ exports.DefaultGlobber = DefaultGlobber;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOperationArgumentValueFromParameter = getOperationArgumentValueFromParameter;
 exports.getOperationRequestInfo = getOperationRequestInfo;
-const state_js_1 = __nccwpck_require__(322);
+const state_js_1 = __nccwpck_require__(323);
 /**
  * @internal
  * Retrieves the value to use for a given operation argument
@@ -74272,17 +73769,17 @@ function getOperationRequestInfo(request) {
 
 /***/ }),
 
-/***/ 425:
+/***/ 426:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(478)
-const { AsyncResource } = __nccwpck_require__(421)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(479)
+const { AsyncResource } = __nccwpck_require__(422)
 const util = __nccwpck_require__(68)
-const { addSignal, removeSignal } = __nccwpck_require__(100)
-const assert = __nccwpck_require__(515)
+const { addSignal, removeSignal } = __nccwpck_require__(101)
+const assert = __nccwpck_require__(517)
 
 class UpgradeHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -74385,14 +73882,14 @@ module.exports = upgrade
 
 /***/ }),
 
-/***/ 426:
+/***/ 427:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const os = __nccwpck_require__(89);
+const os = __nccwpck_require__(90);
 const tty = __nccwpck_require__(177);
-const hasFlag = __nccwpck_require__(358);
+const hasFlag = __nccwpck_require__(359);
 
 const {env} = process;
 
@@ -74528,7 +74025,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 427:
+/***/ 428:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -74590,14 +74087,14 @@ function ensureSecureConnection(request, options) {
 
 /***/ }),
 
-/***/ 428:
+/***/ 429:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CacheServiceClientProtobuf = exports.CacheServiceClientJSON = void 0;
-const cache_1 = __nccwpck_require__(414);
+const cache_1 = __nccwpck_require__(415);
 class CacheServiceClientJSON {
     constructor(rpc) {
         this.rpc = rpc;
@@ -74665,7 +74162,7 @@ exports.CacheServiceClientProtobuf = CacheServiceClientProtobuf;
 
 /***/ }),
 
-/***/ 429:
+/***/ 430:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -74714,7 +74211,7 @@ function decodeStringToString(value) {
 
 /***/ }),
 
-/***/ 430:
+/***/ 431:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -74759,7 +74256,7 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 
 /***/ }),
 
-/***/ 431:
+/***/ 432:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74768,23 +74265,23 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.authorizeRequestOnTenantChallenge = exports.authorizeRequestOnClaimChallenge = exports.serializationPolicyName = exports.serializationPolicy = exports.deserializationPolicyName = exports.deserializationPolicy = exports.XML_CHARKEY = exports.XML_ATTRKEY = exports.createClientPipeline = exports.ServiceClient = exports.MapperTypeNames = exports.createSerializer = void 0;
-var serializer_js_1 = __nccwpck_require__(470);
+var serializer_js_1 = __nccwpck_require__(471);
 Object.defineProperty(exports, "createSerializer", ({ enumerable: true, get: function () { return serializer_js_1.createSerializer; } }));
 Object.defineProperty(exports, "MapperTypeNames", ({ enumerable: true, get: function () { return serializer_js_1.MapperTypeNames; } }));
 var serviceClient_js_1 = __nccwpck_require__(307);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
 var pipeline_js_1 = __nccwpck_require__(277);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
-var interfaces_js_1 = __nccwpck_require__(96);
+var interfaces_js_1 = __nccwpck_require__(97);
 Object.defineProperty(exports, "XML_ATTRKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_ATTRKEY; } }));
 Object.defineProperty(exports, "XML_CHARKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_CHARKEY; } }));
 var deserializationPolicy_js_1 = __nccwpck_require__(83);
 Object.defineProperty(exports, "deserializationPolicy", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicy; } }));
 Object.defineProperty(exports, "deserializationPolicyName", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicyName; } }));
-var serializationPolicy_js_1 = __nccwpck_require__(479);
+var serializationPolicy_js_1 = __nccwpck_require__(480);
 Object.defineProperty(exports, "serializationPolicy", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicy; } }));
 Object.defineProperty(exports, "serializationPolicyName", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicyName; } }));
-var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(108);
+var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(109);
 Object.defineProperty(exports, "authorizeRequestOnClaimChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnClaimChallenge_js_1.authorizeRequestOnClaimChallenge; } }));
 var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(168);
 Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnTenantChallenge_js_1.authorizeRequestOnTenantChallenge; } }));
@@ -74792,7 +74289,7 @@ Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerabl
 
 /***/ }),
 
-/***/ 432:
+/***/ 433:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -74833,7 +74330,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTar = exports.extractTar = exports.listTar = void 0;
 const exec_1 = __nccwpck_require__(17);
 const io = __importStar(__nccwpck_require__(287));
-const fs_1 = __nccwpck_require__(520);
+const fs_1 = __nccwpck_require__(522);
 const path = __importStar(__nccwpck_require__(241));
 const utils = __importStar(__nccwpck_require__(74));
 const constants_1 = __nccwpck_require__(44);
@@ -75071,7 +74568,7 @@ exports.createTar = createTar;
 
 /***/ }),
 
-/***/ 433:
+/***/ 434:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -75108,14 +74605,14 @@ __export(nodeHttpClient_exports, {
 });
 module.exports = __toCommonJS(nodeHttpClient_exports);
 var import_node_http = __toESM(__nccwpck_require__(256));
-var import_node_https = __toESM(__nccwpck_require__(381));
-var import_node_zlib = __toESM(__nccwpck_require__(508));
-var import_node_stream = __nccwpck_require__(422);
+var import_node_https = __toESM(__nccwpck_require__(382));
+var import_node_zlib = __toESM(__nccwpck_require__(509));
+var import_node_stream = __nccwpck_require__(423);
 var import_AbortError = __nccwpck_require__(10);
-var import_httpHeaders = __nccwpck_require__(475);
-var import_restError = __nccwpck_require__(436);
+var import_httpHeaders = __nccwpck_require__(476);
+var import_restError = __nccwpck_require__(437);
 var import_log = __nccwpck_require__(148);
-var import_sanitizer = __nccwpck_require__(118);
+var import_sanitizer = __nccwpck_require__(119);
 const DEFAULT_TLS_SETTINGS = {};
 function isReadableStream(body) {
   return body && typeof body.pipe === "function";
@@ -75420,13 +74917,13 @@ function createNodeHttpClient() {
 
 /***/ }),
 
-/***/ 434:
+/***/ 435:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(448)
+const { webidl } = __nccwpck_require__(449)
 
 const kState = Symbol('ProgressEvent state')
 
@@ -75506,7 +75003,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 435:
+/***/ 436:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -75540,9 +75037,9 @@ exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const crypto = __importStar(__nccwpck_require__(284));
-const fs = __importStar(__nccwpck_require__(520));
-const os = __importStar(__nccwpck_require__(89));
-const utils_1 = __nccwpck_require__(494);
+const fs = __importStar(__nccwpck_require__(522));
+const os = __importStar(__nccwpck_require__(90));
+const utils_1 = __nccwpck_require__(495);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -75575,7 +75072,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 436:
+/***/ 437:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -75603,7 +75100,7 @@ __export(restError_exports, {
 module.exports = __toCommonJS(restError_exports);
 var import_error = __nccwpck_require__(150);
 var import_inspect = __nccwpck_require__(1);
-var import_sanitizer = __nccwpck_require__(118);
+var import_sanitizer = __nccwpck_require__(119);
 const errorSanitizer = new import_sanitizer.Sanitizer();
 class RestError extends Error {
   /**
@@ -75677,7 +75174,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 437:
+/***/ 438:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -75730,7 +75227,7 @@ function wrapAbortSignalLike(abortSignalLike) {
 
 /***/ }),
 
-/***/ 438:
+/***/ 439:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75803,7 +75300,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 439:
+/***/ 440:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75813,25 +75310,25 @@ exports.StorageClient = StorageClient;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = exports.StorageSharedKeyCredentialPolicy = exports.StorageSharedKeyCredential = exports.StorageRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = exports.Credential = exports.CredentialPolicy = exports.BaseRequestPolicy = exports.AnonymousCredentialPolicy = exports.AnonymousCredential = exports.StorageOAuthScopes = exports.newPipeline = exports.isPipelineLike = exports.Pipeline = exports.getBlobServiceAccountAudience = exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTier = exports.generateBlobSASQueryParameters = exports.generateAccountSASQueryParameters = void 0;
 const tslib_1 = __nccwpck_require__(210);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
-tslib_1.__exportStar(__nccwpck_require__(394), exports);
+tslib_1.__exportStar(__nccwpck_require__(395), exports);
 tslib_1.__exportStar(__nccwpck_require__(180), exports);
 tslib_1.__exportStar(__nccwpck_require__(63), exports);
 tslib_1.__exportStar(__nccwpck_require__(199), exports);
 tslib_1.__exportStar(__nccwpck_require__(57), exports);
 tslib_1.__exportStar(__nccwpck_require__(2), exports);
-tslib_1.__exportStar(__nccwpck_require__(372), exports);
+tslib_1.__exportStar(__nccwpck_require__(373), exports);
 var AccountSASSignatureValues_js_1 = __nccwpck_require__(282);
 Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(326), exports);
-tslib_1.__exportStar(__nccwpck_require__(395), exports);
+tslib_1.__exportStar(__nccwpck_require__(327), exports);
+tslib_1.__exportStar(__nccwpck_require__(396), exports);
 tslib_1.__exportStar(__nccwpck_require__(169), exports);
 tslib_1.__exportStar(__nccwpck_require__(493), exports);
 var BlobSASSignatureValues_js_1 = __nccwpck_require__(67);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
 tslib_1.__exportStar(__nccwpck_require__(272), exports);
-var models_js_1 = __nccwpck_require__(407);
+var models_js_1 = __nccwpck_require__(408);
 Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: function () { return models_js_1.BlockBlobTier; } }));
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
@@ -75854,15 +75351,15 @@ Object.defineProperty(exports, "StorageSharedKeyCredential", ({ enumerable: true
 Object.defineProperty(exports, "StorageSharedKeyCredentialPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageSharedKeyCredentialPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
-tslib_1.__exportStar(__nccwpck_require__(514), exports);
+tslib_1.__exportStar(__nccwpck_require__(515), exports);
 tslib_1.__exportStar(__nccwpck_require__(315), exports);
-var log_js_1 = __nccwpck_require__(103);
+var log_js_1 = __nccwpck_require__(104);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 440:
+/***/ 441:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76147,7 +75644,7 @@ exports.SPECIAL_HEADERS = {
 
 /***/ }),
 
-/***/ 441:
+/***/ 442:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76173,11 +75670,11 @@ __export(sendRequest_exports, {
   sendRequest: () => sendRequest
 });
 module.exports = __toCommonJS(sendRequest_exports);
-var import_restError = __nccwpck_require__(436);
-var import_httpHeaders = __nccwpck_require__(475);
-var import_pipelineRequest = __nccwpck_require__(111);
-var import_clientHelpers = __nccwpck_require__(481);
-var import_typeGuards = __nccwpck_require__(486);
+var import_restError = __nccwpck_require__(437);
+var import_httpHeaders = __nccwpck_require__(476);
+var import_pipelineRequest = __nccwpck_require__(112);
+var import_clientHelpers = __nccwpck_require__(482);
+var import_typeGuards = __nccwpck_require__(487);
 var import_multipart = __nccwpck_require__(262);
 async function sendRequest(method, url, pipeline, options = {}, customHttpClient) {
   const httpClient = customHttpClient ?? (0, import_clientHelpers.getCachedDefaultHttpsClient)();
@@ -76331,7 +75828,7 @@ function createParseError(response, err) {
 
 /***/ }),
 
-/***/ 442:
+/***/ 443:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76346,9 +75843,9 @@ const {
   filterResponse,
   makeResponse
 } = __nccwpck_require__(40)
-const { Headers } = __nccwpck_require__(505)
+const { Headers } = __nccwpck_require__(506)
 const { Request, makeRequest } = __nccwpck_require__(81)
-const zlib = __nccwpck_require__(402)
+const zlib = __nccwpck_require__(403)
 const {
   bytesMatch,
   makePolicyContainer,
@@ -76378,9 +75875,9 @@ const {
   urlIsLocal,
   urlIsHttpHttpsScheme,
   urlHasHttpsScheme
-} = __nccwpck_require__(506)
+} = __nccwpck_require__(507)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(14)
-const assert = __nccwpck_require__(515)
+const assert = __nccwpck_require__(517)
 const { safelyExtractBody } = __nccwpck_require__(23)
 const {
   redirectStatusSet,
@@ -76391,14 +75888,14 @@ const {
   DOMException
 } = __nccwpck_require__(29)
 const { kHeadersList } = __nccwpck_require__(190)
-const EE = __nccwpck_require__(460)
-const { Readable, pipeline } = __nccwpck_require__(127)
+const EE = __nccwpck_require__(461)
+const { Readable, pipeline } = __nccwpck_require__(128)
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(68)
 const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(24)
 const { TransformStream } = __nccwpck_require__(250)
-const { getGlobalDispatcher } = __nccwpck_require__(369)
-const { webidl } = __nccwpck_require__(448)
-const { STATUS_CODES } = __nccwpck_require__(321)
+const { getGlobalDispatcher } = __nccwpck_require__(370)
+const { webidl } = __nccwpck_require__(449)
+const { STATUS_CODES } = __nccwpck_require__(322)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
 /** @type {import('buffer').resolveObjectURL} */
@@ -77140,7 +76637,7 @@ function schemeFetch (fetchParams) {
     }
     case 'blob:': {
       if (!resolveObjectURL) {
-        resolveObjectURL = (__nccwpck_require__(115).resolveObjectURL)
+        resolveObjectURL = (__nccwpck_require__(116).resolveObjectURL)
       }
 
       // 1. Let blobURLEntry be request’s current URL’s blob URL entry.
@@ -78487,7 +77984,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 443:
+/***/ 444:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -78545,14 +78042,14 @@ exports.ServerStreamingCall = ServerStreamingCall;
 
 /***/ }),
 
-/***/ 444:
+/***/ 445:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.readMessageOption = exports.readFieldOption = exports.readFieldOptions = exports.normalizeFieldInfo = exports.RepeatType = exports.LongType = exports.ScalarType = void 0;
-const lower_camel_case_1 = __nccwpck_require__(445);
+const lower_camel_case_1 = __nccwpck_require__(446);
 /**
  * Scalar value types. This is a subset of field types declared by protobuf
  * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
@@ -78711,7 +78208,7 @@ exports.readMessageOption = readMessageOption;
 
 /***/ }),
 
-/***/ 445:
+/***/ 446:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -78754,7 +78251,7 @@ exports.lowerCamelCase = lowerCamelCase;
 
 /***/ }),
 
-/***/ 446:
+/***/ 447:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -78817,7 +78314,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 447:
+/***/ 448:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -78892,14 +78389,14 @@ function parseHeaderValueAsNumber(response, headerName) {
 
 /***/ }),
 
-/***/ 448:
+/***/ 449:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { types } = __nccwpck_require__(120)
-const { hasOwn, toUSVString } = __nccwpck_require__(506)
+const { types } = __nccwpck_require__(121)
+const { hasOwn, toUSVString } = __nccwpck_require__(507)
 
 /** @type {import('../../types/webidl').Webidl} */
 const webidl = {}
@@ -79546,7 +79043,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 449:
+/***/ 450:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /**
@@ -79554,7 +79051,7 @@ module.exports = {
  */
 
 const tty = __nccwpck_require__(177);
-const util = __nccwpck_require__(120);
+const util = __nccwpck_require__(121);
 
 /**
  * This is the Node.js implementation of `debug()`.
@@ -79580,7 +79077,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = __nccwpck_require__(426);
+	const supportsColor = __nccwpck_require__(427);
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [
@@ -79816,7 +79313,7 @@ formatters.O = function (v) {
 
 /***/ }),
 
-/***/ 450:
+/***/ 451:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -79855,12 +79352,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.platform = exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = exports.markdownSummary = exports.summary = exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(522);
-const file_command_1 = __nccwpck_require__(435);
-const utils_1 = __nccwpck_require__(494);
-const os = __importStar(__nccwpck_require__(89));
+const command_1 = __nccwpck_require__(524);
+const file_command_1 = __nccwpck_require__(436);
+const utils_1 = __nccwpck_require__(495);
+const os = __importStar(__nccwpck_require__(90));
 const path = __importStar(__nccwpck_require__(241));
-const oidc_utils_1 = __nccwpck_require__(130);
+const oidc_utils_1 = __nccwpck_require__(131);
 /**
  * The code to exit an action
  */
@@ -80145,29 +79642,29 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(337);
+var summary_1 = __nccwpck_require__(338);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(337);
+var summary_2 = __nccwpck_require__(338);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(324);
+var path_utils_1 = __nccwpck_require__(325);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
 /**
  * Platform utilities exports
  */
-exports.platform = __importStar(__nccwpck_require__(410));
+exports.platform = __importStar(__nccwpck_require__(411));
 //# sourceMappingURL=core.js.map
 
 /***/ }),
 
-/***/ 451:
+/***/ 452:
 /***/ ((module) => {
 
 "use strict";
@@ -80185,14 +79682,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 452:
+/***/ 453:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionEquals = void 0;
-const reflection_info_1 = __nccwpck_require__(444);
+const reflection_info_1 = __nccwpck_require__(445);
 /**
  * Determines whether two message of the same type have the same field values.
  * Checks for deep equality, traversing repeated fields, oneof groups, maps
@@ -80270,16 +79767,16 @@ function repeatedMsgEq(type, a, b) {
 
 /***/ }),
 
-/***/ 453:
+/***/ 454:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
-const reflection_info_1 = __nccwpck_require__(444);
+const reflection_info_1 = __nccwpck_require__(445);
 const reflection_long_convert_1 = __nccwpck_require__(154);
-const pb_long_1 = __nccwpck_require__(113);
+const pb_long_1 = __nccwpck_require__(114);
 /**
  * Creates the default value for a scalar type.
  */
@@ -80315,7 +79812,7 @@ exports.reflectionScalarDefault = reflectionScalarDefault;
 
 /***/ }),
 
-/***/ 454:
+/***/ 455:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80353,7 +79850,7 @@ function storageCorrectContentLengthPolicy() {
 
 /***/ }),
 
-/***/ 455:
+/***/ 456:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -80398,7 +79895,7 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 456:
+/***/ 457:
 /***/ ((module) => {
 
 "use strict";
@@ -80457,7 +79954,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 457:
+/***/ 458:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -80482,7 +79979,7 @@ __export(debug_exports, {
   default: () => debug_default
 });
 module.exports = __toCommonJS(debug_exports);
-var import_log = __nccwpck_require__(477);
+var import_log = __nccwpck_require__(478);
 const debugEnvVariable = typeof process !== "undefined" && process.env && process.env.DEBUG || void 0;
 let enabledString;
 let enabledNamespaces = [];
@@ -80647,7 +80144,7 @@ var debug_default = debugObj;
 
 /***/ }),
 
-/***/ 458:
+/***/ 459:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* eslint-env browser */
@@ -80926,7 +80423,7 @@ formatters.j = function (v) {
 
 /***/ }),
 
-/***/ 459:
+/***/ 460:
 /***/ ((module) => {
 
 "use strict";
@@ -80934,7 +80431,7 @@ module.exports = /*#__PURE__*/JSON.parse('{"name":"@actions/cache","version":"4.
 
 /***/ }),
 
-/***/ 460:
+/***/ 461:
 /***/ ((module) => {
 
 "use strict";
@@ -80942,7 +80439,7 @@ module.exports = require("events");
 
 /***/ }),
 
-/***/ 461:
+/***/ 462:
 /***/ ((module) => {
 
 "use strict";
@@ -80973,7 +80470,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 462:
+/***/ 463:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -81247,7 +80744,7 @@ var KnownStorageErrorCode;
 
 /***/ }),
 
-/***/ 463:
+/***/ 464:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -81288,7 +80785,7 @@ function proxyPolicy(proxySettings, options) {
 
 /***/ }),
 
-/***/ 464:
+/***/ 465:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -81323,7 +80820,7 @@ exports.attachCredential = attachCredential;
 exports.httpAuthorizationToString = httpAuthorizationToString;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(99);
 const core_util_1 = __nccwpck_require__(13);
 const constants_js_1 = __nccwpck_require__(35);
 /**
@@ -81868,7 +81365,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 465:
+/***/ 466:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -81893,7 +81390,7 @@ __export(delay_exports, {
   calculateRetryDelay: () => calculateRetryDelay
 });
 module.exports = __toCommonJS(delay_exports);
-var import_random = __nccwpck_require__(496);
+var import_random = __nccwpck_require__(497);
 function calculateRetryDelay(retryAttempt, config) {
   const exponentialDelay = config.retryDelayInMs * Math.pow(2, retryAttempt);
   const clampedDelay = Math.min(config.maxRetryDelayInMs, exponentialDelay);
@@ -81907,7 +81404,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 466:
+/***/ 467:
 /***/ ((module) => {
 
 "use strict";
@@ -81950,7 +81447,7 @@ module.exports = class DecoratorHandler {
 
 /***/ }),
 
-/***/ 467:
+/***/ 468:
 /***/ ((module) => {
 
 "use strict";
@@ -81972,13 +81469,13 @@ module.exports = function basename (path) {
 
 /***/ }),
 
-/***/ 468:
+/***/ 469:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = __nccwpck_require__(460)
+const EventEmitter = __nccwpck_require__(461)
 
 class Dispatcher extends EventEmitter {
   dispatch () {
@@ -81999,14 +81496,14 @@ module.exports = Dispatcher
 
 /***/ }),
 
-/***/ 469:
+/***/ 470:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceType = void 0;
-const reflection_info_1 = __nccwpck_require__(516);
+const reflection_info_1 = __nccwpck_require__(518);
 class ServiceType {
     constructor(typeName, methods, options) {
         this.typeName = typeName;
@@ -82019,7 +81516,7 @@ exports.ServiceType = ServiceType;
 
 /***/ }),
 
-/***/ 470:
+/***/ 471:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82030,8 +81527,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
 const tslib_1 = __nccwpck_require__(210);
-const base64 = tslib_1.__importStar(__nccwpck_require__(429));
-const interfaces_js_1 = __nccwpck_require__(96);
+const base64 = tslib_1.__importStar(__nccwpck_require__(430));
+const interfaces_js_1 = __nccwpck_require__(97);
 const utils_js_1 = __nccwpck_require__(304);
 class SerializerImpl {
     modelMappers;
@@ -82952,7 +82449,7 @@ exports.MapperTypeNames = {
 
 /***/ }),
 
-/***/ 471:
+/***/ 472:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82967,16 +82464,16 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 
 /***/ }),
 
-/***/ 472:
+/***/ 473:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Writable } = __nccwpck_require__(127)
+const { Writable } = __nccwpck_require__(128)
 const diagnosticsChannel = __nccwpck_require__(139)
-const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(456)
-const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(95)
+const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(457)
+const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(96)
 const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(56)
 const { WebsocketFrameSend } = __nccwpck_require__(182)
 
@@ -83319,7 +82816,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 473:
+/***/ 474:
 /***/ ((module) => {
 
 "use strict";
@@ -83343,7 +82840,7 @@ module.exports = function getLimit (limits, name, defaultLimit) {
 
 /***/ }),
 
-/***/ 474:
+/***/ 475:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -83394,7 +82891,7 @@ exports.assertFloat32 = assertFloat32;
 
 /***/ }),
 
-/***/ 475:
+/***/ 476:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -83507,11 +83004,11 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 476:
+/***/ 477:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __nccwpck_require__(344);
-var balanced = __nccwpck_require__(128);
+var concatMap = __nccwpck_require__(345);
+var balanced = __nccwpck_require__(129);
 
 module.exports = expandTop;
 
@@ -83717,7 +83214,7 @@ function expand(str, max, isTop) {
 
 /***/ }),
 
-/***/ 477:
+/***/ 478:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -83752,8 +83249,8 @@ __export(log_exports, {
   log: () => log
 });
 module.exports = __toCommonJS(log_exports);
-var import_node_os = __nccwpck_require__(375);
-var import_node_util = __toESM(__nccwpck_require__(368));
+var import_node_os = __nccwpck_require__(376);
+var import_node_util = __toESM(__nccwpck_require__(369));
 var import_node_process = __toESM(__nccwpck_require__(230));
 function log(message, ...args) {
   import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
@@ -83765,7 +83262,7 @@ function log(message, ...args) {
 
 /***/ }),
 
-/***/ 478:
+/***/ 479:
 /***/ ((module) => {
 
 "use strict";
@@ -84003,7 +83500,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 479:
+/***/ 480:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84015,10 +83512,10 @@ exports.serializationPolicyName = void 0;
 exports.serializationPolicy = serializationPolicy;
 exports.serializeHeaders = serializeHeaders;
 exports.serializeRequestBody = serializeRequestBody;
-const interfaces_js_1 = __nccwpck_require__(96);
-const operationHelpers_js_1 = __nccwpck_require__(424);
-const serializer_js_1 = __nccwpck_require__(470);
-const interfaceHelpers_js_1 = __nccwpck_require__(392);
+const interfaces_js_1 = __nccwpck_require__(97);
+const operationHelpers_js_1 = __nccwpck_require__(425);
+const serializer_js_1 = __nccwpck_require__(471);
+const interfaceHelpers_js_1 = __nccwpck_require__(393);
 /**
  * The programmatic identifier of the serializationPolicy.
  */
@@ -84167,19 +83664,19 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 /***/ }),
 
-/***/ 480:
+/***/ 481:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(498);
-var tls = __nccwpck_require__(495);
-var http = __nccwpck_require__(321);
+var net = __nccwpck_require__(499);
+var tls = __nccwpck_require__(496);
+var http = __nccwpck_require__(322);
 var https = __nccwpck_require__(69);
-var events = __nccwpck_require__(460);
-var assert = __nccwpck_require__(515);
-var util = __nccwpck_require__(120);
+var events = __nccwpck_require__(461);
+var assert = __nccwpck_require__(517);
+var util = __nccwpck_require__(121);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -84439,7 +83936,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 481:
+/***/ 482:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -84465,14 +83962,14 @@ __export(clientHelpers_exports, {
   getCachedDefaultHttpsClient: () => getCachedDefaultHttpsClient
 });
 module.exports = __toCommonJS(clientHelpers_exports);
-var import_defaultHttpClient = __nccwpck_require__(365);
+var import_defaultHttpClient = __nccwpck_require__(366);
 var import_createPipelineFromOptions = __nccwpck_require__(308);
 var import_apiVersionPolicy = __nccwpck_require__(221);
 var import_credentials = __nccwpck_require__(183);
-var import_apiKeyAuthenticationPolicy = __nccwpck_require__(84);
+var import_apiKeyAuthenticationPolicy = __nccwpck_require__(85);
 var import_basicAuthenticationPolicy = __nccwpck_require__(149);
-var import_bearerAuthenticationPolicy = __nccwpck_require__(373);
-var import_oauth2AuthenticationPolicy = __nccwpck_require__(331);
+var import_bearerAuthenticationPolicy = __nccwpck_require__(374);
+var import_oauth2AuthenticationPolicy = __nccwpck_require__(332);
 let cachedHttpClient;
 function createDefaultPipeline(options = {}) {
   const pipeline = (0, import_createPipelineFromOptions.createPipelineFromOptions)(options);
@@ -84512,7 +84009,7 @@ function getCachedDefaultHttpsClient() {
 
 /***/ }),
 
-/***/ 482:
+/***/ 483:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84521,8 +84018,8 @@ function getCachedDefaultHttpsClient() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetriableReadableStream = void 0;
-const abort_controller_1 = __nccwpck_require__(485);
-const node_stream_1 = __nccwpck_require__(422);
+const abort_controller_1 = __nccwpck_require__(486);
+const node_stream_1 = __nccwpck_require__(423);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -84650,21 +84147,6 @@ exports.RetriableReadableStream = RetriableReadableStream;
 
 /***/ }),
 
-/***/ 483:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(489);
-Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
-//# sourceMappingURL=index.js.map
-
-/***/ }),
-
 /***/ 484:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -84674,7 +84156,7 @@ Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function 
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(487);
+var AbortError_js_1 = __nccwpck_require__(490);
 Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
 //# sourceMappingURL=index.js.map
 
@@ -84696,6 +84178,21 @@ Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function 
 /***/ }),
 
 /***/ 486:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.AbortError = void 0;
+var AbortError_js_1 = __nccwpck_require__(489);
+Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 487:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -84745,44 +84242,6 @@ function isBlob(x) {
 0 && (0);
 //# sourceMappingURL=typeGuards.js.map
 
-
-/***/ }),
-
-/***/ 487:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AbortError = void 0;
-/**
- * This error is thrown when an asynchronous operation has been aborted.
- * Check for this error by testing the `name` that the name property of the
- * error matches `"AbortError"`.
- *
- * @example
- * ```ts
- * const controller = new AbortController();
- * controller.abort();
- * try {
- *   doAsyncWork(controller.signal)
- * } catch (e) {
- *   if (e.name === 'AbortError') {
- *     // handle abort error here.
- *   }
- * }
- * ```
- */
-class AbortError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = "AbortError";
-    }
-}
-exports.AbortError = AbortError;
-//# sourceMappingURL=AbortError.js.map
 
 /***/ }),
 
@@ -84863,399 +84322,40 @@ exports.AbortError = AbortError;
 /***/ }),
 
 /***/ 490:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+/***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
 
-// setup-soldr entry point. Owned by Agent 2.
-//
-// Replaces the composite action's main-phase steps with a single JS
-// orchestrator. Calls the helpers in src/lib/* in the same order the
-// composite's steps fire.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(242));
-const os = __importStar(__nccwpck_require__(375));
-const path = __importStar(__nccwpck_require__(497));
-const core = __importStar(__nccwpck_require__(450));
-const cache = __importStar(__nccwpck_require__(208));
-const log_utils_js_1 = __nccwpck_require__(345);
-const resolve_setup_js_1 = __nccwpck_require__(137);
-const phase_timing_js_1 = __nccwpck_require__(329);
-const ensure_rust_toolchain_js_1 = __nccwpck_require__(501);
-const ensure_soldr_js_1 = __nccwpck_require__(332);
-const verify_soldr_js_1 = __nccwpck_require__(351);
-const install_passthrough_js_1 = __nccwpck_require__(116);
-const normalize_source_mtime_js_1 = __nccwpck_require__(364);
-const detect_shared_target_warning_js_1 = __nccwpck_require__(212);
-const ensure_shims_js_1 = __nccwpck_require__(518);
-const cache_compress_js_1 = __nccwpck_require__(276);
-const stats_collector_js_1 = __nccwpck_require__(305);
-const TRUTHY = new Set(["1", "true", "yes", "on"]);
-const FALSY = new Set(["0", "false", "no", "off"]);
-function isTruthy(value) {
-    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
-}
-function isFalsy(value) {
-    return FALSY.has(((value ?? "").trim().toLowerCase()));
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
+exports.AbortError = void 0;
+/**
+ * This error is thrown when an asynchronous operation has been aborted.
+ * Check for this error by testing the `name` that the name property of the
+ * error matches `"AbortError"`.
+ *
+ * @example
+ * ```ts
+ * const controller = new AbortController();
+ * controller.abort();
+ * try {
+ *   doAsyncWork(controller.signal)
+ * } catch (e) {
+ *   if (e.name === 'AbortError') {
+ *     // handle abort error here.
+ *   }
+ * }
+ * ```
+ */
+class AbortError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "AbortError";
     }
 }
-function dirHasContent(p) {
-    try {
-        return fs.readdirSync(p).length > 0;
-    }
-    catch {
-        return false;
-    }
-}
-function buildActionContext() {
-    const env = process.env;
-    const logger = (0, log_utils_js_1.createLogger)(env);
-    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
-    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
-    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
-    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
-    const githubSha = env["GITHUB_SHA"]?.trim() || "";
-    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
-    const parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
-    return {
-        env: { ...env },
-        workspace,
-        runnerTemp,
-        runnerOs,
-        runnerArch,
-        githubSha,
-        githubToken,
-        parentSha,
-        logger,
-    };
-}
-async function restoreCacheSafe(paths, key, restoreKeys, logger) {
-    if (paths.length === 0 || !key) {
-        return { hit: false, matchedKey: "" };
-    }
-    try {
-        const matched = await cache.restoreCache(paths, key, restoreKeys);
-        return { hit: matched === key, matchedKey: matched ?? "" };
-    }
-    catch (err) {
-        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "" };
-    }
-}
-async function run() {
-    const ctx = buildActionContext();
-    const logger = ctx.logger;
-    await (0, phase_timing_js_1.markPhase)("action");
-    // ---- resolve ----
-    await (0, phase_timing_js_1.markPhase)("resolve");
-    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
-    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
-    await (0, resolve_setup_js_1.applyResolveResult)(result);
-    await (0, phase_timing_js_1.finishPhase)("resolve");
-    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
-    if (dryRun) {
-        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
-        await (0, phase_timing_js_1.finishPhase)("action");
-        return;
-    }
-    // Persist resolve state for the post-job step.
-    core.saveState("resolveResult", JSON.stringify(result));
-    core.saveState("buildCacheMode", result.buildCache.mode);
-    const statsMode = result.stats;
-    const debugMode = result.debugMode;
-    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
-    const statsCollector = new stats_collector_js_1.StatsCollector();
-    // ---- source-mtime-normalize ----
-    if (isTruthy(inputs.sourceMtimeNormalize)) {
-        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
-    }
-    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
-    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
-    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
-    core.saveState("setupCacheExactHit", "false");
-    core.saveState("setupCacheMatchedKey", "");
-    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
-    core.saveState("targetCacheExactHit", "false");
-    core.saveState("targetCacheMatchedKey", "");
-    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
-    core.saveState("buildCacheExactHit", "false");
-    core.saveState("buildCacheMatchedKey", "");
-    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
-    core.saveState("cargoRegistryCacheExactHit", "false");
-    core.saveState("cargoRegistryCacheMatchedKey", "");
-    // ---- setup-cache ----
-    await (0, phase_timing_js_1.markPhase)("setup-cache");
-    let setupCacheExactHit = false;
-    if (cacheEnabled && result.setupCache.paths.length > 0) {
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
-        setupCacheExactHit = restore.hit;
-        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("setup_cache_matched_key", restore.matchedKey);
-        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("setupCacheMatchedKey", restore.matchedKey);
-        // Expose for ensure_rust_toolchain to read via env (the python port did this).
-        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
-        statsCollector.record({
-            label: "setup-cache", operation: "restore", hit: restore.hit,
-            key: result.setupCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.setupCache.restorePrefix],
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    }
-    await (0, phase_timing_js_1.finishPhase)("setup-cache");
-    // ---- target-cache ----
-    await (0, phase_timing_js_1.markPhase)("target-cache");
-    if (result.targetCache.enabled) {
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        if (targetPaths.length > 0) {
-            const restoreKeys = [];
-            if (result.targetCache.restoreKeyParent)
-                restoreKeys.push(result.targetCache.restoreKeyParent);
-            if (result.targetCache.restoreKeyLock)
-                restoreKeys.push(result.targetCache.restoreKeyLock);
-            if (result.targetCache.restoreKeyLockfile)
-                restoreKeys.push(result.targetCache.restoreKeyLockfile);
-            const t0 = Date.now();
-            const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
-            core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
-            core.setOutput("target_cache_matched_key", restore.matchedKey);
-            core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
-            core.saveState("targetCacheMatchedKey", restore.matchedKey);
-            statsCollector.record({
-                label: "target-cache", operation: "restore", hit: restore.hit,
-                key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
-                archiveBytes: null, inflatedBytes: null, fileCount: null,
-                durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-            });
-            if (debugMode)
-                debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-        }
-    }
-    await (0, phase_timing_js_1.finishPhase)("target-cache");
-    // ---- build-cache ----
-    await (0, phase_timing_js_1.markPhase)("build-cache");
-    if (buildCacheEnabled) {
-        const buildCachePath = result.buildCache.path;
-        const archivePath = `${buildCachePath}.tar.zst`;
-        const restoreKeys = [];
-        if (result.buildCache.restoreKeyParent)
-            restoreKeys.push(result.buildCache.restoreKeyParent);
-        if (result.buildCache.restoreKeyToolchain)
-            restoreKeys.push(result.buildCache.restoreKeyToolchain);
-        if (result.buildCache.restoreKeyOsArch)
-            restoreKeys.push(result.buildCache.restoreKeyOsArch);
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe([archivePath, buildCachePath], result.buildCache.key, restoreKeys, logger);
-        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("build_cache_matched_key", restore.matchedKey);
-        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("buildCacheMatchedKey", restore.matchedKey);
-        let buildArchiveBytes = null;
-        let buildInflatedBytes = null;
-        let buildFileCount = null;
-        if (fileExists(archivePath)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-            if (magic === "zstd" || magic === "gzip") {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath, debug: debugMode, log: debugLog });
-                    buildArchiveBytes = dr.archiveBytes;
-                    buildInflatedBytes = dr.inflatedBytes;
-                    buildFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        statsCollector.record({
-            label: "build-cache", operation: "restore", hit: restore.hit,
-            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    }
-    await (0, phase_timing_js_1.finishPhase)("build-cache");
-    // ---- target-tree-cache (full mode) ----
-    await (0, phase_timing_js_1.markPhase)("target-tree");
-    // The bundle path is included in target-cache restore paths above when full
-    // mode is requested, so there's no separate restore here. We keep the phase
-    // marker for parity with the composite step ordering.
-    await (0, phase_timing_js_1.finishPhase)("target-tree");
-    // ---- toolchain ----
-    await (0, phase_timing_js_1.markPhase)("toolchain");
-    await (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({ resolveResult: result, setupCacheExactHit });
-    await (0, phase_timing_js_1.finishPhase)("toolchain");
-    // ---- install soldr ----
-    await (0, phase_timing_js_1.markPhase)("install");
-    if (result.enabled) {
-        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
-    }
-    else {
-        (0, install_passthrough_js_1.installPassthrough)({
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
-            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
-            "verbatim, and soldr-aware caching/observability is disabled.");
-    }
-    await (0, phase_timing_js_1.finishPhase)("install");
-    // Export SOLDR_BINARY so shims can exec it directly
-    core.exportVariable("SOLDR_BINARY", result.soldrPath);
-    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
-    // ---- shims ----
-    if (result.shimsEnabled) {
-        await (0, ensure_shims_js_1.ensureShims)({
-            shimsDir: result.shimsDir,
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-    }
-    // ---- verify ----
-    await (0, phase_timing_js_1.markPhase)("verify");
-    if (result.enabled) {
-        const verify = await (0, verify_soldr_js_1.verifySoldr)({
-            soldrPath: result.soldrPath,
-            buildCacheMode: result.buildCache.mode,
-            requireRustPlan: result.targetCache.enabled,
-        });
-        core.setOutput("soldr-version", verify.soldrVersion);
-        core.setOutput("soldr_version", verify.soldrVersion);
-    }
-    else {
-        core.setOutput("soldr-version", "passthrough");
-        core.setOutput("soldr_version", "passthrough");
-    }
-    await (0, phase_timing_js_1.finishPhase)("verify");
-    // ---- cargo-registry restore (if requested) ----
-    if (result.cargoRegistryCache.enabled) {
-        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe([registryArchive, result.cargoRegistryCache.path], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
-        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
-        let regArchiveBytes = null;
-        let regInflatedBytes = null;
-        let regFileCount = null;
-        if (fileExists(registryArchive)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
-            if (magic === "zstd" || magic === "gzip") {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({
-                        archivePath: registryArchive,
-                        targetDir: result.cargoRegistryCache.path,
-                        debug: debugMode, log: debugLog,
-                    });
-                    regArchiveBytes = dr.archiveBytes;
-                    regInflatedBytes = dr.inflatedBytes;
-                    regFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        statsCollector.record({
-            label: "cargo-registry", operation: "restore", hit: restore.hit,
-            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.cargoRegistryCache.restorePrefix],
-            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    }
-    // ---- shared-target warning ----
-    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
-        buildCacheEnabled,
-        effectiveTargetCacheEnabled: result.targetCache.enabled,
-        buildCacheMode: result.buildCache.mode,
-        targetDir: result.targetCache.targetPath,
-    });
-    // ---- stats report ----
-    statsCollector.report(statsMode, (msg) => logger.log(msg));
-    if (statsMode === "detailed") {
-        try {
-            await statsCollector.writeFiles(ctx.runnerTemp);
-            statsCollector.setGithubOutputs();
-        }
-        catch (err) {
-            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    core.saveState("statsCollector", statsCollector.serialize());
-    core.saveState("statsMode", statsMode);
-    core.saveState("compileCacheStats", result.compileCacheStats);
-    core.saveState("runnerTemp", ctx.runnerTemp);
-    await (0, phase_timing_js_1.finishPhase)("action");
-    // dirHasContent is exported for tests; suppress unused warning here.
-    void dirHasContent;
-}
-// Auto-invoke only when this module is run as the main entry point. This lets
-// tests import `run` (and helpers) without triggering the side-effectful
-// orchestration. The dist/main.js produced by ncc is invoked directly by the
-// Actions runtime so the check trips and the action executes normally.
-if (typeof process !== "undefined" &&
-    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
-    // import.meta.url is the file URL of this module; argv[1] is the runner
-    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
-    // the dev path — we rely on the env-var opt-out for tests instead.
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.setFailed(`setup-soldr failed: ${message}`);
-    });
-}
-
+exports.AbortError = AbortError;
+//# sourceMappingURL=AbortError.js.map
 
 /***/ }),
 
@@ -85268,8 +84368,8 @@ if (typeof process !== "undefined" &&
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQuickQueryStream = void 0;
-const node_stream_1 = __nccwpck_require__(422);
-const index_js_1 = __nccwpck_require__(327);
+const node_stream_1 = __nccwpck_require__(423);
+const index_js_1 = __nccwpck_require__(328);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -85415,13 +84515,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
-const os = __importStar(__nccwpck_require__(89));
+const os = __importStar(__nccwpck_require__(90));
 const path = __importStar(__nccwpck_require__(241));
 const pathHelper = __importStar(__nccwpck_require__(216));
-const assert_1 = __importDefault(__nccwpck_require__(515));
-const minimatch_1 = __nccwpck_require__(121);
-const internal_match_kind_1 = __nccwpck_require__(517);
-const internal_path_1 = __nccwpck_require__(117);
+const assert_1 = __importDefault(__nccwpck_require__(517));
+const minimatch_1 = __nccwpck_require__(122);
+const internal_match_kind_1 = __nccwpck_require__(519);
+const internal_path_1 = __nccwpck_require__(118);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, isImplicitPattern = false, segments, homedir) {
@@ -85853,6 +84953,184 @@ exports.BlobSASPermissions = BlobSASPermissions;
 /***/ }),
 
 /***/ 494:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Detect *-unknown-linux-musl cross compilers on PATH and return the
+// cc-rs env-var exports needed to make cc-rs find them.
+//
+// cc-rs strips the "-unknown-" segment from a Rust target triple when
+// probing for a cross compiler, so the cross-tools archives (which
+// ship binaries named with the full triple, e.g.
+// aarch64-unknown-linux-musl-gcc) are missed and cc-rs falls back to
+// the host gcc. The symptom is wheels/binaries that link against host
+// glibc's libgcc_s.so.1 and fail at runtime. Auto-exporting
+// CC_<triple>, CXX_<triple>, and AR_<triple> in snake-case from
+// setup-soldr fixes the build without forcing every consumer to edit
+// their workflow. See PR #111 for background.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.tripleToCcRsSuffix = tripleToCcRsSuffix;
+exports.detectMuslCcEnv = detectMuslCcEnv;
+const fs = __importStar(__nccwpck_require__(242));
+const path = __importStar(__nccwpck_require__(498));
+const MUSL_TRIPLE_RE = /^[a-z0-9_]+-unknown-linux-musl$/;
+function tripleToCcRsSuffix(triple) {
+    return triple.replace(/-/g, "_");
+}
+function findOnPathSync(env, cmd) {
+    const pathRaw = env["PATH"] ?? env["Path"] ?? "";
+    if (!pathRaw)
+        return null;
+    const sep = process.platform === "win32" ? ";" : ":";
+    const exts = process.platform === "win32" ? ["", ".exe"] : [""];
+    for (const dir of pathRaw.split(sep)) {
+        if (!dir)
+            continue;
+        for (const ext of exts) {
+            const candidate = path.join(dir, `${cmd}${ext}`);
+            try {
+                if (fs.statSync(candidate).isFile())
+                    return candidate;
+            }
+            catch {
+                // not present; continue
+            }
+        }
+    }
+    return null;
+}
+function scanPathForMuslTriples(env, readDir) {
+    const triples = new Set();
+    const pathRaw = env["PATH"] ?? env["Path"] ?? "";
+    if (!pathRaw)
+        return triples;
+    const sep = process.platform === "win32" ? ";" : ":";
+    const isWin = process.platform === "win32";
+    const tail = isWin ? /-unknown-linux-musl-gcc(?:\.exe)?$/i : /-unknown-linux-musl-gcc$/;
+    for (const dir of pathRaw.split(sep)) {
+        if (!dir)
+            continue;
+        let entries;
+        try {
+            entries = readDir(dir);
+        }
+        catch {
+            continue;
+        }
+        for (const entry of entries) {
+            const m = entry.match(tail);
+            if (!m)
+                continue;
+            const triple = entry.slice(0, entry.length - m[0].length) + "-unknown-linux-musl";
+            if (MUSL_TRIPLE_RE.test(triple))
+                triples.add(triple);
+        }
+    }
+    return triples;
+}
+/**
+ * Detect *-unknown-linux-musl cross compilers on PATH and return the
+ * cc-rs env-var exports needed to make cc-rs find them.
+ *
+ * Triples are sourced from: CARGO_BUILD_TARGET, any CARGO_TARGET_<T>_*
+ * env vars the user has already set, and PATH-scanning for
+ * `*-unknown-linux-musl-gcc` binaries. A triple is skipped when the user
+ * has already set any of CC_/CXX_/AR_<snake_triple>.
+ */
+function detectMuslCcEnv(env, deps) {
+    const find = deps?.findOnPath ?? ((cmd) => findOnPathSync(env, cmd));
+    const readDir = deps?.readDir ?? ((dir) => fs.readdirSync(dir));
+    const triples = new Set();
+    const cbt = (env["CARGO_BUILD_TARGET"] ?? "").trim();
+    if (cbt && MUSL_TRIPLE_RE.test(cbt))
+        triples.add(cbt);
+    // Cargo encodes triples by uppercasing and replacing `-` with `_`, so
+    // `x86_64-unknown-linux-musl` becomes `X86_64_UNKNOWN_LINUX_MUSL` — the
+    // reverse is ambiguous (the arch may contain a real underscore). Match on
+    // the fixed `_UNKNOWN_LINUX_MUSL_` suffix and treat the prefix as the
+    // verbatim arch name to round-trip safely.
+    for (const name of Object.keys(env)) {
+        const m = name.match(/^CARGO_TARGET_(.+?)_UNKNOWN_LINUX_MUSL_(LINKER|RUSTFLAGS|RUNNER)$/);
+        if (!m)
+            continue;
+        const arch = m[1].toLowerCase();
+        if (!/^[a-z0-9_]+$/.test(arch))
+            continue;
+        const triple = `${arch}-unknown-linux-musl`;
+        if (MUSL_TRIPLE_RE.test(triple))
+            triples.add(triple);
+    }
+    for (const t of scanPathForMuslTriples(env, readDir)) {
+        triples.add(t);
+    }
+    const out = [];
+    for (const triple of [...triples].sort()) {
+        const suffix = tripleToCcRsSuffix(triple);
+        const ccVar = `CC_${suffix}`;
+        const cxxVar = `CXX_${suffix}`;
+        const arVar = `AR_${suffix}`;
+        if ((env[ccVar] ?? "").trim() !== "")
+            continue;
+        if ((env[cxxVar] ?? "").trim() !== "")
+            continue;
+        if ((env[arVar] ?? "").trim() !== "")
+            continue;
+        const ccPath = find(`${triple}-gcc`);
+        const cxxPath = find(`${triple}-g++`);
+        const arPath = find(`${triple}-ar`);
+        if (!ccPath || !cxxPath || !arPath)
+            continue;
+        out.push({
+            triple,
+            exports: {
+                [ccVar]: `${triple}-gcc`,
+                [cxxVar]: `${triple}-g++`,
+                [arVar]: `${triple}-ar`,
+            },
+            resolvedPaths: { cc: ccPath, cxx: cxxPath, ar: arPath },
+        });
+    }
+    return out;
+}
+
+
+/***/ }),
+
+/***/ 495:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -85899,7 +85177,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 495:
+/***/ 496:
 /***/ ((module) => {
 
 "use strict";
@@ -85907,7 +85185,7 @@ module.exports = require("tls");
 
 /***/ }),
 
-/***/ 496:
+/***/ 497:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -85945,7 +85223,7 @@ function getRandomIntegerInclusive(min, max) {
 
 /***/ }),
 
-/***/ 497:
+/***/ 498:
 /***/ ((module) => {
 
 "use strict";
@@ -85953,7 +85231,7 @@ module.exports = require("node:path");
 
 /***/ }),
 
-/***/ 498:
+/***/ 499:
 /***/ ((module) => {
 
 "use strict";
@@ -85961,7 +85239,7 @@ module.exports = require("net");
 
 /***/ }),
 
-/***/ 499:
+/***/ 500:
 /***/ ((module) => {
 
 "use strict";
@@ -85969,21 +85247,21 @@ module.exports = require("timers");
 
 /***/ }),
 
-/***/ 500:
+/***/ 501:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Readable = __nccwpck_require__(125)
+const Readable = __nccwpck_require__(126)
 const {
   InvalidArgumentError,
   RequestAbortedError
-} = __nccwpck_require__(478)
+} = __nccwpck_require__(479)
 const util = __nccwpck_require__(68)
 const { getResolveErrorBodyCallback } = __nccwpck_require__(184)
-const { AsyncResource } = __nccwpck_require__(421)
-const { addSignal, removeSignal } = __nccwpck_require__(100)
+const { AsyncResource } = __nccwpck_require__(422)
+const { addSignal, removeSignal } = __nccwpck_require__(101)
 
 class RequestHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -86157,7 +85435,7 @@ module.exports.RequestHandler = RequestHandler
 
 /***/ }),
 
-/***/ 501:
+/***/ 502:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -86205,13 +85483,13 @@ exports.shouldRefreshToolchain = shouldRefreshToolchain;
 exports.shouldSkipRefreshForExactHit = shouldSkipRefreshForExactHit;
 exports.ensureRustToolchain = ensureRustToolchain;
 const fs = __importStar(__nccwpck_require__(242));
-const os = __importStar(__nccwpck_require__(375));
-const path = __importStar(__nccwpck_require__(497));
-const core = __importStar(__nccwpck_require__(450));
+const os = __importStar(__nccwpck_require__(376));
+const path = __importStar(__nccwpck_require__(498));
+const core = __importStar(__nccwpck_require__(451));
 const exec = __importStar(__nccwpck_require__(17));
 const io = __importStar(__nccwpck_require__(287));
-const tc = __importStar(__nccwpck_require__(511));
-const log_utils_js_1 = __nccwpck_require__(345);
+const tc = __importStar(__nccwpck_require__(512));
+const log_utils_js_1 = __nccwpck_require__(346);
 function rustupInitTargetTriple() {
     const system = process.platform;
     const arch = process.arch;
@@ -86494,7 +85772,7 @@ async function ensureRustToolchain(opts) {
 
 /***/ }),
 
-/***/ 502:
+/***/ 503:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -86515,8 +85793,8 @@ const runtime_1 = __nccwpck_require__(18);
 const rpc_output_stream_1 = __nccwpck_require__(299);
 const rpc_options_1 = __nccwpck_require__(286);
 const unary_call_1 = __nccwpck_require__(55);
-const server_streaming_call_1 = __nccwpck_require__(443);
-const client_streaming_call_1 = __nccwpck_require__(343);
+const server_streaming_call_1 = __nccwpck_require__(444);
+const client_streaming_call_1 = __nccwpck_require__(344);
 const duplex_streaming_call_1 = __nccwpck_require__(298);
 /**
  * Transport for testing.
@@ -86823,7 +86101,7 @@ class TestInputStream {
 
 /***/ }),
 
-/***/ 503:
+/***/ 504:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -86846,7 +86124,7 @@ Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: fu
 
 /***/ }),
 
-/***/ 504:
+/***/ 505:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /**
@@ -86855,15 +86133,15 @@ Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: fu
  */
 
 if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
-	module.exports = __nccwpck_require__(458);
+	module.exports = __nccwpck_require__(459);
 } else {
-	module.exports = __nccwpck_require__(449);
+	module.exports = __nccwpck_require__(450);
 }
 
 
 /***/ }),
 
-/***/ 505:
+/***/ 506:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -86878,10 +86156,10 @@ const {
   makeIterator,
   isValidHeaderName,
   isValidHeaderValue
-} = __nccwpck_require__(506)
-const util = __nccwpck_require__(120)
-const { webidl } = __nccwpck_require__(448)
-const assert = __nccwpck_require__(515)
+} = __nccwpck_require__(507)
+const util = __nccwpck_require__(121)
+const { webidl } = __nccwpck_require__(449)
+const assert = __nccwpck_require__(517)
 
 const kHeadersMap = Symbol('headers map')
 const kHeadersSortedMap = Symbol('headers map sorted')
@@ -87464,17 +86742,17 @@ module.exports = {
 
 /***/ }),
 
-/***/ 506:
+/***/ 507:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(29)
-const { getGlobalOrigin } = __nccwpck_require__(136)
+const { getGlobalOrigin } = __nccwpck_require__(137)
 const { performance } = __nccwpck_require__(313)
 const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(68)
-const assert = __nccwpck_require__(515)
+const assert = __nccwpck_require__(517)
 const { isUint8Array } = __nccwpck_require__(193)
 
 let supportedHashes = []
@@ -88616,7 +87894,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 507:
+/***/ 508:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -88692,7 +87970,7 @@ exports.Mutex = Mutex;
 
 /***/ }),
 
-/***/ 508:
+/***/ 509:
 /***/ ((module) => {
 
 "use strict";
@@ -88700,15 +87978,15 @@ module.exports = require("node:zlib");
 
 /***/ }),
 
-/***/ 509:
+/***/ 510:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(480);
+module.exports = __nccwpck_require__(481);
 
 
 /***/ }),
 
-/***/ 510:
+/***/ 511:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -88753,7 +88031,7 @@ function throttlingRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 511:
+/***/ 512:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -88792,18 +88070,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.evaluateVersions = exports.isExplicitVersion = exports.findFromManifest = exports.getManifestFromRepo = exports.findAllVersions = exports.find = exports.cacheFile = exports.cacheDir = exports.extractZip = exports.extractXar = exports.extractTar = exports.extract7z = exports.downloadTool = exports.HTTPError = void 0;
-const core = __importStar(__nccwpck_require__(450));
+const core = __importStar(__nccwpck_require__(451));
 const io = __importStar(__nccwpck_require__(287));
 const crypto = __importStar(__nccwpck_require__(284));
-const fs = __importStar(__nccwpck_require__(520));
-const mm = __importStar(__nccwpck_require__(323));
-const os = __importStar(__nccwpck_require__(89));
+const fs = __importStar(__nccwpck_require__(522));
+const mm = __importStar(__nccwpck_require__(324));
+const os = __importStar(__nccwpck_require__(90));
 const path = __importStar(__nccwpck_require__(241));
 const httpm = __importStar(__nccwpck_require__(278));
 const semver = __importStar(__nccwpck_require__(174));
-const stream = __importStar(__nccwpck_require__(127));
-const util = __importStar(__nccwpck_require__(120));
-const assert_1 = __nccwpck_require__(515);
+const stream = __importStar(__nccwpck_require__(128));
+const util = __importStar(__nccwpck_require__(121));
+const assert_1 = __nccwpck_require__(517);
 const exec_1 = __nccwpck_require__(17);
 const retry_helper_1 = __nccwpck_require__(9);
 class HTTPError extends Error {
@@ -89426,7 +88704,7 @@ function _unique(values) {
 
 /***/ }),
 
-/***/ 512:
+/***/ 513:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -89452,7 +88730,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(388);
+var import_exponentialRetryStrategy = __nccwpck_require__(389);
 var import_retryPolicy = __nccwpck_require__(15);
 var import_constants = __nccwpck_require__(47);
 const exponentialRetryPolicyName = "exponentialRetryPolicy";
@@ -89476,7 +88754,7 @@ function exponentialRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 513:
+/***/ 514:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -89690,7 +88968,7 @@ function createEmptyPipeline() {
 
 /***/ }),
 
-/***/ 514:
+/***/ 515:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -89699,7 +88977,7 @@ function createEmptyPipeline() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SASQueryParameters = exports.SASProtocol = void 0;
-const SasIPRange_js_1 = __nccwpck_require__(352);
+const SasIPRange_js_1 = __nccwpck_require__(353);
 const utils_common_js_1 = __nccwpck_require__(151);
 /**
  * Protocols for generated SAS.
@@ -90064,7 +89342,802 @@ exports.SASQueryParameters = SASQueryParameters;
 
 /***/ }),
 
-/***/ 515:
+/***/ 516:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Top-level resolve-setup entry point. Owned by Agent 1.
+//
+// Full port of resolve_setup.py::main(). Reads INPUT_* / GITHUB_* env vars,
+// resolves the toolchain spec, derives all cache keys, computes the env
+// exports + outputs the orchestrator needs.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.buildOutputs = exports.detectMuslCcEnv = void 0;
+exports.readRawInputs = readRawInputs;
+exports.parseCacheShutdownOnIdleSeconds = parseCacheShutdownOnIdleSeconds;
+exports.detectUserLinkerEnv = detectUserLinkerEnv;
+exports.resolveSetup = resolveSetup;
+exports.applyResolveResult = applyResolveResult;
+exports.pythonDefaultJson = pythonDefaultJson;
+const os = __importStar(__nccwpck_require__(376));
+const path = __importStar(__nccwpck_require__(498));
+const fs = __importStar(__nccwpck_require__(242));
+const core = __importStar(__nccwpck_require__(451));
+const cache_keys_js_1 = __nccwpck_require__(161);
+const log_utils_js_1 = __nccwpck_require__(346);
+const detect_musl_cc_js_1 = __nccwpck_require__(494);
+Object.defineProperty(exports, "detectMuslCcEnv", ({ enumerable: true, get: function () { return detect_musl_cc_js_1.detectMuslCcEnv; } }));
+const build_outputs_js_1 = __nccwpck_require__(319);
+Object.defineProperty(exports, "buildOutputs", ({ enumerable: true, get: function () { return build_outputs_js_1.buildOutputs; } }));
+const toolchain_js_1 = __nccwpck_require__(360);
+const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
+const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
+const ALLOWED_LINKER_VALUES = [
+    "default",
+    "platform-default",
+    "ld",
+    "mold",
+    "rust-lld",
+    "fast",
+];
+// CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
+// FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
+// causes "failed to connect to jobserver" warnings in every downstream step.
+// See setup-soldr#71.
+const GITHUB_ENV_DENY_LIST = new Set(["CARGO_MAKEFLAGS", "MAKEFLAGS"]);
+function expanduser(p, env) {
+    if (!p)
+        return p;
+    if (p.startsWith("~")) {
+        const home = env["HOME"] || env["USERPROFILE"] || "";
+        if (p === "~")
+            return home;
+        if (p.startsWith("~/") || p.startsWith("~\\")) {
+            return path.join(home, p.slice(2));
+        }
+    }
+    return p;
+}
+function resolveAbsolute(p, env) {
+    return path.resolve(expanduser(p, env));
+}
+function readRawInputs(env) {
+    const get = (name) => env[`INPUT_${name}`] ?? "";
+    return {
+        enable: get("ENABLE"),
+        version: get("VERSION"),
+        repo: get("REPO"),
+        ref: get("REF"),
+        cache: get("CACHE"),
+        cacheDir: get("CACHE_DIR"),
+        cacheKeySuffix: get("CACHE_KEY_SUFFIX"),
+        toolchain: get("TOOLCHAIN"),
+        toolchainFile: get("TOOLCHAIN_FILE"),
+        trustMode: get("TRUST_MODE"),
+        linker: get("LINKER"),
+        compilePriority: get("COMPILE_PRIORITY"),
+        timestamps: get("TIMESTAMPS"),
+        lockfile: get("LOCKFILE"),
+        buildCache: get("BUILD_CACHE"),
+        buildCacheMode: get("BUILD_CACHE_MODE"),
+        targetCache: get("TARGET_CACHE"),
+        targetCacheMode: get("TARGET_CACHE_MODE"),
+        targetDir: get("TARGET_DIR"),
+        targetCacheProfile: get("TARGET_CACHE_PROFILE"),
+        targetCacheStripDebuginfo: get("TARGET_CACHE_STRIP_DEBUGINFO"),
+        targetCacheIncludeIncremental: get("TARGET_CACHE_INCLUDE_INCREMENTAL"),
+        targetCacheIncludeBuildScriptBinaries: get("TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES"),
+        targetCacheCompress: get("TARGET_CACHE_COMPRESS"),
+        targetCacheCompressLevel: get("TARGET_CACHE_COMPRESS_LEVEL"),
+        sourceMtimeNormalize: get("SOURCE_MTIME_NORMALIZE"),
+        cargoRegistryCache: get("CARGO_REGISTRY_CACHE"),
+        compileCacheStats: get("COMPILE_CACHE_STATS"),
+        shims: get("SHIMS"),
+        stats: get("STATS"),
+        debugMode: get("DEBUG"),
+        cacheShutdownOnIdle: get("CACHE_SHUTDOWN_ON_IDLE"),
+    };
+}
+/**
+ * Parse the `cache-shutdown-on-idle` input into a seconds count.
+ *
+ * Accepts:
+ *   - "" / "0" / "off" / "false" / "no" → null (disabled)
+ *   - bare integer ("30")               → that many seconds
+ *   - "<N>s" / "<N>m" / "<N>h"          → seconds / minutes / hours
+ *
+ * Throws on any other value so misspellings ("30sec", "thirty") surface
+ * loudly at action start rather than silently being treated as "off".
+ */
+function parseCacheShutdownOnIdleSeconds(raw) {
+    const value = raw.trim().toLowerCase();
+    if (value === "" || value === "0" || value === "off" || value === "false" || value === "no") {
+        return null;
+    }
+    const m = value.match(/^(\d+)\s*(s|m|h)?$/);
+    if (!m) {
+        throw new Error(`invalid 'cache-shutdown-on-idle' input: '${raw}'. ` +
+            "Expected <seconds>, <N>s, <N>m, <N>h, or empty/off/false to disable.");
+    }
+    const n = parseInt(m[1], 10);
+    if (!Number.isFinite(n) || n < 0) {
+        throw new Error(`invalid 'cache-shutdown-on-idle' input: '${raw}'.`);
+    }
+    const unit = m[2] ?? "s";
+    if (unit === "s")
+        return n;
+    if (unit === "m")
+        return n * 60;
+    return n * 3600;
+}
+/**
+ * Detect cross-compile env vars the user has already set that soldr's
+ * `linker: fast` default would silently overwrite (CARGO_TARGET_<TRIPLE>_LINKER
+ * and CARGO_TARGET_<TRIPLE>_RUSTFLAGS). Returns the list of `NAME=value`
+ * strings to surface in the deferral log. See issue #108.
+ */
+function detectUserLinkerEnv(env) {
+    const hits = [];
+    for (const [name, raw] of Object.entries(env)) {
+        if (raw === undefined || raw === "")
+            continue;
+        if (!name.startsWith("CARGO_TARGET_"))
+            continue;
+        if (name.endsWith("_LINKER") || name.endsWith("_RUSTFLAGS")) {
+            hits.push(`${name}=${raw}`);
+        }
+    }
+    hits.sort();
+    return hits;
+}
+function normalizeStatsMode(raw) {
+    const v = raw.trim().toLowerCase();
+    if (v === "none" || v === "summarize" || v === "detailed")
+        return v;
+    return "summarize";
+}
+function normalizeCompileCacheStats(raw) {
+    const v = raw.trim().toLowerCase();
+    if (v === "none")
+        return "none";
+    if (v === "detailed" || v === "insights")
+        return "detailed";
+    return "summarize";
+}
+function isFalsy(value) {
+    return FALSY_VALUES.has(value.trim().toLowerCase());
+}
+function isTruthy(value) {
+    return TRUTHY_VALUES.has(value.trim().toLowerCase());
+}
+function defaultHomeDir(env, name) {
+    const home = env["HOME"] || env["USERPROFILE"] || os.homedir();
+    return path.resolve(path.join(home, name));
+}
+function makeDirs(...paths) {
+    for (const p of paths) {
+        fs.mkdirSync(p, { recursive: true });
+    }
+}
+async function fetchReleaseTagDefault(repo, version, env) {
+    if (version) {
+        // For explicit (non-latest) versions, return as-is. Caller normalizes.
+        return "";
+    }
+    const url = `https://api.github.com/repos/${repo}/releases/latest`;
+    const headers = {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "setup-soldr-action",
+    };
+    const token = (env["GITHUB_TOKEN"] ?? "").trim() || (env["INPUT_TOKEN"] ?? "").trim();
+    if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 10_000);
+    try {
+        const response = await fetch(url, { headers, signal: controller.signal });
+        if (!response.ok) {
+            throw new Error(`GitHub API returned HTTP ${response.status} for ${repo}`);
+        }
+        const payload = (await response.json());
+        if (typeof payload !== "object" || payload === null) {
+            throw new Error(`unexpected GitHub release payload for ${repo}`);
+        }
+        const tag = payload["tag_name"];
+        const tagName = typeof tag === "string" ? tag.trim() : "";
+        if (!tagName) {
+            throw new Error(`failed to resolve latest soldr release tag from ${repo}`);
+        }
+        return tagName;
+    }
+    finally {
+        clearTimeout(timer);
+    }
+}
+async function resolveSoldrReleaseVersion(repo, version, ref, env, deps) {
+    if (ref.trim()) {
+        return "";
+    }
+    const requested = version.trim();
+    if (requested && requested.toLowerCase() !== "latest") {
+        return requested.startsWith("v") ? requested : `v${requested}`;
+    }
+    const fetcher = deps?.fetchReleaseTag ?? fetchReleaseTagDefault;
+    const tagName = await fetcher(repo, "", env);
+    if (!tagName) {
+        throw new Error(`failed to resolve latest soldr release tag from ${repo}`);
+    }
+    return tagName;
+}
+/**
+ * Resolve setup state. The orchestrator calls this once at the start of the
+ * action and uses the returned ResolveResult to drive every subsequent step.
+ */
+async function resolveSetup(ctx, inputs, deps) {
+    const env = { ...ctx.env };
+    // ---- timing seed ----
+    const logStart = String(Math.floor(Date.now() / 1000));
+    const timestamps = (inputs.timestamps && inputs.timestamps.trim()) || "true";
+    env["SETUP_SOLDR_LOG_START_EPOCH"] = logStart;
+    env["SETUP_SOLDR_TIMESTAMPS"] = timestamps;
+    const logger = ctx.logger ?? (0, log_utils_js_1.createLogger)(env);
+    const log = (msg) => logger.log(msg);
+    if (!ctx.workspace) {
+        throw new Error("ACTION_WORKSPACE / ctx.workspace must be set");
+    }
+    const workspace = path.resolve(ctx.workspace);
+    const runnerTemp = ctx.runnerTemp
+        ? path.resolve(ctx.runnerTemp)
+        : path.resolve(path.join(workspace, ".tmp"));
+    // ---- cache roots ----
+    const requestedCacheDir = inputs.cacheDir.trim();
+    const cacheRoot = requestedCacheDir
+        ? resolveAbsolute(requestedCacheDir, env)
+        : path.resolve(path.join(runnerTemp, "setup-soldr"));
+    const soldrRoot = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-soldr`);
+    const cargoHomeInput = (env["CARGO_HOME"] ?? "").trim();
+    const cargoHome = cargoHomeInput
+        ? resolveAbsolute(cargoHomeInput, env)
+        : defaultHomeDir(env, ".cargo");
+    const binDir = path.join(cacheRoot, "bin");
+    const setupCachePath = cacheRoot;
+    const soldrBinCachePath = path.join(soldrRoot, "bin");
+    const zccacheCacheDir = path.join(soldrRoot, "cache", "zccache");
+    const thinTargetCacheBundlePath = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-target-thin`);
+    // When the action is disabled (`enable: false`), we write a script-based
+    // passthrough stub at soldrPath instead of installing the real binary.
+    // The stub is a bash script on Unix and a .cmd shim on Windows — Windows
+    // cannot spawn a script via the .exe extension without a real PE, so
+    // soldrPath must end in .cmd in passthrough mode.
+    const enableRaw = inputs.enable.trim() || "true";
+    if (!TRUTHY_VALUES.has(enableRaw.toLowerCase()) && !FALSY_VALUES.has(enableRaw.toLowerCase())) {
+        throw new Error(`invalid 'enable' input: '${enableRaw}'. Allowed: true | false`);
+    }
+    const enabled = !FALSY_VALUES.has(enableRaw.toLowerCase());
+    const soldrBinary = enabled
+        ? process.platform === "win32"
+            ? "soldr.exe"
+            : "soldr"
+        : process.platform === "win32"
+            ? "soldr.cmd"
+            : "soldr";
+    const soldrPath = path.join(binDir, soldrBinary);
+    // ---- toolchain ----
+    const toolchain = await (0, toolchain_js_1.loadToolchainSpec)({
+        workspace,
+        toolchainFile: inputs.toolchainFile || "rust-toolchain.toml",
+        toolchainOverride: inputs.toolchain,
+        log,
+    });
+    // ---- rustup home selection ----
+    const explicitRustupHome = (env["RUSTUP_HOME"] ?? "").trim();
+    let rustupHome;
+    let rustupStrategy;
+    if (explicitRustupHome) {
+        rustupHome = resolveAbsolute(explicitRustupHome, env);
+        rustupStrategy = "explicit";
+    }
+    else {
+        const runnerRustupHome = defaultHomeDir(env, ".rustup");
+        let satisfied = false;
+        if (deps?.systemRustupOverride) {
+            satisfied = await deps.systemRustupOverride(cargoHome, runnerRustupHome, toolchain);
+        }
+        else {
+            satisfied = await (0, toolchain_js_1.systemRustupSatisfiesRequest)({
+                cargoHome,
+                rustupHome: runnerRustupHome,
+                toolchain,
+                env,
+                logger,
+                deps: deps?.systemRustup,
+            });
+        }
+        if (satisfied) {
+            rustupHome = runnerRustupHome;
+            rustupStrategy = "system";
+        }
+        else {
+            rustupHome = path.join(cacheRoot, "rustup-home");
+            rustupStrategy = "managed";
+        }
+    }
+    const setupCachePathsList = (0, cache_keys_js_1.setupCachePaths)(setupCachePath, binDir, soldrBinCachePath, rustupHome);
+    const setupCacheLayoutValue = (0, cache_keys_js_1.setupCacheLayout)(setupCachePath, rustupHome);
+    for (const dir of [
+        cacheRoot,
+        soldrRoot,
+        path.join(soldrRoot, "cache"),
+        soldrBinCachePath,
+        cargoHome,
+        path.join(cargoHome, "bin"),
+        rustupHome,
+        binDir,
+        zccacheCacheDir,
+        thinTargetCacheBundlePath,
+    ]) {
+        makeDirs(dir);
+    }
+    const soldrRepo = inputs.repo.trim() || "zackees/soldr";
+    const soldrRef = inputs.ref.trim();
+    const soldrVersionRequested = inputs.version.trim();
+    const soldrVersionResolved = await resolveSoldrReleaseVersion(soldrRepo, soldrVersionRequested, soldrRef, env, deps);
+    const toolchainSignature = {
+        channel: toolchain.cacheChannel,
+        profile: toolchain.profile,
+        components: toolchain.components,
+        targets: toolchain.targets,
+        source: toolchain.source,
+        file_hash: toolchain.fileHash,
+        setup_cache_layout: setupCacheLayoutValue,
+        soldr_repo: soldrRepo,
+        soldr_ref: soldrRef || "release",
+        soldr_version: soldrVersionResolved || soldrRef || "source-ref",
+    };
+    // Python uses json.dumps(sort_keys=True) without compact separators here,
+    // so canonical_json_stringify is wrong; mirror Python's default separators
+    // (", " and ": ") to match byte-for-byte.
+    const signatureString = pythonDefaultJson(toolchainSignature);
+    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 267, 23));
+    const digest = createHash("sha256").update(signatureString, "utf8").digest("hex").slice(0, 16);
+    const runnerOs = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_OS"] ?? process.platform).toLowerCase());
+    const runnerArch = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_ARCH"] ?? "unknown").toLowerCase());
+    const cachePrefix = `setup-soldr-v4-${runnerOs}-${runnerArch}`;
+    let cacheKey = `${cachePrefix}-${digest}`;
+    const wsManifestHash = await (0, cache_keys_js_1.workspaceManifestHash)(workspace);
+    const cargoConfigHashValue = await (0, cache_keys_js_1.cargoConfigHash)(workspace);
+    const suffix = inputs.cacheKeySuffix.trim();
+    const sanitizedSuffix = suffix ? (0, cache_keys_js_1.sanitizeFragment)(suffix) : "";
+    if (suffix) {
+        cacheKey = `${cacheKey}-${sanitizedSuffix}`;
+    }
+    // ---- build cache ----
+    const githubSha = (env["GITHUB_SHA"] ?? "").trim() || "nosha";
+    let parentSha = (env["ACTION_PARENT_SHA"] ?? "").trim();
+    if (parentSha === githubSha) {
+        parentSha = "";
+    }
+    const buildCachePrefix = `setup-soldr-buildcache-v2-${runnerOs}-${runnerArch}`;
+    const buildCacheToolchainPrefix = `${buildCachePrefix}-${digest}-`;
+    let buildCacheKey = `${buildCacheToolchainPrefix}${githubSha}`;
+    let buildCacheParentKey = parentSha ? `${buildCacheToolchainPrefix}${parentSha}` : "";
+    // ---- target cache ----
+    const targetDirInput = inputs.targetDir.trim() || "target";
+    let targetCachePath = expanduser(targetDirInput, env);
+    if (!path.isAbsolute(targetCachePath)) {
+        targetCachePath = path.join(workspace, targetCachePath);
+    }
+    targetCachePath = path.resolve(targetCachePath);
+    makeDirs(targetCachePath);
+    const lockfilePath = (0, cache_keys_js_1.resolveLockfilePath)(workspace, targetCachePath, inputs.lockfile);
+    const cargoLockHash = lockfilePath ? await (0, cache_keys_js_1.shortFileHash)(lockfilePath, "no-lock") : "no-lock";
+    const legacyTargetCacheModeInput = inputs.targetCacheMode;
+    const legacyTargetCacheMode = (0, cache_keys_js_1.normalizeLegacyTargetCacheMode)(legacyTargetCacheModeInput, log);
+    const targetCacheProfile = (0, cache_keys_js_1.normalizeTargetCacheProfile)(inputs.targetCacheProfile);
+    const targetCacheInputRaw = inputs.targetCache.trim() || "true";
+    const targetCacheRequested = !isFalsy(targetCacheInputRaw) && legacyTargetCacheMode !== "off";
+    const explicitBuildCacheMode = inputs.buildCacheMode.trim();
+    const buildCacheMode = (0, cache_keys_js_1.normalizeBuildCacheMode)(inputs.buildCacheMode, legacyTargetCacheModeInput, !explicitBuildCacheMode && targetCacheRequested, log);
+    const buildCacheInputRaw = inputs.buildCache.trim() || "true";
+    const buildCacheEnabled = !isFalsy(buildCacheInputRaw);
+    const buildCacheRuntimeMode = buildCacheMode === "once" ? "full" : buildCacheMode;
+    let targetCacheEnabled = buildCacheEnabled && targetCacheRequested;
+    if (buildCacheMode === "thin" && cargoLockHash === "no-lock") {
+        log("build-cache-mode 'thin' requires Cargo.lock; target artifact cache disabled.");
+        targetCacheEnabled = false;
+    }
+    const [targetCacheBudgetBytes, targetCacheBudgetFiles] = (0, cache_keys_js_1.targetCacheSoftBudget)(targetCacheEnabled, buildCacheMode);
+    const targetShapeHash = (0, cache_keys_js_1.shortJsonHash)({
+        target_dir: targetCachePath,
+        target_dir_input: targetDirInput,
+        target_env: (0, cache_keys_js_1.targetEnvHash)(env),
+    });
+    const targetInputsHash = (0, cache_keys_js_1.shortJsonHash)({
+        cargo_config: cargoConfigHashValue,
+        cargo_lock: cargoLockHash,
+        manifest: wsManifestHash,
+        target_shape: targetShapeHash,
+        toolchain: digest,
+    });
+    const lockfileOnlyHash = (0, cache_keys_js_1.shortJsonHash)({
+        cargo_lock: cargoLockHash,
+        toolchain: digest,
+    });
+    const targetCacheBundlePath = thinTargetCacheBundlePath;
+    const targetTreeCacheEnabled = targetCacheEnabled && buildCacheMode === "full";
+    let targetCachePaths;
+    let targetCacheEffectiveMode;
+    let targetCachePrefix;
+    let targetCacheLockPrefix;
+    let targetCacheLockfilePrefix;
+    let targetCacheKey;
+    let targetCacheParentKey;
+    if (!targetCacheEnabled) {
+        targetCachePaths = "";
+        targetCacheEffectiveMode = "off";
+        targetCachePrefix = `setup-soldr-targetcache-off-v1-${runnerOs}-${runnerArch}`;
+        targetCacheLockPrefix = "";
+        targetCacheLockfilePrefix = "";
+        targetCacheKey = `${targetCachePrefix}-${targetInputsHash}`;
+        targetCacheParentKey = "";
+    }
+    else if (targetTreeCacheEnabled) {
+        targetCachePaths = [targetCachePath, targetCacheBundlePath].join("\n");
+        targetCacheEffectiveMode = buildCacheMode;
+        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v1-${runnerOs}-${runnerArch}`;
+        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
+        targetCacheLockPrefix = `${targetCachePrefix}-${digest}-${cargoLockHash}-${targetShapeHash}-${sf}`;
+        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
+        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
+        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
+    }
+    else {
+        targetCachePaths = targetCacheBundlePath;
+        targetCacheEffectiveMode = buildCacheMode;
+        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v1-${runnerOs}-${runnerArch}`;
+        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
+        targetCacheLockPrefix = `${targetCachePrefix}-${targetInputsHash}-${sf}`;
+        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
+        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
+        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
+    }
+    if (suffix) {
+        buildCacheKey = `${buildCacheKey}-${sanitizedSuffix}`;
+        if (buildCacheParentKey) {
+            buildCacheParentKey = `${buildCacheParentKey}-${sanitizedSuffix}`;
+        }
+    }
+    // ---- cargo registry cache ----
+    const cargoRegistryCacheRequested = isTruthy(inputs.cargoRegistryCache.trim() || "true");
+    const cargoRegistryCachePath = path.join(cargoHome, "registry");
+    const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-v1-${runnerOs}-${runnerArch}`;
+    const cargoRegistryCacheRestorePrefix = `${cargoRegistryCachePrefix}-${cargoLockHash}-`;
+    let cargoRegistryCacheKey = `${cargoRegistryCacheRestorePrefix}${digest}-${githubSha}`;
+    if (suffix) {
+        cargoRegistryCacheKey = `${cargoRegistryCacheKey}-${sanitizedSuffix}`;
+    }
+    const cargoRegistryCacheEnabled = cargoRegistryCacheRequested;
+    if (cargoRegistryCacheEnabled) {
+        makeDirs(cargoRegistryCachePath);
+    }
+    // ---- env exports ----
+    const cacheShutdownOnIdleSeconds = parseCacheShutdownOnIdleSeconds(inputs.cacheShutdownOnIdle);
+    const envExports = {};
+    const setEnv = (name, value) => {
+        if (GITHUB_ENV_DENY_LIST.has(name))
+            return;
+        envExports[name] = value;
+    };
+    setEnv("SOLDR_CACHE_DIR", soldrRoot);
+    setEnv("CARGO_HOME", cargoHome);
+    setEnv("RUSTUP_HOME", rustupHome);
+    setEnv("ZCCACHE_CACHE_DIR", zccacheCacheDir);
+    setEnv("SETUP_SOLDR_BUILD_CACHE_MODE", buildCacheMode);
+    setEnv("SOLDR_BUILD_CACHE_MODE", buildCacheRuntimeMode);
+    setEnv("SOLDR_TARGET_CACHE_MODE", targetCacheEnabled ? buildCacheRuntimeMode : "off");
+    setEnv("SOLDR_TARGET_CACHE_DIR", targetCachePath);
+    setEnv("SOLDR_TARGET_CACHE_BUNDLE_DIR", targetCacheBundlePath);
+    setEnv("SOLDR_TARGET_CACHE_PROFILE", targetCacheProfile);
+    const stripDebug = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-strip-debuginfo", inputs.targetCacheStripDebuginfo);
+    if (stripDebug !== null) {
+        setEnv("SOLDR_TARGET_CACHE_STRIP_DEBUGINFO", stripDebug);
+    }
+    const includeIncremental = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-incremental", inputs.targetCacheIncludeIncremental);
+    if (includeIncremental !== null) {
+        setEnv("SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL", includeIncremental);
+    }
+    const includeBuildScripts = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-build-script-binaries", inputs.targetCacheIncludeBuildScriptBinaries);
+    if (includeBuildScripts !== null) {
+        setEnv("SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES", includeBuildScripts);
+    }
+    const targetCacheCompress = (0, cache_keys_js_1.normalizeTargetCacheCompress)(inputs.targetCacheCompress);
+    const targetCacheCompressLevel = (0, cache_keys_js_1.normalizeTargetCacheCompressLevel)(inputs.targetCacheCompressLevel);
+    setEnv("SOLDR_TARGET_CACHE_COMPRESS", targetCacheCompress);
+    setEnv("SOLDR_TARGET_CACHE_COMPRESS_LEVEL", targetCacheCompressLevel);
+    if (cargoRegistryCacheEnabled) {
+        setEnv("SOLDR_SKIP_CARGO_REGISTRY_SAVE", "1");
+    }
+    setEnv("SOLDR_TARGET_CACHE_BACKEND", "local");
+    setEnv("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain.channel);
+    setEnv("SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL", toolchain.cacheChannel);
+    setEnv("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain.profile);
+    setEnv("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", JSON.stringify(toolchain.components));
+    setEnv("SETUP_SOLDR_TOOLCHAIN_TARGETS", JSON.stringify(toolchain.targets));
+    setEnv("SETUP_SOLDR_LOG_START_EPOCH", logStart);
+    setEnv("SETUP_SOLDR_TIMESTAMPS", timestamps);
+    if (!FALSY_VALUES.has(timestamps.toLowerCase()) && env["NO_COLOR"] === undefined) {
+        if (!env["CARGO_TERM_COLOR"])
+            setEnv("CARGO_TERM_COLOR", "always");
+        if (!env["CLICOLOR_FORCE"])
+            setEnv("CLICOLOR_FORCE", "1");
+        if (!env["FORCE_COLOR"])
+            setEnv("FORCE_COLOR", "1");
+    }
+    if (inputs.trustMode.trim()) {
+        setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
+    }
+    const linkerRaw = inputs.linker.trim();
+    if (linkerRaw === "") {
+        const preset = detectUserLinkerEnv(env);
+        if (preset.length > 0) {
+            logger.info(`setup-soldr: deferring to user-set ${preset.join(", ")}; skipping default SOLDR_LINKER=fast injection. See https://github.com/zackees/setup-soldr/issues/108`);
+        }
+        else {
+            setEnv("SOLDR_LINKER", "fast");
+            logger.warning("setup-soldr: defaulting SOLDR_LINKER=fast (mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows) for faster CI links. Soldr's native default is no injection, which produces a smaller build-cache and a slower link. Set `linker: platform-default` to opt out and keep cargo/rust-toolchain.toml in charge, or set `linker: <value>` to silence this warning.");
+        }
+    }
+    else if (!ALLOWED_LINKER_VALUES.includes(linkerRaw)) {
+        throw new Error(`invalid 'linker' input: '${linkerRaw}'. Allowed: default | platform-default | ld | mold | rust-lld | fast`);
+    }
+    else if (linkerRaw !== "default" && linkerRaw !== "platform-default") {
+        setEnv("SOLDR_LINKER", linkerRaw);
+    }
+    const compilePriorityRaw = inputs.compilePriority.trim();
+    if (compilePriorityRaw !== "") {
+        setEnv("ZCCACHE_COMPILE_PRIORITY", compilePriorityRaw);
+    }
+    if (cacheShutdownOnIdleSeconds !== null) {
+        // Set both env vars. zccache reads its own, sccache reads the
+        // SCCACHE_-prefixed one; exporting both means a zccache fork that
+        // still honors only the sccache name keeps working, and a vanilla
+        // sccache invoked via this action would too.
+        const seconds = String(cacheShutdownOnIdleSeconds);
+        setEnv("ZCCACHE_IDLE_TIMEOUT", seconds);
+        setEnv("SCCACHE_IDLE_TIMEOUT", seconds);
+    }
+    // Auto-export cc-rs cross-compile env for *-unknown-linux-musl triples
+    // when the matching `<triple>-gcc/g++/ar` binaries are on PATH. cc-rs
+    // strips the "-unknown-" segment when looking up cross compilers, so
+    // archives that ship binaries with the full triple are missed without
+    // these per-target overrides. See setup-soldr#... and the cc-rs docs.
+    const muslCcHits = (0, detect_musl_cc_js_1.detectMuslCcEnv)(env);
+    for (const hit of muslCcHits) {
+        const suffix = (0, detect_musl_cc_js_1.tripleToCcRsSuffix)(hit.triple);
+        for (const [name, value] of Object.entries(hit.exports)) {
+            setEnv(name, value);
+        }
+        logger.warning(`setup-soldr: auto-exporting cc-rs cross-compile env for ${hit.triple} ` +
+            `(CC_${suffix}=${hit.exports[`CC_${suffix}`]}, ` +
+            `CXX_${suffix}=${hit.exports[`CXX_${suffix}`]}, ` +
+            `AR_${suffix}=${hit.exports[`AR_${suffix}`]}) ` +
+            "because cc-rs strips \"-unknown-\" from the triple when probing for a " +
+            "cross compiler and would otherwise fall back to the host gcc. " +
+            `Resolved: cc=${hit.resolvedPaths.cc}, cxx=${hit.resolvedPaths.cxx}, ar=${hit.resolvedPaths.ar}. ` +
+            `Pre-set CC_${suffix} yourself to opt out.`);
+    }
+    // ---- path additions ----
+    const pathAdditions = [binDir, path.join(cargoHome, "bin")];
+    // ---- logging summary ----
+    log("setup-soldr cache plan");
+    log(`cache key=${cacheKey}`);
+    log(`cache restore-key=${cachePrefix}-`);
+    log(`build-cache key=${buildCacheKey}`);
+    log(`build-cache mode=${buildCacheMode}`);
+    log(`build-cache soldr-mode=${buildCacheRuntimeMode}`);
+    if (buildCacheParentKey) {
+        log(`build-cache restore-key-parent=${buildCacheParentKey}`);
+    }
+    log(`build-cache restore-key-toolchain=${buildCacheToolchainPrefix}`);
+    log(`build-cache restore-key-os-arch=${buildCachePrefix}-`);
+    log(`target-cache key=${targetCacheKey}`);
+    log(`target-cache enabled=${targetCacheEnabled ? "true" : "false"}`);
+    log(`target-cache mode=${targetCacheEffectiveMode}`);
+    log("target-cache backend=local");
+    if (targetCacheEnabled) {
+        log(`target-cache soft-budget-bytes=${targetCacheBudgetBytes}`);
+        log(`target-cache soft-budget-files=${targetCacheBudgetFiles}`);
+    }
+    log(`soldr repo=${soldrRepo}`);
+    log(`soldr ref=${soldrRef || "release"}`);
+    if (soldrVersionResolved) {
+        log(`soldr version=${soldrVersionResolved}`);
+    }
+    log(`toolchain channel=${toolchain.channel}`);
+    log(`toolchain cache-channel=${toolchain.cacheChannel}`);
+    log(`rustup strategy=${rustupStrategy}`);
+    log(`setup-cache layout=${setupCacheLayoutValue}`);
+    if (targetCacheParentKey) {
+        log(`target-cache restore-key-parent=${targetCacheParentKey}`);
+    }
+    log(`target-cache restore-key-lock=${targetCacheLockPrefix}`);
+    log(`target-cache restore-key-lockfile=${targetCacheLockfilePrefix}`);
+    log(`target-cache paths=${targetCachePaths}`);
+    log(`target-cache bundle-dir=${targetCacheBundlePath}`);
+    log(`target-cache lockfile=${(0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath)}`);
+    log(`target-cache lockfile-hash=${cargoLockHash}`);
+    // ---- assemble plans ----
+    const setupCache = {
+        key: cacheKey,
+        restorePrefix: `${cachePrefix}-`,
+        paths: setupCachePathsList ? setupCachePathsList.split("\n") : [],
+        setupCachePath,
+        layout: setupCacheLayoutValue,
+    };
+    const buildCache = {
+        key: buildCacheKey,
+        restoreKeyParent: buildCacheParentKey,
+        restoreKeyToolchain: buildCacheToolchainPrefix,
+        restoreKeyOsArch: `${buildCachePrefix}-`,
+        path: zccacheCacheDir,
+        mode: buildCacheMode,
+    };
+    const targetCache = {
+        enabled: targetCacheEnabled,
+        key: targetCacheKey,
+        restoreKeyParent: targetCacheParentKey,
+        restoreKeyLock: targetCacheLockPrefix,
+        restoreKeyLockfile: targetCacheLockfilePrefix,
+        paths: targetCachePaths,
+        bundlePath: targetCacheBundlePath,
+        targetPath: targetCachePath,
+        effectiveMode: targetCacheEffectiveMode,
+        profile: targetCacheProfile,
+        budgetBytes: targetCacheBudgetBytes,
+        budgetFiles: targetCacheBudgetFiles,
+        lockfilePath: (0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath),
+        lockfileHash: cargoLockHash,
+    };
+    const cargoRegistryCachePlan = {
+        enabled: cargoRegistryCacheEnabled,
+        key: cargoRegistryCacheKey,
+        restorePrefix: cargoRegistryCacheRestorePrefix,
+        path: cargoRegistryCachePath,
+    };
+    // Avoid unused warnings on alias helper.
+    void toolchain_js_1.rollingToolchainAlias;
+    void cache_keys_js_1.canonicalJsonStringify;
+    const compileCacheStats = normalizeCompileCacheStats(inputs.compileCacheStats);
+    const stats = normalizeStatsMode(inputs.stats);
+    const debugMode = isTruthy(inputs.debugMode.trim() || "false");
+    // ---- shims ----
+    const shimsRaw = inputs.shims.trim() || "false";
+    const shimsEnabled = !isFalsy(shimsRaw);
+    const shimsDir = path.join(cacheRoot, "shims");
+    return {
+        enabled,
+        workspace,
+        cacheRoot,
+        soldrRoot,
+        binDir,
+        cargoHome,
+        rustupHome,
+        soldrPath,
+        soldrBinCachePath,
+        toolchain,
+        rustupStrategy,
+        soldrRepo,
+        soldrRef,
+        soldrVersionRequested,
+        soldrVersionResolved,
+        setupCache,
+        buildCache,
+        targetCache,
+        cargoRegistryCache: cargoRegistryCachePlan,
+        targetCacheCompress,
+        targetCacheCompressLevel,
+        envExports,
+        pathAdditions,
+        logStartEpoch: logStart,
+        timestamps,
+        shimsEnabled,
+        shimsDir,
+        compileCacheStats,
+        stats,
+        debugMode,
+        cacheShutdownOnIdleSeconds,
+    };
+}
+/**
+ * Apply ResolveResult to the runner: write $GITHUB_ENV, $GITHUB_PATH, and
+ * $GITHUB_OUTPUT keys.
+ */
+async function applyResolveResult(result) {
+    for (const [name, value] of Object.entries(result.envExports)) {
+        if (GITHUB_ENV_DENY_LIST.has(name))
+            continue;
+        core.exportVariable(name, value);
+    }
+    for (const p of result.pathAdditions) {
+        core.addPath(p);
+    }
+    const outputs = (0, build_outputs_js_1.buildOutputs)(result);
+    for (const [key, value] of Object.entries(outputs)) {
+        core.setOutput(key, value);
+    }
+}
+// --------------------- Python-default JSON serialization ---------------------
+/**
+ * Mirror Python's `json.dumps(value, sort_keys=True)` with default separators
+ * (", " between items, ": " between key/value). Used for the toolchain
+ * signature digest where Python does NOT pass compact separators.
+ */
+function pythonDefaultJson(value) {
+    return formatDefaultJson(value);
+}
+function formatDefaultJson(value) {
+    if (value === null || value === undefined)
+        return "null";
+    if (typeof value === "string")
+        return JSON.stringify(value);
+    if (typeof value === "number") {
+        return Number.isFinite(value) ? JSON.stringify(value) : "null";
+    }
+    if (typeof value === "boolean")
+        return value ? "true" : "false";
+    if (Array.isArray(value)) {
+        const parts = value.map((item) => formatDefaultJson(item));
+        return `[${parts.join(", ")}]`;
+    }
+    if (typeof value === "object") {
+        const obj = value;
+        const keys = Object.keys(obj).sort();
+        const parts = keys.map((key) => `${JSON.stringify(key)}: ${formatDefaultJson(obj[key])}`);
+        return `{${parts.join(", ")}}`;
+    }
+    return JSON.stringify(value);
+}
+
+
+/***/ }),
+
+/***/ 517:
 /***/ ((module) => {
 
 "use strict";
@@ -90072,7 +90145,7 @@ module.exports = require("assert");
 
 /***/ }),
 
-/***/ 516:
+/***/ 518:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -90137,7 +90210,7 @@ exports.readServiceOption = readServiceOption;
 
 /***/ }),
 
-/***/ 517:
+/***/ 519:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -90162,7 +90235,7 @@ var MatchKind;
 
 /***/ }),
 
-/***/ 518:
+/***/ 520:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -90203,8 +90276,8 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureShims = ensureShims;
 const fs = __importStar(__nccwpck_require__(242));
-const path = __importStar(__nccwpck_require__(497));
-const core = __importStar(__nccwpck_require__(450));
+const path = __importStar(__nccwpck_require__(498));
+const core = __importStar(__nccwpck_require__(451));
 // Tools that route through `soldr <tool>`:
 const ROUTED_TOOLS = ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"];
 // Unix bash shim template (per tool):
@@ -90260,27 +90333,27 @@ async function ensureShims(opts) {
 
 /***/ }),
 
-/***/ 519:
+/***/ 521:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(398);
-const reflection_info_1 = __nccwpck_require__(444);
+const message_type_contract_1 = __nccwpck_require__(399);
+const reflection_info_1 = __nccwpck_require__(445);
 const reflection_type_check_1 = __nccwpck_require__(283);
-const reflection_json_reader_1 = __nccwpck_require__(336);
-const reflection_json_writer_1 = __nccwpck_require__(87);
-const reflection_binary_reader_1 = __nccwpck_require__(400);
+const reflection_json_reader_1 = __nccwpck_require__(337);
+const reflection_json_writer_1 = __nccwpck_require__(88);
+const reflection_binary_reader_1 = __nccwpck_require__(401);
 const reflection_binary_writer_1 = __nccwpck_require__(181);
 const reflection_create_1 = __nccwpck_require__(200);
-const reflection_merge_partial_1 = __nccwpck_require__(133);
-const json_typings_1 = __nccwpck_require__(387);
+const reflection_merge_partial_1 = __nccwpck_require__(134);
+const json_typings_1 = __nccwpck_require__(388);
 const json_format_contract_1 = __nccwpck_require__(235);
-const reflection_equals_1 = __nccwpck_require__(452);
+const reflection_equals_1 = __nccwpck_require__(453);
 const binary_writer_1 = __nccwpck_require__(244);
-const binary_reader_1 = __nccwpck_require__(131);
+const binary_reader_1 = __nccwpck_require__(132);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
 const messageTypeDescriptor = baseDescriptors[message_type_contract_1.MESSAGE_TYPE] = {};
 /**
@@ -90445,7 +90518,7 @@ exports.MessageType = MessageType;
 
 /***/ }),
 
-/***/ 520:
+/***/ 522:
 /***/ ((module) => {
 
 "use strict";
@@ -90453,7 +90526,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 521:
+/***/ 523:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -90535,7 +90608,7 @@ exports.stackDuplexStreamingInterceptors = stackDuplexStreamingInterceptors;
 
 /***/ }),
 
-/***/ 522:
+/***/ 524:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -90565,8 +90638,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(89));
-const utils_1 = __nccwpck_require__(494);
+const os = __importStar(__nccwpck_require__(90));
+const utils_1 = __nccwpck_require__(495);
 /**
  * Commands
  *
@@ -90638,7 +90711,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 523:
+/***/ 525:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -90883,7 +90956,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(490);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(84);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/src/lib/build-outputs.ts
+++ b/src/lib/build-outputs.ts
@@ -1,0 +1,66 @@
+// $GITHUB_OUTPUT key/value mapping for setup-soldr. Pure function of
+// the resolved state — split out of resolve-setup.ts to keep the
+// orchestration module focused on input parsing / cache-key derivation.
+// Mirrors resolve_setup.py's `_write_outputs()` call so tests can
+// assert byte-for-byte.
+
+import type { ResolveResult } from "./types.js";
+
+/**
+ * Build the $GITHUB_OUTPUT key/value map. Exposed for tests so they
+ * can assert byte-for-byte parity with the legacy Python action's
+ * `_write_outputs()` call.
+ */
+export function buildOutputs(result: ResolveResult): Record<string, string> {
+  return {
+    cache_root: result.cacheRoot,
+    setup_cache_path: result.setupCache.setupCachePath,
+    setup_cache_paths: result.setupCache.paths.join("\n"),
+    cache_key: result.setupCache.key,
+    cache_restore_prefix: result.setupCache.restorePrefix,
+    build_cache_key: result.buildCache.key,
+    build_cache_restore_key_parent: result.buildCache.restoreKeyParent,
+    build_cache_restore_key_toolchain: result.buildCache.restoreKeyToolchain,
+    build_cache_restore_key_os_arch: result.buildCache.restoreKeyOsArch,
+    build_cache_path: result.buildCache.path,
+    build_cache_mode: result.buildCache.mode,
+    target_cache_path: result.targetCache.targetPath,
+    target_cache_bundle_path: result.targetCache.bundlePath,
+    target_cache_paths: result.targetCache.paths,
+    target_cache_enabled: result.targetCache.enabled ? "true" : "false",
+    target_cache_mode: result.targetCache.effectiveMode,
+    target_cache_profile: result.targetCache.profile,
+    target_cache_compress: result.targetCacheCompress,
+    target_cache_compress_level: result.targetCacheCompressLevel,
+    target_cache_key: result.targetCache.key,
+    target_cache_restore_key_parent: result.targetCache.restoreKeyParent,
+    target_cache_restore_key_lock: result.targetCache.restoreKeyLock,
+    target_cache_restore_key_lockfile: result.targetCache.restoreKeyLockfile,
+    target_cache_budget_bytes: result.targetCache.budgetBytes,
+    target_cache_budget_files: result.targetCache.budgetFiles,
+    target_lockfile_path: result.targetCache.lockfilePath,
+    target_lockfile_hash: result.targetCache.lockfileHash,
+    cargo_registry_cache_enabled: result.cargoRegistryCache.enabled ? "true" : "false",
+    cargo_registry_cache_path: result.cargoRegistryCache.path,
+    cargo_registry_cache_key: result.cargoRegistryCache.key,
+    cargo_registry_cache_restore_prefix: result.cargoRegistryCache.restorePrefix,
+    soldr_root: result.soldrRoot,
+    soldr_bin_cache_path: result.soldrBinCachePath,
+    cargo_home: result.cargoHome,
+    rustup_home: result.rustupHome,
+    setup_cache_layout: result.setupCache.layout,
+    bin_dir: result.binDir,
+    shims_dir: result.shimsDir,
+    soldr_path: result.soldrPath,
+    soldr_repo: result.soldrRepo,
+    soldr_ref: result.soldrRef,
+    soldr_version_requested: result.soldrVersionRequested,
+    soldr_version_resolved: result.soldrVersionResolved,
+    toolchain_channel: result.toolchain.channel,
+    toolchain_cache_channel: result.toolchain.cacheChannel,
+    toolchain_profile: result.toolchain.profile,
+    toolchain_source: result.toolchain.source,
+    toolchain: result.toolchain.channel,
+    enabled: result.enabled ? "true" : "false",
+  };
+}

--- a/src/lib/detect-musl-cc.ts
+++ b/src/lib/detect-musl-cc.ts
@@ -1,0 +1,143 @@
+// Detect *-unknown-linux-musl cross compilers on PATH and return the
+// cc-rs env-var exports needed to make cc-rs find them.
+//
+// cc-rs strips the "-unknown-" segment from a Rust target triple when
+// probing for a cross compiler, so the cross-tools archives (which
+// ship binaries named with the full triple, e.g.
+// aarch64-unknown-linux-musl-gcc) are missed and cc-rs falls back to
+// the host gcc. The symptom is wheels/binaries that link against host
+// glibc's libgcc_s.so.1 and fail at runtime. Auto-exporting
+// CC_<triple>, CXX_<triple>, and AR_<triple> in snake-case from
+// setup-soldr fixes the build without forcing every consumer to edit
+// their workflow. See PR #111 for background.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const MUSL_TRIPLE_RE = /^[a-z0-9_]+-unknown-linux-musl$/;
+
+export function tripleToCcRsSuffix(triple: string): string {
+  return triple.replace(/-/g, "_");
+}
+
+function findOnPathSync(env: Record<string, string | undefined>, cmd: string): string | null {
+  const pathRaw = env["PATH"] ?? env["Path"] ?? "";
+  if (!pathRaw) return null;
+  const sep = process.platform === "win32" ? ";" : ":";
+  const exts = process.platform === "win32" ? ["", ".exe"] : [""];
+  for (const dir of pathRaw.split(sep)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const candidate = path.join(dir, `${cmd}${ext}`);
+      try {
+        if (fs.statSync(candidate).isFile()) return candidate;
+      } catch {
+        // not present; continue
+      }
+    }
+  }
+  return null;
+}
+
+function scanPathForMuslTriples(
+  env: Record<string, string | undefined>,
+  readDir: (dir: string) => string[],
+): Set<string> {
+  const triples = new Set<string>();
+  const pathRaw = env["PATH"] ?? env["Path"] ?? "";
+  if (!pathRaw) return triples;
+  const sep = process.platform === "win32" ? ";" : ":";
+  const isWin = process.platform === "win32";
+  const tail = isWin ? /-unknown-linux-musl-gcc(?:\.exe)?$/i : /-unknown-linux-musl-gcc$/;
+  for (const dir of pathRaw.split(sep)) {
+    if (!dir) continue;
+    let entries: string[];
+    try {
+      entries = readDir(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const m = entry.match(tail);
+      if (!m) continue;
+      const triple = entry.slice(0, entry.length - m[0].length) + "-unknown-linux-musl";
+      if (MUSL_TRIPLE_RE.test(triple)) triples.add(triple);
+    }
+  }
+  return triples;
+}
+
+export interface MuslCcResolution {
+  triple: string;
+  exports: Record<string, string>;
+  resolvedPaths: { cc: string; cxx: string; ar: string };
+}
+
+export interface DetectMuslCcDeps {
+  findOnPath?: (cmd: string) => string | null;
+  readDir?: (dir: string) => string[];
+}
+
+/**
+ * Detect *-unknown-linux-musl cross compilers on PATH and return the
+ * cc-rs env-var exports needed to make cc-rs find them.
+ *
+ * Triples are sourced from: CARGO_BUILD_TARGET, any CARGO_TARGET_<T>_*
+ * env vars the user has already set, and PATH-scanning for
+ * `*-unknown-linux-musl-gcc` binaries. A triple is skipped when the user
+ * has already set any of CC_/CXX_/AR_<snake_triple>.
+ */
+export function detectMuslCcEnv(
+  env: Record<string, string | undefined>,
+  deps?: DetectMuslCcDeps,
+): MuslCcResolution[] {
+  const find = deps?.findOnPath ?? ((cmd: string) => findOnPathSync(env, cmd));
+  const readDir = deps?.readDir ?? ((dir: string) => fs.readdirSync(dir));
+  const triples = new Set<string>();
+
+  const cbt = (env["CARGO_BUILD_TARGET"] ?? "").trim();
+  if (cbt && MUSL_TRIPLE_RE.test(cbt)) triples.add(cbt);
+
+  // Cargo encodes triples by uppercasing and replacing `-` with `_`, so
+  // `x86_64-unknown-linux-musl` becomes `X86_64_UNKNOWN_LINUX_MUSL` — the
+  // reverse is ambiguous (the arch may contain a real underscore). Match on
+  // the fixed `_UNKNOWN_LINUX_MUSL_` suffix and treat the prefix as the
+  // verbatim arch name to round-trip safely.
+  for (const name of Object.keys(env)) {
+    const m = name.match(/^CARGO_TARGET_(.+?)_UNKNOWN_LINUX_MUSL_(LINKER|RUSTFLAGS|RUNNER)$/);
+    if (!m) continue;
+    const arch = m[1]!.toLowerCase();
+    if (!/^[a-z0-9_]+$/.test(arch)) continue;
+    const triple = `${arch}-unknown-linux-musl`;
+    if (MUSL_TRIPLE_RE.test(triple)) triples.add(triple);
+  }
+
+  for (const t of scanPathForMuslTriples(env, readDir)) {
+    triples.add(t);
+  }
+
+  const out: MuslCcResolution[] = [];
+  for (const triple of [...triples].sort()) {
+    const suffix = tripleToCcRsSuffix(triple);
+    const ccVar = `CC_${suffix}`;
+    const cxxVar = `CXX_${suffix}`;
+    const arVar = `AR_${suffix}`;
+    if ((env[ccVar] ?? "").trim() !== "") continue;
+    if ((env[cxxVar] ?? "").trim() !== "") continue;
+    if ((env[arVar] ?? "").trim() !== "") continue;
+    const ccPath = find(`${triple}-gcc`);
+    const cxxPath = find(`${triple}-g++`);
+    const arPath = find(`${triple}-ar`);
+    if (!ccPath || !cxxPath || !arPath) continue;
+    out.push({
+      triple,
+      exports: {
+        [ccVar]: `${triple}-gcc`,
+        [cxxVar]: `${triple}-g++`,
+        [arVar]: `${triple}-ar`,
+      },
+      resolvedPaths: { cc: ccPath, cxx: cxxPath, ar: arPath },
+    });
+  }
+  return out;
+}

--- a/src/lib/resolve-setup.ts
+++ b/src/lib/resolve-setup.ts
@@ -30,6 +30,13 @@ import {
 } from "./cache-keys.js";
 import { createLogger } from "./log-utils.js";
 import {
+  detectMuslCcEnv,
+  tripleToCcRsSuffix,
+  type DetectMuslCcDeps,
+  type MuslCcResolution,
+} from "./detect-musl-cc.js";
+import { buildOutputs } from "./build-outputs.js";
+import {
   loadToolchainSpec,
   rollingToolchainAlias,
   systemRustupSatisfiesRequest,
@@ -171,139 +178,11 @@ export function detectUserLinkerEnv(env: Record<string, string | undefined>): st
   return hits;
 }
 
-const MUSL_TRIPLE_RE = /^[a-z0-9_]+-unknown-linux-musl$/;
-
-function tripleToCcRsSuffix(triple: string): string {
-  return triple.replace(/-/g, "_");
-}
-
-function findOnPathSync(env: Record<string, string | undefined>, cmd: string): string | null {
-  const pathRaw = env["PATH"] ?? env["Path"] ?? "";
-  if (!pathRaw) return null;
-  const sep = process.platform === "win32" ? ";" : ":";
-  const exts = process.platform === "win32" ? ["", ".exe"] : [""];
-  for (const dir of pathRaw.split(sep)) {
-    if (!dir) continue;
-    for (const ext of exts) {
-      const candidate = path.join(dir, `${cmd}${ext}`);
-      try {
-        if (fs.statSync(candidate).isFile()) return candidate;
-      } catch {
-        // not present; continue
-      }
-    }
-  }
-  return null;
-}
-
-function scanPathForMuslTriples(
-  env: Record<string, string | undefined>,
-  readDir: (dir: string) => string[],
-): Set<string> {
-  const triples = new Set<string>();
-  const pathRaw = env["PATH"] ?? env["Path"] ?? "";
-  if (!pathRaw) return triples;
-  const sep = process.platform === "win32" ? ";" : ":";
-  const isWin = process.platform === "win32";
-  const tail = isWin ? /-unknown-linux-musl-gcc(?:\.exe)?$/i : /-unknown-linux-musl-gcc$/;
-  for (const dir of pathRaw.split(sep)) {
-    if (!dir) continue;
-    let entries: string[];
-    try {
-      entries = readDir(dir);
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      const m = entry.match(tail);
-      if (!m) continue;
-      const triple = entry.slice(0, entry.length - m[0].length) + "-unknown-linux-musl";
-      if (MUSL_TRIPLE_RE.test(triple)) triples.add(triple);
-    }
-  }
-  return triples;
-}
-
-export interface MuslCcResolution {
-  triple: string;
-  exports: Record<string, string>;
-  resolvedPaths: { cc: string; cxx: string; ar: string };
-}
-
-export interface DetectMuslCcDeps {
-  findOnPath?: (cmd: string) => string | null;
-  readDir?: (dir: string) => string[];
-}
-
-/**
- * Detect *-unknown-linux-musl cross compilers on PATH and return the
- * cc-rs env-var exports needed to make cc-rs find them. cc-rs strips the
- * "-unknown-" segment from the Rust target triple when searching for a
- * cross compiler, so the cross-tools archives (which ship binaries named
- * with the full triple, e.g. aarch64-unknown-linux-musl-gcc) are missed
- * and cc-rs falls back to the host gcc. Auto-exporting CC_<triple>,
- * CXX_<triple>, and AR_<triple> in snake-case fixes the build without
- * any workflow edits.
- *
- * Triples are sourced from: CARGO_BUILD_TARGET, any CARGO_TARGET_<T>_*
- * env vars the user has already set, and PATH-scanning for
- * `*-unknown-linux-musl-gcc` binaries. A triple is skipped when the user
- * has already set any of CC_/CXX_/AR_<snake_triple>.
- */
-export function detectMuslCcEnv(
-  env: Record<string, string | undefined>,
-  deps?: DetectMuslCcDeps,
-): MuslCcResolution[] {
-  const find = deps?.findOnPath ?? ((cmd: string) => findOnPathSync(env, cmd));
-  const readDir = deps?.readDir ?? ((dir: string) => fs.readdirSync(dir));
-  const triples = new Set<string>();
-
-  const cbt = (env["CARGO_BUILD_TARGET"] ?? "").trim();
-  if (cbt && MUSL_TRIPLE_RE.test(cbt)) triples.add(cbt);
-
-  // Cargo encodes triples by uppercasing and replacing `-` with `_`, so
-  // `x86_64-unknown-linux-musl` becomes `X86_64_UNKNOWN_LINUX_MUSL` — the
-  // reverse is ambiguous (the arch may contain a real underscore). Match on
-  // the fixed `_UNKNOWN_LINUX_MUSL_` suffix and treat the prefix as the
-  // verbatim arch name to round-trip safely.
-  for (const name of Object.keys(env)) {
-    const m = name.match(/^CARGO_TARGET_(.+?)_UNKNOWN_LINUX_MUSL_(LINKER|RUSTFLAGS|RUNNER)$/);
-    if (!m) continue;
-    const arch = m[1]!.toLowerCase();
-    if (!/^[a-z0-9_]+$/.test(arch)) continue;
-    const triple = `${arch}-unknown-linux-musl`;
-    if (MUSL_TRIPLE_RE.test(triple)) triples.add(triple);
-  }
-
-  for (const t of scanPathForMuslTriples(env, readDir)) {
-    triples.add(t);
-  }
-
-  const out: MuslCcResolution[] = [];
-  for (const triple of [...triples].sort()) {
-    const suffix = tripleToCcRsSuffix(triple);
-    const ccVar = `CC_${suffix}`;
-    const cxxVar = `CXX_${suffix}`;
-    const arVar = `AR_${suffix}`;
-    if ((env[ccVar] ?? "").trim() !== "") continue;
-    if ((env[cxxVar] ?? "").trim() !== "") continue;
-    if ((env[arVar] ?? "").trim() !== "") continue;
-    const ccPath = find(`${triple}-gcc`);
-    const cxxPath = find(`${triple}-g++`);
-    const arPath = find(`${triple}-ar`);
-    if (!ccPath || !cxxPath || !arPath) continue;
-    out.push({
-      triple,
-      exports: {
-        [ccVar]: `${triple}-gcc`,
-        [cxxVar]: `${triple}-g++`,
-        [arVar]: `${triple}-ar`,
-      },
-      resolvedPaths: { cc: ccPath, cxx: cxxPath, ar: arPath },
-    });
-  }
-  return out;
-}
+// Re-exports kept for backward compatibility with tests and external
+// consumers that imported the musl cc-rs helpers from this module
+// before the split. New code should import directly from
+// ./detect-musl-cc.js.
+export { detectMuslCcEnv, type MuslCcResolution, type DetectMuslCcDeps };
 
 function normalizeStatsMode(raw: string): StatsMode {
   const v = raw.trim().toLowerCase();
@@ -980,63 +859,10 @@ export async function applyResolveResult(result: ResolveResult): Promise<void> {
   }
 }
 
-/**
- * Build the $GITHUB_OUTPUT key/value map mirroring resolve_setup.py's
- * `_write_outputs()` call. Exposed for tests so they can assert byte-for-byte.
- */
-export function buildOutputs(result: ResolveResult): Record<string, string> {
-  return {
-    cache_root: result.cacheRoot,
-    setup_cache_path: result.setupCache.setupCachePath,
-    setup_cache_paths: result.setupCache.paths.join("\n"),
-    cache_key: result.setupCache.key,
-    cache_restore_prefix: result.setupCache.restorePrefix,
-    build_cache_key: result.buildCache.key,
-    build_cache_restore_key_parent: result.buildCache.restoreKeyParent,
-    build_cache_restore_key_toolchain: result.buildCache.restoreKeyToolchain,
-    build_cache_restore_key_os_arch: result.buildCache.restoreKeyOsArch,
-    build_cache_path: result.buildCache.path,
-    build_cache_mode: result.buildCache.mode,
-    target_cache_path: result.targetCache.targetPath,
-    target_cache_bundle_path: result.targetCache.bundlePath,
-    target_cache_paths: result.targetCache.paths,
-    target_cache_enabled: result.targetCache.enabled ? "true" : "false",
-    target_cache_mode: result.targetCache.effectiveMode,
-    target_cache_profile: result.targetCache.profile,
-    target_cache_compress: result.targetCacheCompress,
-    target_cache_compress_level: result.targetCacheCompressLevel,
-    target_cache_key: result.targetCache.key,
-    target_cache_restore_key_parent: result.targetCache.restoreKeyParent,
-    target_cache_restore_key_lock: result.targetCache.restoreKeyLock,
-    target_cache_restore_key_lockfile: result.targetCache.restoreKeyLockfile,
-    target_cache_budget_bytes: result.targetCache.budgetBytes,
-    target_cache_budget_files: result.targetCache.budgetFiles,
-    target_lockfile_path: result.targetCache.lockfilePath,
-    target_lockfile_hash: result.targetCache.lockfileHash,
-    cargo_registry_cache_enabled: result.cargoRegistryCache.enabled ? "true" : "false",
-    cargo_registry_cache_path: result.cargoRegistryCache.path,
-    cargo_registry_cache_key: result.cargoRegistryCache.key,
-    cargo_registry_cache_restore_prefix: result.cargoRegistryCache.restorePrefix,
-    soldr_root: result.soldrRoot,
-    soldr_bin_cache_path: result.soldrBinCachePath,
-    cargo_home: result.cargoHome,
-    rustup_home: result.rustupHome,
-    setup_cache_layout: result.setupCache.layout,
-    bin_dir: result.binDir,
-    shims_dir: result.shimsDir,
-    soldr_path: result.soldrPath,
-    soldr_repo: result.soldrRepo,
-    soldr_ref: result.soldrRef,
-    soldr_version_requested: result.soldrVersionRequested,
-    soldr_version_resolved: result.soldrVersionResolved,
-    toolchain_channel: result.toolchain.channel,
-    toolchain_cache_channel: result.toolchain.cacheChannel,
-    toolchain_profile: result.toolchain.profile,
-    toolchain_source: result.toolchain.source,
-    toolchain: result.toolchain.channel,
-    enabled: result.enabled ? "true" : "false",
-  };
-}
+// Re-export buildOutputs for backward compatibility with existing
+// test imports. New code should import directly from
+// ./build-outputs.js.
+export { buildOutputs };
 
 // --------------------- Python-default JSON serialization ---------------------
 


### PR DESCRIPTION
## Summary
`resolve-setup.ts` grew to 1072 lines after the recent feature batch (`enable`, musl cc-rs autodetect, `cache-shutdown-on-idle`). Pulling two self-contained sections into their own modules keeps the orchestrator focused on input parsing and cache-key derivation:

- `src/lib/detect-musl-cc.ts` — `detectMuslCcEnv` + private PATH helpers + types (~130 LOC).
- `src/lib/build-outputs.ts` — `buildOutputs`, the pure ResolveResult → `$GITHUB_OUTPUT` mapping (~52 LOC).

`resolve-setup.ts` re-exports `detectMuslCcEnv`, the related types, and `buildOutputs` so existing test imports keep working without any test edits. Pure refactor — no behavior change.

`resolve-setup.ts`: 1072 → 898 lines.

## Test plan
- [x] `npm run typecheck` clean
- [x] Full suite: 201 pass / 4 skipped / 0 fail (unchanged from before split)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)