### PR TITLE
fix(passthrough): write bash twin next to soldr.cmd on Windows + handle `stop`

### DIFF
--- a/__tests__/install-passthrough.test.ts
+++ b/__tests__/install-passthrough.test.ts
@@ -33,6 +33,38 @@ test("installPassthrough writes a stub at the requested path", () => {
   }
 });
 
+test("installPassthrough on Windows writes a bash-twin alongside soldr.cmd for Git Bash callers", () => {
+  const dir = mkTmp("setup-soldr-passthrough-twin-");
+  try {
+    const cmdPath = path.join(dir, "soldr.cmd");
+    installPassthrough({ soldrPath: cmdPath, isWindows: true, log: () => {} });
+    assert.ok(fs.statSync(cmdPath).isFile(), "soldr.cmd was created");
+    const twinPath = path.join(dir, "soldr");
+    assert.ok(
+      fs.statSync(twinPath).isFile(),
+      "no-extension soldr bash twin was created next to soldr.cmd",
+    );
+    const twin = fs.readFileSync(twinPath, "utf8");
+    assert.match(twin, /^#!\/usr\/bin\/env bash/, "twin has bash shebang");
+    assert.match(twin, /exec "\$@"/, "twin forwards argv via exec");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("bash stub treats `stop` as a silent no-op (passthrough has no daemon)", { skip: process.platform === "win32" }, () => {
+  const dir = mkTmp("setup-soldr-passthrough-stop-");
+  try {
+    const target = path.join(dir, "soldr");
+    installPassthrough({ soldrPath: target, isWindows: false, log: () => {} });
+    const result = spawnSync(target, ["stop"], { encoding: "utf8" });
+    assert.equal(result.status, 0, `stop should exit 0; stdout=${result.stdout} stderr=${result.stderr}`);
+    assert.equal(result.stdout.trim(), "", "stop should produce no stdout");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("bash stub forwards argv[1..] to the named tool", { skip: process.platform === "win32" }, () => {
   const dir = mkTmp("setup-soldr-passthrough-fwd-");
   try {

--- a/dist/main.js
+++ b/dist/main.js
@@ -14,15 +14,15 @@
 //  * support limits.fieldNameSize
 //     -- this will require modifications to utils.parseParams
 
-const { Readable } = __nccwpck_require__(427)
-const { inherits } = __nccwpck_require__(372)
+const { Readable } = __nccwpck_require__(426)
+const { inherits } = __nccwpck_require__(371)
 
 const Dicer = __nccwpck_require__(13)
 
-const parseParams = __nccwpck_require__(189)
-const decodeText = __nccwpck_require__(270)
-const basename = __nccwpck_require__(473)
-const getLimit = __nccwpck_require__(479)
+const parseParams = __nccwpck_require__(188)
+const decodeText = __nccwpck_require__(269)
+const basename = __nccwpck_require__(472)
+const getLimit = __nccwpck_require__(478)
 
 const RE_BOUNDARY = /^boundary$/i
 const RE_FIELD = /^form-data$/i
@@ -340,7 +340,7 @@ __export(inspect_exports, {
   custom: () => custom
 });
 module.exports = __toCommonJS(inspect_exports);
-var import_node_util = __nccwpck_require__(372);
+var import_node_util = __nccwpck_require__(371);
 const custom = import_node_util.inspect.custom;
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -469,17 +469,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = exports.downloadCacheHttpClient = exports.DownloadProgress = void 0;
-const core = __importStar(__nccwpck_require__(456));
-const http_client_1 = __nccwpck_require__(280);
-const storage_blob_1 = __nccwpck_require__(445);
+const core = __importStar(__nccwpck_require__(455));
+const http_client_1 = __nccwpck_require__(279);
+const storage_blob_1 = __nccwpck_require__(444);
 const buffer = __importStar(__nccwpck_require__(117));
 const fs = __importStar(__nccwpck_require__(526));
-const stream = __importStar(__nccwpck_require__(129));
-const util = __importStar(__nccwpck_require__(122));
+const stream = __importStar(__nccwpck_require__(128));
+const util = __importStar(__nccwpck_require__(121));
 const utils = __importStar(__nccwpck_require__(75));
 const constants_1 = __nccwpck_require__(45);
-const requestUtils_1 = __nccwpck_require__(256);
-const abort_controller_1 = __nccwpck_require__(224);
+const requestUtils_1 = __nccwpck_require__(255);
+const abort_controller_1 = __nccwpck_require__(223);
 /**
  * Pipes the body of a HTTP response to a stream
  *
@@ -839,14 +839,14 @@ exports.SearchState = SearchState;
 "use strict";
 
 
-const { InvalidArgumentError } = __nccwpck_require__(484)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(192)
+const { InvalidArgumentError } = __nccwpck_require__(483)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(191)
 const DispatcherBase = __nccwpck_require__(62)
-const Pool = __nccwpck_require__(334)
-const Client = __nccwpck_require__(87)
+const Pool = __nccwpck_require__(333)
+const Client = __nccwpck_require__(86)
 const util = __nccwpck_require__(69)
-const createRedirectInterceptor = __nccwpck_require__(250)
-const { WeakRef, FinalizationRegistry } = __nccwpck_require__(410)()
+const createRedirectInterceptor = __nccwpck_require__(249)
+const { WeakRef, FinalizationRegistry } = __nccwpck_require__(409)()
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -1071,21 +1071,21 @@ function isNamedKeyCredential(credential) {
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(228)
+const { MockNotMatchedError } = __nccwpck_require__(227)
 const {
   kDispatches,
   kMockAgent,
   kOriginalDispatch,
   kOrigin,
   kGetNetConnect
-} = __nccwpck_require__(467)
+} = __nccwpck_require__(466)
 const { buildURL, nop } = __nccwpck_require__(69)
-const { STATUS_CODES } = __nccwpck_require__(325)
+const { STATUS_CODES } = __nccwpck_require__(324)
 const {
   types: {
     isPromise
   }
-} = __nccwpck_require__(122)
+} = __nccwpck_require__(121)
 
 function matchValue (match, value) {
   if (typeof match === 'string') {
@@ -1510,7 +1510,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetryHelper = void 0;
-const core = __importStar(__nccwpck_require__(456));
+const core = __importStar(__nccwpck_require__(455));
 /**
  * Internal class for retries
  */
@@ -1655,18 +1655,18 @@ function formatDefaultJson(value) {
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(155)
+const { kConstruct } = __nccwpck_require__(154)
 const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(78)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(69)
-const { kHeadersList } = __nccwpck_require__(192)
-const { webidl } = __nccwpck_require__(454)
+const { kHeadersList } = __nccwpck_require__(191)
+const { webidl } = __nccwpck_require__(453)
 const { Response, cloneResponse } = __nccwpck_require__(41)
-const { Request } = __nccwpck_require__(83)
+const { Request } = __nccwpck_require__(82)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(15)
-const { fetching } = __nccwpck_require__(448)
+const { fetching } = __nccwpck_require__(447)
 const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(512)
 const assert = __nccwpck_require__(521)
-const { getGlobalDispatcher } = __nccwpck_require__(373)
+const { getGlobalDispatcher } = __nccwpck_require__(372)
 
 /**
  * @see https://w3c.github.io/ServiceWorker/#dfn-cache-batch-operation
@@ -2501,8 +2501,8 @@ module.exports = {
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(427).Writable)
-const inherits = (__nccwpck_require__(372).inherits)
+const WritableStream = (__nccwpck_require__(426).Writable)
+const inherits = (__nccwpck_require__(371).inherits)
 
 const StreamSearch = __nccwpck_require__(112)
 
@@ -2734,15 +2734,15 @@ exports.isObject = isObject;
 exports.randomUUID = randomUUID;
 exports.uint8ArrayToString = uint8ArrayToString;
 exports.stringToUint8Array = stringToUint8Array;
-const tslib_1 = __nccwpck_require__(212);
-const tspRuntime = tslib_1.__importStar(__nccwpck_require__(145));
+const tslib_1 = __nccwpck_require__(211);
+const tspRuntime = tslib_1.__importStar(__nccwpck_require__(144));
 var aborterUtils_js_1 = __nccwpck_require__(99);
 Object.defineProperty(exports, "cancelablePromiseRace", ({ enumerable: true, get: function () { return aborterUtils_js_1.cancelablePromiseRace; } }));
-var createAbortablePromise_js_1 = __nccwpck_require__(255);
+var createAbortablePromise_js_1 = __nccwpck_require__(254);
 Object.defineProperty(exports, "createAbortablePromise", ({ enumerable: true, get: function () { return createAbortablePromise_js_1.createAbortablePromise; } }));
 var delay_js_1 = __nccwpck_require__(111);
 Object.defineProperty(exports, "delay", ({ enumerable: true, get: function () { return delay_js_1.delay; } }));
-var error_js_1 = __nccwpck_require__(209);
+var error_js_1 = __nccwpck_require__(208);
 Object.defineProperty(exports, "getErrorMessage", ({ enumerable: true, get: function () { return error_js_1.getErrorMessage; } }));
 var typeGuards_js_1 = __nccwpck_require__(109);
 Object.defineProperty(exports, "isDefined", ({ enumerable: true, get: function () { return typeGuards_js_1.isDefined; } }));
@@ -2917,10 +2917,10 @@ __export(retryPolicy_exports, {
   retryPolicy: () => retryPolicy
 });
 module.exports = __toCommonJS(retryPolicy_exports);
-var import_helpers = __nccwpck_require__(453);
-var import_restError = __nccwpck_require__(442);
+var import_helpers = __nccwpck_require__(452);
+var import_restError = __nccwpck_require__(441);
 var import_AbortError = __nccwpck_require__(10);
-var import_logger = __nccwpck_require__(241);
+var import_logger = __nccwpck_require__(240);
 var import_constants = __nccwpck_require__(48);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("ts-http-runtime retryPolicy");
 const retryPolicyName = "retryPolicy";
@@ -3077,8 +3077,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
-const string_decoder_1 = __nccwpck_require__(148);
-const tr = __importStar(__nccwpck_require__(124));
+const string_decoder_1 = __nccwpck_require__(147);
+const tr = __importStar(__nccwpck_require__(123));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -3162,27 +3162,27 @@ exports.getExecOutput = getExecOutput;
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Convenience JSON typings and corresponding type guards
-var json_typings_1 = __nccwpck_require__(391);
+var json_typings_1 = __nccwpck_require__(390);
 Object.defineProperty(exports, "typeofJsonValue", ({ enumerable: true, get: function () { return json_typings_1.typeofJsonValue; } }));
 Object.defineProperty(exports, "isJsonObject", ({ enumerable: true, get: function () { return json_typings_1.isJsonObject; } }));
 // Base 64 encoding
-var base64_1 = __nccwpck_require__(297);
+var base64_1 = __nccwpck_require__(296);
 Object.defineProperty(exports, "base64decode", ({ enumerable: true, get: function () { return base64_1.base64decode; } }));
 Object.defineProperty(exports, "base64encode", ({ enumerable: true, get: function () { return base64_1.base64encode; } }));
 // UTF8 encoding
-var protobufjs_utf8_1 = __nccwpck_require__(342);
+var protobufjs_utf8_1 = __nccwpck_require__(341);
 Object.defineProperty(exports, "utf8read", ({ enumerable: true, get: function () { return protobufjs_utf8_1.utf8read; } }));
 // Binary format contracts, options for reading and writing, for example
-var binary_format_contract_1 = __nccwpck_require__(329);
+var binary_format_contract_1 = __nccwpck_require__(328);
 Object.defineProperty(exports, "WireType", ({ enumerable: true, get: function () { return binary_format_contract_1.WireType; } }));
 Object.defineProperty(exports, "mergeBinaryOptions", ({ enumerable: true, get: function () { return binary_format_contract_1.mergeBinaryOptions; } }));
 Object.defineProperty(exports, "UnknownFieldHandler", ({ enumerable: true, get: function () { return binary_format_contract_1.UnknownFieldHandler; } }));
 // Standard IBinaryReader implementation
-var binary_reader_1 = __nccwpck_require__(133);
+var binary_reader_1 = __nccwpck_require__(132);
 Object.defineProperty(exports, "BinaryReader", ({ enumerable: true, get: function () { return binary_reader_1.BinaryReader; } }));
 Object.defineProperty(exports, "binaryReadOptions", ({ enumerable: true, get: function () { return binary_reader_1.binaryReadOptions; } }));
 // Standard IBinaryWriter implementation
-var binary_writer_1 = __nccwpck_require__(246);
+var binary_writer_1 = __nccwpck_require__(245);
 Object.defineProperty(exports, "BinaryWriter", ({ enumerable: true, get: function () { return binary_writer_1.BinaryWriter; } }));
 Object.defineProperty(exports, "binaryWriteOptions", ({ enumerable: true, get: function () { return binary_writer_1.binaryWriteOptions; } }));
 // Int64 and UInt64 implementations required for the binary format
@@ -3190,18 +3190,18 @@ var pb_long_1 = __nccwpck_require__(115);
 Object.defineProperty(exports, "PbLong", ({ enumerable: true, get: function () { return pb_long_1.PbLong; } }));
 Object.defineProperty(exports, "PbULong", ({ enumerable: true, get: function () { return pb_long_1.PbULong; } }));
 // JSON format contracts, options for reading and writing, for example
-var json_format_contract_1 = __nccwpck_require__(237);
+var json_format_contract_1 = __nccwpck_require__(236);
 Object.defineProperty(exports, "jsonReadOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonReadOptions; } }));
 Object.defineProperty(exports, "jsonWriteOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonWriteOptions; } }));
 Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: function () { return json_format_contract_1.mergeJsonOptions; } }));
 // Message type contract
-var message_type_contract_1 = __nccwpck_require__(402);
+var message_type_contract_1 = __nccwpck_require__(401);
 Object.defineProperty(exports, "MESSAGE_TYPE", ({ enumerable: true, get: function () { return message_type_contract_1.MESSAGE_TYPE; } }));
 // Message type implementation via reflection
 var message_type_1 = __nccwpck_require__(525);
 Object.defineProperty(exports, "MessageType", ({ enumerable: true, get: function () { return message_type_1.MessageType; } }));
 // Reflection info, generated by the plugin, exposed to the user, used by reflection ops
-var reflection_info_1 = __nccwpck_require__(450);
+var reflection_info_1 = __nccwpck_require__(449);
 Object.defineProperty(exports, "ScalarType", ({ enumerable: true, get: function () { return reflection_info_1.ScalarType; } }));
 Object.defineProperty(exports, "LongType", ({ enumerable: true, get: function () { return reflection_info_1.LongType; } }));
 Object.defineProperty(exports, "RepeatType", ({ enumerable: true, get: function () { return reflection_info_1.RepeatType; } }));
@@ -3210,44 +3210,44 @@ Object.defineProperty(exports, "readFieldOptions", ({ enumerable: true, get: fun
 Object.defineProperty(exports, "readFieldOption", ({ enumerable: true, get: function () { return reflection_info_1.readFieldOption; } }));
 Object.defineProperty(exports, "readMessageOption", ({ enumerable: true, get: function () { return reflection_info_1.readMessageOption; } }));
 // Message operations via reflection
-var reflection_type_check_1 = __nccwpck_require__(285);
+var reflection_type_check_1 = __nccwpck_require__(284);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
-var reflection_create_1 = __nccwpck_require__(202);
+var reflection_create_1 = __nccwpck_require__(201);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
-var reflection_scalar_default_1 = __nccwpck_require__(459);
+var reflection_scalar_default_1 = __nccwpck_require__(458);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
-var reflection_merge_partial_1 = __nccwpck_require__(135);
+var reflection_merge_partial_1 = __nccwpck_require__(134);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
-var reflection_equals_1 = __nccwpck_require__(458);
+var reflection_equals_1 = __nccwpck_require__(457);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
-var reflection_binary_reader_1 = __nccwpck_require__(404);
+var reflection_binary_reader_1 = __nccwpck_require__(403);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
-var reflection_binary_writer_1 = __nccwpck_require__(183);
+var reflection_binary_writer_1 = __nccwpck_require__(182);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
-var reflection_json_reader_1 = __nccwpck_require__(340);
+var reflection_json_reader_1 = __nccwpck_require__(339);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
-var reflection_json_writer_1 = __nccwpck_require__(89);
+var reflection_json_writer_1 = __nccwpck_require__(88);
 Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get: function () { return reflection_json_writer_1.ReflectionJsonWriter; } }));
 var reflection_contains_message_type_1 = __nccwpck_require__(50);
 Object.defineProperty(exports, "containsMessageType", ({ enumerable: true, get: function () { return reflection_contains_message_type_1.containsMessageType; } }));
 // Oneof helpers
-var oneof_1 = __nccwpck_require__(187);
+var oneof_1 = __nccwpck_require__(186);
 Object.defineProperty(exports, "isOneofGroup", ({ enumerable: true, get: function () { return oneof_1.isOneofGroup; } }));
 Object.defineProperty(exports, "setOneofValue", ({ enumerable: true, get: function () { return oneof_1.setOneofValue; } }));
 Object.defineProperty(exports, "getOneofValue", ({ enumerable: true, get: function () { return oneof_1.getOneofValue; } }));
 Object.defineProperty(exports, "clearOneofValue", ({ enumerable: true, get: function () { return oneof_1.clearOneofValue; } }));
 Object.defineProperty(exports, "getSelectedOneofValue", ({ enumerable: true, get: function () { return oneof_1.getSelectedOneofValue; } }));
 // Enum object type guard and reflection util, may be interesting to the user.
-var enum_object_1 = __nccwpck_require__(267);
+var enum_object_1 = __nccwpck_require__(266);
 Object.defineProperty(exports, "listEnumValues", ({ enumerable: true, get: function () { return enum_object_1.listEnumValues; } }));
 Object.defineProperty(exports, "listEnumNames", ({ enumerable: true, get: function () { return enum_object_1.listEnumNames; } }));
 Object.defineProperty(exports, "listEnumNumbers", ({ enumerable: true, get: function () { return enum_object_1.listEnumNumbers; } }));
 Object.defineProperty(exports, "isEnumObject", ({ enumerable: true, get: function () { return enum_object_1.isEnumObject; } }));
 // lowerCamelCase() is exported for plugin, rpc-runtime and other rpc packages
-var lower_camel_case_1 = __nccwpck_require__(451);
+var lower_camel_case_1 = __nccwpck_require__(450);
 Object.defineProperty(exports, "lowerCamelCase", ({ enumerable: true, get: function () { return lower_camel_case_1.lowerCamelCase; } }));
 // assertion functions are exported for plugin, may also be useful to user
-var assert_1 = __nccwpck_require__(480);
+var assert_1 = __nccwpck_require__(479);
 Object.defineProperty(exports, "assert", ({ enumerable: true, get: function () { return assert_1.assert; } }));
 Object.defineProperty(exports, "assertNever", ({ enumerable: true, get: function () { return assert_1.assertNever; } }));
 Object.defineProperty(exports, "assertInt32", ({ enumerable: true, get: function () { return assert_1.assertInt32; } }));
@@ -3282,7 +3282,7 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_ts_http_runtime = __nccwpck_require__(88);
+var import_ts_http_runtime = __nccwpck_require__(87);
 function createPipelineRequest(options) {
   return (0, import_ts_http_runtime.createPipelineRequest)(options);
 }
@@ -3330,7 +3330,7 @@ const XML_CHARKEY = "_";
 /***/ 22:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(192)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(191)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -3394,7 +3394,7 @@ __export(throttlingRetryPolicy_exports, {
   throttlingRetryPolicyName: () => throttlingRetryPolicyName
 });
 module.exports = __toCommonJS(throttlingRetryPolicy_exports);
-var import_policies = __nccwpck_require__(281);
+var import_policies = __nccwpck_require__(280);
 const throttlingRetryPolicyName = import_policies.throttlingRetryPolicyName;
 function throttlingRetryPolicy(options = {}) {
   return (0, import_policies.throttlingRetryPolicy)(options);
@@ -3411,7 +3411,7 @@ function throttlingRetryPolicy(options = {}) {
 "use strict";
 
 
-const Busboy = __nccwpck_require__(412)
+const Busboy = __nccwpck_require__(411)
 const util = __nccwpck_require__(69)
 const {
   ReadableStreamFrom,
@@ -3421,21 +3421,21 @@ const {
   createDeferredPromise,
   fullyReadBody
 } = __nccwpck_require__(512)
-const { FormData } = __nccwpck_require__(204)
+const { FormData } = __nccwpck_require__(203)
 const { kState } = __nccwpck_require__(15)
-const { webidl } = __nccwpck_require__(454)
+const { webidl } = __nccwpck_require__(453)
 const { DOMException, structuredClone } = __nccwpck_require__(30)
 const { Blob, File: NativeFile } = __nccwpck_require__(117)
-const { kBodyUsed } = __nccwpck_require__(192)
+const { kBodyUsed } = __nccwpck_require__(191)
 const assert = __nccwpck_require__(521)
 const { isErrored } = __nccwpck_require__(69)
-const { isUint8Array, isArrayBuffer } = __nccwpck_require__(195)
-const { File: UndiciFile } = __nccwpck_require__(360)
+const { isUint8Array, isArrayBuffer } = __nccwpck_require__(194)
+const { File: UndiciFile } = __nccwpck_require__(359)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(25)
 
 let random
 try {
-  const crypto = __nccwpck_require__(269)
+  const crypto = __nccwpck_require__(268)
   random = (max) => crypto.randomInt(0, max)
 } catch {
   random = (max) => Math.floor(Math.random(max))
@@ -3451,7 +3451,7 @@ const textDecoder = new TextDecoder()
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 function extractBody (object, keepalive = false) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(252).ReadableStream)
+    ReadableStream = (__nccwpck_require__(251).ReadableStream)
   }
 
   // 1. Let stream be null.
@@ -3672,7 +3672,7 @@ function extractBody (object, keepalive = false) {
 function safelyExtractBody (object, keepalive = false) {
   if (!ReadableStream) {
     // istanbul ignore next
-    ReadableStream = (__nccwpck_require__(252).ReadableStream)
+    ReadableStream = (__nccwpck_require__(251).ReadableStream)
   }
 
   // To safely extract a body and a `Content-Type` value from
@@ -4674,9 +4674,9 @@ module.exports = {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(212);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(437));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(177));
+const tslib_1 = __nccwpck_require__(211);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(436));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing AppendBlob operations. */
 class AppendBlobImpl {
@@ -5009,7 +5009,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(392);
+var import_exponentialRetryStrategy = __nccwpck_require__(391);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_constants = __nccwpck_require__(48);
 const systemErrorRetryPolicyName = "systemErrorRetryPolicy";
@@ -5083,7 +5083,7 @@ function rangeResponseFromModel(response) {
 "use strict";
 
 
-const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(313)
+const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(312)
 
 const corsSafeListedMethods = ['GET', 'HEAD', 'POST']
 const corsSafeListedMethodsSet = new Set(corsSafeListedMethods)
@@ -5246,7 +5246,7 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tracingClient = void 0;
 const core_tracing_1 = __nccwpck_require__(80);
-const constants_js_1 = __nccwpck_require__(147);
+const constants_js_1 = __nccwpck_require__(146);
 /**
  * Creates a span using the global tracer.
  * @internal
@@ -5370,18 +5370,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.reserveCache = exports.downloadCache = exports.getCacheEntry = void 0;
-const core = __importStar(__nccwpck_require__(456));
-const http_client_1 = __nccwpck_require__(280);
+const core = __importStar(__nccwpck_require__(455));
+const http_client_1 = __nccwpck_require__(279);
 const auth_1 = __nccwpck_require__(27);
 const fs = __importStar(__nccwpck_require__(526));
-const url_1 = __nccwpck_require__(84);
+const url_1 = __nccwpck_require__(83);
 const utils = __importStar(__nccwpck_require__(75));
-const uploadUtils_1 = __nccwpck_require__(158);
+const uploadUtils_1 = __nccwpck_require__(157);
 const downloadUtils_1 = __nccwpck_require__(3);
-const options_1 = __nccwpck_require__(260);
-const requestUtils_1 = __nccwpck_require__(256);
+const options_1 = __nccwpck_require__(259);
+const requestUtils_1 = __nccwpck_require__(255);
 const config_1 = __nccwpck_require__(37);
-const user_agent_1 = __nccwpck_require__(358);
+const user_agent_1 = __nccwpck_require__(357);
 function getCacheApiUrl(resource) {
     const baseUrl = (0, config_1.getCacheServiceURL)();
     if (!baseUrl) {
@@ -5620,7 +5620,7 @@ __export(throttlingRetryStrategy_exports, {
   throttlingRetryStrategy: () => throttlingRetryStrategy
 });
 module.exports = __toCommonJS(throttlingRetryStrategy_exports);
-var import_helpers = __nccwpck_require__(453);
+var import_helpers = __nccwpck_require__(452);
 const RetryAfterHeader = "Retry-After";
 const AllRetryAfterHeaders = ["retry-after-ms", "x-ms-retry-after-ms", RetryAfterHeader];
 function getRetryAfterInMs(response) {
@@ -5835,9 +5835,9 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_https_proxy_agent = __nccwpck_require__(131);
-var import_http_proxy_agent = __nccwpck_require__(220);
-var import_log = __nccwpck_require__(150);
+var import_https_proxy_agent = __nccwpck_require__(130);
+var import_http_proxy_agent = __nccwpck_require__(219);
+var import_log = __nccwpck_require__(149);
 const HTTPS_PROXY = "HTTPS_PROXY";
 const HTTP_PROXY = "HTTP_PROXY";
 const ALL_PROXY = "ALL_PROXY";
@@ -6029,15 +6029,15 @@ const {
   DOMException
 } = __nccwpck_require__(30)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(15)
-const { webidl } = __nccwpck_require__(454)
-const { FormData } = __nccwpck_require__(204)
-const { getGlobalOrigin } = __nccwpck_require__(138)
+const { webidl } = __nccwpck_require__(453)
+const { FormData } = __nccwpck_require__(203)
+const { getGlobalOrigin } = __nccwpck_require__(137)
 const { URLSerializer } = __nccwpck_require__(25)
-const { kHeadersList, kConstruct } = __nccwpck_require__(192)
+const { kHeadersList, kConstruct } = __nccwpck_require__(191)
 const assert = __nccwpck_require__(521)
-const { types } = __nccwpck_require__(122)
+const { types } = __nccwpck_require__(121)
 
-const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(252).ReadableStream)
+const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(251).ReadableStream)
 const textEncoder = new TextEncoder('utf-8')
 
 // https://fetch.spec.whatwg.org/#response-class
@@ -6671,7 +6671,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
-const pathHelper = __importStar(__nccwpck_require__(218));
+const pathHelper = __importStar(__nccwpck_require__(217));
 const internal_match_kind_1 = __nccwpck_require__(523);
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -6758,7 +6758,7 @@ exports.AzureLogger = void 0;
 exports.setLogLevel = setLogLevel;
 exports.getLogLevel = getLogLevel;
 exports.createClientLogger = createClientLogger;
-const logger_1 = __nccwpck_require__(146);
+const logger_1 = __nccwpck_require__(145);
 const context = (0, logger_1.createLoggerContext)({
     logLevelEnvVarName: "AZURE_LOG_LEVEL",
     namespace: "azure",
@@ -6910,9 +6910,9 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(212);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(437));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(177));
+const tslib_1 = __nccwpck_require__(211);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(436));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Blob operations. */
 class BlobImpl {
@@ -7985,7 +7985,7 @@ exports.StorageBrowserPolicy = void 0;
 const RequestPolicy_js_1 = __nccwpck_require__(46);
 const core_util_1 = __nccwpck_require__(14);
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(470);
+const utils_common_js_1 = __nccwpck_require__(469);
 /**
  * StorageBrowserPolicy will handle differences between Node.js and browser runtime, including:
  *
@@ -8038,7 +8038,7 @@ exports.StorageBrowserPolicy = StorageBrowserPolicy;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.containsMessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(402);
+const message_type_contract_1 = __nccwpck_require__(401);
 /**
  * Check if the provided object is a proto message.
  *
@@ -8062,8 +8062,8 @@ exports.containsMessageType = containsMessageType;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollHttpOperation = exports.isOperationError = exports.getResourceLocation = exports.getOperationStatus = exports.getOperationLocation = exports.initHttpOperation = exports.getStatusFromInitialResponse = exports.getErrorFromResponse = exports.parseRetryAfter = exports.inferLroMode = void 0;
-const operation_js_1 = __nccwpck_require__(139);
-const logger_js_1 = __nccwpck_require__(188);
+const operation_js_1 = __nccwpck_require__(138);
+const logger_js_1 = __nccwpck_require__(187);
 function getOperationLocationPollingUrl(inputs) {
     const { azureAsyncOperation, operationLocation } = inputs;
     return operationLocation !== null && operationLocation !== void 0 ? operationLocation : azureAsyncOperation;
@@ -8461,13 +8461,13 @@ const {
   kResult,
   kAborted,
   kLastProgressEventFired
-} = __nccwpck_require__(457)
-const { ProgressEvent } = __nccwpck_require__(440)
+} = __nccwpck_require__(456)
+const { ProgressEvent } = __nccwpck_require__(439)
 const { getEncoding } = __nccwpck_require__(96)
 const { DOMException } = __nccwpck_require__(30)
 const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(25)
-const { types } = __nccwpck_require__(122)
-const { StringDecoder } = __nccwpck_require__(148)
+const { types } = __nccwpck_require__(121)
+const { StringDecoder } = __nccwpck_require__(147)
 const { btoa } = __nccwpck_require__(117)
 
 /** @type {PropertyDescriptor} */
@@ -8854,7 +8854,7 @@ module.exports = {
 
 "use strict";
 
-const f = __nccwpck_require__(400)
+const f = __nccwpck_require__(399)
 const DateTime = global.Date
 
 class Date extends DateTime {
@@ -8906,7 +8906,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_policies = __nccwpck_require__(281);
+var import_policies = __nccwpck_require__(280);
 const defaultRetryPolicyName = import_policies.defaultRetryPolicyName;
 function defaultRetryPolicy(options = {}) {
   return (0, import_policies.defaultRetryPolicy)(options);
@@ -8981,8 +8981,8 @@ exports.UnaryCall = UnaryCall;
 
 
 const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(97)
-const { states, opcodes } = __nccwpck_require__(462)
-const { MessageEvent, ErrorEvent } = __nccwpck_require__(245)
+const { states, opcodes } = __nccwpck_require__(461)
+const { MessageEvent, ErrorEvent } = __nccwpck_require__(244)
 
 /* globals Blob */
 
@@ -9463,15 +9463,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.internalCacheTwirpClient = void 0;
-const core_1 = __nccwpck_require__(456);
-const user_agent_1 = __nccwpck_require__(358);
-const errors_1 = __nccwpck_require__(299);
+const core_1 = __nccwpck_require__(455);
+const user_agent_1 = __nccwpck_require__(357);
+const errors_1 = __nccwpck_require__(298);
 const config_1 = __nccwpck_require__(37);
 const cacheUtils_1 = __nccwpck_require__(75);
 const auth_1 = __nccwpck_require__(27);
-const http_client_1 = __nccwpck_require__(280);
-const cache_twirp_client_1 = __nccwpck_require__(434);
-const util_1 = __nccwpck_require__(290);
+const http_client_1 = __nccwpck_require__(279);
+const cache_twirp_client_1 = __nccwpck_require__(433);
+const util_1 = __nccwpck_require__(289);
 /**
  * This class is a wrapper around the CacheServiceClientJSON class generated by Twirp.
  *
@@ -9622,13 +9622,13 @@ exports.internalCacheTwirpClient = internalCacheTwirpClient;
 "use strict";
 
 
-const Dispatcher = __nccwpck_require__(474)
+const Dispatcher = __nccwpck_require__(473)
 const {
   ClientDestroyedError,
   ClientClosedError,
   InvalidArgumentError
-} = __nccwpck_require__(484)
-const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(192)
+} = __nccwpck_require__(483)
+const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(191)
 
 const kDestroyed = Symbol('destroyed')
 const kClosed = Symbol('closed')
@@ -9844,7 +9844,7 @@ __export(requestPolicyFactoryPolicy_exports, {
 });
 module.exports = __toCommonJS(requestPolicyFactoryPolicy_exports);
 var import_util = __nccwpck_require__(108);
-var import_response = __nccwpck_require__(408);
+var import_response = __nccwpck_require__(407);
 var HttpPipelineLogLevel = /* @__PURE__ */ ((HttpPipelineLogLevel2) => {
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["ERROR"] = 1] = "ERROR";
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["INFO"] = 3] = "INFO";
@@ -9897,15 +9897,15 @@ exports.ContainerClient = void 0;
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(14);
 const core_auth_1 = __nccwpck_require__(509);
-const storage_common_1 = __nccwpck_require__(271);
-const Pipeline_js_1 = __nccwpck_require__(180);
-const StorageClient_js_1 = __nccwpck_require__(452);
+const storage_common_1 = __nccwpck_require__(270);
+const Pipeline_js_1 = __nccwpck_require__(179);
+const StorageClient_js_1 = __nccwpck_require__(451);
 const tracing_js_1 = __nccwpck_require__(31);
-const utils_common_js_1 = __nccwpck_require__(153);
+const utils_common_js_1 = __nccwpck_require__(152);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
-const BlobLeaseClient_js_1 = __nccwpck_require__(201);
-const Clients_js_1 = __nccwpck_require__(182);
-const BlobBatchClient_js_1 = __nccwpck_require__(399);
+const BlobLeaseClient_js_1 = __nccwpck_require__(200);
+const Clients_js_1 = __nccwpck_require__(181);
+const BlobBatchClient_js_1 = __nccwpck_require__(398);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
  */
@@ -11207,7 +11207,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.action3 = exports.action2 = exports.leaseId1 = exports.action1 = exports.proposedLeaseId = exports.duration = exports.action = exports.comp10 = exports.sourceLeaseId = exports.sourceContainerName = exports.comp9 = exports.deletedContainerVersion = exports.deletedContainerName = exports.comp8 = exports.containerAcl = exports.comp7 = exports.comp6 = exports.ifUnmodifiedSince = exports.ifModifiedSince = exports.leaseId = exports.preventEncryptionScopeOverride = exports.defaultEncryptionScope = exports.access = exports.metadata = exports.restype2 = exports.where = exports.comp5 = exports.multipartContentType = exports.contentLength = exports.comp4 = exports.body = exports.restype1 = exports.comp3 = exports.keyInfo = exports.include = exports.maxPageSize = exports.marker = exports.prefix = exports.comp2 = exports.comp1 = exports.accept1 = exports.requestId = exports.version = exports.timeoutInSeconds = exports.comp = exports.restype = exports.url = exports.accept = exports.blobServiceProperties = exports.contentType = void 0;
 exports.copySourceTags = exports.copySourceAuthorization = exports.sourceContentMD5 = exports.xMsRequiresSync = exports.legalHold1 = exports.sealBlob = exports.blobTagsString = exports.copySource = exports.sourceIfTags = exports.sourceIfNoneMatch = exports.sourceIfMatch = exports.sourceIfUnmodifiedSince = exports.sourceIfModifiedSince = exports.rehydratePriority = exports.tier = exports.comp14 = exports.encryptionScope = exports.legalHold = exports.comp13 = exports.immutabilityPolicyMode = exports.immutabilityPolicyExpiry = exports.comp12 = exports.blobContentDisposition = exports.blobContentLanguage = exports.blobContentEncoding = exports.blobContentMD5 = exports.blobContentType = exports.blobCacheControl = exports.expiresOn = exports.expiryOptions = exports.comp11 = exports.blobDeleteType = exports.deleteSnapshots = exports.ifTags = exports.ifNoneMatch = exports.ifMatch = exports.encryptionAlgorithm = exports.encryptionKeySha256 = exports.encryptionKey = exports.rangeGetContentCRC64 = exports.rangeGetContentMD5 = exports.range = exports.versionId = exports.snapshot = exports.delimiter = exports.startFrom = exports.include1 = exports.proposedLeaseId1 = exports.action4 = exports.breakPeriod = void 0;
 exports.listType = exports.comp25 = exports.blocks = exports.blockId = exports.comp24 = exports.copySourceBlobProperties = exports.blobType2 = exports.comp23 = exports.sourceRange1 = exports.appendPosition = exports.maxSize = exports.comp22 = exports.blobType1 = exports.comp21 = exports.sequenceNumberAction = exports.prevSnapshotUrl = exports.prevsnapshot = exports.comp20 = exports.range1 = exports.sourceContentCrc64 = exports.sourceRange = exports.sourceUrl = exports.pageWrite1 = exports.ifSequenceNumberEqualTo = exports.ifSequenceNumberLessThan = exports.ifSequenceNumberLessThanOrEqualTo = exports.pageWrite = exports.comp19 = exports.accept2 = exports.body1 = exports.contentType1 = exports.blobSequenceNumber = exports.blobContentLength = exports.blobType = exports.transactionalContentCrc64 = exports.transactionalContentMD5 = exports.tags = exports.ifNoneMatch1 = exports.ifMatch1 = exports.ifUnmodifiedSince1 = exports.ifModifiedSince1 = exports.comp18 = exports.comp17 = exports.queryRequest = exports.tier1 = exports.comp16 = exports.copyId = exports.copyActionAbortConstant = exports.comp15 = exports.fileRequestIntent = void 0;
-const mappers_js_1 = __nccwpck_require__(177);
+const mappers_js_1 = __nccwpck_require__(176);
 exports.contentType = {
     parameterPath: ["options", "contentType"],
     mapper: {
@@ -12883,8 +12883,8 @@ exports.listType = {
 "use strict";
 
 
-const inherits = (__nccwpck_require__(372).inherits)
-const ReadableStream = (__nccwpck_require__(427).Readable)
+const inherits = (__nccwpck_require__(371).inherits)
+const ReadableStream = (__nccwpck_require__(426).Readable)
 
 function PartStream (opts) {
   ReadableStream.call(this, opts)
@@ -12916,14 +12916,14 @@ exports.generateBlobSASQueryParameters = generateBlobSASQueryParameters;
 exports.generateBlobSASQueryParametersInternal = generateBlobSASQueryParametersInternal;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const BlobSASPermissions_js_1 = __nccwpck_require__(498);
-const ContainerSASPermissions_js_1 = __nccwpck_require__(274);
-const storage_common_1 = __nccwpck_require__(271);
-const SasIPRange_js_1 = __nccwpck_require__(356);
+const BlobSASPermissions_js_1 = __nccwpck_require__(497);
+const ContainerSASPermissions_js_1 = __nccwpck_require__(273);
+const storage_common_1 = __nccwpck_require__(270);
+const SasIPRange_js_1 = __nccwpck_require__(355);
 const SASQueryParameters_js_1 = __nccwpck_require__(520);
-const constants_js_1 = __nccwpck_require__(147);
-const utils_common_js_1 = __nccwpck_require__(153);
-const storage_common_2 = __nccwpck_require__(271);
+const constants_js_1 = __nccwpck_require__(146);
+const utils_common_js_1 = __nccwpck_require__(152);
+const storage_common_2 = __nccwpck_require__(270);
 function generateBlobSASQueryParameters(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName) {
     return generateBlobSASQueryParametersInternal(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName).sasQueryParameters;
 }
@@ -13590,14 +13590,14 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 
 
 const assert = __nccwpck_require__(521)
-const { kDestroyed, kBodyUsed } = __nccwpck_require__(192)
-const { IncomingMessage } = __nccwpck_require__(325)
-const stream = __nccwpck_require__(129)
-const net = __nccwpck_require__(504)
-const { InvalidArgumentError } = __nccwpck_require__(484)
+const { kDestroyed, kBodyUsed } = __nccwpck_require__(191)
+const { IncomingMessage } = __nccwpck_require__(324)
+const stream = __nccwpck_require__(128)
+const net = __nccwpck_require__(503)
+const { InvalidArgumentError } = __nccwpck_require__(483)
 const { Blob } = __nccwpck_require__(117)
-const nodeUtil = __nccwpck_require__(122)
-const { stringify } = __nccwpck_require__(128)
+const nodeUtil = __nccwpck_require__(121)
+const { stringify } = __nccwpck_require__(127)
 const { headerNameLowerCasedRecord } = __nccwpck_require__(73)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
@@ -13967,7 +13967,7 @@ async function * convertIterableToBuffer (iterable) {
 let ReadableStream
 function ReadableStreamFrom (iterable) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(252).ReadableStream)
+    ReadableStream = (__nccwpck_require__(251).ReadableStream)
   }
 
   if (ReadableStream.from) {
@@ -14147,8 +14147,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(181);
-var import_policies = __nccwpck_require__(281);
+var import_log = __nccwpck_require__(180);
+var import_policies = __nccwpck_require__(280);
 const logPolicyName = import_policies.logPolicyName;
 function logPolicy(options = {}) {
   return (0, import_policies.logPolicy)({
@@ -14194,11 +14194,11 @@ __export(src_exports, {
   toHttpHeadersLike: () => import_util.toHttpHeadersLike
 });
 module.exports = __toCommonJS(src_exports);
-var import_extendedClient = __nccwpck_require__(211);
-var import_response = __nccwpck_require__(408);
+var import_extendedClient = __nccwpck_require__(210);
+var import_response = __nccwpck_require__(407);
 var import_requestPolicyFactoryPolicy = __nccwpck_require__(63);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_httpClientAdapter = __nccwpck_require__(207);
+var import_httpClientAdapter = __nccwpck_require__(206);
 var import_util = __nccwpck_require__(108);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -14789,15 +14789,15 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
-const core = __importStar(__nccwpck_require__(456));
+const core = __importStar(__nccwpck_require__(455));
 const exec = __importStar(__nccwpck_require__(18));
-const glob = __importStar(__nccwpck_require__(166));
-const io = __importStar(__nccwpck_require__(289));
-const crypto = __importStar(__nccwpck_require__(286));
+const glob = __importStar(__nccwpck_require__(165));
+const io = __importStar(__nccwpck_require__(288));
+const crypto = __importStar(__nccwpck_require__(285));
 const fs = __importStar(__nccwpck_require__(526));
-const path = __importStar(__nccwpck_require__(243));
-const semver = __importStar(__nccwpck_require__(176));
-const util = __importStar(__nccwpck_require__(122));
+const path = __importStar(__nccwpck_require__(242));
+const semver = __importStar(__nccwpck_require__(175));
+const util = __importStar(__nccwpck_require__(121));
 const constants_1 = __nccwpck_require__(45);
 const versionSalt = '1.0';
 // From https://github.com/actions/toolkit/blob/main/packages/tool-cache/src/tool-cache.ts#L23
@@ -14984,10 +14984,10 @@ module.exports = 'AGFzbQEAAAABMAhgAX8Bf2ADf39/AX9gBH9/f38Bf2AAAGADf39/AGABfwBgAn
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageSharedKeyCredentialPolicyName = void 0;
 exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
-const node_crypto_1 = __nccwpck_require__(269);
+const node_crypto_1 = __nccwpck_require__(268);
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(470);
-const SharedKeyComparator_js_1 = __nccwpck_require__(174);
+const utils_common_js_1 = __nccwpck_require__(469);
+const SharedKeyComparator_js_1 = __nccwpck_require__(173);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
  */
@@ -15184,12 +15184,12 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageRetryPolicy = void 0;
 exports.NewRetryPolicyFactory = NewRetryPolicyFactory;
-const abort_controller_1 = __nccwpck_require__(490);
+const abort_controller_1 = __nccwpck_require__(489);
 const RequestPolicy_js_1 = __nccwpck_require__(46);
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(470);
+const utils_common_js_1 = __nccwpck_require__(469);
 const log_js_1 = __nccwpck_require__(17);
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(414);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(413);
 /**
  * A factory method used to generated a RetryPolicy factory.
  *
@@ -15414,412 +15414,15 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = exports.useInstrumenter = void 0;
-var instrumenter_js_1 = __nccwpck_require__(403);
+var instrumenter_js_1 = __nccwpck_require__(402);
 Object.defineProperty(exports, "useInstrumenter", ({ enumerable: true, get: function () { return instrumenter_js_1.useInstrumenter; } }));
-var tracingClient_js_1 = __nccwpck_require__(344);
+var tracingClient_js_1 = __nccwpck_require__(343);
 Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: function () { return tracingClient_js_1.createTracingClient; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
 /***/ 81:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// setup-soldr entry point. Owned by Agent 2.
-//
-// Replaces the composite action's main-phase steps with a single JS
-// orchestrator. Calls the helpers in src/lib/* in the same order the
-// composite's steps fire.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(244));
-const os = __importStar(__nccwpck_require__(379));
-const path = __importStar(__nccwpck_require__(503));
-const core = __importStar(__nccwpck_require__(456));
-const cache = __importStar(__nccwpck_require__(210));
-const log_utils_js_1 = __nccwpck_require__(349);
-const resolve_setup_js_1 = __nccwpck_require__(322);
-const phase_timing_js_1 = __nccwpck_require__(333);
-const ensure_rust_toolchain_js_1 = __nccwpck_require__(507);
-const ensure_soldr_js_1 = __nccwpck_require__(336);
-const verify_soldr_js_1 = __nccwpck_require__(355);
-const install_passthrough_js_1 = __nccwpck_require__(118);
-const normalize_source_mtime_js_1 = __nccwpck_require__(368);
-const detect_shared_target_warning_js_1 = __nccwpck_require__(214);
-const ensure_shims_js_1 = __nccwpck_require__(524);
-const cache_compress_js_1 = __nccwpck_require__(278);
-const stats_collector_js_1 = __nccwpck_require__(307);
-const TRUTHY = new Set(["1", "true", "yes", "on"]);
-const FALSY = new Set(["0", "false", "no", "off"]);
-function isTruthy(value) {
-    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
-}
-function isFalsy(value) {
-    return FALSY.has(((value ?? "").trim().toLowerCase()));
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
-    }
-}
-function dirHasContent(p) {
-    try {
-        return fs.readdirSync(p).length > 0;
-    }
-    catch {
-        return false;
-    }
-}
-function buildActionContext() {
-    const env = process.env;
-    const logger = (0, log_utils_js_1.createLogger)(env);
-    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
-    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
-    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
-    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
-    const githubSha = env["GITHUB_SHA"]?.trim() || "";
-    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
-    const parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
-    return {
-        env: { ...env },
-        workspace,
-        runnerTemp,
-        runnerOs,
-        runnerArch,
-        githubSha,
-        githubToken,
-        parentSha,
-        logger,
-    };
-}
-async function restoreCacheSafe(paths, key, restoreKeys, logger) {
-    if (paths.length === 0 || !key) {
-        return { hit: false, matchedKey: "" };
-    }
-    try {
-        const matched = await cache.restoreCache(paths, key, restoreKeys);
-        return { hit: matched === key, matchedKey: matched ?? "" };
-    }
-    catch (err) {
-        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "" };
-    }
-}
-async function run() {
-    const ctx = buildActionContext();
-    const logger = ctx.logger;
-    await (0, phase_timing_js_1.markPhase)("action");
-    // ---- resolve ----
-    await (0, phase_timing_js_1.markPhase)("resolve");
-    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
-    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
-    await (0, resolve_setup_js_1.applyResolveResult)(result);
-    await (0, phase_timing_js_1.finishPhase)("resolve");
-    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
-    if (dryRun) {
-        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
-        await (0, phase_timing_js_1.finishPhase)("action");
-        return;
-    }
-    // Persist resolve state for the post-job step.
-    core.saveState("resolveResult", JSON.stringify(result));
-    core.saveState("buildCacheMode", result.buildCache.mode);
-    const statsMode = result.stats;
-    const debugMode = result.debugMode;
-    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
-    const statsCollector = new stats_collector_js_1.StatsCollector();
-    // ---- source-mtime-normalize ----
-    if (isTruthy(inputs.sourceMtimeNormalize)) {
-        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
-    }
-    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
-    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
-    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
-    core.saveState("setupCacheExactHit", "false");
-    core.saveState("setupCacheMatchedKey", "");
-    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
-    core.saveState("targetCacheExactHit", "false");
-    core.saveState("targetCacheMatchedKey", "");
-    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
-    core.saveState("buildCacheExactHit", "false");
-    core.saveState("buildCacheMatchedKey", "");
-    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
-    core.saveState("cargoRegistryCacheExactHit", "false");
-    core.saveState("cargoRegistryCacheMatchedKey", "");
-    // ---- setup-cache ----
-    await (0, phase_timing_js_1.markPhase)("setup-cache");
-    let setupCacheExactHit = false;
-    if (cacheEnabled && result.setupCache.paths.length > 0) {
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
-        setupCacheExactHit = restore.hit;
-        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("setup_cache_matched_key", restore.matchedKey);
-        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("setupCacheMatchedKey", restore.matchedKey);
-        // Expose for ensure_rust_toolchain to read via env (the python port did this).
-        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
-        statsCollector.record({
-            label: "setup-cache", operation: "restore", hit: restore.hit,
-            key: result.setupCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.setupCache.restorePrefix],
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    }
-    await (0, phase_timing_js_1.finishPhase)("setup-cache");
-    // ---- target-cache ----
-    await (0, phase_timing_js_1.markPhase)("target-cache");
-    if (result.targetCache.enabled) {
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        if (targetPaths.length > 0) {
-            const restoreKeys = [];
-            if (result.targetCache.restoreKeyParent)
-                restoreKeys.push(result.targetCache.restoreKeyParent);
-            if (result.targetCache.restoreKeyLock)
-                restoreKeys.push(result.targetCache.restoreKeyLock);
-            if (result.targetCache.restoreKeyLockfile)
-                restoreKeys.push(result.targetCache.restoreKeyLockfile);
-            const t0 = Date.now();
-            const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
-            core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
-            core.setOutput("target_cache_matched_key", restore.matchedKey);
-            core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
-            core.saveState("targetCacheMatchedKey", restore.matchedKey);
-            statsCollector.record({
-                label: "target-cache", operation: "restore", hit: restore.hit,
-                key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
-                archiveBytes: null, inflatedBytes: null, fileCount: null,
-                durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-            });
-            if (debugMode)
-                debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-        }
-    }
-    await (0, phase_timing_js_1.finishPhase)("target-cache");
-    // ---- build-cache ----
-    await (0, phase_timing_js_1.markPhase)("build-cache");
-    if (buildCacheEnabled) {
-        const buildCachePath = result.buildCache.path;
-        const archivePath = `${buildCachePath}.tar.zst`;
-        const restoreKeys = [];
-        if (result.buildCache.restoreKeyParent)
-            restoreKeys.push(result.buildCache.restoreKeyParent);
-        if (result.buildCache.restoreKeyToolchain)
-            restoreKeys.push(result.buildCache.restoreKeyToolchain);
-        if (result.buildCache.restoreKeyOsArch)
-            restoreKeys.push(result.buildCache.restoreKeyOsArch);
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe([archivePath, buildCachePath], result.buildCache.key, restoreKeys, logger);
-        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("build_cache_matched_key", restore.matchedKey);
-        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("buildCacheMatchedKey", restore.matchedKey);
-        let buildArchiveBytes = null;
-        let buildInflatedBytes = null;
-        let buildFileCount = null;
-        if (fileExists(archivePath)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-            if (magic === "zstd" || magic === "gzip") {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath, debug: debugMode, log: debugLog });
-                    buildArchiveBytes = dr.archiveBytes;
-                    buildInflatedBytes = dr.inflatedBytes;
-                    buildFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        statsCollector.record({
-            label: "build-cache", operation: "restore", hit: restore.hit,
-            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    }
-    await (0, phase_timing_js_1.finishPhase)("build-cache");
-    // ---- target-tree-cache (full mode) ----
-    await (0, phase_timing_js_1.markPhase)("target-tree");
-    // The bundle path is included in target-cache restore paths above when full
-    // mode is requested, so there's no separate restore here. We keep the phase
-    // marker for parity with the composite step ordering.
-    await (0, phase_timing_js_1.finishPhase)("target-tree");
-    // ---- toolchain ----
-    await (0, phase_timing_js_1.markPhase)("toolchain");
-    await (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({ resolveResult: result, setupCacheExactHit });
-    await (0, phase_timing_js_1.finishPhase)("toolchain");
-    // ---- install soldr ----
-    await (0, phase_timing_js_1.markPhase)("install");
-    if (result.enabled) {
-        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
-    }
-    else {
-        (0, install_passthrough_js_1.installPassthrough)({
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
-            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
-            "verbatim, and soldr-aware caching/observability is disabled.");
-    }
-    await (0, phase_timing_js_1.finishPhase)("install");
-    // Export SOLDR_BINARY so shims can exec it directly
-    core.exportVariable("SOLDR_BINARY", result.soldrPath);
-    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
-    // ---- shims ----
-    if (result.shimsEnabled) {
-        await (0, ensure_shims_js_1.ensureShims)({
-            shimsDir: result.shimsDir,
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-    }
-    // ---- verify ----
-    await (0, phase_timing_js_1.markPhase)("verify");
-    if (result.enabled) {
-        const verify = await (0, verify_soldr_js_1.verifySoldr)({
-            soldrPath: result.soldrPath,
-            buildCacheMode: result.buildCache.mode,
-            requireRustPlan: result.targetCache.enabled,
-        });
-        core.setOutput("soldr-version", verify.soldrVersion);
-        core.setOutput("soldr_version", verify.soldrVersion);
-    }
-    else {
-        core.setOutput("soldr-version", "passthrough");
-        core.setOutput("soldr_version", "passthrough");
-    }
-    await (0, phase_timing_js_1.finishPhase)("verify");
-    // ---- cargo-registry restore (if requested) ----
-    if (result.cargoRegistryCache.enabled) {
-        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe([registryArchive, result.cargoRegistryCache.path], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
-        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
-        let regArchiveBytes = null;
-        let regInflatedBytes = null;
-        let regFileCount = null;
-        if (fileExists(registryArchive)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
-            if (magic === "zstd" || magic === "gzip") {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({
-                        archivePath: registryArchive,
-                        targetDir: result.cargoRegistryCache.path,
-                        debug: debugMode, log: debugLog,
-                    });
-                    regArchiveBytes = dr.archiveBytes;
-                    regInflatedBytes = dr.inflatedBytes;
-                    regFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        statsCollector.record({
-            label: "cargo-registry", operation: "restore", hit: restore.hit,
-            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.cargoRegistryCache.restorePrefix],
-            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    }
-    // ---- shared-target warning ----
-    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
-        buildCacheEnabled,
-        effectiveTargetCacheEnabled: result.targetCache.enabled,
-        buildCacheMode: result.buildCache.mode,
-        targetDir: result.targetCache.targetPath,
-    });
-    // ---- stats report ----
-    statsCollector.report(statsMode, (msg) => logger.log(msg));
-    if (statsMode === "detailed") {
-        try {
-            await statsCollector.writeFiles(ctx.runnerTemp);
-            statsCollector.setGithubOutputs();
-        }
-        catch (err) {
-            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    core.saveState("statsCollector", statsCollector.serialize());
-    core.saveState("statsMode", statsMode);
-    core.saveState("compileCacheStats", result.compileCacheStats);
-    core.saveState("runnerTemp", ctx.runnerTemp);
-    await (0, phase_timing_js_1.finishPhase)("action");
-    // dirHasContent is exported for tests; suppress unused warning here.
-    void dirHasContent;
-}
-// Auto-invoke only when this module is run as the main entry point. This lets
-// tests import `run` (and helpers) without triggering the side-effectful
-// orchestration. The dist/main.js produced by ncc is invoked directly by the
-// Actions runtime so the check trips and the action executes normally.
-if (typeof process !== "undefined" &&
-    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
-    // import.meta.url is the file URL of this module; argv[1] is the runner
-    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
-    // the dev path — we rely on the env-var opt-out for tests instead.
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.setFailed(`setup-soldr failed: ${message}`);
-    });
-}
-
-
-/***/ }),
-
-/***/ 82:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -15831,7 +15434,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 83:
+/***/ 82:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15841,7 +15444,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 const { extractBody, mixinBody, cloneBody } = __nccwpck_require__(24)
 const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(511)
-const { FinalizationRegistry } = __nccwpck_require__(410)()
+const { FinalizationRegistry } = __nccwpck_require__(409)()
 const util = __nccwpck_require__(69)
 const {
   isValidHTTPToken,
@@ -15862,12 +15465,12 @@ const {
 } = __nccwpck_require__(30)
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(15)
-const { webidl } = __nccwpck_require__(454)
-const { getGlobalOrigin } = __nccwpck_require__(138)
+const { webidl } = __nccwpck_require__(453)
+const { getGlobalOrigin } = __nccwpck_require__(137)
 const { URLSerializer } = __nccwpck_require__(25)
-const { kHeadersList, kConstruct } = __nccwpck_require__(192)
+const { kHeadersList, kConstruct } = __nccwpck_require__(191)
 const assert = __nccwpck_require__(521)
-const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(466)
+const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(465)
 
 let TransformStream = globalThis.TransformStream
 
@@ -16354,7 +15957,7 @@ class Request {
 
       // 2. Set finalBody to the result of creating a proxy for inputBody.
       if (!TransformStream) {
-        TransformStream = (__nccwpck_require__(252).TransformStream)
+        TransformStream = (__nccwpck_require__(251).TransformStream)
       }
 
       // https://streams.spec.whatwg.org/#readablestream-create-a-proxy
@@ -16785,7 +16388,7 @@ module.exports = { Request, makeRequest }
 
 /***/ }),
 
-/***/ 84:
+/***/ 83:
 /***/ ((module) => {
 
 "use strict";
@@ -16793,7 +16396,7 @@ module.exports = require("url");
 
 /***/ }),
 
-/***/ 85:
+/***/ 84:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16805,8 +16408,8 @@ exports.deserializationPolicyName = void 0;
 exports.deserializationPolicy = deserializationPolicy;
 const interfaces_js_1 = __nccwpck_require__(98);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
-const serializer_js_1 = __nccwpck_require__(476);
-const operationHelpers_js_1 = __nccwpck_require__(429);
+const serializer_js_1 = __nccwpck_require__(475);
+const operationHelpers_js_1 = __nccwpck_require__(428);
 const defaultJsonContentTypes = ["application/json", "text/json"];
 const defaultXmlContentTypes = ["application/xml", "application/atom+xml"];
 /**
@@ -17034,7 +16637,7 @@ async function parse(jsonContentTypes, xmlContentTypes, operationResponse, opts,
 
 /***/ }),
 
-/***/ 86:
+/***/ 85:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -17060,7 +16663,7 @@ __export(apiKeyAuthenticationPolicy_exports, {
   apiKeyAuthenticationPolicyName: () => apiKeyAuthenticationPolicyName
 });
 module.exports = __toCommonJS(apiKeyAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(433);
+var import_checkInsecureConnection = __nccwpck_require__(432);
 const apiKeyAuthenticationPolicyName = "apiKeyAuthenticationPolicy";
 function apiKeyAuthenticationPolicy(options) {
   return {
@@ -17086,7 +16689,7 @@ function apiKeyAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 87:
+/***/ 86:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -17097,12 +16700,12 @@ function apiKeyAuthenticationPolicy(options) {
 /* global WebAssembly */
 
 const assert = __nccwpck_require__(521)
-const net = __nccwpck_require__(504)
-const http = __nccwpck_require__(325)
-const { pipeline } = __nccwpck_require__(129)
+const net = __nccwpck_require__(503)
+const http = __nccwpck_require__(324)
+const { pipeline } = __nccwpck_require__(128)
 const util = __nccwpck_require__(69)
-const timers = __nccwpck_require__(324)
-const Request = __nccwpck_require__(293)
+const timers = __nccwpck_require__(323)
+const Request = __nccwpck_require__(292)
 const DispatcherBase = __nccwpck_require__(62)
 const {
   RequestContentLengthMismatchError,
@@ -17117,8 +16720,8 @@ const {
   HTTPParserError,
   ResponseExceededMaxSizeError,
   ClientDestroyedError
-} = __nccwpck_require__(484)
-const buildConnector = __nccwpck_require__(261)
+} = __nccwpck_require__(483)
+const buildConnector = __nccwpck_require__(260)
 const {
   kUrl,
   kReset,
@@ -17170,7 +16773,7 @@ const {
   kHTTP2BuildRequest,
   kHTTP2CopyHeaders,
   kHTTP1BuildRequest
-} = __nccwpck_require__(192)
+} = __nccwpck_require__(191)
 
 /** @type {import('http2')} */
 let http2
@@ -17203,7 +16806,7 @@ const kClosedResolve = Symbol('kClosedResolve')
 const channels = {}
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(140)
+  const diagnosticsChannel = __nccwpck_require__(139)
   channels.sendHeaders = diagnosticsChannel.channel('undici:client:sendHeaders')
   channels.beforeConnect = diagnosticsChannel.channel('undici:client:beforeConnect')
   channels.connectError = diagnosticsChannel.channel('undici:client:connectError')
@@ -17576,8 +17179,8 @@ function onHTTP2GoAway (code) {
   resume(client)
 }
 
-const constants = __nccwpck_require__(446)
-const createRedirectInterceptor = __nccwpck_require__(250)
+const constants = __nccwpck_require__(445)
+const createRedirectInterceptor = __nccwpck_require__(249)
 const EMPTY_BUF = Buffer.alloc(0)
 
 async function lazyllhttp () {
@@ -19377,7 +18980,7 @@ module.exports = Client
 
 /***/ }),
 
-/***/ 88:
+/***/ 87:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -19418,16 +19021,16 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 var import_AbortError = __nccwpck_require__(10);
-var import_logger = __nccwpck_require__(241);
-var import_httpHeaders = __nccwpck_require__(481);
+var import_logger = __nccwpck_require__(240);
+var import_httpHeaders = __nccwpck_require__(480);
 var import_pipelineRequest = __nccwpck_require__(113);
 var import_pipeline = __nccwpck_require__(519);
-var import_restError = __nccwpck_require__(442);
-var import_bytesEncoding = __nccwpck_require__(282);
-var import_defaultHttpClient = __nccwpck_require__(369);
-var import_getClient = __nccwpck_require__(206);
-var import_operationOptionHelpers = __nccwpck_require__(380);
-var import_restError2 = __nccwpck_require__(364);
+var import_restError = __nccwpck_require__(441);
+var import_bytesEncoding = __nccwpck_require__(281);
+var import_defaultHttpClient = __nccwpck_require__(368);
+var import_getClient = __nccwpck_require__(205);
+var import_operationOptionHelpers = __nccwpck_require__(379);
+var import_restError2 = __nccwpck_require__(363);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -19435,17 +19038,17 @@ var import_restError2 = __nccwpck_require__(364);
 
 /***/ }),
 
-/***/ 89:
+/***/ 88:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
-const base64_1 = __nccwpck_require__(297);
+const base64_1 = __nccwpck_require__(296);
 const pb_long_1 = __nccwpck_require__(115);
-const reflection_info_1 = __nccwpck_require__(450);
-const assert_1 = __nccwpck_require__(480);
+const reflection_info_1 = __nccwpck_require__(449);
+const assert_1 = __nccwpck_require__(479);
 /**
  * Writes proto3 messages in canonical JSON format using reflection
  * information.
@@ -19673,7 +19276,7 @@ exports.ReflectionJsonWriter = ReflectionJsonWriter;
 
 /***/ }),
 
-/***/ 90:
+/***/ 89:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19684,7 +19287,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Batch = void 0;
 // In browser, during webpack or browserify bundling, this module will be replaced by 'events'
 // https://github.com/Gozala/events
-const events_1 = __nccwpck_require__(466);
+const events_1 = __nccwpck_require__(465);
 /**
  * States for Batch.
  */
@@ -19814,7 +19417,7 @@ exports.Batch = Batch;
 
 /***/ }),
 
-/***/ 91:
+/***/ 90:
 /***/ ((module) => {
 
 "use strict";
@@ -19822,7 +19425,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 92:
+/***/ 91:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19831,7 +19434,7 @@ module.exports = require("os");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredentialPolicy = void 0;
-const CredentialPolicy_js_1 = __nccwpck_require__(303);
+const CredentialPolicy_js_1 = __nccwpck_require__(302);
 /**
  * AnonymousCredentialPolicy is used with HTTP(S) requests that read public resources
  * or for use with Shared Access Signatures (SAS).
@@ -19853,7 +19456,7 @@ exports.AnonymousCredentialPolicy = AnonymousCredentialPolicy;
 
 /***/ }),
 
-/***/ 93:
+/***/ 92:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19870,8 +19473,8 @@ const {
   kResult,
   kEvents,
   kAborted
-} = __nccwpck_require__(457)
-const { webidl } = __nccwpck_require__(454)
+} = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(453)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 
 class FileReader extends EventTarget {
@@ -20205,7 +19808,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 94:
+/***/ 93:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20231,6 +19834,403 @@ class Credential {
 }
 exports.Credential = Credential;
 //# sourceMappingURL=Credential.js.map
+
+/***/ }),
+
+/***/ 94:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr entry point. Owned by Agent 2.
+//
+// Replaces the composite action's main-phase steps with a single JS
+// orchestrator. Calls the helpers in src/lib/* in the same order the
+// composite's steps fire.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(243));
+const os = __importStar(__nccwpck_require__(378));
+const path = __importStar(__nccwpck_require__(502));
+const core = __importStar(__nccwpck_require__(455));
+const cache = __importStar(__nccwpck_require__(209));
+const log_utils_js_1 = __nccwpck_require__(348);
+const resolve_setup_js_1 = __nccwpck_require__(321);
+const phase_timing_js_1 = __nccwpck_require__(332);
+const ensure_rust_toolchain_js_1 = __nccwpck_require__(506);
+const ensure_soldr_js_1 = __nccwpck_require__(335);
+const verify_soldr_js_1 = __nccwpck_require__(354);
+const install_passthrough_js_1 = __nccwpck_require__(508);
+const normalize_source_mtime_js_1 = __nccwpck_require__(367);
+const detect_shared_target_warning_js_1 = __nccwpck_require__(213);
+const ensure_shims_js_1 = __nccwpck_require__(524);
+const cache_compress_js_1 = __nccwpck_require__(277);
+const stats_collector_js_1 = __nccwpck_require__(306);
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+function isTruthy(value) {
+    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
+}
+function isFalsy(value) {
+    return FALSY.has(((value ?? "").trim().toLowerCase()));
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+function dirHasContent(p) {
+    try {
+        return fs.readdirSync(p).length > 0;
+    }
+    catch {
+        return false;
+    }
+}
+function buildActionContext() {
+    const env = process.env;
+    const logger = (0, log_utils_js_1.createLogger)(env);
+    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
+    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
+    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
+    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
+    const githubSha = env["GITHUB_SHA"]?.trim() || "";
+    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
+    const parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
+    return {
+        env: { ...env },
+        workspace,
+        runnerTemp,
+        runnerOs,
+        runnerArch,
+        githubSha,
+        githubToken,
+        parentSha,
+        logger,
+    };
+}
+async function restoreCacheSafe(paths, key, restoreKeys, logger) {
+    if (paths.length === 0 || !key) {
+        return { hit: false, matchedKey: "" };
+    }
+    try {
+        const matched = await cache.restoreCache(paths, key, restoreKeys);
+        return { hit: matched === key, matchedKey: matched ?? "" };
+    }
+    catch (err) {
+        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "" };
+    }
+}
+async function run() {
+    const ctx = buildActionContext();
+    const logger = ctx.logger;
+    await (0, phase_timing_js_1.markPhase)("action");
+    // ---- resolve ----
+    await (0, phase_timing_js_1.markPhase)("resolve");
+    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
+    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
+    await (0, resolve_setup_js_1.applyResolveResult)(result);
+    await (0, phase_timing_js_1.finishPhase)("resolve");
+    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
+    if (dryRun) {
+        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
+        await (0, phase_timing_js_1.finishPhase)("action");
+        return;
+    }
+    // Persist resolve state for the post-job step.
+    core.saveState("resolveResult", JSON.stringify(result));
+    core.saveState("buildCacheMode", result.buildCache.mode);
+    const statsMode = result.stats;
+    const debugMode = result.debugMode;
+    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
+    const statsCollector = new stats_collector_js_1.StatsCollector();
+    // ---- source-mtime-normalize ----
+    if (isTruthy(inputs.sourceMtimeNormalize)) {
+        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
+    }
+    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
+    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
+    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
+    core.saveState("setupCacheExactHit", "false");
+    core.saveState("setupCacheMatchedKey", "");
+    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
+    core.saveState("targetCacheExactHit", "false");
+    core.saveState("targetCacheMatchedKey", "");
+    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
+    core.saveState("buildCacheExactHit", "false");
+    core.saveState("buildCacheMatchedKey", "");
+    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
+    core.saveState("cargoRegistryCacheExactHit", "false");
+    core.saveState("cargoRegistryCacheMatchedKey", "");
+    // ---- setup-cache ----
+    await (0, phase_timing_js_1.markPhase)("setup-cache");
+    let setupCacheExactHit = false;
+    if (cacheEnabled && result.setupCache.paths.length > 0) {
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
+        setupCacheExactHit = restore.hit;
+        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("setup_cache_matched_key", restore.matchedKey);
+        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("setupCacheMatchedKey", restore.matchedKey);
+        // Expose for ensure_rust_toolchain to read via env (the python port did this).
+        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
+        statsCollector.record({
+            label: "setup-cache", operation: "restore", hit: restore.hit,
+            key: result.setupCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.setupCache.restorePrefix],
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    }
+    await (0, phase_timing_js_1.finishPhase)("setup-cache");
+    // ---- target-cache ----
+    await (0, phase_timing_js_1.markPhase)("target-cache");
+    if (result.targetCache.enabled) {
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (targetPaths.length > 0) {
+            const restoreKeys = [];
+            if (result.targetCache.restoreKeyParent)
+                restoreKeys.push(result.targetCache.restoreKeyParent);
+            if (result.targetCache.restoreKeyLock)
+                restoreKeys.push(result.targetCache.restoreKeyLock);
+            if (result.targetCache.restoreKeyLockfile)
+                restoreKeys.push(result.targetCache.restoreKeyLockfile);
+            const t0 = Date.now();
+            const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
+            core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
+            core.setOutput("target_cache_matched_key", restore.matchedKey);
+            core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
+            core.saveState("targetCacheMatchedKey", restore.matchedKey);
+            statsCollector.record({
+                label: "target-cache", operation: "restore", hit: restore.hit,
+                key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
+                archiveBytes: null, inflatedBytes: null, fileCount: null,
+                durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+            });
+            if (debugMode)
+                debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+        }
+    }
+    await (0, phase_timing_js_1.finishPhase)("target-cache");
+    // ---- build-cache ----
+    await (0, phase_timing_js_1.markPhase)("build-cache");
+    if (buildCacheEnabled) {
+        const buildCachePath = result.buildCache.path;
+        const archivePath = `${buildCachePath}.tar.zst`;
+        const restoreKeys = [];
+        if (result.buildCache.restoreKeyParent)
+            restoreKeys.push(result.buildCache.restoreKeyParent);
+        if (result.buildCache.restoreKeyToolchain)
+            restoreKeys.push(result.buildCache.restoreKeyToolchain);
+        if (result.buildCache.restoreKeyOsArch)
+            restoreKeys.push(result.buildCache.restoreKeyOsArch);
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe([archivePath, buildCachePath], result.buildCache.key, restoreKeys, logger);
+        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("build_cache_matched_key", restore.matchedKey);
+        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("buildCacheMatchedKey", restore.matchedKey);
+        let buildArchiveBytes = null;
+        let buildInflatedBytes = null;
+        let buildFileCount = null;
+        if (fileExists(archivePath)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+            if (magic === "zstd" || magic === "gzip") {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath, debug: debugMode, log: debugLog });
+                    buildArchiveBytes = dr.archiveBytes;
+                    buildInflatedBytes = dr.inflatedBytes;
+                    buildFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        statsCollector.record({
+            label: "build-cache", operation: "restore", hit: restore.hit,
+            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    }
+    await (0, phase_timing_js_1.finishPhase)("build-cache");
+    // ---- target-tree-cache (full mode) ----
+    await (0, phase_timing_js_1.markPhase)("target-tree");
+    // The bundle path is included in target-cache restore paths above when full
+    // mode is requested, so there's no separate restore here. We keep the phase
+    // marker for parity with the composite step ordering.
+    await (0, phase_timing_js_1.finishPhase)("target-tree");
+    // ---- toolchain ----
+    await (0, phase_timing_js_1.markPhase)("toolchain");
+    await (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({ resolveResult: result, setupCacheExactHit });
+    await (0, phase_timing_js_1.finishPhase)("toolchain");
+    // ---- install soldr ----
+    await (0, phase_timing_js_1.markPhase)("install");
+    if (result.enabled) {
+        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
+    }
+    else {
+        (0, install_passthrough_js_1.installPassthrough)({
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
+            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
+            "verbatim, and soldr-aware caching/observability is disabled.");
+    }
+    await (0, phase_timing_js_1.finishPhase)("install");
+    // Export SOLDR_BINARY so shims can exec it directly
+    core.exportVariable("SOLDR_BINARY", result.soldrPath);
+    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
+    // ---- shims ----
+    if (result.shimsEnabled) {
+        await (0, ensure_shims_js_1.ensureShims)({
+            shimsDir: result.shimsDir,
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+    }
+    // ---- verify ----
+    await (0, phase_timing_js_1.markPhase)("verify");
+    if (result.enabled) {
+        const verify = await (0, verify_soldr_js_1.verifySoldr)({
+            soldrPath: result.soldrPath,
+            buildCacheMode: result.buildCache.mode,
+            requireRustPlan: result.targetCache.enabled,
+        });
+        core.setOutput("soldr-version", verify.soldrVersion);
+        core.setOutput("soldr_version", verify.soldrVersion);
+    }
+    else {
+        core.setOutput("soldr-version", "passthrough");
+        core.setOutput("soldr_version", "passthrough");
+    }
+    await (0, phase_timing_js_1.finishPhase)("verify");
+    // ---- cargo-registry restore (if requested) ----
+    if (result.cargoRegistryCache.enabled) {
+        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe([registryArchive, result.cargoRegistryCache.path], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
+        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
+        let regArchiveBytes = null;
+        let regInflatedBytes = null;
+        let regFileCount = null;
+        if (fileExists(registryArchive)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
+            if (magic === "zstd" || magic === "gzip") {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({
+                        archivePath: registryArchive,
+                        targetDir: result.cargoRegistryCache.path,
+                        debug: debugMode, log: debugLog,
+                    });
+                    regArchiveBytes = dr.archiveBytes;
+                    regInflatedBytes = dr.inflatedBytes;
+                    regFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        statsCollector.record({
+            label: "cargo-registry", operation: "restore", hit: restore.hit,
+            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.cargoRegistryCache.restorePrefix],
+            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    }
+    // ---- shared-target warning ----
+    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
+        buildCacheEnabled,
+        effectiveTargetCacheEnabled: result.targetCache.enabled,
+        buildCacheMode: result.buildCache.mode,
+        targetDir: result.targetCache.targetPath,
+    });
+    // ---- stats report ----
+    statsCollector.report(statsMode, (msg) => logger.log(msg));
+    if (statsMode === "detailed") {
+        try {
+            await statsCollector.writeFiles(ctx.runnerTemp);
+            statsCollector.setGithubOutputs();
+        }
+        catch (err) {
+            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    core.saveState("statsCollector", statsCollector.serialize());
+    core.saveState("statsMode", statsMode);
+    core.saveState("compileCacheStats", result.compileCacheStats);
+    core.saveState("runnerTemp", ctx.runnerTemp);
+    await (0, phase_timing_js_1.finishPhase)("action");
+    // dirHasContent is exported for tests; suppress unused warning here.
+    void dirHasContent;
+}
+// Auto-invoke only when this module is run as the main entry point. This lets
+// tests import `run` (and helpers) without triggering the side-effectful
+// orchestration. The dist/main.js produced by ncc is invoked directly by the
+// Actions runtime so the check trips and the action executes normally.
+if (typeof process !== "undefined" &&
+    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
+    // import.meta.url is the file URL of this module; argv[1] is the runner
+    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
+    // the dev path — we rely on the env-var opt-out for tests instead.
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    run().catch((err) => {
+        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        core.setFailed(`setup-soldr failed: ${message}`);
+    });
+}
+
 
 /***/ }),
 
@@ -20694,32 +20694,32 @@ __export(src_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(src_exports);
-var import_pipeline = __nccwpck_require__(240);
-var import_createPipelineFromOptions = __nccwpck_require__(275);
-var import_defaultHttpClient = __nccwpck_require__(231);
-var import_httpHeaders = __nccwpck_require__(238);
+var import_pipeline = __nccwpck_require__(239);
+var import_createPipelineFromOptions = __nccwpck_require__(274);
+var import_defaultHttpClient = __nccwpck_require__(230);
+var import_httpHeaders = __nccwpck_require__(237);
 var import_pipelineRequest = __nccwpck_require__(20);
-var import_restError = __nccwpck_require__(350);
-var import_decompressResponsePolicy = __nccwpck_require__(234);
-var import_exponentialRetryPolicy = __nccwpck_require__(389);
-var import_setClientRequestIdPolicy = __nccwpck_require__(149);
+var import_restError = __nccwpck_require__(349);
+var import_decompressResponsePolicy = __nccwpck_require__(233);
+var import_exponentialRetryPolicy = __nccwpck_require__(388);
+var import_setClientRequestIdPolicy = __nccwpck_require__(148);
 var import_logPolicy = __nccwpck_require__(71);
-var import_multipartPolicy = __nccwpck_require__(266);
-var import_proxyPolicy = __nccwpck_require__(469);
-var import_redirectPolicy = __nccwpck_require__(338);
-var import_systemErrorRetryPolicy = __nccwpck_require__(215);
+var import_multipartPolicy = __nccwpck_require__(265);
+var import_proxyPolicy = __nccwpck_require__(468);
+var import_redirectPolicy = __nccwpck_require__(337);
+var import_systemErrorRetryPolicy = __nccwpck_require__(214);
 var import_throttlingRetryPolicy = __nccwpck_require__(23);
-var import_retryPolicy = __nccwpck_require__(208);
-var import_tracingPolicy = __nccwpck_require__(332);
+var import_retryPolicy = __nccwpck_require__(207);
+var import_tracingPolicy = __nccwpck_require__(331);
 var import_defaultRetryPolicy = __nccwpck_require__(55);
-var import_userAgentPolicy = __nccwpck_require__(386);
-var import_tlsPolicy = __nccwpck_require__(375);
-var import_formDataPolicy = __nccwpck_require__(263);
-var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(213);
-var import_ndJsonPolicy = __nccwpck_require__(235);
-var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(190);
-var import_agentPolicy = __nccwpck_require__(227);
-var import_file = __nccwpck_require__(323);
+var import_userAgentPolicy = __nccwpck_require__(385);
+var import_tlsPolicy = __nccwpck_require__(374);
+var import_formDataPolicy = __nccwpck_require__(262);
+var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(212);
+var import_ndJsonPolicy = __nccwpck_require__(234);
+var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(189);
+var import_agentPolicy = __nccwpck_require__(226);
+var import_file = __nccwpck_require__(322);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 
@@ -20752,8 +20752,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(150);
-var import_sanitizer = __nccwpck_require__(120);
+var import_log = __nccwpck_require__(149);
+var import_sanitizer = __nccwpck_require__(119);
 const logPolicyName = "logPolicy";
 function logPolicy(options = {}) {
   const logger = options.logger ?? import_log.logger.info;
@@ -20786,7 +20786,7 @@ function logPolicy(options = {}) {
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const { addAbortListener } = __nccwpck_require__(69)
-const { RequestAbortedError } = __nccwpck_require__(484)
+const { RequestAbortedError } = __nccwpck_require__(483)
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')
@@ -20884,14 +20884,14 @@ const {
   Readable,
   Duplex,
   PassThrough
-} = __nccwpck_require__(129)
+} = __nccwpck_require__(128)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(484)
+} = __nccwpck_require__(483)
 const util = __nccwpck_require__(69)
-const { AsyncResource } = __nccwpck_require__(426)
+const { AsyncResource } = __nccwpck_require__(425)
 const { addSignal, removeSignal } = __nccwpck_require__(102)
 const assert = __nccwpck_require__(521)
 
@@ -21155,9 +21155,9 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 "use strict";
 
 
-const EventEmitter = (__nccwpck_require__(142).EventEmitter)
-const inherits = (__nccwpck_require__(372).inherits)
-const getLimit = __nccwpck_require__(479)
+const EventEmitter = (__nccwpck_require__(141).EventEmitter)
+const inherits = (__nccwpck_require__(371).inherits)
+const getLimit = __nccwpck_require__(478)
 
 const StreamSearch = __nccwpck_require__(112)
 
@@ -21591,8 +21591,8 @@ function objectHasProperty(thing, property) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseCAEChallenge = parseCAEChallenge;
 exports.authorizeRequestOnClaimChallenge = authorizeRequestOnClaimChallenge;
-const log_js_1 = __nccwpck_require__(477);
-const base64_js_1 = __nccwpck_require__(435);
+const log_js_1 = __nccwpck_require__(476);
+const base64_js_1 = __nccwpck_require__(434);
 /**
  * Converts: `Bearer a="b", c="d", Bearer d="e", f="g"`.
  * Into: `[ { a: 'b', c: 'd' }, { d: 'e', f: 'g' } ]`.
@@ -21674,8 +21674,8 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.delay = delay;
 exports.calculateRetryDelay = calculateRetryDelay;
-const createAbortablePromise_js_1 = __nccwpck_require__(255);
-const util_1 = __nccwpck_require__(145);
+const createAbortablePromise_js_1 = __nccwpck_require__(254);
+const util_1 = __nccwpck_require__(144);
 const StandardAbortMessage = "The delay was aborted.";
 /**
  * A wrapper for setTimeout that resolves a promise after timeInMs milliseconds.
@@ -21746,8 +21746,8 @@ function calculateRetryDelay(retryAttempt, config) {
  * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
-const EventEmitter = (__nccwpck_require__(142).EventEmitter)
-const inherits = (__nccwpck_require__(372).inherits)
+const EventEmitter = (__nccwpck_require__(141).EventEmitter)
+const inherits = (__nccwpck_require__(371).inherits)
 
 function SBMH (needle) {
   if (typeof needle === 'string') {
@@ -21975,8 +21975,8 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_httpHeaders = __nccwpck_require__(481);
-var import_uuidUtils = __nccwpck_require__(390);
+var import_httpHeaders = __nccwpck_require__(480);
+var import_uuidUtils = __nccwpck_require__(389);
 class PipelineRequestImpl {
   url;
   method;
@@ -22065,8 +22065,8 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(379));
-var import_node_process = __toESM(__nccwpck_require__(232));
+var import_node_os = __toESM(__nccwpck_require__(378));
+var import_node_process = __toESM(__nccwpck_require__(231));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -22096,7 +22096,7 @@ async function setPlatformSpecificData(map) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PbLong = exports.PbULong = exports.detectBi = void 0;
-const goog_varint_1 = __nccwpck_require__(200);
+const goog_varint_1 = __nccwpck_require__(199);
 let BI;
 function detectBi() {
     const dv = new DataView(new ArrayBuffer(8));
@@ -22365,145 +22365,6 @@ module.exports = require("buffer");
 
 "use strict";
 
-// Passthrough soldr stub. Written when `enable: false` instead of
-// downloading the real soldr binary.
-//
-// The stub recognizes the small set of subcommands soldr-aware code paths
-// query (`version`, `cache`, `status`) and returns stub JSON so verify
-// and post don't crash. For anything else, it execs argv[1..] verbatim —
-// `soldr cargo build --release` runs as `cargo build --release`.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports._internal = void 0;
-exports.installPassthrough = installPassthrough;
-const fs = __importStar(__nccwpck_require__(244));
-const path = __importStar(__nccwpck_require__(503));
-const STUB_VERSION = "passthrough";
-function bashStub() {
-    return `#!/usr/bin/env bash
-# setup-soldr passthrough stub (enable=false). Forwards \`soldr <tool>\`
-# to \`<tool>\` and returns stub JSON for soldr-aware subcommands.
-set -e
-if [ "$#" -eq 0 ]; then
-  echo "soldr passthrough stub: no arguments (setup-soldr was invoked with enable=false)" >&2
-  exit 0
-fi
-case "$1" in
-  version)
-    cat <<'JSON'
-{"soldr_version": "${STUB_VERSION}", "managed_zccache_version": null, "setup_soldr_passthrough": true}
-JSON
-    exit 0
-    ;;
-  cache)
-    cat <<'JSON'
-{"status": "ok", "soldr_version": "${STUB_VERSION}", "managed_zccache_version": null, "last_session": null, "rollups": null, "notes": ["setup-soldr enable=false: soldr passthrough stub"]}
-JSON
-    exit 0
-    ;;
-  status)
-    cat <<'JSON'
-{"status": "ok", "setup_soldr_passthrough": true}
-JSON
-    exit 0
-    ;;
-  *)
-    exec "$@"
-    ;;
-esac
-`;
-}
-function cmdStub() {
-    // Windows .cmd shim. Note that newlines must be CRLF for cmd.exe to
-    // parse multi-line scripts reliably; we use \r\n explicitly.
-    const stubJsonVersion = `{"soldr_version": "${STUB_VERSION}", "managed_zccache_version": null, "setup_soldr_passthrough": true}`;
-    const stubJsonCache = `{"status": "ok", "soldr_version": "${STUB_VERSION}", "managed_zccache_version": null, "last_session": null, "rollups": null, "notes": ["setup-soldr enable=false: soldr passthrough stub"]}`;
-    const stubJsonStatus = `{"status": "ok", "setup_soldr_passthrough": true}`;
-    const lines = [
-        "@echo off",
-        "setlocal enableextensions",
-        'if "%~1"=="" (',
-        "  echo soldr passthrough stub: no arguments ^(setup-soldr was invoked with enable=false^) 1^>^&2",
-        "  exit /b 0",
-        ")",
-        'if /I "%~1"=="version" (',
-        `  echo ${stubJsonVersion}`,
-        "  exit /b 0",
-        ")",
-        'if /I "%~1"=="cache" (',
-        `  echo ${stubJsonCache}`,
-        "  exit /b 0",
-        ")",
-        'if /I "%~1"=="status" (',
-        `  echo ${stubJsonStatus}`,
-        "  exit /b 0",
-        ")",
-        'set "TOOL=%~1"',
-        "shift",
-        '"%TOOL%" %*',
-        "exit /b %ERRORLEVEL%",
-    ];
-    return lines.join("\r\n") + "\r\n";
-}
-/**
- * Write a passthrough stub at soldrPath. `soldrPath` is expected to end
- * in `.cmd` on Windows and have no extension on Unix; resolveSetup picks
- * the right name when `enable: false`.
- */
-function installPassthrough(opts) {
-    const { soldrPath, isWindows, log } = opts;
-    fs.mkdirSync(path.dirname(soldrPath), { recursive: true });
-    if (isWindows) {
-        fs.writeFileSync(soldrPath, cmdStub(), "utf8");
-    }
-    else {
-        fs.writeFileSync(soldrPath, bashStub(), { encoding: "utf8", mode: 0o755 });
-    }
-    log(`setup-soldr: installed passthrough stub at ${soldrPath} (enable=false)`);
-}
-// Exported for tests.
-exports._internal = { bashStub, cmdStub, STUB_VERSION };
-
-
-/***/ }),
-
-/***/ 119:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
@@ -22528,8 +22389,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
-const path = __importStar(__nccwpck_require__(243));
-const pathHelper = __importStar(__nccwpck_require__(218));
+const path = __importStar(__nccwpck_require__(242));
+const pathHelper = __importStar(__nccwpck_require__(217));
 const assert_1 = __importDefault(__nccwpck_require__(521));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -22619,7 +22480,7 @@ exports.Path = Path;
 
 /***/ }),
 
-/***/ 120:
+/***/ 119:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -22644,7 +22505,7 @@ __export(sanitizer_exports, {
   Sanitizer: () => Sanitizer
 });
 module.exports = __toCommonJS(sanitizer_exports);
-var import_object = __nccwpck_require__(143);
+var import_object = __nccwpck_require__(142);
 const RedactedString = "REDACTED";
 const defaultAllowedHeaderNames = [
   "x-ms-client-request-id",
@@ -22793,7 +22654,7 @@ class Sanitizer {
 
 /***/ }),
 
-/***/ 121:
+/***/ 120:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22810,7 +22671,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 122:
+/***/ 121:
 /***/ ((module) => {
 
 "use strict";
@@ -22818,19 +22679,19 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 123:
+/***/ 122:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
-var path = (function () { try { return __nccwpck_require__(243) } catch (e) {}}()) || {
+var path = (function () { try { return __nccwpck_require__(242) } catch (e) {}}()) || {
   sep: '/'
 }
 minimatch.sep = path.sep
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __nccwpck_require__(482)
+var expand = __nccwpck_require__(481)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -23830,7 +23691,7 @@ function regExpEscape (s) {
 
 /***/ }),
 
-/***/ 124:
+/***/ 123:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -23865,13 +23726,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
-const os = __importStar(__nccwpck_require__(91));
-const events = __importStar(__nccwpck_require__(466));
-const child = __importStar(__nccwpck_require__(162));
-const path = __importStar(__nccwpck_require__(243));
-const io = __importStar(__nccwpck_require__(289));
-const ioUtil = __importStar(__nccwpck_require__(221));
-const timers_1 = __nccwpck_require__(505);
+const os = __importStar(__nccwpck_require__(90));
+const events = __importStar(__nccwpck_require__(465));
+const child = __importStar(__nccwpck_require__(161));
+const path = __importStar(__nccwpck_require__(242));
+const io = __importStar(__nccwpck_require__(288));
+const ioUtil = __importStar(__nccwpck_require__(220));
+const timers_1 = __nccwpck_require__(504);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -24455,7 +24316,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 125:
+/***/ 124:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24465,9 +24326,9 @@ class ExecState extends events.EventEmitter {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredentialPolicy = void 0;
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(470);
-const CredentialPolicy_js_1 = __nccwpck_require__(303);
-const SharedKeyComparator_js_1 = __nccwpck_require__(174);
+const utils_common_js_1 = __nccwpck_require__(469);
+const CredentialPolicy_js_1 = __nccwpck_require__(302);
+const SharedKeyComparator_js_1 = __nccwpck_require__(173);
 /**
  * StorageSharedKeyCredentialPolicy is a policy used to sign HTTP request with a shared key.
  */
@@ -24611,7 +24472,7 @@ exports.StorageSharedKeyCredentialPolicy = StorageSharedKeyCredentialPolicy;
 
 /***/ }),
 
-/***/ 126:
+/***/ 125:
 /***/ ((module) => {
 
 "use strict";
@@ -24631,7 +24492,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 127:
+/***/ 126:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24640,8 +24501,8 @@ module.exports = {
 
 
 const assert = __nccwpck_require__(521)
-const { Readable } = __nccwpck_require__(129)
-const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(484)
+const { Readable } = __nccwpck_require__(128)
+const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(483)
 const util = __nccwpck_require__(69)
 const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(69)
 
@@ -24961,7 +24822,7 @@ function consumeFinish (consume, err) {
 
 /***/ }),
 
-/***/ 128:
+/***/ 127:
 /***/ ((module) => {
 
 "use strict";
@@ -24969,7 +24830,7 @@ module.exports = require("querystring");
 
 /***/ }),
 
-/***/ 129:
+/***/ 128:
 /***/ ((module) => {
 
 "use strict";
@@ -24977,7 +24838,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 130:
+/***/ 129:
 /***/ ((module) => {
 
 "use strict";
@@ -25047,7 +24908,7 @@ function range(a, b, str) {
 
 /***/ }),
 
-/***/ 131:
+/***/ 130:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -25080,13 +24941,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpsProxyAgent = void 0;
-const net = __importStar(__nccwpck_require__(504));
-const tls = __importStar(__nccwpck_require__(501));
+const net = __importStar(__nccwpck_require__(503));
+const tls = __importStar(__nccwpck_require__(500));
 const assert_1 = __importDefault(__nccwpck_require__(521));
 const debug_1 = __importDefault(__nccwpck_require__(510));
-const agent_base_1 = __nccwpck_require__(236);
-const url_1 = __nccwpck_require__(84);
-const parse_proxy_response_1 = __nccwpck_require__(416);
+const agent_base_1 = __nccwpck_require__(235);
+const url_1 = __nccwpck_require__(83);
+const parse_proxy_response_1 = __nccwpck_require__(415);
 const debug = (0, debug_1.default)('https-proxy-agent');
 const setServernameFromNonIpHost = (options) => {
     if (options.servername === undefined &&
@@ -25234,7 +25095,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 132:
+/***/ 131:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -25250,9 +25111,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(280);
+const http_client_1 = __nccwpck_require__(279);
 const auth_1 = __nccwpck_require__(27);
-const core_1 = __nccwpck_require__(456);
+const core_1 = __nccwpck_require__(455);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -25318,16 +25179,16 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 133:
+/***/ 132:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
-const binary_format_contract_1 = __nccwpck_require__(329);
+const binary_format_contract_1 = __nccwpck_require__(328);
 const pb_long_1 = __nccwpck_require__(115);
-const goog_varint_1 = __nccwpck_require__(200);
+const goog_varint_1 = __nccwpck_require__(199);
 const defaultsRead = {
     readUnknownField: true,
     readerFactory: bytes => new BinaryReader(bytes),
@@ -25509,7 +25370,7 @@ exports.BinaryReader = BinaryReader;
 
 /***/ }),
 
-/***/ 134:
+/***/ 133:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25523,8 +25384,8 @@ const {
   kDefaultTrailers,
   kContentLength,
   kMockDispatch
-} = __nccwpck_require__(467)
-const { InvalidArgumentError } = __nccwpck_require__(484)
+} = __nccwpck_require__(466)
+const { InvalidArgumentError } = __nccwpck_require__(483)
 const { buildURL } = __nccwpck_require__(69)
 
 /**
@@ -25723,7 +25584,7 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 135:
+/***/ 134:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -25821,7 +25682,7 @@ exports.reflectionMergePartial = reflectionMergePartial;
 
 /***/ }),
 
-/***/ 136:
+/***/ 135:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -25847,7 +25708,7 @@ __export(xml_exports, {
   stringifyXML: () => stringifyXML
 });
 module.exports = __toCommonJS(xml_exports);
-var import_fast_xml_parser = __nccwpck_require__(316);
+var import_fast_xml_parser = __nccwpck_require__(315);
 var import_xml_common = __nccwpck_require__(21);
 function getCommonOptions(options) {
   return {
@@ -25914,22 +25775,22 @@ async function parseXML(str, opts = {}) {
 
 /***/ }),
 
-/***/ 137:
+/***/ 136:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-module.exports.request = __nccwpck_require__(506)
-module.exports.stream = __nccwpck_require__(351)
+module.exports.request = __nccwpck_require__(505)
+module.exports.stream = __nccwpck_require__(350)
 module.exports.pipeline = __nccwpck_require__(104)
-module.exports.upgrade = __nccwpck_require__(431)
-module.exports.connect = __nccwpck_require__(370)
+module.exports.upgrade = __nccwpck_require__(430)
+module.exports.connect = __nccwpck_require__(369)
 
 
 /***/ }),
 
-/***/ 138:
+/***/ 137:
 /***/ ((module) => {
 
 "use strict";
@@ -25977,7 +25838,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 139:
+/***/ 138:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25986,7 +25847,7 @@ module.exports = {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollOperation = exports.initOperation = exports.deserializeState = void 0;
-const logger_js_1 = __nccwpck_require__(188);
+const logger_js_1 = __nccwpck_require__(187);
 const constants_js_1 = __nccwpck_require__(60);
 /**
  * Deserializes the state
@@ -26156,7 +26017,7 @@ exports.pollOperation = pollOperation;
 
 /***/ }),
 
-/***/ 140:
+/***/ 139:
 /***/ ((module) => {
 
 "use strict";
@@ -26164,7 +26025,7 @@ module.exports = require("diagnostics_channel");
 
 /***/ }),
 
-/***/ 141:
+/***/ 140:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -26180,7 +26041,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(371);
+	createDebug.humanize = __nccwpck_require__(370);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -26463,7 +26324,7 @@ module.exports = setup;
 
 /***/ }),
 
-/***/ 142:
+/***/ 141:
 /***/ ((module) => {
 
 "use strict";
@@ -26471,7 +26332,7 @@ module.exports = require("node:events");
 
 /***/ }),
 
-/***/ 143:
+/***/ 142:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -26506,7 +26367,7 @@ function isObject(input) {
 
 /***/ }),
 
-/***/ 144:
+/***/ 143:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -26574,7 +26435,7 @@ async function resolveSoldrReleaseVersion(repo, version, ref, env, deps) {
 
 /***/ }),
 
-/***/ 145:
+/***/ 144:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26615,15 +26476,15 @@ __export(internal_exports, {
   uint8ArrayToString: () => import_bytesEncoding.uint8ArrayToString
 });
 module.exports = __toCommonJS(internal_exports);
-var import_delay = __nccwpck_require__(471);
-var import_random = __nccwpck_require__(502);
-var import_object = __nccwpck_require__(143);
-var import_error = __nccwpck_require__(152);
-var import_sha256 = __nccwpck_require__(197);
-var import_uuidUtils = __nccwpck_require__(390);
-var import_checkEnvironment = __nccwpck_require__(436);
-var import_bytesEncoding = __nccwpck_require__(282);
-var import_sanitizer = __nccwpck_require__(120);
+var import_delay = __nccwpck_require__(470);
+var import_random = __nccwpck_require__(501);
+var import_object = __nccwpck_require__(142);
+var import_error = __nccwpck_require__(151);
+var import_sha256 = __nccwpck_require__(196);
+var import_uuidUtils = __nccwpck_require__(389);
+var import_checkEnvironment = __nccwpck_require__(435);
+var import_bytesEncoding = __nccwpck_require__(281);
+var import_sanitizer = __nccwpck_require__(119);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -26631,7 +26492,7 @@ var import_sanitizer = __nccwpck_require__(120);
 
 /***/ }),
 
-/***/ 146:
+/***/ 145:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26656,7 +26517,7 @@ __export(internal_exports, {
   createLoggerContext: () => import_logger.createLoggerContext
 });
 module.exports = __toCommonJS(internal_exports);
-var import_logger = __nccwpck_require__(241);
+var import_logger = __nccwpck_require__(240);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -26664,7 +26525,7 @@ var import_logger = __nccwpck_require__(241);
 
 /***/ }),
 
-/***/ 147:
+/***/ 146:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -26900,7 +26761,7 @@ exports.PathStylePorts = [
 
 /***/ }),
 
-/***/ 148:
+/***/ 147:
 /***/ ((module) => {
 
 "use strict";
@@ -26908,7 +26769,7 @@ module.exports = require("string_decoder");
 
 /***/ }),
 
-/***/ 149:
+/***/ 148:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -26952,7 +26813,7 @@ function setClientRequestIdPolicy(requestIdHeaderName = "x-ms-client-request-id"
 
 /***/ }),
 
-/***/ 150:
+/***/ 149:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26977,7 +26838,7 @@ __export(log_exports, {
   logger: () => logger
 });
 module.exports = __toCommonJS(log_exports);
-var import_logger = __nccwpck_require__(241);
+var import_logger = __nccwpck_require__(240);
 const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -26986,7 +26847,7 @@ const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 
 /***/ }),
 
-/***/ 151:
+/***/ 150:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -27012,8 +26873,8 @@ __export(basicAuthenticationPolicy_exports, {
   basicAuthenticationPolicyName: () => basicAuthenticationPolicyName
 });
 module.exports = __toCommonJS(basicAuthenticationPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(282);
-var import_checkInsecureConnection = __nccwpck_require__(433);
+var import_bytesEncoding = __nccwpck_require__(281);
+var import_checkInsecureConnection = __nccwpck_require__(432);
 const basicAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function basicAuthenticationPolicy(options) {
   return {
@@ -27043,7 +26904,7 @@ function basicAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 152:
+/***/ 151:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -27068,7 +26929,7 @@ __export(error_exports, {
   isError: () => isError
 });
 module.exports = __toCommonJS(error_exports);
-var import_object = __nccwpck_require__(143);
+var import_object = __nccwpck_require__(142);
 function isError(e) {
   if ((0, import_object.isObject)(e)) {
     const hasName = typeof e.name === "string";
@@ -27084,7 +26945,7 @@ function isError(e) {
 
 /***/ }),
 
-/***/ 153:
+/***/ 152:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -27130,7 +26991,7 @@ exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(14);
-const constants_js_1 = __nccwpck_require__(147);
+const constants_js_1 = __nccwpck_require__(146);
 /**
  * Reserved URL characters must be properly escaped for Storage services like Blob or File.
  *
@@ -27898,7 +27759,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 154:
+/***/ 153:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -27928,27 +27789,27 @@ exports.StorageBrowserPolicyFactory = StorageBrowserPolicyFactory;
 
 /***/ }),
 
-/***/ 155:
+/***/ 154:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(192).kConstruct)
+  kConstruct: (__nccwpck_require__(191).kConstruct)
 }
 
 
 /***/ }),
 
-/***/ 156:
+/***/ 155:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionLongConvert = void 0;
-const reflection_info_1 = __nccwpck_require__(450);
+const reflection_info_1 = __nccwpck_require__(449);
 /**
  * Utility method to convert a PbLong or PbUlong to a JavaScript
  * representation during runtime.
@@ -27973,7 +27834,7 @@ exports.reflectionLongConvert = reflectionLongConvert;
 
 /***/ }),
 
-/***/ 157:
+/***/ 156:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -28007,7 +27868,7 @@ const DEFAULT_RETRY_POLICY_COUNT = 3;
 
 /***/ }),
 
-/***/ 158:
+/***/ 157:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28046,9 +27907,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.uploadCacheArchiveSDK = exports.UploadProgress = void 0;
-const core = __importStar(__nccwpck_require__(456));
-const storage_blob_1 = __nccwpck_require__(445);
-const errors_1 = __nccwpck_require__(299);
+const core = __importStar(__nccwpck_require__(455));
+const storage_blob_1 = __nccwpck_require__(444);
+const errors_1 = __nccwpck_require__(298);
 /**
  * Class for tracking the upload state and displaying stats.
  */
@@ -28181,7 +28042,7 @@ exports.uploadCacheArchiveSDK = uploadCacheArchiveSDK;
 
 /***/ }),
 
-/***/ 159:
+/***/ 158:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28211,7 +28072,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.req = exports.json = exports.toBuffer = void 0;
-const http = __importStar(__nccwpck_require__(325));
+const http = __importStar(__nccwpck_require__(324));
 const https = __importStar(__nccwpck_require__(70));
 async function toBuffer(stream) {
     let length = 0;
@@ -28254,7 +28115,7 @@ exports.req = req;
 
 /***/ }),
 
-/***/ 160:
+/***/ 159:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -28392,36 +28253,36 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 
 /***/ }),
 
-/***/ 161:
+/***/ 160:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Client = __nccwpck_require__(87)
-const Dispatcher = __nccwpck_require__(474)
-const errors = __nccwpck_require__(484)
-const Pool = __nccwpck_require__(334)
-const BalancedPool = __nccwpck_require__(378)
+const Client = __nccwpck_require__(86)
+const Dispatcher = __nccwpck_require__(473)
+const errors = __nccwpck_require__(483)
+const Pool = __nccwpck_require__(333)
+const BalancedPool = __nccwpck_require__(377)
 const Agent = __nccwpck_require__(5)
 const util = __nccwpck_require__(69)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(137)
-const buildConnector = __nccwpck_require__(261)
-const MockClient = __nccwpck_require__(196)
-const MockAgent = __nccwpck_require__(374)
-const MockPool = __nccwpck_require__(346)
-const mockErrors = __nccwpck_require__(228)
-const ProxyAgent = __nccwpck_require__(339)
-const RetryHandler = __nccwpck_require__(268)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(373)
-const DecoratorHandler = __nccwpck_require__(472)
-const RedirectHandler = __nccwpck_require__(387)
-const createRedirectInterceptor = __nccwpck_require__(250)
+const api = __nccwpck_require__(136)
+const buildConnector = __nccwpck_require__(260)
+const MockClient = __nccwpck_require__(195)
+const MockAgent = __nccwpck_require__(373)
+const MockPool = __nccwpck_require__(345)
+const mockErrors = __nccwpck_require__(227)
+const ProxyAgent = __nccwpck_require__(338)
+const RetryHandler = __nccwpck_require__(267)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(372)
+const DecoratorHandler = __nccwpck_require__(471)
+const RedirectHandler = __nccwpck_require__(386)
+const createRedirectInterceptor = __nccwpck_require__(249)
 
 let hasCrypto
 try {
-  __nccwpck_require__(286)
+  __nccwpck_require__(285)
   hasCrypto = true
 } catch {
   hasCrypto = false
@@ -28500,7 +28361,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   let fetchImpl = null
   module.exports.fetch = async function fetch (resource) {
     if (!fetchImpl) {
-      fetchImpl = (__nccwpck_require__(448).fetch)
+      fetchImpl = (__nccwpck_require__(447).fetch)
     }
 
     try {
@@ -28515,18 +28376,18 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   }
   module.exports.Headers = __nccwpck_require__(511).Headers
   module.exports.Response = __nccwpck_require__(41).Response
-  module.exports.Request = __nccwpck_require__(83).Request
-  module.exports.FormData = __nccwpck_require__(204).FormData
-  module.exports.File = __nccwpck_require__(360).File
-  module.exports.FileReader = __nccwpck_require__(93).FileReader
+  module.exports.Request = __nccwpck_require__(82).Request
+  module.exports.FormData = __nccwpck_require__(203).FormData
+  module.exports.File = __nccwpck_require__(359).File
+  module.exports.FileReader = __nccwpck_require__(92).FileReader
 
-  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(138)
+  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(137)
 
   module.exports.setGlobalOrigin = setGlobalOrigin
   module.exports.getGlobalOrigin = getGlobalOrigin
 
-  const { CacheStorage } = __nccwpck_require__(277)
-  const { kConstruct } = __nccwpck_require__(155)
+  const { CacheStorage } = __nccwpck_require__(276)
+  const { kConstruct } = __nccwpck_require__(154)
 
   // Cache & CacheStorage are tightly coupled with fetch. Even if it may run
   // in an older version of Node, it doesn't have any use without fetch.
@@ -28534,7 +28395,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
 }
 
 if (util.nodeMajor >= 16) {
-  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(383)
+  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(382)
 
   module.exports.deleteCookie = deleteCookie
   module.exports.getCookies = getCookies
@@ -28548,7 +28409,7 @@ if (util.nodeMajor >= 16) {
 }
 
 if (util.nodeMajor >= 18 && hasCrypto) {
-  const { WebSocket } = __nccwpck_require__(295)
+  const { WebSocket } = __nccwpck_require__(294)
 
   module.exports.WebSocket = WebSocket
 }
@@ -28567,7 +28428,7 @@ module.exports.mockErrors = mockErrors
 
 /***/ }),
 
-/***/ 162:
+/***/ 161:
 /***/ ((module) => {
 
 "use strict";
@@ -28575,7 +28436,7 @@ module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 163:
+/***/ 162:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28653,9 +28514,9 @@ exports.resolveLockfilePath = resolveLockfilePath;
 exports.setupCachePaths = setupCachePaths;
 exports.setupCacheLayout = setupCacheLayout;
 exports.pathForOutput = pathForOutput;
-const node_crypto_1 = __nccwpck_require__(269);
-const fs = __importStar(__nccwpck_require__(244));
-const path = __importStar(__nccwpck_require__(503));
+const node_crypto_1 = __nccwpck_require__(268);
+const fs = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(502));
 const TARGET_CACHE_PROFILES = ["thin-v1", "thin-v2"];
 const TARGET_CACHE_BOOL_TRUE = new Set(["true", "1", "yes", "on"]);
 const TARGET_CACHE_BOOL_FALSE = new Set(["false", "0", "no", "off"]);
@@ -29031,7 +28892,7 @@ function pathForOutput(workspace, p) {
 
 /***/ }),
 
-/***/ 164:
+/***/ 163:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29044,18 +28905,18 @@ function pathForOutput(workspace, p) {
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(212);
+const tslib_1 = __nccwpck_require__(211);
 tslib_1.__exportStar(__nccwpck_require__(116), exports);
-tslib_1.__exportStar(__nccwpck_require__(178), exports);
-tslib_1.__exportStar(__nccwpck_require__(121), exports);
-tslib_1.__exportStar(__nccwpck_require__(311), exports);
-tslib_1.__exportStar(__nccwpck_require__(205), exports);
-tslib_1.__exportStar(__nccwpck_require__(265), exports);
+tslib_1.__exportStar(__nccwpck_require__(177), exports);
+tslib_1.__exportStar(__nccwpck_require__(120), exports);
+tslib_1.__exportStar(__nccwpck_require__(310), exports);
+tslib_1.__exportStar(__nccwpck_require__(204), exports);
+tslib_1.__exportStar(__nccwpck_require__(264), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 165:
+/***/ 164:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29065,12 +28926,12 @@ tslib_1.__exportStar(__nccwpck_require__(265), exports);
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageRetryPolicyName = void 0;
 exports.storageRetryPolicy = storageRetryPolicy;
-const abort_controller_1 = __nccwpck_require__(490);
+const abort_controller_1 = __nccwpck_require__(489);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(14);
-const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(320);
+const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(319);
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(470);
+const utils_common_js_1 = __nccwpck_require__(469);
 const log_js_1 = __nccwpck_require__(17);
 /**
  * Name of the {@link storageRetryPolicy}
@@ -29230,7 +29091,7 @@ function storageRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 166:
+/***/ 165:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29246,7 +29107,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.create = void 0;
-const internal_globber_1 = __nccwpck_require__(428);
+const internal_globber_1 = __nccwpck_require__(427);
 /**
  * Constructs a globber
  *
@@ -29263,7 +29124,7 @@ exports.create = create;
 
 /***/ }),
 
-/***/ 167:
+/***/ 166:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29272,7 +29133,7 @@ exports.create = create;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.UserDelegationKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(269);
+const node_crypto_1 = __nccwpck_require__(268);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -29317,7 +29178,7 @@ exports.UserDelegationKeyCredential = UserDelegationKeyCredential;
 
 /***/ }),
 
-/***/ 168:
+/***/ 167:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -29343,10 +29204,10 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(282);
-var import_typeGuards = __nccwpck_require__(492);
-var import_uuidUtils = __nccwpck_require__(390);
-var import_concat = __nccwpck_require__(298);
+var import_bytesEncoding = __nccwpck_require__(281);
+var import_typeGuards = __nccwpck_require__(491);
+var import_uuidUtils = __nccwpck_require__(389);
+var import_concat = __nccwpck_require__(297);
 function generateBoundary() {
   return `----AzSDKFormBoundary${(0, import_uuidUtils.randomUUID)()}`;
 }
@@ -29455,12 +29316,12 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 169:
+/***/ 168:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(400)
+const f = __nccwpck_require__(399)
 
 class FloatingDateTime extends Date {
   constructor (value) {
@@ -29487,7 +29348,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 170:
+/***/ 169:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -29614,7 +29475,7 @@ function requestToOptions(request) {
 
 /***/ }),
 
-/***/ 171:
+/***/ 170:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -29626,7 +29487,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 172:
+/***/ 171:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29635,28 +29496,28 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Note: we do not use `export * from ...` to help tree shakers,
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-var service_type_1 = __nccwpck_require__(475);
+var service_type_1 = __nccwpck_require__(474);
 Object.defineProperty(exports, "ServiceType", ({ enumerable: true, get: function () { return service_type_1.ServiceType; } }));
 var reflection_info_1 = __nccwpck_require__(522);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
 Object.defineProperty(exports, "readMethodOption", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOption; } }));
 Object.defineProperty(exports, "readServiceOption", ({ enumerable: true, get: function () { return reflection_info_1.readServiceOption; } }));
-var rpc_error_1 = __nccwpck_require__(173);
+var rpc_error_1 = __nccwpck_require__(172);
 Object.defineProperty(exports, "RpcError", ({ enumerable: true, get: function () { return rpc_error_1.RpcError; } }));
-var rpc_options_1 = __nccwpck_require__(288);
+var rpc_options_1 = __nccwpck_require__(287);
 Object.defineProperty(exports, "mergeRpcOptions", ({ enumerable: true, get: function () { return rpc_options_1.mergeRpcOptions; } }));
-var rpc_output_stream_1 = __nccwpck_require__(301);
+var rpc_output_stream_1 = __nccwpck_require__(300);
 Object.defineProperty(exports, "RpcOutputStreamController", ({ enumerable: true, get: function () { return rpc_output_stream_1.RpcOutputStreamController; } }));
-var test_transport_1 = __nccwpck_require__(508);
+var test_transport_1 = __nccwpck_require__(507);
 Object.defineProperty(exports, "TestTransport", ({ enumerable: true, get: function () { return test_transport_1.TestTransport; } }));
 var deferred_1 = __nccwpck_require__(52);
 Object.defineProperty(exports, "Deferred", ({ enumerable: true, get: function () { return deferred_1.Deferred; } }));
 Object.defineProperty(exports, "DeferredState", ({ enumerable: true, get: function () { return deferred_1.DeferredState; } }));
-var duplex_streaming_call_1 = __nccwpck_require__(300);
+var duplex_streaming_call_1 = __nccwpck_require__(299);
 Object.defineProperty(exports, "DuplexStreamingCall", ({ enumerable: true, get: function () { return duplex_streaming_call_1.DuplexStreamingCall; } }));
-var client_streaming_call_1 = __nccwpck_require__(347);
+var client_streaming_call_1 = __nccwpck_require__(346);
 Object.defineProperty(exports, "ClientStreamingCall", ({ enumerable: true, get: function () { return client_streaming_call_1.ClientStreamingCall; } }));
-var server_streaming_call_1 = __nccwpck_require__(449);
+var server_streaming_call_1 = __nccwpck_require__(448);
 Object.defineProperty(exports, "ServerStreamingCall", ({ enumerable: true, get: function () { return server_streaming_call_1.ServerStreamingCall; } }));
 var unary_call_1 = __nccwpck_require__(56);
 Object.defineProperty(exports, "UnaryCall", ({ enumerable: true, get: function () { return unary_call_1.UnaryCall; } }));
@@ -29666,13 +29527,13 @@ Object.defineProperty(exports, "stackDuplexStreamingInterceptors", ({ enumerable
 Object.defineProperty(exports, "stackClientStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackClientStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackServerStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackServerStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackUnaryInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackUnaryInterceptors; } }));
-var server_call_context_1 = __nccwpck_require__(421);
+var server_call_context_1 = __nccwpck_require__(420);
 Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: true, get: function () { return server_call_context_1.ServerCallContextController; } }));
 
 
 /***/ }),
 
-/***/ 173:
+/***/ 172:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -29716,7 +29577,7 @@ exports.RpcError = RpcError;
 
 /***/ }),
 
-/***/ 174:
+/***/ 173:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -29799,7 +29660,7 @@ function isLessThan(lhs, rhs) {
 
 /***/ }),
 
-/***/ 175:
+/***/ 174:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29808,10 +29669,10 @@ function isLessThan(lhs, rhs) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-const operation_js_1 = __nccwpck_require__(354);
+const operation_js_1 = __nccwpck_require__(353);
 const constants_js_1 = __nccwpck_require__(60);
 const poller_js_1 = __nccwpck_require__(74);
-const operation_js_2 = __nccwpck_require__(139);
+const operation_js_2 = __nccwpck_require__(138);
 /**
  * The LRO Engine, a class that performs polling.
  */
@@ -29839,7 +29700,7 @@ exports.LroEngine = LroEngine;
 
 /***/ }),
 
-/***/ 176:
+/***/ 175:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -31489,7 +31350,7 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 177:
+/***/ 176:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -39832,7 +39693,7 @@ exports.BlockBlobGetBlockListExceptionHeaders = {
 
 /***/ }),
 
-/***/ 178:
+/***/ 177:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -39849,7 +39710,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 179:
+/***/ 178:
 /***/ ((module) => {
 
 "use strict";
@@ -39857,7 +39718,7 @@ module.exports = require("tty");
 
 /***/ }),
 
-/***/ 180:
+/***/ 179:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -39872,12 +39733,12 @@ exports.getCoreClientOptions = getCoreClientOptions;
 exports.getCredentialFromPipeline = getCredentialFromPipeline;
 const core_http_compat_1 = __nccwpck_require__(72);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
-const core_client_1 = __nccwpck_require__(437);
-const core_xml_1 = __nccwpck_require__(191);
+const core_client_1 = __nccwpck_require__(436);
+const core_xml_1 = __nccwpck_require__(190);
 const core_auth_1 = __nccwpck_require__(509);
 const log_js_1 = __nccwpck_require__(105);
-const storage_common_1 = __nccwpck_require__(271);
-const constants_js_1 = __nccwpck_require__(147);
+const storage_common_1 = __nccwpck_require__(270);
+const constants_js_1 = __nccwpck_require__(146);
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return constants_js_1.StorageOAuthScopes; } }));
 /**
  * A helper to decide if a given argument satisfies the Pipeline contract
@@ -40141,7 +40002,7 @@ function isCoreHttpPolicyFactory(factory) {
 
 /***/ }),
 
-/***/ 181:
+/***/ 180:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -40174,7 +40035,7 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 
 /***/ }),
 
-/***/ 182:
+/***/ 181:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -40187,23 +40048,23 @@ const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_auth_1 = __nccwpck_require__(509);
 const core_util_1 = __nccwpck_require__(14);
 const core_util_2 = __nccwpck_require__(14);
-const BlobDownloadResponse_js_1 = __nccwpck_require__(423);
-const BlobQueryResponse_js_1 = __nccwpck_require__(198);
-const storage_common_1 = __nccwpck_require__(271);
-const models_js_1 = __nccwpck_require__(411);
+const BlobDownloadResponse_js_1 = __nccwpck_require__(422);
+const BlobQueryResponse_js_1 = __nccwpck_require__(197);
+const storage_common_1 = __nccwpck_require__(270);
+const models_js_1 = __nccwpck_require__(410);
 const PageBlobRangeResponse_js_1 = __nccwpck_require__(29);
-const Pipeline_js_1 = __nccwpck_require__(180);
+const Pipeline_js_1 = __nccwpck_require__(179);
 const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(529);
 const Range_js_1 = __nccwpck_require__(103);
-const StorageClient_js_1 = __nccwpck_require__(452);
-const Batch_js_1 = __nccwpck_require__(90);
-const storage_common_2 = __nccwpck_require__(271);
-const constants_js_1 = __nccwpck_require__(147);
+const StorageClient_js_1 = __nccwpck_require__(451);
+const Batch_js_1 = __nccwpck_require__(89);
+const storage_common_2 = __nccwpck_require__(270);
+const constants_js_1 = __nccwpck_require__(146);
 const tracing_js_1 = __nccwpck_require__(31);
-const utils_common_js_1 = __nccwpck_require__(153);
-const utils_js_1 = __nccwpck_require__(199);
+const utils_common_js_1 = __nccwpck_require__(152);
+const utils_js_1 = __nccwpck_require__(198);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
-const BlobLeaseClient_js_1 = __nccwpck_require__(201);
+const BlobLeaseClient_js_1 = __nccwpck_require__(200);
 /**
  * A BlobClient represents a URL to an Azure Storage blob; the blob may be a block blob,
  * append blob, or page blob.
@@ -43033,16 +42894,16 @@ exports.PageBlobClient = PageBlobClient;
 
 /***/ }),
 
-/***/ 183:
+/***/ 182:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryWriter = void 0;
-const binary_format_contract_1 = __nccwpck_require__(329);
-const reflection_info_1 = __nccwpck_require__(450);
-const assert_1 = __nccwpck_require__(480);
+const binary_format_contract_1 = __nccwpck_require__(328);
+const reflection_info_1 = __nccwpck_require__(449);
+const assert_1 = __nccwpck_require__(479);
 const pb_long_1 = __nccwpck_require__(115);
 /**
  * Writes proto3 messages in binary format using reflection information.
@@ -43274,18 +43135,18 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 
 /***/ }),
 
-/***/ 184:
+/***/ 183:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxUnsigned16Bit } = __nccwpck_require__(462)
+const { maxUnsigned16Bit } = __nccwpck_require__(461)
 
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(286)
+  crypto = __nccwpck_require__(285)
 } catch {
 
 }
@@ -43355,7 +43216,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 185:
+/***/ 184:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -43402,13 +43263,13 @@ function isApiKeyCredential(credential) {
 
 /***/ }),
 
-/***/ 186:
+/***/ 185:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(521)
 const {
   ResponseStatusCodeError
-} = __nccwpck_require__(484)
+} = __nccwpck_require__(483)
 const { toUSVString } = __nccwpck_require__(69)
 
 async function getResolveErrorBodyCallback ({ callback, body, contentType, statusCode, statusMessage, headers }) {
@@ -43455,7 +43316,7 @@ module.exports = { getResolveErrorBodyCallback }
 
 /***/ }),
 
-/***/ 187:
+/***/ 186:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -43577,7 +43438,7 @@ exports.getSelectedOneofValue = getSelectedOneofValue;
 
 /***/ }),
 
-/***/ 188:
+/***/ 187:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -43596,14 +43457,14 @@ exports.logger = (0, logger_1.createClientLogger)("core-lro");
 
 /***/ }),
 
-/***/ 189:
+/***/ 188:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 /* eslint-disable object-property-newline */
 
 
-const decodeText = __nccwpck_require__(270)
+const decodeText = __nccwpck_require__(269)
 
 const RE_ENCODED = /%[a-fA-F0-9][a-fA-F0-9]/g
 
@@ -43800,7 +43661,7 @@ module.exports = parseParams
 
 /***/ }),
 
-/***/ 190:
+/***/ 189:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -43826,8 +43687,8 @@ __export(auxiliaryAuthenticationHeaderPolicy_exports, {
   auxiliaryAuthenticationHeaderPolicyName: () => auxiliaryAuthenticationHeaderPolicyName
 });
 module.exports = __toCommonJS(auxiliaryAuthenticationHeaderPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(160);
-var import_log = __nccwpck_require__(181);
+var import_tokenCycler = __nccwpck_require__(159);
+var import_log = __nccwpck_require__(180);
 const auxiliaryAuthenticationHeaderPolicyName = "auxiliaryAuthenticationHeaderPolicy";
 const AUTHORIZATION_AUXILIARY_HEADER = "x-ms-authorization-auxiliary";
 async function sendAuthorizeRequest(options) {
@@ -43893,7 +43754,7 @@ function auxiliaryAuthenticationHeaderPolicy(options) {
 
 /***/ }),
 
-/***/ 191:
+/***/ 190:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -43921,7 +43782,7 @@ __export(src_exports, {
   stringifyXML: () => import_xml.stringifyXML
 });
 module.exports = __toCommonJS(src_exports);
-var import_xml = __nccwpck_require__(136);
+var import_xml = __nccwpck_require__(135);
 var import_xml_common = __nccwpck_require__(21);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -43930,7 +43791,7 @@ var import_xml_common = __nccwpck_require__(21);
 
 /***/ }),
 
-/***/ 192:
+/***/ 191:
 /***/ ((module) => {
 
 module.exports = {
@@ -44000,7 +43861,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 193:
+/***/ 192:
 /***/ ((module) => {
 
 "use strict";
@@ -44125,7 +43986,7 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 194:
+/***/ 193:
 /***/ ((module) => {
 
 "use strict";
@@ -44133,7 +43994,7 @@ module.exports = require("node:child_process");
 
 /***/ }),
 
-/***/ 195:
+/***/ 194:
 /***/ ((module) => {
 
 "use strict";
@@ -44141,14 +44002,14 @@ module.exports = require("util/types");
 
 /***/ }),
 
-/***/ 196:
+/***/ 195:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(122)
-const Client = __nccwpck_require__(87)
+const { promisify } = __nccwpck_require__(121)
+const Client = __nccwpck_require__(86)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
   kDispatches,
@@ -44158,10 +44019,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(467)
-const { MockInterceptor } = __nccwpck_require__(134)
-const Symbols = __nccwpck_require__(192)
-const { InvalidArgumentError } = __nccwpck_require__(484)
+} = __nccwpck_require__(466)
+const { MockInterceptor } = __nccwpck_require__(133)
+const Symbols = __nccwpck_require__(191)
+const { InvalidArgumentError } = __nccwpck_require__(483)
 
 /**
  * MockClient provides an API that extends the Client to influence the mockDispatches.
@@ -44208,7 +44069,7 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 197:
+/***/ 196:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -44234,7 +44095,7 @@ __export(sha256_exports, {
   computeSha256Hmac: () => computeSha256Hmac
 });
 module.exports = __toCommonJS(sha256_exports);
-var import_node_crypto = __nccwpck_require__(269);
+var import_node_crypto = __nccwpck_require__(268);
 async function computeSha256Hmac(key, stringToSign, encoding) {
   const decodedKey = Buffer.from(key, "base64");
   return (0, import_node_crypto.createHmac)("sha256", decodedKey).update(stringToSign).digest(encoding);
@@ -44249,7 +44110,7 @@ async function computeSha256Hash(content, encoding) {
 
 /***/ }),
 
-/***/ 198:
+/***/ 197:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44259,7 +44120,7 @@ async function computeSha256Hash(content, encoding) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQueryResponse = void 0;
 const core_util_1 = __nccwpck_require__(14);
-const BlobQuickQueryStream_js_1 = __nccwpck_require__(496);
+const BlobQuickQueryStream_js_1 = __nccwpck_require__(495);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -44629,7 +44490,7 @@ exports.BlobQueryResponse = BlobQueryResponse;
 
 /***/ }),
 
-/***/ 199:
+/***/ 198:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44642,10 +44503,10 @@ exports.streamToBuffer = streamToBuffer;
 exports.streamToBuffer2 = streamToBuffer2;
 exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
-const tslib_1 = __nccwpck_require__(212);
-const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(244));
-const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(372));
-const constants_js_1 = __nccwpck_require__(147);
+const tslib_1 = __nccwpck_require__(211);
+const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(243));
+const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(371));
+const constants_js_1 = __nccwpck_require__(146);
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
  *
@@ -44776,7 +44637,7 @@ exports.fsCreateReadStream = node_fs_1.default.createReadStream;
 
 /***/ }),
 
-/***/ 200:
+/***/ 199:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -45058,7 +44919,7 @@ exports.varint32read = varint32read;
 
 /***/ }),
 
-/***/ 201:
+/***/ 200:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45068,9 +44929,9 @@ exports.varint32read = varint32read;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobLeaseClient = void 0;
 const core_util_1 = __nccwpck_require__(14);
-const constants_js_1 = __nccwpck_require__(147);
+const constants_js_1 = __nccwpck_require__(146);
 const tracing_js_1 = __nccwpck_require__(31);
-const utils_common_js_1 = __nccwpck_require__(153);
+const utils_common_js_1 = __nccwpck_require__(152);
 /**
  * A client that manages leases for a {@link ContainerClient} or a {@link BlobClient}.
  */
@@ -45270,15 +45131,15 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 /***/ }),
 
-/***/ 202:
+/***/ 201:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionCreate = void 0;
-const reflection_scalar_default_1 = __nccwpck_require__(459);
-const message_type_contract_1 = __nccwpck_require__(402);
+const reflection_scalar_default_1 = __nccwpck_require__(458);
+const message_type_contract_1 = __nccwpck_require__(401);
 /**
  * Creates an instance of the generic message, using the field
  * information.
@@ -45326,7 +45187,7 @@ exports.reflectionCreate = reflectionCreate;
 
 /***/ }),
 
-/***/ 203:
+/***/ 202:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45338,7 +45199,7 @@ exports.storageBrowserPolicyName = void 0;
 exports.storageBrowserPolicy = storageBrowserPolicy;
 const core_util_1 = __nccwpck_require__(14);
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(470);
+const utils_common_js_1 = __nccwpck_require__(469);
 /**
  * The programmatic identifier of the StorageBrowserPolicy.
  */
@@ -45368,7 +45229,7 @@ function storageBrowserPolicy() {
 
 /***/ }),
 
-/***/ 204:
+/***/ 203:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45376,8 +45237,8 @@ function storageBrowserPolicy() {
 
 const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(512)
 const { kState } = __nccwpck_require__(15)
-const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(360)
-const { webidl } = __nccwpck_require__(454)
+const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(359)
+const { webidl } = __nccwpck_require__(453)
 const { Blob, File: NativeFile } = __nccwpck_require__(117)
 
 /** @type {globalThis['File']} */
@@ -45641,7 +45502,7 @@ module.exports = { FormData }
 
 /***/ }),
 
-/***/ 205:
+/***/ 204:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -45658,7 +45519,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 206:
+/***/ 205:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45683,10 +45544,10 @@ __export(getClient_exports, {
   getClient: () => getClient
 });
 module.exports = __toCommonJS(getClient_exports);
-var import_clientHelpers = __nccwpck_require__(487);
-var import_sendRequest = __nccwpck_require__(447);
-var import_urlHelpers = __nccwpck_require__(318);
-var import_checkEnvironment = __nccwpck_require__(436);
+var import_clientHelpers = __nccwpck_require__(486);
+var import_sendRequest = __nccwpck_require__(446);
+var import_urlHelpers = __nccwpck_require__(317);
+var import_checkEnvironment = __nccwpck_require__(435);
 function getClient(endpoint, clientOptions = {}) {
   const pipeline = clientOptions.pipeline ?? (0, import_clientHelpers.createDefaultPipeline)(clientOptions);
   if (clientOptions.additionalPolicies?.length) {
@@ -45841,7 +45702,7 @@ function buildOperation(method, url, pipeline, options, allowInsecureConnection,
 
 /***/ }),
 
-/***/ 207:
+/***/ 206:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45866,7 +45727,7 @@ __export(httpClientAdapter_exports, {
   convertHttpClient: () => convertHttpClient
 });
 module.exports = __toCommonJS(httpClientAdapter_exports);
-var import_response = __nccwpck_require__(408);
+var import_response = __nccwpck_require__(407);
 var import_util = __nccwpck_require__(108);
 function convertHttpClient(requestPolicyClient) {
   return {
@@ -45885,7 +45746,7 @@ function convertHttpClient(requestPolicyClient) {
 
 /***/ }),
 
-/***/ 208:
+/***/ 207:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45911,8 +45772,8 @@ __export(retryPolicy_exports, {
 });
 module.exports = __toCommonJS(retryPolicy_exports);
 var import_logger = __nccwpck_require__(44);
-var import_constants = __nccwpck_require__(157);
-var import_policies = __nccwpck_require__(281);
+var import_constants = __nccwpck_require__(156);
+var import_policies = __nccwpck_require__(280);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("core-rest-pipeline retryPolicy");
 function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAULT_RETRY_POLICY_COUNT }) {
   return (0, import_policies.retryPolicy)(strategies, {
@@ -45926,7 +45787,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 
 /***/ }),
 
-/***/ 209:
+/***/ 208:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45935,7 +45796,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getErrorMessage = getErrorMessage;
-const util_1 = __nccwpck_require__(145);
+const util_1 = __nccwpck_require__(144);
 /**
  * Given what is thought to be an error object, return the message if possible.
  * If the message is missing, returns a stringified version of the input.
@@ -45966,7 +45827,7 @@ function getErrorMessage(e) {
 
 /***/ }),
 
-/***/ 210:
+/***/ 209:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -46005,14 +45866,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.restoreCache = exports.isFeatureAvailable = exports.FinalizeCacheError = exports.ReserveCacheError = exports.ValidationError = void 0;
-const core = __importStar(__nccwpck_require__(456));
-const path = __importStar(__nccwpck_require__(243));
+const core = __importStar(__nccwpck_require__(455));
+const path = __importStar(__nccwpck_require__(242));
 const utils = __importStar(__nccwpck_require__(75));
 const cacheHttpClient = __importStar(__nccwpck_require__(34));
 const cacheTwirpClient = __importStar(__nccwpck_require__(61));
 const config_1 = __nccwpck_require__(37);
-const tar_1 = __nccwpck_require__(438);
-const http_client_1 = __nccwpck_require__(280);
+const tar_1 = __nccwpck_require__(437);
+const http_client_1 = __nccwpck_require__(279);
 class ValidationError extends Error {
     constructor(message) {
         super(message);
@@ -46492,7 +46353,7 @@ function saveCacheV2(paths, key, options, enableCrossOsArchive = false) {
 
 /***/ }),
 
-/***/ 211:
+/***/ 210:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -46519,8 +46380,8 @@ __export(extendedClient_exports, {
 module.exports = __toCommonJS(extendedClient_exports);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
 var import_core_rest_pipeline = __nccwpck_require__(100);
-var import_core_client = __nccwpck_require__(437);
-var import_response = __nccwpck_require__(408);
+var import_core_client = __nccwpck_require__(436);
+var import_response = __nccwpck_require__(407);
 class ExtendedServiceClient extends import_core_client.ServiceClient {
   constructor(options) {
     super(options);
@@ -46569,7 +46430,7 @@ class ExtendedServiceClient extends import_core_client.ServiceClient {
 
 /***/ }),
 
-/***/ 212:
+/***/ 211:
 /***/ ((module) => {
 
 /******************************************************************************
@@ -47027,7 +46888,7 @@ var __rewriteRelativeImportExtension;
 
 /***/ }),
 
-/***/ 213:
+/***/ 212:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47054,9 +46915,9 @@ __export(bearerTokenAuthenticationPolicy_exports, {
   parseChallenges: () => parseChallenges
 });
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(160);
-var import_log = __nccwpck_require__(181);
-var import_restError = __nccwpck_require__(350);
+var import_tokenCycler = __nccwpck_require__(159);
+var import_log = __nccwpck_require__(180);
+var import_restError = __nccwpck_require__(349);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
   try {
@@ -47246,7 +47107,7 @@ function getCaeChallengeClaims(challenges) {
 
 /***/ }),
 
-/***/ 214:
+/***/ 213:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -47295,10 +47156,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.targetDirHasCompiledArtifacts = targetDirHasCompiledArtifacts;
 exports.shouldEmitSharedTargetWarning = shouldEmitSharedTargetWarning;
 exports.detectSharedTargetWarning = detectSharedTargetWarning;
-const fs = __importStar(__nccwpck_require__(244));
-const path = __importStar(__nccwpck_require__(503));
-const core = __importStar(__nccwpck_require__(456));
-const log_utils_js_1 = __nccwpck_require__(349);
+const fs = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(502));
+const core = __importStar(__nccwpck_require__(455));
+const log_utils_js_1 = __nccwpck_require__(348);
 const WARNING_MESSAGE = "setup-soldr detected a pre-populated shared target directory; a " +
     "subsequent `soldr cargo build` using the same `--target-dir` may fail " +
     "with a missing .rmeta error - see README 'Known limitations'.";
@@ -47392,7 +47253,7 @@ async function detectSharedTargetWarning(opts) {
 
 /***/ }),
 
-/***/ 215:
+/***/ 214:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47418,7 +47279,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_policies = __nccwpck_require__(281);
+var import_policies = __nccwpck_require__(280);
 const systemErrorRetryPolicyName = import_policies.systemErrorRetryPolicyName;
 function systemErrorRetryPolicy(options = {}) {
   return (0, import_policies.systemErrorRetryPolicy)(options);
@@ -47429,7 +47290,7 @@ function systemErrorRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 216:
+/***/ 215:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47443,9 +47304,9 @@ function systemErrorRetryPolicy(options = {}) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
-const tslib_1 = __nccwpck_require__(212);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(437));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(177));
+const tslib_1 = __nccwpck_require__(211);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(436));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Container operations. */
 class ContainerImpl {
@@ -48157,7 +48018,7 @@ const getAccountInfoOperationSpec = {
 
 /***/ }),
 
-/***/ 217:
+/***/ 216:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -48202,7 +48063,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 218:
+/***/ 217:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -48231,7 +48092,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.safeTrimTrailingSeparator = exports.normalizeSeparators = exports.hasRoot = exports.hasAbsoluteRoot = exports.ensureAbsoluteRoot = exports.dirname = void 0;
-const path = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(242));
 const assert_1 = __importDefault(__nccwpck_require__(521));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -48407,20 +48268,20 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 
 /***/ }),
 
-/***/ 219:
+/***/ 218:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-module.exports = __nccwpck_require__(283)
-module.exports.async = __nccwpck_require__(407)
-module.exports.stream = __nccwpck_require__(417)
-module.exports.prettyError = __nccwpck_require__(273)
+module.exports = __nccwpck_require__(282)
+module.exports.async = __nccwpck_require__(406)
+module.exports.stream = __nccwpck_require__(416)
+module.exports.prettyError = __nccwpck_require__(272)
 
 
 /***/ }),
 
-/***/ 220:
+/***/ 219:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -48453,12 +48314,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpProxyAgent = void 0;
-const net = __importStar(__nccwpck_require__(504));
-const tls = __importStar(__nccwpck_require__(501));
+const net = __importStar(__nccwpck_require__(503));
+const tls = __importStar(__nccwpck_require__(500));
 const debug_1 = __importDefault(__nccwpck_require__(510));
-const events_1 = __nccwpck_require__(466);
-const agent_base_1 = __nccwpck_require__(236);
-const url_1 = __nccwpck_require__(84);
+const events_1 = __nccwpck_require__(465);
+const agent_base_1 = __nccwpck_require__(235);
+const url_1 = __nccwpck_require__(83);
 const debug = (0, debug_1.default)('http-proxy-agent');
 /**
  * The `HttpProxyAgent` implements an HTTP Agent subclass that connects
@@ -48575,7 +48436,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 221:
+/***/ 220:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -48612,7 +48473,7 @@ var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
 const fs = __importStar(__nccwpck_require__(526));
-const path = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(242));
 _a = fs.promises
 // export const {open} = 'fs'
 , exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
@@ -48765,7 +48626,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 222:
+/***/ 221:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -48774,8 +48635,8 @@ exports.getCmdPath = getCmdPath;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
-const tslib_1 = __nccwpck_require__(212);
-var poller_js_1 = __nccwpck_require__(314);
+const tslib_1 = __nccwpck_require__(211);
+var poller_js_1 = __nccwpck_require__(313);
 Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: function () { return poller_js_1.createHttpPoller; } }));
 /**
  * This can be uncommented to expose the protocol-agnostic poller
@@ -48789,14 +48650,14 @@ Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: fun
 // } from "./poller/models";
 // export { buildCreatePoller } from "./poller/poller";
 /** legacy */
-tslib_1.__exportStar(__nccwpck_require__(239), exports);
+tslib_1.__exportStar(__nccwpck_require__(238), exports);
 tslib_1.__exportStar(__nccwpck_require__(74), exports);
 tslib_1.__exportStar(__nccwpck_require__(40), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 223:
+/***/ 222:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -48842,7 +48703,7 @@ function apiVersionPolicy(options) {
 
 /***/ }),
 
-/***/ 224:
+/***/ 223:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -49089,7 +48950,7 @@ exports.AbortSignal = AbortSignal;
 
 /***/ }),
 
-/***/ 225:
+/***/ 224:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -49106,7 +48967,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 
 /***/ }),
 
-/***/ 226:
+/***/ 225:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49120,9 +48981,9 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
-const tslib_1 = __nccwpck_require__(212);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(437));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(177));
+const tslib_1 = __nccwpck_require__(211);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(436));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Service operations. */
 class ServiceImpl {
@@ -49442,7 +49303,7 @@ const filterBlobsOperationSpec = {
 
 /***/ }),
 
-/***/ 227:
+/***/ 226:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49468,7 +49329,7 @@ __export(agentPolicy_exports, {
   agentPolicyName: () => agentPolicyName
 });
 module.exports = __toCommonJS(agentPolicy_exports);
-var import_policies = __nccwpck_require__(281);
+var import_policies = __nccwpck_require__(280);
 const agentPolicyName = import_policies.agentPolicyName;
 function agentPolicy(agent) {
   return (0, import_policies.agentPolicy)(agent);
@@ -49479,13 +49340,13 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 228:
+/***/ 227:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { UndiciError } = __nccwpck_require__(484)
+const { UndiciError } = __nccwpck_require__(483)
 
 class MockNotMatchedError extends UndiciError {
   constructor (message) {
@@ -49504,13 +49365,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 229:
+/***/ 228:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Transform } = __nccwpck_require__(129)
+const { Transform } = __nccwpck_require__(128)
 const { Console } = __nccwpck_require__(32)
 
 /**
@@ -49552,7 +49413,7 @@ module.exports = class PendingInterceptorsFormatter {
 
 /***/ }),
 
-/***/ 230:
+/***/ 229:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49564,7 +49425,7 @@ const runtime_2 = __nccwpck_require__(19);
 const runtime_3 = __nccwpck_require__(19);
 const runtime_4 = __nccwpck_require__(19);
 const runtime_5 = __nccwpck_require__(19);
-const cachescope_1 = __nccwpck_require__(393);
+const cachescope_1 = __nccwpck_require__(392);
 // @generated message type with reflection information, may provide speed optimized methods
 class CacheMetadata$Type extends runtime_5.MessageType {
     constructor() {
@@ -49623,7 +49484,7 @@ exports.CacheMetadata = new CacheMetadata$Type();
 
 /***/ }),
 
-/***/ 231:
+/***/ 230:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49648,8 +49509,8 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_ts_http_runtime = __nccwpck_require__(88);
-var import_wrapAbortSignal = __nccwpck_require__(443);
+var import_ts_http_runtime = __nccwpck_require__(87);
+var import_wrapAbortSignal = __nccwpck_require__(442);
 function createDefaultHttpClient() {
   const client = (0, import_ts_http_runtime.createDefaultHttpClient)();
   return {
@@ -49670,7 +49531,7 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 232:
+/***/ 231:
 /***/ ((module) => {
 
 "use strict";
@@ -49678,7 +49539,7 @@ module.exports = require("node:process");
 
 /***/ }),
 
-/***/ 233:
+/***/ 232:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49688,8 +49549,8 @@ module.exports = require("node:process");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRequestUrl = getRequestUrl;
 exports.appendQueryParams = appendQueryParams;
-const operationHelpers_js_1 = __nccwpck_require__(429);
-const interfaceHelpers_js_1 = __nccwpck_require__(396);
+const operationHelpers_js_1 = __nccwpck_require__(428);
+const interfaceHelpers_js_1 = __nccwpck_require__(395);
 const CollectionFormatToDelimiterMap = {
     CSV: ",",
     SSV: " ",
@@ -49922,7 +49783,7 @@ function appendQueryParams(url, queryParams, sequenceParams, noOverwrite = false
 
 /***/ }),
 
-/***/ 234:
+/***/ 233:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49948,7 +49809,7 @@ __export(decompressResponsePolicy_exports, {
   decompressResponsePolicyName: () => decompressResponsePolicyName
 });
 module.exports = __toCommonJS(decompressResponsePolicy_exports);
-var import_policies = __nccwpck_require__(281);
+var import_policies = __nccwpck_require__(280);
 const decompressResponsePolicyName = import_policies.decompressResponsePolicyName;
 function decompressResponsePolicy() {
   return (0, import_policies.decompressResponsePolicy)();
@@ -49959,7 +49820,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 235:
+/***/ 234:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -50006,7 +49867,7 @@ function ndJsonPolicy() {
 
 /***/ }),
 
-/***/ 236:
+/***/ 235:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -50039,10 +49900,10 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Agent = void 0;
-const net = __importStar(__nccwpck_require__(504));
-const http = __importStar(__nccwpck_require__(325));
+const net = __importStar(__nccwpck_require__(503));
+const http = __importStar(__nccwpck_require__(324));
 const https_1 = __nccwpck_require__(70);
-__exportStar(__nccwpck_require__(159), exports);
+__exportStar(__nccwpck_require__(158), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
 class Agent extends http.Agent {
     constructor(opts) {
@@ -50191,7 +50052,7 @@ exports.Agent = Agent;
 
 /***/ }),
 
-/***/ 237:
+/***/ 236:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50234,7 +50095,7 @@ exports.mergeJsonOptions = mergeJsonOptions;
 
 /***/ }),
 
-/***/ 238:
+/***/ 237:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -50259,7 +50120,7 @@ __export(httpHeaders_exports, {
   createHttpHeaders: () => createHttpHeaders
 });
 module.exports = __toCommonJS(httpHeaders_exports);
-var import_ts_http_runtime = __nccwpck_require__(88);
+var import_ts_http_runtime = __nccwpck_require__(87);
 function createHttpHeaders(rawHeaders) {
   return (0, import_ts_http_runtime.createHttpHeaders)(rawHeaders);
 }
@@ -50269,7 +50130,7 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 239:
+/***/ 238:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50278,13 +50139,13 @@ function createHttpHeaders(rawHeaders) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-var lroEngine_js_1 = __nccwpck_require__(175);
+var lroEngine_js_1 = __nccwpck_require__(174);
 Object.defineProperty(exports, "LroEngine", ({ enumerable: true, get: function () { return lroEngine_js_1.LroEngine; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 240:
+/***/ 239:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -50309,7 +50170,7 @@ __export(pipeline_exports, {
   createEmptyPipeline: () => createEmptyPipeline
 });
 module.exports = __toCommonJS(pipeline_exports);
-var import_ts_http_runtime = __nccwpck_require__(88);
+var import_ts_http_runtime = __nccwpck_require__(87);
 function createEmptyPipeline() {
   return (0, import_ts_http_runtime.createEmptyPipeline)();
 }
@@ -50319,7 +50180,7 @@ function createEmptyPipeline() {
 
 /***/ }),
 
-/***/ 241:
+/***/ 240:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -50358,7 +50219,7 @@ __export(logger_exports, {
   setLogLevel: () => setLogLevel
 });
 module.exports = __toCommonJS(logger_exports);
-var import_debug = __toESM(__nccwpck_require__(463));
+var import_debug = __toESM(__nccwpck_require__(462));
 const TYPESPEC_RUNTIME_LOG_LEVELS = ["verbose", "info", "warning", "error"];
 const levelMap = {
   verbose: 400,
@@ -50464,7 +50325,7 @@ function createClientLogger(namespace) {
 
 /***/ }),
 
-/***/ 242:
+/***/ 241:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50511,7 +50372,7 @@ function isTokenCredential(credential) {
 
 /***/ }),
 
-/***/ 243:
+/***/ 242:
 /***/ ((module) => {
 
 "use strict";
@@ -50519,7 +50380,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 244:
+/***/ 243:
 /***/ ((module) => {
 
 "use strict";
@@ -50527,15 +50388,15 @@ module.exports = require("node:fs");
 
 /***/ }),
 
-/***/ 245:
+/***/ 244:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(454)
+const { webidl } = __nccwpck_require__(453)
 const { kEnumerableProperty } = __nccwpck_require__(69)
-const { MessagePort } = __nccwpck_require__(313)
+const { MessagePort } = __nccwpck_require__(312)
 
 /**
  * @see https://html.spec.whatwg.org/multipage/comms.html#messageevent
@@ -50838,7 +50699,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 246:
+/***/ 245:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50846,8 +50707,8 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryWriter = exports.binaryWriteOptions = void 0;
 const pb_long_1 = __nccwpck_require__(115);
-const goog_varint_1 = __nccwpck_require__(200);
-const assert_1 = __nccwpck_require__(480);
+const goog_varint_1 = __nccwpck_require__(199);
+const assert_1 = __nccwpck_require__(479);
 const defaultsWrite = {
     writeUnknownFields: true,
     writerFactory: () => new BinaryWriter(),
@@ -51078,7 +50939,7 @@ exports.BinaryWriter = BinaryWriter;
 
 /***/ }),
 
-/***/ 247:
+/***/ 246:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51087,8 +50948,8 @@ exports.BinaryWriter = BinaryWriter;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
-const AvroReadable_js_1 = __nccwpck_require__(384);
-const abort_controller_1 = __nccwpck_require__(491);
+const AvroReadable_js_1 = __nccwpck_require__(383);
+const abort_controller_1 = __nccwpck_require__(490);
 const buffer_1 = __nccwpck_require__(117);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
 class AvroReadableFromStream extends AvroReadable_js_1.AvroReadable {
@@ -51175,7 +51036,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 
 /***/ }),
 
-/***/ 248:
+/***/ 247:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51196,7 +51057,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 249:
+/***/ 248:
 /***/ ((module) => {
 
 "use strict";
@@ -51233,13 +51094,13 @@ module.exports = class Pluralizer {
 
 /***/ }),
 
-/***/ 250:
+/***/ 249:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const RedirectHandler = __nccwpck_require__(387)
+const RedirectHandler = __nccwpck_require__(386)
 
 function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections }) {
   return (dispatch) => {
@@ -51262,7 +51123,7 @@ module.exports = createRedirectInterceptor
 
 /***/ }),
 
-/***/ 251:
+/***/ 250:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51288,7 +51149,7 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(425);
+var import_userAgentPlatform = __nccwpck_require__(424);
 var import_constants = __nccwpck_require__(48);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
@@ -51316,7 +51177,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 252:
+/***/ 251:
 /***/ ((module) => {
 
 "use strict";
@@ -51324,7 +51185,7 @@ module.exports = require("stream/web");
 
 /***/ }),
 
-/***/ 253:
+/***/ 252:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51334,8 +51195,8 @@ module.exports = require("stream/web");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getBodyAsText = getBodyAsText;
 exports.utf8ByteLength = utf8ByteLength;
-const utils_js_1 = __nccwpck_require__(199);
-const constants_js_1 = __nccwpck_require__(147);
+const utils_js_1 = __nccwpck_require__(198);
+const constants_js_1 = __nccwpck_require__(146);
 async function getBodyAsText(batchResponse) {
     let buffer = Buffer.alloc(constants_js_1.BATCH_MAX_PAYLOAD_IN_BYTES);
     const responseLength = await (0, utils_js_1.streamToBuffer2)(batchResponse.readableStreamBody, buffer);
@@ -51350,7 +51211,7 @@ function utf8ByteLength(str) {
 
 /***/ }),
 
-/***/ 254:
+/***/ 253:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51376,7 +51237,7 @@ __export(wrapAbortSignalLikePolicy_exports, {
   wrapAbortSignalLikePolicyName: () => wrapAbortSignalLikePolicyName
 });
 module.exports = __toCommonJS(wrapAbortSignalLikePolicy_exports);
-var import_wrapAbortSignal = __nccwpck_require__(443);
+var import_wrapAbortSignal = __nccwpck_require__(442);
 const wrapAbortSignalLikePolicyName = "wrapAbortSignalLikePolicy";
 function wrapAbortSignalLikePolicy() {
   return {
@@ -51401,7 +51262,7 @@ function wrapAbortSignalLikePolicy() {
 
 /***/ }),
 
-/***/ 255:
+/***/ 254:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51410,7 +51271,7 @@ function wrapAbortSignalLikePolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createAbortablePromise = createAbortablePromise;
-const abort_controller_1 = __nccwpck_require__(489);
+const abort_controller_1 = __nccwpck_require__(488);
 /**
  * Creates an abortable promise.
  * @param buildPromise - A function that takes the resolve and reject functions as parameters.
@@ -51453,7 +51314,7 @@ function createAbortablePromise(buildPromise, options) {
 
 /***/ }),
 
-/***/ 256:
+/***/ 255:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -51492,8 +51353,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.retryHttpClientResponse = exports.retryTypedResponse = exports.retry = exports.isRetryableStatusCode = exports.isServerErrorStatusCode = exports.isSuccessStatusCode = void 0;
-const core = __importStar(__nccwpck_require__(456));
-const http_client_1 = __nccwpck_require__(280);
+const core = __importStar(__nccwpck_require__(455));
+const http_client_1 = __nccwpck_require__(279);
 const constants_1 = __nccwpck_require__(45);
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
@@ -51597,7 +51458,7 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 
 /***/ }),
 
-/***/ 257:
+/***/ 256:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51606,9 +51467,9 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(269);
-const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(125);
-const Credential_js_1 = __nccwpck_require__(94);
+const node_crypto_1 = __nccwpck_require__(268);
+const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(124);
+const Credential_js_1 = __nccwpck_require__(93);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -51656,7 +51517,7 @@ exports.StorageSharedKeyCredential = StorageSharedKeyCredential;
 
 /***/ }),
 
-/***/ 258:
+/***/ 257:
 /***/ ((module) => {
 
 "use strict";
@@ -51664,7 +51525,7 @@ module.exports = require("node:http");
 
 /***/ }),
 
-/***/ 259:
+/***/ 258:
 /***/ ((module) => {
 
 "use strict";
@@ -51672,7 +51533,7 @@ module.exports = require("node:buffer");
 
 /***/ }),
 
-/***/ 260:
+/***/ 259:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -51702,7 +51563,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDownloadOptions = exports.getUploadOptions = void 0;
-const core = __importStar(__nccwpck_require__(456));
+const core = __importStar(__nccwpck_require__(455));
 /**
  * Returns a copy of the upload options with defaults filled in.
  *
@@ -51796,16 +51657,16 @@ exports.getDownloadOptions = getDownloadOptions;
 
 /***/ }),
 
-/***/ 261:
+/***/ 260:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const net = __nccwpck_require__(504)
+const net = __nccwpck_require__(503)
 const assert = __nccwpck_require__(521)
 const util = __nccwpck_require__(69)
-const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(484)
+const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(483)
 
 let tls // include tls conditionally since it is not always available
 
@@ -51888,7 +51749,7 @@ function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, ...o
     let socket
     if (protocol === 'https:') {
       if (!tls) {
-        tls = __nccwpck_require__(501)
+        tls = __nccwpck_require__(500)
       }
       servername = servername || options.servername || util.getServerName(host) || null
 
@@ -51993,7 +51854,7 @@ module.exports = buildConnector
 
 /***/ }),
 
-/***/ 262:
+/***/ 261:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52002,7 +51863,7 @@ module.exports = buildConnector
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageContextClient = void 0;
-const index_js_1 = __nccwpck_require__(291);
+const index_js_1 = __nccwpck_require__(290);
 /**
  * @internal
  */
@@ -52021,7 +51882,7 @@ exports.StorageContextClient = StorageContextClient;
 
 /***/ }),
 
-/***/ 263:
+/***/ 262:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52047,7 +51908,7 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_policies = __nccwpck_require__(281);
+var import_policies = __nccwpck_require__(280);
 const formDataPolicyName = import_policies.formDataPolicyName;
 function formDataPolicy() {
   return (0, import_policies.formDataPolicy)();
@@ -52058,7 +51919,7 @@ function formDataPolicy() {
 
 /***/ }),
 
-/***/ 264:
+/***/ 263:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52084,10 +51945,10 @@ __export(multipart_exports, {
   buildMultipartBody: () => buildMultipartBody
 });
 module.exports = __toCommonJS(multipart_exports);
-var import_restError = __nccwpck_require__(442);
-var import_httpHeaders = __nccwpck_require__(481);
-var import_bytesEncoding = __nccwpck_require__(282);
-var import_typeGuards = __nccwpck_require__(492);
+var import_restError = __nccwpck_require__(441);
+var import_httpHeaders = __nccwpck_require__(480);
+var import_bytesEncoding = __nccwpck_require__(281);
+var import_typeGuards = __nccwpck_require__(491);
 function getHeaderValue(descriptor, headerName) {
   if (descriptor.headers) {
     const actualHeaderName = Object.keys(descriptor.headers).find(
@@ -52196,7 +52057,7 @@ function buildMultipartBody(parts) {
 
 /***/ }),
 
-/***/ 265:
+/***/ 264:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -52213,7 +52074,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 266:
+/***/ 265:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52239,8 +52100,8 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_policies = __nccwpck_require__(281);
-var import_file = __nccwpck_require__(323);
+var import_policies = __nccwpck_require__(280);
+var import_file = __nccwpck_require__(322);
 const multipartPolicyName = import_policies.multipartPolicyName;
 function multipartPolicy() {
   const tspPolicy = (0, import_policies.multipartPolicy)();
@@ -52264,7 +52125,7 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 267:
+/***/ 266:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -52359,13 +52220,13 @@ exports.listEnumNumbers = listEnumNumbers;
 
 /***/ }),
 
-/***/ 268:
+/***/ 267:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(521)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(192)
-const { RequestRetryError } = __nccwpck_require__(484)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(191)
+const { RequestRetryError } = __nccwpck_require__(483)
 const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(69)
 
 function calculateRetryAfterHeader (retryAfter) {
@@ -52702,7 +52563,7 @@ module.exports = RetryHandler
 
 /***/ }),
 
-/***/ 269:
+/***/ 268:
 /***/ ((module) => {
 
 "use strict";
@@ -52710,7 +52571,7 @@ module.exports = require("node:crypto");
 
 /***/ }),
 
-/***/ 270:
+/***/ 269:
 /***/ (function(module) {
 
 "use strict";
@@ -52832,7 +52693,7 @@ module.exports = decodeText
 
 /***/ }),
 
-/***/ 271:
+/***/ 270:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52841,32 +52702,32 @@ module.exports = decodeText
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
-const tslib_1 = __nccwpck_require__(212);
-tslib_1.__exportStar(__nccwpck_require__(359), exports);
-var cache_js_1 = __nccwpck_require__(248);
+const tslib_1 = __nccwpck_require__(211);
+tslib_1.__exportStar(__nccwpck_require__(358), exports);
+var cache_js_1 = __nccwpck_require__(247);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(82), exports);
-tslib_1.__exportStar(__nccwpck_require__(154), exports);
-tslib_1.__exportStar(__nccwpck_require__(394), exports);
-tslib_1.__exportStar(__nccwpck_require__(94), exports);
-tslib_1.__exportStar(__nccwpck_require__(257), exports);
-tslib_1.__exportStar(__nccwpck_require__(320), exports);
+tslib_1.__exportStar(__nccwpck_require__(81), exports);
+tslib_1.__exportStar(__nccwpck_require__(153), exports);
+tslib_1.__exportStar(__nccwpck_require__(393), exports);
+tslib_1.__exportStar(__nccwpck_require__(93), exports);
+tslib_1.__exportStar(__nccwpck_require__(256), exports);
+tslib_1.__exportStar(__nccwpck_require__(319), exports);
 var RequestPolicy_js_1 = __nccwpck_require__(46);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
-tslib_1.__exportStar(__nccwpck_require__(92), exports);
-tslib_1.__exportStar(__nccwpck_require__(303), exports);
-tslib_1.__exportStar(__nccwpck_require__(203), exports);
-tslib_1.__exportStar(__nccwpck_require__(460), exports);
-tslib_1.__exportStar(__nccwpck_require__(165), exports);
-tslib_1.__exportStar(__nccwpck_require__(125), exports);
+tslib_1.__exportStar(__nccwpck_require__(91), exports);
+tslib_1.__exportStar(__nccwpck_require__(302), exports);
+tslib_1.__exportStar(__nccwpck_require__(202), exports);
+tslib_1.__exportStar(__nccwpck_require__(459), exports);
+tslib_1.__exportStar(__nccwpck_require__(164), exports);
+tslib_1.__exportStar(__nccwpck_require__(124), exports);
 tslib_1.__exportStar(__nccwpck_require__(77), exports);
-tslib_1.__exportStar(__nccwpck_require__(424), exports);
-tslib_1.__exportStar(__nccwpck_require__(167), exports);
+tslib_1.__exportStar(__nccwpck_require__(423), exports);
+tslib_1.__exportStar(__nccwpck_require__(166), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 272:
+/***/ 271:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52879,18 +52740,18 @@ tslib_1.__exportStar(__nccwpck_require__(167), exports);
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(212);
-tslib_1.__exportStar(__nccwpck_require__(226), exports);
-tslib_1.__exportStar(__nccwpck_require__(216), exports);
+const tslib_1 = __nccwpck_require__(211);
+tslib_1.__exportStar(__nccwpck_require__(225), exports);
+tslib_1.__exportStar(__nccwpck_require__(215), exports);
 tslib_1.__exportStar(__nccwpck_require__(47), exports);
-tslib_1.__exportStar(__nccwpck_require__(276), exports);
+tslib_1.__exportStar(__nccwpck_require__(275), exports);
 tslib_1.__exportStar(__nccwpck_require__(26), exports);
-tslib_1.__exportStar(__nccwpck_require__(352), exports);
+tslib_1.__exportStar(__nccwpck_require__(351), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 273:
+/***/ 272:
 /***/ ((module) => {
 
 "use strict";
@@ -52931,7 +52792,7 @@ function prettyError (err, buf) {
 
 /***/ }),
 
-/***/ 274:
+/***/ 273:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -53161,7 +53022,7 @@ exports.ContainerSASPermissions = ContainerSASPermissions;
 
 /***/ }),
 
-/***/ 275:
+/***/ 274:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53187,20 +53048,20 @@ __export(createPipelineFromOptions_exports, {
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(71);
-var import_pipeline = __nccwpck_require__(240);
-var import_redirectPolicy = __nccwpck_require__(338);
-var import_userAgentPolicy = __nccwpck_require__(386);
-var import_multipartPolicy = __nccwpck_require__(266);
-var import_decompressResponsePolicy = __nccwpck_require__(234);
+var import_pipeline = __nccwpck_require__(239);
+var import_redirectPolicy = __nccwpck_require__(337);
+var import_userAgentPolicy = __nccwpck_require__(385);
+var import_multipartPolicy = __nccwpck_require__(265);
+var import_decompressResponsePolicy = __nccwpck_require__(233);
 var import_defaultRetryPolicy = __nccwpck_require__(55);
-var import_formDataPolicy = __nccwpck_require__(263);
+var import_formDataPolicy = __nccwpck_require__(262);
 var import_core_util = __nccwpck_require__(14);
-var import_proxyPolicy = __nccwpck_require__(469);
-var import_setClientRequestIdPolicy = __nccwpck_require__(149);
-var import_agentPolicy = __nccwpck_require__(227);
-var import_tlsPolicy = __nccwpck_require__(375);
-var import_tracingPolicy = __nccwpck_require__(332);
-var import_wrapAbortSignalLikePolicy = __nccwpck_require__(254);
+var import_proxyPolicy = __nccwpck_require__(468);
+var import_setClientRequestIdPolicy = __nccwpck_require__(148);
+var import_agentPolicy = __nccwpck_require__(226);
+var import_tlsPolicy = __nccwpck_require__(374);
+var import_tracingPolicy = __nccwpck_require__(331);
+var import_wrapAbortSignalLikePolicy = __nccwpck_require__(253);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_core_util.isNodeLike) {
@@ -53234,7 +53095,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 276:
+/***/ 275:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53248,9 +53109,9 @@ function createPipelineFromOptions(options) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(212);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(437));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(177));
+const tslib_1 = __nccwpck_require__(211);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(436));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing PageBlob operations. */
 class PageBlobImpl {
@@ -53704,15 +53565,15 @@ const copyIncrementalOperationSpec = {
 
 /***/ }),
 
-/***/ 277:
+/***/ 276:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(155)
+const { kConstruct } = __nccwpck_require__(154)
 const { Cache } = __nccwpck_require__(12)
-const { webidl } = __nccwpck_require__(454)
+const { webidl } = __nccwpck_require__(453)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 
 class CacheStorage {
@@ -53856,7 +53717,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 278:
+/***/ 277:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -53908,10 +53769,10 @@ exports.detectCompressMagic = detectCompressMagic;
 exports.decompressCache = decompressCache;
 exports.compressCache = compressCache;
 const fs = __importStar(__nccwpck_require__(107));
-const path = __importStar(__nccwpck_require__(503));
-const core = __importStar(__nccwpck_require__(456));
+const path = __importStar(__nccwpck_require__(502));
+const core = __importStar(__nccwpck_require__(455));
 const exec = __importStar(__nccwpck_require__(18));
-const io = __importStar(__nccwpck_require__(289));
+const io = __importStar(__nccwpck_require__(288));
 /**
  * Recursively walk a directory and sum file sizes.
  */
@@ -54108,7 +53969,7 @@ function parseLevel(value) {
  * Bubbles non-zero exit codes from either side.
  */
 async function runPipe(producer, consumer) {
-    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 194, 23));
+    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 193, 23));
     const [pCmd, pArgs] = producer;
     const [cCmd, cArgs] = consumer;
     await new Promise((resolve, reject) => {
@@ -54148,7 +54009,7 @@ async function runPipe(producer, consumer) {
 
 /***/ }),
 
-/***/ 279:
+/***/ 278:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -54157,9 +54018,9 @@ async function runPipe(producer, consumer) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createClientPipeline = createClientPipeline;
-const deserializationPolicy_js_1 = __nccwpck_require__(85);
+const deserializationPolicy_js_1 = __nccwpck_require__(84);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
-const serializationPolicy_js_1 = __nccwpck_require__(485);
+const serializationPolicy_js_1 = __nccwpck_require__(484);
 /**
  * Creates a new Pipeline for use with a Service Client.
  * Adds in deserializationPolicy by default.
@@ -54184,7 +54045,7 @@ function createClientPipeline(options = {}) {
 
 /***/ }),
 
-/***/ 280:
+/***/ 279:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -54224,11 +54085,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
-const http = __importStar(__nccwpck_require__(325));
+const http = __importStar(__nccwpck_require__(324));
 const https = __importStar(__nccwpck_require__(70));
-const pm = __importStar(__nccwpck_require__(305));
+const pm = __importStar(__nccwpck_require__(304));
 const tunnel = __importStar(__nccwpck_require__(515));
-const undici_1 = __nccwpck_require__(161);
+const undici_1 = __nccwpck_require__(160);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -54843,7 +54704,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 281:
+/***/ 280:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -54895,20 +54756,20 @@ __export(internal_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(internal_exports);
-var import_agentPolicy = __nccwpck_require__(461);
-var import_decompressResponsePolicy = __nccwpck_require__(353);
-var import_defaultRetryPolicy = __nccwpck_require__(319);
+var import_agentPolicy = __nccwpck_require__(460);
+var import_decompressResponsePolicy = __nccwpck_require__(352);
+var import_defaultRetryPolicy = __nccwpck_require__(318);
 var import_exponentialRetryPolicy = __nccwpck_require__(518);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_systemErrorRetryPolicy = __nccwpck_require__(28);
 var import_throttlingRetryPolicy = __nccwpck_require__(516);
-var import_formDataPolicy = __nccwpck_require__(337);
+var import_formDataPolicy = __nccwpck_require__(336);
 var import_logPolicy = __nccwpck_require__(101);
-var import_multipartPolicy = __nccwpck_require__(168);
+var import_multipartPolicy = __nccwpck_require__(167);
 var import_proxyPolicy = __nccwpck_require__(39);
-var import_redirectPolicy = __nccwpck_require__(312);
-var import_tlsPolicy = __nccwpck_require__(217);
-var import_userAgentPolicy = __nccwpck_require__(357);
+var import_redirectPolicy = __nccwpck_require__(311);
+var import_tlsPolicy = __nccwpck_require__(216);
+var import_userAgentPolicy = __nccwpck_require__(356);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -54916,7 +54777,7 @@ var import_userAgentPolicy = __nccwpck_require__(357);
 
 /***/ }),
 
-/***/ 282:
+/***/ 281:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -54955,15 +54816,15 @@ function stringToUint8Array(value, format) {
 
 /***/ }),
 
-/***/ 283:
+/***/ 282:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseString
 
-const TOMLParser = __nccwpck_require__(343)
-const prettyError = __nccwpck_require__(273)
+const TOMLParser = __nccwpck_require__(342)
+const prettyError = __nccwpck_require__(272)
 
 function parseString (str) {
   if (global.Buffer && global.Buffer.isBuffer(str)) {
@@ -54981,7 +54842,7 @@ function parseString (str) {
 
 /***/ }),
 
-/***/ 284:
+/***/ 283:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -54993,11 +54854,11 @@ exports.generateAccountSASQueryParameters = generateAccountSASQueryParameters;
 exports.generateAccountSASQueryParametersInternal = generateAccountSASQueryParametersInternal;
 const AccountSASPermissions_js_1 = __nccwpck_require__(58);
 const AccountSASResourceTypes_js_1 = __nccwpck_require__(2);
-const AccountSASServices_js_1 = __nccwpck_require__(376);
-const SasIPRange_js_1 = __nccwpck_require__(356);
+const AccountSASServices_js_1 = __nccwpck_require__(375);
+const SasIPRange_js_1 = __nccwpck_require__(355);
 const SASQueryParameters_js_1 = __nccwpck_require__(520);
-const constants_js_1 = __nccwpck_require__(147);
-const utils_common_js_1 = __nccwpck_require__(153);
+const constants_js_1 = __nccwpck_require__(146);
+const utils_common_js_1 = __nccwpck_require__(152);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -55092,15 +54953,15 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 
 /***/ }),
 
-/***/ 285:
+/***/ 284:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
-const reflection_info_1 = __nccwpck_require__(450);
-const oneof_1 = __nccwpck_require__(187);
+const reflection_info_1 = __nccwpck_require__(449);
+const oneof_1 = __nccwpck_require__(186);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
     constructor(info) {
@@ -55330,7 +55191,7 @@ exports.ReflectionTypeCheck = ReflectionTypeCheck;
 
 /***/ }),
 
-/***/ 286:
+/***/ 285:
 /***/ ((module) => {
 
 "use strict";
@@ -55338,7 +55199,7 @@ module.exports = require("crypto");
 
 /***/ }),
 
-/***/ 287:
+/***/ 286:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -55365,7 +55226,7 @@ __export(userAgent_exports, {
 });
 module.exports = __toCommonJS(userAgent_exports);
 var import_userAgentPlatform = __nccwpck_require__(114);
-var import_constants = __nccwpck_require__(157);
+var import_constants = __nccwpck_require__(156);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
   for (const [key, value] of telemetryInfo) {
@@ -55391,7 +55252,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 288:
+/***/ 287:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55465,7 +55326,7 @@ function copy(a, into) {
 
 /***/ }),
 
-/***/ 289:
+/***/ 288:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -55501,8 +55362,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
 const assert_1 = __nccwpck_require__(521);
-const path = __importStar(__nccwpck_require__(243));
-const ioUtil = __importStar(__nccwpck_require__(221));
+const path = __importStar(__nccwpck_require__(242));
+const ioUtil = __importStar(__nccwpck_require__(220));
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -55771,14 +55632,14 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 290:
+/***/ 289:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.maskSecretUrls = exports.maskSigUrl = void 0;
-const core_1 = __nccwpck_require__(456);
+const core_1 = __nccwpck_require__(455);
 /**
  * Masks the `sig` parameter in a URL and sets it as a secret.
  *
@@ -55852,7 +55713,7 @@ exports.maskSecretUrls = maskSecretUrls;
 
 /***/ }),
 
-/***/ 291:
+/***/ 290:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55866,16 +55727,16 @@ exports.maskSecretUrls = maskSecretUrls;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(212);
-tslib_1.__exportStar(__nccwpck_require__(468), exports);
-var storageClient_js_1 = __nccwpck_require__(444);
+const tslib_1 = __nccwpck_require__(211);
+tslib_1.__exportStar(__nccwpck_require__(467), exports);
+var storageClient_js_1 = __nccwpck_require__(443);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(164), exports);
+tslib_1.__exportStar(__nccwpck_require__(163), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 292:
+/***/ 291:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -55925,7 +55786,7 @@ exports.AzureKeyCredential = AzureKeyCredential;
 
 /***/ }),
 
-/***/ 293:
+/***/ 292:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55934,9 +55795,9 @@ exports.AzureKeyCredential = AzureKeyCredential;
 const {
   InvalidArgumentError,
   NotSupportedError
-} = __nccwpck_require__(484)
+} = __nccwpck_require__(483)
 const assert = __nccwpck_require__(521)
-const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(192)
+const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(191)
 const util = __nccwpck_require__(69)
 
 // tokenRegExp and headerCharRegex have been lifted from
@@ -55967,7 +55828,7 @@ const channels = {}
 let extractBody
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(140)
+  const diagnosticsChannel = __nccwpck_require__(139)
   channels.create = diagnosticsChannel.channel('undici:request:create')
   channels.bodySent = diagnosticsChannel.channel('undici:request:bodySent')
   channels.headers = diagnosticsChannel.channel('undici:request:headers')
@@ -56432,7 +56293,7 @@ module.exports = Request
 
 /***/ }),
 
-/***/ 294:
+/***/ 293:
 /***/ ((module) => {
 
 "use strict";
@@ -56736,17 +56597,17 @@ function stringifyComplexTable (prefix, indent, key, value) {
 
 /***/ }),
 
-/***/ 295:
+/***/ 294:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(454)
+const { webidl } = __nccwpck_require__(453)
 const { DOMException } = __nccwpck_require__(30)
 const { URLSerializer } = __nccwpck_require__(25)
-const { getGlobalOrigin } = __nccwpck_require__(138)
-const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(462)
+const { getGlobalOrigin } = __nccwpck_require__(137)
+const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(461)
 const {
   kWebSocketURL,
   kReadyState,
@@ -56757,12 +56618,12 @@ const {
   kByteParser
 } = __nccwpck_require__(97)
 const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(57)
-const { establishWebSocketConnection } = __nccwpck_require__(361)
-const { WebsocketFrameSend } = __nccwpck_require__(184)
-const { ByteParser } = __nccwpck_require__(478)
+const { establishWebSocketConnection } = __nccwpck_require__(360)
+const { WebsocketFrameSend } = __nccwpck_require__(183)
+const { ByteParser } = __nccwpck_require__(477)
 const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(69)
-const { getGlobalDispatcher } = __nccwpck_require__(373)
-const { types } = __nccwpck_require__(122)
+const { getGlobalDispatcher } = __nccwpck_require__(372)
+const { types } = __nccwpck_require__(121)
 
 let experimentalWarned = false
 
@@ -57385,7 +57246,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 296:
+/***/ 295:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -57720,7 +57581,7 @@ class AvroRecordType extends AvroType {
 
 /***/ }),
 
-/***/ 297:
+/***/ 296:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -57846,7 +57707,7 @@ exports.base64encode = base64encode;
 
 /***/ }),
 
-/***/ 298:
+/***/ 297:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -57871,8 +57732,8 @@ __export(concat_exports, {
   concat: () => concat
 });
 module.exports = __toCommonJS(concat_exports);
-var import_stream = __nccwpck_require__(129);
-var import_typeGuards = __nccwpck_require__(492);
+var import_stream = __nccwpck_require__(128);
+var import_typeGuards = __nccwpck_require__(491);
 async function* streamAsyncIterator() {
   const reader = this.getReader();
   try {
@@ -57933,7 +57794,7 @@ async function concat(sources) {
 
 /***/ }),
 
-/***/ 299:
+/***/ 298:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58010,7 +57871,7 @@ UsageError.isUsageErrorMessage = (msg) => {
 
 /***/ }),
 
-/***/ 300:
+/***/ 299:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -58067,7 +57928,7 @@ exports.DuplexStreamingCall = DuplexStreamingCall;
 
 /***/ }),
 
-/***/ 301:
+/***/ 300:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -58245,7 +58106,7 @@ exports.RpcOutputStreamController = RpcOutputStreamController;
 
 /***/ }),
 
-/***/ 302:
+/***/ 301:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58267,7 +58128,7 @@ exports.enumToMap = enumToMap;
 
 /***/ }),
 
-/***/ 303:
+/***/ 302:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -58307,7 +58168,7 @@ exports.CredentialPolicy = CredentialPolicy;
 
 /***/ }),
 
-/***/ 304:
+/***/ 303:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -58318,8 +58179,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BatchResponseParser = void 0;
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_http_compat_1 = __nccwpck_require__(72);
-const constants_js_1 = __nccwpck_require__(147);
-const BatchUtils_js_1 = __nccwpck_require__(253);
+const constants_js_1 = __nccwpck_require__(146);
+const BatchUtils_js_1 = __nccwpck_require__(252);
 const log_js_1 = __nccwpck_require__(105);
 const HTTP_HEADER_DELIMITER = ": ";
 const SPACE_DELIMITER = " ";
@@ -58460,7 +58321,7 @@ exports.BatchResponseParser = BatchResponseParser;
 
 /***/ }),
 
-/***/ 305:
+/***/ 304:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58562,7 +58423,7 @@ class DecodedURL extends URL {
 
 /***/ }),
 
-/***/ 306:
+/***/ 305:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58703,7 +58564,7 @@ function flattenResponse(fullResponse, responseSpec) {
 
 /***/ }),
 
-/***/ 307:
+/***/ 306:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -58744,8 +58605,8 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StatsCollector = void 0;
 const fs = __importStar(__nccwpck_require__(107));
-const path = __importStar(__nccwpck_require__(503));
-const core = __importStar(__nccwpck_require__(456));
+const path = __importStar(__nccwpck_require__(502));
+const core = __importStar(__nccwpck_require__(455));
 function fmtBytes(n) {
     if (n === null)
         return "-";
@@ -58900,7 +58761,7 @@ exports.StatsCollector = StatsCollector;
 
 /***/ }),
 
-/***/ 308:
+/***/ 307:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -58909,7 +58770,7 @@ exports.StatsCollector = StatsCollector;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.buildCreatePoller = void 0;
-const operation_js_1 = __nccwpck_require__(139);
+const operation_js_1 = __nccwpck_require__(138);
 const constants_js_1 = __nccwpck_require__(60);
 const core_util_1 = __nccwpck_require__(14);
 const createStateProxy = () => ({
@@ -59081,7 +58942,7 @@ exports.buildCreatePoller = buildCreatePoller;
 
 /***/ }),
 
-/***/ 309:
+/***/ 308:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59091,13 +58952,13 @@ exports.buildCreatePoller = buildCreatePoller;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
 const core_rest_pipeline_1 = __nccwpck_require__(100);
-const pipeline_js_1 = __nccwpck_require__(279);
-const utils_js_1 = __nccwpck_require__(306);
-const httpClientCache_js_1 = __nccwpck_require__(395);
-const operationHelpers_js_1 = __nccwpck_require__(429);
-const urlHelpers_js_1 = __nccwpck_require__(233);
-const interfaceHelpers_js_1 = __nccwpck_require__(396);
-const log_js_1 = __nccwpck_require__(477);
+const pipeline_js_1 = __nccwpck_require__(278);
+const utils_js_1 = __nccwpck_require__(305);
+const httpClientCache_js_1 = __nccwpck_require__(394);
+const operationHelpers_js_1 = __nccwpck_require__(428);
+const urlHelpers_js_1 = __nccwpck_require__(232);
+const interfaceHelpers_js_1 = __nccwpck_require__(395);
+const log_js_1 = __nccwpck_require__(476);
 /**
  * Initializes a new instance of the ServiceClient.
  */
@@ -59264,7 +59125,7 @@ function getCredentialScopes(options) {
 
 /***/ }),
 
-/***/ 310:
+/***/ 309:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -59291,16 +59152,16 @@ __export(createPipelineFromOptions_exports, {
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(101);
 var import_pipeline = __nccwpck_require__(519);
-var import_redirectPolicy = __nccwpck_require__(312);
-var import_userAgentPolicy = __nccwpck_require__(357);
-var import_decompressResponsePolicy = __nccwpck_require__(353);
-var import_defaultRetryPolicy = __nccwpck_require__(319);
-var import_formDataPolicy = __nccwpck_require__(337);
-var import_checkEnvironment = __nccwpck_require__(436);
+var import_redirectPolicy = __nccwpck_require__(311);
+var import_userAgentPolicy = __nccwpck_require__(356);
+var import_decompressResponsePolicy = __nccwpck_require__(352);
+var import_defaultRetryPolicy = __nccwpck_require__(318);
+var import_formDataPolicy = __nccwpck_require__(336);
+var import_checkEnvironment = __nccwpck_require__(435);
 var import_proxyPolicy = __nccwpck_require__(39);
-var import_agentPolicy = __nccwpck_require__(461);
-var import_tlsPolicy = __nccwpck_require__(217);
-var import_multipartPolicy = __nccwpck_require__(168);
+var import_agentPolicy = __nccwpck_require__(460);
+var import_tlsPolicy = __nccwpck_require__(216);
+var import_multipartPolicy = __nccwpck_require__(167);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_checkEnvironment.isNodeLike) {
@@ -59330,7 +59191,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 311:
+/***/ 310:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59347,7 +59208,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 312:
+/***/ 311:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -59373,7 +59234,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_log = __nccwpck_require__(150);
+var import_log = __nccwpck_require__(149);
 const redirectPolicyName = "redirectPolicy";
 const allowedRedirect = ["GET", "HEAD"];
 function redirectPolicy(options = {}) {
@@ -59419,7 +59280,7 @@ async function handleRedirect(next, response, maxRetries, allowCrossOriginRedire
 
 /***/ }),
 
-/***/ 313:
+/***/ 312:
 /***/ ((module) => {
 
 "use strict";
@@ -59427,7 +59288,7 @@ module.exports = require("worker_threads");
 
 /***/ }),
 
-/***/ 314:
+/***/ 313:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59437,7 +59298,7 @@ module.exports = require("worker_threads");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
 const operation_js_1 = __nccwpck_require__(51);
-const poller_js_1 = __nccwpck_require__(308);
+const poller_js_1 = __nccwpck_require__(307);
 /**
  * Creates a poller that can be used to poll a long-running operation.
  * @param lro - Description of the long-running operation
@@ -59482,7 +59343,7 @@ exports.createHttpPoller = createHttpPoller;
 
 /***/ }),
 
-/***/ 315:
+/***/ 314:
 /***/ ((module) => {
 
 "use strict";
@@ -59490,14 +59351,14 @@ module.exports = require("perf_hooks");
 
 /***/ }),
 
-/***/ 316:
+/***/ 315:
 /***/ ((module) => {
 
 (()=>{"use strict";var t={d:(e,n)=>{for(var i in n)t.o(n,i)&&!t.o(e,i)&&Object.defineProperty(e,i,{enumerable:!0,get:n[i]})},o:(t,e)=>Object.prototype.hasOwnProperty.call(t,e),r:t=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(t,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(t,"__esModule",{value:!0})}},e={};t.r(e),t.d(e,{XMLBuilder:()=>ie,XMLParser:()=>Lt,XMLValidator:()=>se});const n=":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD",i=new RegExp("^["+n+"]["+n+"\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$");function s(t,e){const n=[];let i=e.exec(t);for(;i;){const s=[];s.startIndex=e.lastIndex-i[0].length;const r=i.length;for(let t=0;t<r;t++)s.push(i[t]);n.push(s),i=e.exec(t)}return n}const r=function(t){return!(null==i.exec(t))},o=["hasOwnProperty","toString","valueOf","__defineGetter__","__defineSetter__","__lookupGetter__","__lookupSetter__"],a=["__proto__","constructor","prototype"],h={allowBooleanAttributes:!1,unpairedTags:[]};function l(t,e){e=Object.assign({},h,e);const n=[];let i=!1,s=!1;"\ufeff"===t[0]&&(t=t.substr(1));for(let r=0;r<t.length;r++)if("<"===t[r]&&"?"===t[r+1]){if(r+=2,r=p(t,r),r.err)return r}else{if("<"!==t[r]){if(u(t[r]))continue;return b("InvalidChar","char '"+t[r]+"' is not expected.",w(t,r))}{let o=r;if(r++,"!"===t[r]){r=c(t,r);continue}{let a=!1;"/"===t[r]&&(a=!0,r++);let h="";for(;r<t.length&&">"!==t[r]&&" "!==t[r]&&"\t"!==t[r]&&"\n"!==t[r]&&"\r"!==t[r];r++)h+=t[r];if(h=h.trim(),"/"===h[h.length-1]&&(h=h.substring(0,h.length-1),r--),!E(h)){let e;return e=0===h.trim().length?"Invalid space after '<'.":"Tag '"+h+"' is an invalid name.",b("InvalidTag",e,w(t,r))}const l=g(t,r);if(!1===l)return b("InvalidAttr","Attributes for '"+h+"' have open quote.",w(t,r));let d=l.value;if(r=l.index,"/"===d[d.length-1]){const n=r-d.length;d=d.substring(0,d.length-1);const s=x(d,e);if(!0!==s)return b(s.err.code,s.err.msg,w(t,n+s.err.line));i=!0}else if(a){if(!l.tagClosed)return b("InvalidTag","Closing tag '"+h+"' doesn't have proper closing.",w(t,r));if(d.trim().length>0)return b("InvalidTag","Closing tag '"+h+"' can't have attributes or invalid starting.",w(t,o));if(0===n.length)return b("InvalidTag","Closing tag '"+h+"' has not been opened.",w(t,o));{const e=n.pop();if(h!==e.tagName){let n=w(t,e.tagStartPos);return b("InvalidTag","Expected closing tag '"+e.tagName+"' (opened in line "+n.line+", col "+n.col+") instead of closing tag '"+h+"'.",w(t,o))}0==n.length&&(s=!0)}}else{const a=x(d,e);if(!0!==a)return b(a.err.code,a.err.msg,w(t,r-d.length+a.err.line));if(!0===s)return b("InvalidXml","Multiple possible root nodes found.",w(t,r));-1!==e.unpairedTags.indexOf(h)||n.push({tagName:h,tagStartPos:o}),i=!0}for(r++;r<t.length;r++)if("<"===t[r]){if("!"===t[r+1]){r++,r=c(t,r);continue}if("?"!==t[r+1])break;if(r=p(t,++r),r.err)return r}else if("&"===t[r]){const e=N(t,r);if(-1==e)return b("InvalidChar","char '&' is not expected.",w(t,r));r=e}else if(!0===s&&!u(t[r]))return b("InvalidXml","Extra text at the end",w(t,r));"<"===t[r]&&r--}}}return i?1==n.length?b("InvalidTag","Unclosed tag '"+n[0].tagName+"'.",w(t,n[0].tagStartPos)):!(n.length>0)||b("InvalidXml","Invalid '"+JSON.stringify(n.map(t=>t.tagName),null,4).replace(/\r?\n/g,"")+"' found.",{line:1,col:1}):b("InvalidXml","Start tag expected.",1)}function u(t){return" "===t||"\t"===t||"\n"===t||"\r"===t}function p(t,e){const n=e;for(;e<t.length;e++)if("?"==t[e]||" "==t[e]){const i=t.substr(n,e-n);if(e>5&&"xml"===i)return b("InvalidXml","XML declaration allowed only at the start of the document.",w(t,e));if("?"==t[e]&&">"==t[e+1]){e++;break}continue}return e}function c(t,e){if(t.length>e+5&&"-"===t[e+1]&&"-"===t[e+2]){for(e+=3;e<t.length;e++)if("-"===t[e]&&"-"===t[e+1]&&">"===t[e+2]){e+=2;break}}else if(t.length>e+8&&"D"===t[e+1]&&"O"===t[e+2]&&"C"===t[e+3]&&"T"===t[e+4]&&"Y"===t[e+5]&&"P"===t[e+6]&&"E"===t[e+7]){let n=1;for(e+=8;e<t.length;e++)if("<"===t[e])n++;else if(">"===t[e]&&(n--,0===n))break}else if(t.length>e+9&&"["===t[e+1]&&"C"===t[e+2]&&"D"===t[e+3]&&"A"===t[e+4]&&"T"===t[e+5]&&"A"===t[e+6]&&"["===t[e+7])for(e+=8;e<t.length;e++)if("]"===t[e]&&"]"===t[e+1]&&">"===t[e+2]){e+=2;break}return e}const d='"',f="'";function g(t,e){let n="",i="",s=!1;for(;e<t.length;e++){if(t[e]===d||t[e]===f)""===i?i=t[e]:i!==t[e]||(i="");else if(">"===t[e]&&""===i){s=!0;break}n+=t[e]}return""===i&&{value:n,index:e,tagClosed:s}}const m=new RegExp("(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['\"])(([\\s\\S])*?)\\5)?","g");function x(t,e){const n=s(t,m),i={};for(let t=0;t<n.length;t++){if(0===n[t][1].length)return b("InvalidAttr","Attribute '"+n[t][2]+"' has no space in starting.",v(n[t]));if(void 0!==n[t][3]&&void 0===n[t][4])return b("InvalidAttr","Attribute '"+n[t][2]+"' is without value.",v(n[t]));if(void 0===n[t][3]&&!e.allowBooleanAttributes)return b("InvalidAttr","boolean attribute '"+n[t][2]+"' is not allowed.",v(n[t]));const s=n[t][2];if(!y(s))return b("InvalidAttr","Attribute '"+s+"' is an invalid name.",v(n[t]));if(Object.prototype.hasOwnProperty.call(i,s))return b("InvalidAttr","Attribute '"+s+"' is repeated.",v(n[t]));i[s]=1}return!0}function N(t,e){if(";"===t[++e])return-1;if("#"===t[e])return function(t,e){let n=/\d/;for("x"===t[e]&&(e++,n=/[\da-fA-F]/);e<t.length;e++){if(";"===t[e])return e;if(!t[e].match(n))break}return-1}(t,++e);let n=0;for(;e<t.length;e++,n++)if(!(t[e].match(/\w/)&&n<20)){if(";"===t[e])break;return-1}return e}function b(t,e,n){return{err:{code:t,msg:e,line:n.line||n,col:n.col}}}function y(t){return r(t)}function E(t){return r(t)}function w(t,e){const n=t.substring(0,e).split(/\r?\n/);return{line:n.length,col:n[n.length-1].length+1}}function v(t){return t.startIndex+t[1].length}const S=t=>o.includes(t)?"__"+t:t,_={preserveOrder:!1,attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,removeNSPrefix:!1,allowBooleanAttributes:!1,parseTagValue:!0,parseAttributeValue:!1,trimValues:!0,cdataPropName:!1,numberParseOptions:{hex:!0,leadingZeros:!0,eNotation:!0},tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},stopNodes:[],alwaysCreateTextNode:!1,isArray:()=>!1,commentPropName:!1,unpairedTags:[],processEntities:!0,htmlEntities:!1,entityDecoder:null,ignoreDeclaration:!1,ignorePiTags:!1,transformTagName:!1,transformAttributeName:!1,updateTag:function(t,e,n){return t},captureMetaData:!1,maxNestedTags:100,strictReservedNames:!0,jPath:!0,onDangerousProperty:S};function A(t,e){if("string"!=typeof t)return;const n=t.toLowerCase();if(o.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);if(a.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`)}function T(t,e){return"boolean"==typeof t?{enabled:t,maxEntitySize:1e4,maxExpansionDepth:1e4,maxTotalExpansions:1/0,maxExpandedLength:1e5,maxEntityCount:1e3,allowedTags:null,tagFilter:null,appliesTo:"all"}:"object"==typeof t&&null!==t?{enabled:!1!==t.enabled,maxEntitySize:Math.max(1,t.maxEntitySize??1e4),maxExpansionDepth:Math.max(1,t.maxExpansionDepth??1e4),maxTotalExpansions:Math.max(1,t.maxTotalExpansions??1/0),maxExpandedLength:Math.max(1,t.maxExpandedLength??1e5),maxEntityCount:Math.max(1,t.maxEntityCount??1e3),allowedTags:t.allowedTags??null,tagFilter:t.tagFilter??null,appliesTo:t.appliesTo??"all"}:T(!0)}const C=function(t){const e=Object.assign({},_,t),n=[{value:e.attributeNamePrefix,name:"attributeNamePrefix"},{value:e.attributesGroupName,name:"attributesGroupName"},{value:e.textNodeName,name:"textNodeName"},{value:e.cdataPropName,name:"cdataPropName"},{value:e.commentPropName,name:"commentPropName"}];for(const{value:t,name:e}of n)t&&A(t,e);return null===e.onDangerousProperty&&(e.onDangerousProperty=S),e.processEntities=T(e.processEntities,e.htmlEntities),e.unpairedTagsSet=new Set(e.unpairedTags),e.stopNodes&&Array.isArray(e.stopNodes)&&(e.stopNodes=e.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),e};let P;P="function"!=typeof Symbol?"@@xmlMetadata":Symbol("XML Node Metadata");class ${constructor(t){this.tagname=t,this.child=[],this[":@"]=Object.create(null)}add(t,e){"__proto__"===t&&(t="#__proto__"),this.child.push({[t]:e})}addChild(t,e){"__proto__"===t.tagname&&(t.tagname="#__proto__"),t[":@"]&&Object.keys(t[":@"]).length>0?this.child.push({[t.tagname]:t.child,":@":t[":@"]}):this.child.push({[t.tagname]:t.child}),void 0!==e&&(this.child[this.child.length-1][P]={startIndex:e})}static getMetaDataSymbol(){return P}}const O=":A-Za-z_À-ÖØ-öø-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�",I=":A-Za-z_À-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�𐀀-󯿿",V=I+"\\-\\.\\d·̀-ͯ҇‿-⁀",D=(t,e,n="")=>{const i=`[${t.replace(":","")}][${e.replace(":","")}]*`;return{name:new RegExp(`^[${t}][${e}]*$`,n),ncName:new RegExp(`^${i}$`,n),qName:new RegExp(`^${i}(?::${i})?$`,n),nmToken:new RegExp(`^[${e}]+$`,n),nmTokens:new RegExp(`^[${e}]+(?:\\s+[${e}]+)*$`,n)}},M=D(O,O+"\\-\\.\\d·̀-ͯ‿-⁀"),j=D(I,V,"u"),L=(t,{xmlVersion:e="1.0"}={})=>((t="1.0")=>"1.1"===t?j:M)(e).qName.test(t);class k{constructor(t,e){this.suppressValidationErr=!t,this.options=t,this.xmlVersion=e||1}setXmlVersion(t=1){this.xmlVersion=t}readDocType(t,e){const n=Object.create(null);let i=0;if("O"!==t[e+3]||"C"!==t[e+4]||"T"!==t[e+5]||"Y"!==t[e+6]||"P"!==t[e+7]||"E"!==t[e+8])throw new Error("Invalid Tag instead of DOCTYPE");{e+=9;let s=1,r=!1,o=!1,a="";for(;e<t.length;e++)if("<"!==t[e]||o)if(">"===t[e]){if(o?"-"===t[e-1]&&"-"===t[e-2]&&(o=!1,s--):s--,0===s)break}else"["===t[e]?r=!0:a+=t[e];else{if(r&&F(t,"!ENTITY",e)){let s,r;if(e+=7,[s,r,e]=this.readEntityExp(t,e+1,this.suppressValidationErr),-1===r.indexOf("&")){if(!1!==this.options.enabled&&null!=this.options.maxEntityCount&&i>=this.options.maxEntityCount)throw new Error(`Entity count (${i+1}) exceeds maximum allowed (${this.options.maxEntityCount})`);n[s]=r,i++}}else if(r&&F(t,"!ELEMENT",e)){e+=8;const{index:n}=this.readElementExp(t,e+1);e=n}else if(r&&F(t,"!ATTLIST",e))e+=8;else if(r&&F(t,"!NOTATION",e)){e+=9;const{index:n}=this.readNotationExp(t,e+1,this.suppressValidationErr);e=n}else{if(!F(t,"!--",e))throw new Error("Invalid DOCTYPE");o=!0}s++,a=""}if(0!==s)throw new Error("Unclosed DOCTYPE")}return{entities:n,i:e}}readEntityExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e])&&'"'!==t[e]&&"'"!==t[e];)e++;let i=t.substring(n,e);if(G(i,{xmlVersion:this.xmlVersion}),e=R(t,e),!this.suppressValidationErr){if("SYSTEM"===t.substring(e,e+6).toUpperCase())throw new Error("External entities are not supported");if("%"===t[e])throw new Error("Parameter entities are not supported")}let s="";if([e,s]=this.readIdentifierVal(t,e,"entity"),!1!==this.options.enabled&&null!=this.options.maxEntitySize&&s.length>this.options.maxEntitySize)throw new Error(`Entity "${i}" size (${s.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`);return[i,s,--e]}readNotationExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);!this.suppressValidationErr&&G(i,{xmlVersion:this.xmlVersion}),e=R(t,e);const s=t.substring(e,e+6).toUpperCase();if(!this.suppressValidationErr&&"SYSTEM"!==s&&"PUBLIC"!==s)throw new Error(`Expected SYSTEM or PUBLIC, found "${s}"`);e+=s.length,e=R(t,e);let r=null,o=null;if("PUBLIC"===s)[e,r]=this.readIdentifierVal(t,e,"publicIdentifier"),'"'!==t[e=R(t,e)]&&"'"!==t[e]||([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"));else if("SYSTEM"===s&&([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"),!this.suppressValidationErr&&!o))throw new Error("Missing mandatory system identifier for SYSTEM notation");return{notationName:i,publicIdentifier:r,systemIdentifier:o,index:--e}}readIdentifierVal(t,e,n){let i="";const s=t[e];if('"'!==s&&"'"!==s)throw new Error(`Expected quoted string, found "${s}"`);const r=++e;for(;e<t.length&&t[e]!==s;)e++;if(i=t.substring(r,e),t[e]!==s)throw new Error(`Unterminated ${n} value`);return[++e,i]}readElementExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);if(!this.suppressValidationErr&&!L(i,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid element name: "${i}"`);let s="";if("E"===t[e=R(t,e)]&&F(t,"MPTY",e))e+=4;else if("A"===t[e]&&F(t,"NY",e))e+=2;else if("("===t[e]){const n=++e;for(;e<t.length&&")"!==t[e];)e++;if(s=t.substring(n,e),")"!==t[e])throw new Error("Unterminated content model")}else if(!this.suppressValidationErr)throw new Error(`Invalid Element Expression, found "${t[e]}"`);return{elementName:i,contentModel:s.trim(),index:e}}readAttlistExp(t,e){let n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);for(G(i,{xmlVersion:this.xmlVersion}),n=e=R(t,e);e<t.length&&!/\s/.test(t[e]);)e++;let s=t.substring(n,e);if(!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid attribute name: "${s}"`);e=R(t,e);let r="";if("NOTATION"===t.substring(e,e+8).toUpperCase()){if(r="NOTATION","("!==t[e=R(t,e+=8)])throw new Error(`Expected '(', found "${t[e]}"`);e++;let n=[];for(;e<t.length&&")"!==t[e];){const i=e;for(;e<t.length&&"|"!==t[e]&&")"!==t[e];)e++;let s=t.substring(i,e);if(s=s.trim(),!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid notation name: "${s}"`);n.push(s),"|"===t[e]&&(e++,e=R(t,e))}if(")"!==t[e])throw new Error("Unterminated list of notations");e++,r+=" ("+n.join("|")+")"}else{const n=e;for(;e<t.length&&!/\s/.test(t[e]);)e++;r+=t.substring(n,e);const i=["CDATA","ID","IDREF","IDREFS","ENTITY","ENTITIES","NMTOKEN","NMTOKENS"];if(!this.suppressValidationErr&&!i.includes(r.toUpperCase()))throw new Error(`Invalid attribute type: "${r}"`)}e=R(t,e);let o="";return"#REQUIRED"===t.substring(e,e+8).toUpperCase()?(o="#REQUIRED",e+=8):"#IMPLIED"===t.substring(e,e+7).toUpperCase()?(o="#IMPLIED",e+=7):[e,o]=this.readIdentifierVal(t,e,"ATTLIST"),{elementName:i,attributeName:s,attributeType:r,defaultValue:o,index:e}}}const R=(t,e)=>{for(;e<t.length&&/\s/.test(t[e]);)e++;return e};function F(t,e,n){for(let i=0;i<e.length;i++)if(e[i]!==t[n+i+1])return!1;return!0}function G(t,e){if(L(t,{xmlVersion:e}))return t;throw new Error(`Invalid entity name ${t}`)}const U=/^[-+]?0x[a-fA-F0-9]+$/,B=/^0b[01]+$/,W=/^0o[0-7]+$/,z=/^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/,X={hex:!0,binary:!1,octal:!1,leadingZeros:!0,decimalPoint:".",eNotation:!0,infinity:"original"};const Y=/^([-+])?(0*)(\d*(\.\d*)?[eE][-\+]?\d+)$/;function q(t,e){const n=t.trim();if(2!==e&&8!==e||(t=n.substring(2)),parseInt)return parseInt(t,e);if(Number.parseInt)return Number.parseInt(t,e);if(window&&window.parseInt)return window.parseInt(t,e);throw new Error("parseInt, Number.parseInt, window.parseInt are not supported")}class Z{constructor(t){this._matcher=t}get separator(){return this._matcher.separator}getCurrentTag(){const t=this._matcher.path;return t.length>0?t[t.length-1].tag:void 0}getCurrentNamespace(){const t=this._matcher.path;return t.length>0?t[t.length-1].namespace:void 0}getAttrValue(t){const e=this._matcher.path;if(0!==e.length)return e[e.length-1].values?.[t]}hasAttr(t){const e=this._matcher.path;if(0===e.length)return!1;const n=e[e.length-1];return void 0!==n.values&&t in n.values}getPosition(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].position??0}getCounter(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this._matcher.path.length}toString(t,e=!0){return this._matcher.toString(t,e)}toArray(){return this._matcher.path.map(t=>t.tag)}matches(t){return this._matcher.matches(t)}matchesAny(t){return t.matchesAny(this._matcher)}}class J{constructor(t={}){this.separator=t.separator||".",this.path=[],this.siblingStacks=[],this._pathStringCache=null,this._view=new Z(this)}push(t,e=null,n=null){this._pathStringCache=null,this.path.length>0&&(this.path[this.path.length-1].values=void 0);const i=this.path.length;this.siblingStacks[i]||(this.siblingStacks[i]=new Map);const s=this.siblingStacks[i],r=n?`${n}:${t}`:t,o=s.get(r)||0;let a=0;for(const t of s.values())a+=t;s.set(r,o+1);const h={tag:t,position:a,counter:o};null!=n&&(h.namespace=n),null!=e&&(h.values=e),this.path.push(h)}pop(){if(0===this.path.length)return;this._pathStringCache=null;const t=this.path.pop();return this.siblingStacks.length>this.path.length+1&&(this.siblingStacks.length=this.path.length+1),t}updateCurrent(t){if(this.path.length>0){const e=this.path[this.path.length-1];null!=t&&(e.values=t)}}getCurrentTag(){return this.path.length>0?this.path[this.path.length-1].tag:void 0}getCurrentNamespace(){return this.path.length>0?this.path[this.path.length-1].namespace:void 0}getAttrValue(t){if(0!==this.path.length)return this.path[this.path.length-1].values?.[t]}hasAttr(t){if(0===this.path.length)return!1;const e=this.path[this.path.length-1];return void 0!==e.values&&t in e.values}getPosition(){return 0===this.path.length?-1:this.path[this.path.length-1].position??0}getCounter(){return 0===this.path.length?-1:this.path[this.path.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this.path.length}toString(t,e=!0){const n=t||this.separator;if(n===this.separator&&!0===e){if(null!==this._pathStringCache)return this._pathStringCache;const t=this.path.map(t=>t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n);return this._pathStringCache=t,t}return this.path.map(t=>e&&t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n)}toArray(){return this.path.map(t=>t.tag)}reset(){this._pathStringCache=null,this.path=[],this.siblingStacks=[]}matches(t){const e=t.segments;return 0!==e.length&&(t.hasDeepWildcard()?this._matchWithDeepWildcard(e):this._matchSimple(e))}_matchSimple(t){if(this.path.length!==t.length)return!1;for(let e=0;e<t.length;e++)if(!this._matchSegment(t[e],this.path[e],e===this.path.length-1))return!1;return!0}_matchWithDeepWildcard(t){let e=this.path.length-1,n=t.length-1;for(;n>=0&&e>=0;){const i=t[n];if("deep-wildcard"===i.type){if(n--,n<0)return!0;const i=t[n];let s=!1;for(let t=e;t>=0;t--)if(this._matchSegment(i,this.path[t],t===this.path.length-1)){e=t-1,n--,s=!0;break}if(!s)return!1}else{if(!this._matchSegment(i,this.path[e],e===this.path.length-1))return!1;e--,n--}}return n<0}_matchSegment(t,e,n){if("*"!==t.tag&&t.tag!==e.tag)return!1;if(void 0!==t.namespace&&"*"!==t.namespace&&t.namespace!==e.namespace)return!1;if(void 0!==t.attrName){if(!n)return!1;if(!e.values||!(t.attrName in e.values))return!1;if(void 0!==t.attrValue&&String(e.values[t.attrName])!==String(t.attrValue))return!1}if(void 0!==t.position){if(!n)return!1;const i=e.counter??0;if("first"===t.position&&0!==i)return!1;if("odd"===t.position&&i%2!=1)return!1;if("even"===t.position&&i%2!=0)return!1;if("nth"===t.position&&i!==t.positionValue)return!1}return!0}matchesAny(t){return t.matchesAny(this)}snapshot(){return{path:this.path.map(t=>({...t})),siblingStacks:this.siblingStacks.map(t=>new Map(t))}}restore(t){this._pathStringCache=null,this.path=t.path.map(t=>({...t})),this.siblingStacks=t.siblingStacks.map(t=>new Map(t))}readOnly(){return this._view}}class K{constructor(t,e={},n){this.pattern=t,this.separator=e.separator||".",this.segments=this._parse(t),this.data=n,this._hasDeepWildcard=this.segments.some(t=>"deep-wildcard"===t.type),this._hasAttributeCondition=this.segments.some(t=>void 0!==t.attrName),this._hasPositionSelector=this.segments.some(t=>void 0!==t.position)}_parse(t){const e=[];let n=0,i="";for(;n<t.length;)t[n]===this.separator?n+1<t.length&&t[n+1]===this.separator?(i.trim()&&(e.push(this._parseSegment(i.trim())),i=""),e.push({type:"deep-wildcard"}),n+=2):(i.trim()&&e.push(this._parseSegment(i.trim())),i="",n++):(i+=t[n],n++);return i.trim()&&e.push(this._parseSegment(i.trim())),e}_parseSegment(t){const e={type:"tag"};let n=null,i=t;const s=t.match(/^([^\[]+)(\[[^\]]*\])(.*)$/);if(s&&(i=s[1]+s[3],s[2])){const t=s[2].slice(1,-1);t&&(n=t)}let r,o,a=i;if(i.includes("::")){const e=i.indexOf("::");if(r=i.substring(0,e).trim(),a=i.substring(e+2).trim(),!r)throw new Error(`Invalid namespace in pattern: ${t}`)}let h=null;if(a.includes(":")){const t=a.lastIndexOf(":"),e=a.substring(0,t).trim(),n=a.substring(t+1).trim();["first","last","odd","even"].includes(n)||/^nth\(\d+\)$/.test(n)?(o=e,h=n):o=a}else o=a;if(!o)throw new Error(`Invalid segment pattern: ${t}`);if(e.tag=o,r&&(e.namespace=r),n)if(n.includes("=")){const t=n.indexOf("=");e.attrName=n.substring(0,t).trim(),e.attrValue=n.substring(t+1).trim()}else e.attrName=n.trim();if(h){const t=h.match(/^nth\((\d+)\)$/);t?(e.position="nth",e.positionValue=parseInt(t[1],10)):e.position=h}return e}get length(){return this.segments.length}hasDeepWildcard(){return this._hasDeepWildcard}hasAttributeCondition(){return this._hasAttributeCondition}hasPositionSelector(){return this._hasPositionSelector}toString(){return this.pattern}}class Q{constructor(){this._byDepthAndTag=new Map,this._wildcardByDepth=new Map,this._deepWildcards=[],this._patterns=new Set,this._sealed=!1}add(t){if(this._sealed)throw new TypeError("ExpressionSet is sealed. Create a new ExpressionSet to add more expressions.");if(this._patterns.has(t.pattern))return this;if(this._patterns.add(t.pattern),t.hasDeepWildcard())return this._deepWildcards.push(t),this;const e=t.length,n=t.segments[t.segments.length-1],i=n?.tag;if(i&&"*"!==i){const n=`${e}:${i}`;this._byDepthAndTag.has(n)||this._byDepthAndTag.set(n,[]),this._byDepthAndTag.get(n).push(t)}else this._wildcardByDepth.has(e)||this._wildcardByDepth.set(e,[]),this._wildcardByDepth.get(e).push(t);return this}addAll(t){for(const e of t)this.add(e);return this}has(t){return this._patterns.has(t.pattern)}get size(){return this._patterns.size}seal(){return this._sealed=!0,this}get isSealed(){return this._sealed}matchesAny(t){return null!==this.findMatch(t)}findMatch(t){const e=t.getDepth(),n=`${e}:${t.getCurrentTag()}`,i=this._byDepthAndTag.get(n);if(i)for(let e=0;e<i.length;e++)if(t.matches(i[e]))return i[e];const s=this._wildcardByDepth.get(e);if(s)for(let e=0;e<s.length;e++)if(t.matches(s[e]))return s[e];for(let e=0;e<this._deepWildcards.length;e++)if(t.matches(this._deepWildcards[e]))return this._deepWildcards[e];return null}}const H={cent:"¢",pound:"£",curren:"¤",yen:"¥",euro:"€",dollar:"$",euro:"€",fnof:"ƒ",inr:"₹",af:"؋",birr:"ብር",peso:"₱",rub:"₽",won:"₩",yuan:"¥",cedil:"¸"},tt={amp:"&",apos:"'",gt:">",lt:"<",quot:'"'},et={nbsp:" ",copy:"©",reg:"®",trade:"™",mdash:"—",ndash:"–",hellip:"…",laquo:"«",raquo:"»",lsquo:"‘",rsquo:"’",ldquo:"“",rdquo:"”",bull:"•",para:"¶",sect:"§",deg:"°",frac12:"½",frac14:"¼",frac34:"¾"},nt=new Set("!?\\\\/[]$%{}^&*()<>|+");function it(t){if("#"===t[0])throw new Error(`[EntityReplacer] Invalid character '#' in entity name: "${t}"`);for(const e of t)if(nt.has(e))throw new Error(`[EntityReplacer] Invalid character '${e}' in entity name: "${t}"`);return t}function st(...t){const e=Object.create(null);for(const n of t)if(n)for(const t of Object.keys(n)){const i=n[t];if("string"==typeof i)e[t]=i;else if(i&&"object"==typeof i&&void 0!==i.val){const n=i.val;"string"==typeof n&&(e[t]=n)}}return e}const rt="external",ot="base",at="all",ht=Object.freeze({allow:0,leave:1,remove:2,throw:3}),lt=new Set([9,10,13]);class ut{constructor(t={}){var e;this._limit=t.limit||{},this._maxTotalExpansions=this._limit.maxTotalExpansions||0,this._maxExpandedLength=this._limit.maxExpandedLength||0,this._postCheck="function"==typeof t.postCheck?t.postCheck:t=>t,this._limitTiers=(e=this._limit.applyLimitsTo??rt)&&e!==rt?e===at?new Set([at]):e===ot?new Set([ot]):Array.isArray(e)?new Set(e):new Set([rt]):new Set([rt]),this._numericAllowed=t.numericAllowed??!0,this._baseMap=st(tt,t.namedEntities||null),this._externalMap=Object.create(null),this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this._removeSet=new Set(t.remove&&Array.isArray(t.remove)?t.remove:[]),this._leaveSet=new Set(t.leave&&Array.isArray(t.leave)?t.leave:[]);const n=function(t){if(!t)return{xmlVersion:1,onLevel:ht.allow,nullLevel:ht.remove};const e=1.1===t.xmlVersion?1.1:1,n=ht[t.onNCR]??ht.allow,i=ht[t.nullNCR]??ht.remove;return{xmlVersion:e,onLevel:n,nullLevel:Math.max(i,ht.remove)}}(t.ncr);this._ncrXmlVersion=n.xmlVersion,this._ncrOnLevel=n.onLevel,this._ncrNullLevel=n.nullLevel}setExternalEntities(t){if(t)for(const e of Object.keys(t))it(e);this._externalMap=st(t)}addExternalEntity(t,e){it(t),"string"==typeof e&&-1===e.indexOf("&")&&(this._externalMap[t]=e)}addInputEntities(t){this._totalExpansions=0,this._expandedLength=0,this._inputMap=st(t)}reset(){return this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this}setXmlVersion(t){this._ncrXmlVersion=1.1===t?1.1:1}decode(t){if("string"!=typeof t||0===t.length)return t;const e=t,n=[],i=t.length;let s=0,r=0;const o=this._maxTotalExpansions>0,a=this._maxExpandedLength>0,h=o||a;for(;r<i;){if(38!==t.charCodeAt(r)){r++;continue}let e=r+1;for(;e<i&&59!==t.charCodeAt(e)&&e-r<=32;)e++;if(e>=i||59!==t.charCodeAt(e)){r++;continue}const l=t.slice(r+1,e);if(0===l.length){r++;continue}let u,p;if(this._removeSet.has(l))u="",void 0===p&&(p=rt);else{if(this._leaveSet.has(l)){r++;continue}if(35===l.charCodeAt(0)){const t=this._resolveNCR(l);if(void 0===t){r++;continue}u=t,p=ot}else{const t=this._resolveName(l);u=t?.value,p=t?.tier}}if(void 0!==u){if(r>s&&n.push(t.slice(s,r)),n.push(u),s=e+1,r=s,h&&this._tierCounts(p)){if(o&&(this._totalExpansions++,this._totalExpansions>this._maxTotalExpansions))throw new Error(`[EntityReplacer] Entity expansion count limit exceeded: ${this._totalExpansions} > ${this._maxTotalExpansions}`);if(a){const t=u.length-(l.length+2);if(t>0&&(this._expandedLength+=t,this._expandedLength>this._maxExpandedLength))throw new Error(`[EntityReplacer] Expanded content length limit exceeded: ${this._expandedLength} > ${this._maxExpandedLength}`)}}}else r++}s<i&&n.push(t.slice(s));const l=0===n.length?t:n.join("");return this._postCheck(l,e)}_tierCounts(t){return!!this._limitTiers.has(at)||this._limitTiers.has(t)}_resolveName(t){return t in this._inputMap?{value:this._inputMap[t],tier:rt}:t in this._externalMap?{value:this._externalMap[t],tier:rt}:t in this._baseMap?{value:this._baseMap[t],tier:ot}:void 0}_classifyNCR(t){return 0===t?this._ncrNullLevel:t>=55296&&t<=57343||1===this._ncrXmlVersion&&t>=1&&t<=31&&!lt.has(t)?ht.remove:-1}_applyNCRAction(t,e,n){switch(t){case ht.allow:return String.fromCodePoint(n);case ht.remove:return"";case ht.leave:return;case ht.throw:throw new Error(`[EntityDecoder] Prohibited numeric character reference &${e}; (U+${n.toString(16).toUpperCase().padStart(4,"0")})`);default:return String.fromCodePoint(n)}}_resolveNCR(t){const e=t.charCodeAt(1);let n;if(n=120===e||88===e?parseInt(t.slice(2),16):parseInt(t.slice(1),10),Number.isNaN(n)||n<0||n>1114111)return;const i=this._classifyNCR(n);if(!this._numericAllowed&&i<ht.remove)return;const s=-1===i?this._ncrOnLevel:Math.max(this._ncrOnLevel,i);return this._applyNCRAction(s,t,n)}}function pt(t,e){if(!t)return{};const n=e.attributesGroupName?t[e.attributesGroupName]:t;if(!n)return{};const i={};for(const t in n)t.startsWith(e.attributeNamePrefix)?i[t.substring(e.attributeNamePrefix.length)]=n[t]:i[t]=n[t];return i}function ct(t){if(!t||"string"!=typeof t)return;const e=t.indexOf(":");if(-1!==e&&e>0){const n=t.substring(0,e);if("xmlns"!==n)return n}}class dt{constructor(t,e){var n;this.options=t,this.currentNode=null,this.tagsNodeStack=[],this.parseXml=Nt,this.parseTextData=ft,this.resolveNameSpace=gt,this.buildAttributesMap=xt,this.isItStopNode=wt,this.replaceEntitiesValue=yt,this.readStopNodeData=At,this.saveTextToParentTag=Et,this.addChild=bt,this.ignoreAttributesFn="function"==typeof(n=this.options.ignoreAttributes)?n:Array.isArray(n)?t=>{for(const e of n){if("string"==typeof e&&t===e)return!0;if(e instanceof RegExp&&e.test(t))return!0}}:()=>!1,this.entityExpansionCount=0,this.currentExpandedLength=0;let i={...tt};this.options.entityDecoder?this.entityDecoder=this.options.entityDecoder:("object"==typeof this.options.htmlEntities?i=this.options.htmlEntities:!0===this.options.htmlEntities&&(i={...et,...H}),this.entityDecoder=new ut({namedEntities:{...i,...e},numericAllowed:this.options.htmlEntities,limit:{maxTotalExpansions:this.options.processEntities.maxTotalExpansions,maxExpandedLength:this.options.processEntities.maxExpandedLength,applyLimitsTo:this.options.processEntities.appliesTo}})),this.matcher=new J,this.readonlyMatcher=this.matcher.readOnly(),this.isCurrentNodeStopNode=!1,this.stopNodeExpressionsSet=new Q;const s=this.options.stopNodes;if(s&&s.length>0){for(let t=0;t<s.length;t++){const e=s[t];"string"==typeof e?this.stopNodeExpressionsSet.add(new K(e)):e instanceof K&&this.stopNodeExpressionsSet.add(e)}this.stopNodeExpressionsSet.seal()}}}function ft(t,e,n,i,s,r,o){const a=this.options;if(void 0!==t&&(a.trimValues&&!i&&(t=t.trim()),t.length>0)){o||(t=this.replaceEntitiesValue(t,e,n));const i=a.jPath?n.toString():n,h=a.tagValueProcessor(e,t,i,s,r);return null==h?t:typeof h!=typeof t||h!==t?h:a.trimValues||t.trim()===t?Tt(t,a.parseTagValue,a.numberParseOptions):t}}function gt(t){if(this.options.removeNSPrefix){const e=t.split(":"),n="/"===t.charAt(0)?"/":"";if("xmlns"===e[0])return"";2===e.length&&(t=n+e[1])}return t}const mt=new RegExp("([^\\s=]+)\\s*(=\\s*(['\"])([\\s\\S]*?)\\3)?","gm");function xt(t,e,n,i=!1){const r=this.options;if(!0===i||!0!==r.ignoreAttributes&&"string"==typeof t){const i=s(t,mt),o=i.length,a={},h=new Array(o);let l=!1;const u={};for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]),s=i[t][4];if(e.length&&void 0!==s){let i=s;r.trimValues&&(i=i.trim()),i=this.replaceEntitiesValue(i,n,this.readonlyMatcher),h[t]=i,u[e]=i,l=!0}}l&&"object"==typeof e&&e.updateCurrent&&e.updateCurrent(u);const p=r.jPath?e.toString():this.readonlyMatcher;let c=!1;for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]);if(this.ignoreAttributesFn(e,p))continue;let n=r.attributeNamePrefix+e;if(e.length)if(r.transformAttributeName&&(n=r.transformAttributeName(n)),n=Pt(n,r),void 0!==i[t][4]){const i=h[t],s=r.attributeValueProcessor(e,i,p);a[n]=null==s?i:typeof s!=typeof i||s!==i?s:Tt(i,r.parseAttributeValue,r.numberParseOptions),c=!0}else r.allowBooleanAttributes&&(a[n]=!0,c=!0)}if(!c)return;if(r.attributesGroupName&&!r.preserveOrder){const t={};return t[r.attributesGroupName]=a,t}return a}}const Nt=function(t){t=t.replace(/\r\n?/g,"\n");const e=new $("!xml");let n=e,i="";this.matcher.reset(),this.entityDecoder.reset(),this.entityExpansionCount=0,this.currentExpandedLength=0;const s=this.options,r=new k(s.processEntities),o=t.length;for(let a=0;a<o;a++)if("<"===t[a]){const h=t.charCodeAt(a+1);if(47===h){const e=vt(t,">",a,"Closing Tag is not closed.");let r=t.substring(a+2,e).trim();if(s.removeNSPrefix){const t=r.indexOf(":");-1!==t&&(r=r.substr(t+1))}r=Ct(s.transformTagName,r,"",s).tagName,n&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher));const o=this.matcher.getCurrentTag();if(r&&s.unpairedTagsSet.has(r))throw new Error(`Unpaired tag can not be used as closing tag: </${r}>`);o&&s.unpairedTagsSet.has(o)&&(this.matcher.pop(),this.tagsNodeStack.pop()),this.matcher.pop(),this.isCurrentNodeStopNode=!1,n=this.tagsNodeStack.pop(),i="",a=e}else if(63===h){let e=_t(t,a,!1,"?>");if(!e)throw new Error("Pi Tag is not closed.");i=this.saveTextToParentTag(i,n,this.readonlyMatcher);const o=this.buildAttributesMap(e.tagExp,this.matcher,e.tagName,!0);if(o){const t=o[this.options.attributeNamePrefix+"version"];this.entityDecoder.setXmlVersion(Number(t)||1),r.setXmlVersion(Number(t)||1)}if(s.ignoreDeclaration&&"?xml"===e.tagName||s.ignorePiTags);else{const t=new $(e.tagName);t.add(s.textNodeName,""),e.tagName!==e.tagExp&&e.attrExpPresent&&!0!==s.ignoreAttributes&&(t[":@"]=o),this.addChild(n,t,this.readonlyMatcher,a)}a=e.closeIndex+1}else if(33===h&&45===t.charCodeAt(a+2)&&45===t.charCodeAt(a+3)){const e=vt(t,"--\x3e",a+4,"Comment is not closed.");if(s.commentPropName){const r=t.substring(a+4,e-2);i=this.saveTextToParentTag(i,n,this.readonlyMatcher),n.add(s.commentPropName,[{[s.textNodeName]:r}])}a=e}else if(33===h&&68===t.charCodeAt(a+2)){const e=r.readDocType(t,a);this.entityDecoder.addInputEntities(e.entities),a=e.i}else if(33===h&&91===t.charCodeAt(a+2)){const e=vt(t,"]]>",a,"CDATA is not closed.")-2,r=t.substring(a+9,e);i=this.saveTextToParentTag(i,n,this.readonlyMatcher);let o=this.parseTextData(r,n.tagname,this.readonlyMatcher,!0,!1,!0,!0);null==o&&(o=""),s.cdataPropName?n.add(s.cdataPropName,[{[s.textNodeName]:r}]):n.add(s.textNodeName,o),a=e+2}else{let r=_t(t,a,s.removeNSPrefix);if(!r){const e=t.substring(Math.max(0,a-50),Math.min(o,a+50));throw new Error(`readTagExp returned undefined at position ${a}. Context: "${e}"`)}let h=r.tagName;const l=r.rawTagName;let u=r.tagExp,p=r.attrExpPresent,c=r.closeIndex;if(({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s)),s.strictReservedNames&&(h===s.commentPropName||h===s.cdataPropName||h===s.textNodeName||h===s.attributesGroupName))throw new Error(`Invalid tag name: ${h}`);n&&i&&"!xml"!==n.tagname&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher,!1));const d=n;d&&s.unpairedTagsSet.has(d.tagname)&&(n=this.tagsNodeStack.pop(),this.matcher.pop());let f=!1;u.length>0&&u.lastIndexOf("/")===u.length-1&&(f=!0,"/"===h[h.length-1]?(h=h.substr(0,h.length-1),u=h):u=u.substr(0,u.length-1),p=h!==u);let g,m=null,x={};g=ct(l),h!==e.tagname&&this.matcher.push(h,{},g),h!==u&&p&&(m=this.buildAttributesMap(u,this.matcher,h),m&&(x=pt(m,s))),h!==e.tagname&&(this.isCurrentNodeStopNode=this.isItStopNode());const N=a;if(this.isCurrentNodeStopNode){let e="";if(f)a=r.closeIndex;else if(s.unpairedTagsSet.has(h))a=r.closeIndex;else{const n=this.readStopNodeData(t,l,c+1);if(!n)throw new Error(`Unexpected end of ${l}`);a=n.i,e=n.tagContent}const i=new $(h);m&&(i[":@"]=m),i.add(s.textNodeName,e),this.matcher.pop(),this.isCurrentNodeStopNode=!1,this.addChild(n,i,this.readonlyMatcher,N)}else{if(f){({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s));const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1}else{if(s.unpairedTagsSet.has(h)){const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1,a=r.closeIndex;continue}{const t=new $(h);if(this.tagsNodeStack.length>s.maxNestedTags)throw new Error("Maximum nested tags exceeded");this.tagsNodeStack.push(n),m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),n=t}}i="",a=c}}}else i+=t[a];return e.child};function bt(t,e,n,i){this.options.captureMetaData||(i=void 0);const s=this.options.jPath?n.toString():n,r=this.options.updateTag(e.tagname,s,e[":@"]);!1===r||("string"==typeof r?(e.tagname=r,t.addChild(e,i)):t.addChild(e,i))}function yt(t,e,n){const i=this.options.processEntities;if(!i||!i.enabled)return t;if(i.allowedTags){const s=this.options.jPath?n.toString():n;if(!(Array.isArray(i.allowedTags)?i.allowedTags.includes(e):i.allowedTags(e,s)))return t}if(i.tagFilter){const s=this.options.jPath?n.toString():n;if(!i.tagFilter(e,s))return t}return this.entityDecoder.decode(t)}function Et(t,e,n,i){return t&&(void 0===i&&(i=0===e.child.length),void 0!==(t=this.parseTextData(t,e.tagname,n,!1,!!e[":@"]&&0!==Object.keys(e[":@"]).length,i))&&""!==t&&e.add(this.options.textNodeName,t),t=""),t}function wt(){return 0!==this.stopNodeExpressionsSet.size&&this.matcher.matchesAny(this.stopNodeExpressionsSet)}function vt(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s+e.length-1}function St(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s}function _t(t,e,n,i=">"){const s=function(t,e,n=">"){let i=0;const s=t.length,r=n.charCodeAt(0),o=n.length>1?n.charCodeAt(1):-1;let a="",h=e;for(let n=e;n<s;n++){const e=t.charCodeAt(n);if(i)e===i&&(i=0);else if(34===e||39===e)i=e;else if(e===r){if(-1===o)return a+=t.substring(h,n),{data:a,index:n};if(t.charCodeAt(n+1)===o)return a+=t.substring(h,n),{data:a,index:n}}else 9!==e||i||(a+=t.substring(h,n)+" ",h=n+1)}}(t,e+1,i);if(!s)return;let r=s.data;const o=s.index,a=r.search(/\s/);let h=r,l=!0;-1!==a&&(h=r.substring(0,a),r=r.substring(a+1).trimStart());const u=h;if(n){const t=h.indexOf(":");-1!==t&&(h=h.substr(t+1),l=h!==s.data.substr(t+1))}return{tagName:h,tagExp:r,closeIndex:o,attrExpPresent:l,rawTagName:u}}function At(t,e,n){const i=n;let s=1;const r=t.length;for(;n<r;n++)if("<"===t[n]){const r=t.charCodeAt(n+1);if(47===r){const r=St(t,">",n,`${e} is not closed`);if(t.substring(n+2,r).trim()===e&&(s--,0===s))return{tagContent:t.substring(i,n),i:r};n=r}else if(63===r)n=vt(t,"?>",n+1,"StopNode is not closed.");else if(33===r&&45===t.charCodeAt(n+2)&&45===t.charCodeAt(n+3))n=vt(t,"--\x3e",n+3,"StopNode is not closed.");else if(33===r&&91===t.charCodeAt(n+2))n=vt(t,"]]>",n,"StopNode is not closed.")-2;else{const i=_t(t,n,!1);i&&((i&&i.tagName)===e&&"/"!==i.tagExp[i.tagExp.length-1]&&s++,n=i.closeIndex)}}}function Tt(t,e,n){if(e&&"string"==typeof t){const e=t.trim();return"true"===e||"false"!==e&&function(t,e={}){if(e=Object.assign({},X,e),!t||"string"!=typeof t)return t;let n=t.trim();if(0===n.length)return t;if(void 0!==e.skipLike&&e.skipLike.test(n))return t;if("0"===n)return 0;if(e.hex&&U.test(n))return q(n,16);if(e.binary&&B.test(n))return q(n,2);if(e.octal&&W.test(n))return q(n,8);if(isFinite(n)){if(n.includes("e")||n.includes("E"))return function(t,e,n){if(!n.eNotation)return t;const i=e.match(Y);if(i){let s=i[1]||"";const r=-1===i[3].indexOf("e")?"E":"e",o=i[2],a=s?t[o.length+1]===r:t[o.length]===r;return o.length>1&&a?t:(1!==o.length||!i[3].startsWith(`.${r}`)&&i[3][0]!==r)&&o.length>0?n.leadingZeros&&!a?(e=(i[1]||"")+i[3],Number(e)):t:Number(e)}return t}(t,n,e);{const s=z.exec(n);if(s){const r=s[1]||"",o=s[2];let a=(i=s[3])&&-1!==i.indexOf(".")?("."===(i=i.replace(/0+$/,""))?i="0":"."===i[0]?i="0"+i:"."===i[i.length-1]&&(i=i.substring(0,i.length-1)),i):i;const h=r?"."===t[o.length+1]:"."===t[o.length];if(!e.leadingZeros&&(o.length>1||1===o.length&&!h))return t;{const i=Number(n),s=String(i);if(0===i)return i;if(-1!==s.search(/[eE]/))return e.eNotation?i:t;if(-1!==n.indexOf("."))return"0"===s||s===a||s===`${r}${a}`?i:t;let h=o?a:n;return o?h===s||r+h===s?i:t:h===s||h===r+s?i:t}}return t}}var i;return function(t,e,n){const i=e===1/0;switch(n.infinity.toLowerCase()){case"null":return null;case"infinity":return e;case"string":return i?"Infinity":"-Infinity";default:return t}}(t,Number(n),e)}(t,n)}return void 0!==t?t:""}function Ct(t,e,n,i){if(t){const i=t(e);n===e&&(n=i),e=i}return{tagName:e=Pt(e,i),tagExp:n}}function Pt(t,e){if(a.includes(t))throw new Error(`[SECURITY] Invalid name: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);return o.includes(t)?e.onDangerousProperty(t):t}const $t=$.getMetaDataSymbol();function Ot(t,e){if(!t||"object"!=typeof t)return{};if(!e)return t;const n={};for(const i in t)i.startsWith(e)?n[i.substring(e.length)]=t[i]:n[i]=t[i];return n}function It(t,e,n,i){return Vt(t,e,n,i)}function Vt(t,e,n,i){let s;const r={};for(let o=0;o<t.length;o++){const a=t[o],h=Dt(a);if(void 0!==h&&h!==e.textNodeName){const t=Ot(a[":@"]||{},e.attributeNamePrefix);n.push(h,t)}if(h===e.textNodeName)void 0===s?s=a[h]:s+=""+a[h];else{if(void 0===h)continue;if(a[h]){let t=Vt(a[h],e,n,i);const s=jt(t,e);if(0===Object.keys(t).length&&e.alwaysCreateTextNode&&(t[e.textNodeName]=""),a[":@"]?Mt(t,a[":@"],i,e):1!==Object.keys(t).length||void 0===t[e.textNodeName]||e.alwaysCreateTextNode?0===Object.keys(t).length&&(e.alwaysCreateTextNode?t[e.textNodeName]="":t=""):t=t[e.textNodeName],void 0!==a[$t]&&"object"==typeof t&&null!==t&&(t[$t]=a[$t]),void 0!==r[h]&&Object.prototype.hasOwnProperty.call(r,h))Array.isArray(r[h])||(r[h]=[r[h]]),r[h].push(t);else{const n=e.jPath?i.toString():i;e.isArray(h,n,s)?r[h]=[t]:r[h]=t}void 0!==h&&h!==e.textNodeName&&n.pop()}}}return"string"==typeof s?s.length>0&&(r[e.textNodeName]=s):void 0!==s&&(r[e.textNodeName]=s),r}function Dt(t){const e=Object.keys(t);for(let t=0;t<e.length;t++){const n=e[t];if(":@"!==n)return n}}function Mt(t,e,n,i){if(e){const s=Object.keys(e),r=s.length;for(let o=0;o<r;o++){const r=s[o],a=r.startsWith(i.attributeNamePrefix)?r.substring(i.attributeNamePrefix.length):r,h=i.jPath?n.toString()+"."+a:n;i.isArray(r,h,!0,!0)?t[r]=[e[r]]:t[r]=e[r]}}}function jt(t,e){const{textNodeName:n}=e,i=Object.keys(t).length;return 0===i||!(1!==i||!t[n]&&"boolean"!=typeof t[n]&&0!==t[n])}class Lt{constructor(t){this.externalEntities={},this.options=C(t)}parse(t,e){if("string"!=typeof t&&t.toString)t=t.toString();else if("string"!=typeof t)throw new Error("XML data is accepted in String or Bytes[] form.");if(e){!0===e&&(e={});const n=l(t,e);if(!0!==n)throw Error(`${n.err.msg}:${n.err.line}:${n.err.col}`)}const n=new dt(this.options,this.externalEntities),i=n.parseXml(t);return this.options.preserveOrder||void 0===i?i:It(i,this.options,n.matcher,n.readonlyMatcher)}addEntity(t,e){if(-1!==e.indexOf("&"))throw new Error("Entity value can't have '&'");if(-1!==t.indexOf("&")||-1!==t.indexOf(";"))throw new Error("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");if("&"===e)throw new Error("An entity with value '&' is not permitted");this.externalEntities[t]=e}static getMetaDataSymbol(){return $.getMetaDataSymbol()}}function kt(t){return String(t).replace(/--/g,"- -").replace(/--/g,"- -").replace(/-$/,"- ")}function Rt(t){return String(t).replace(/\]\]>/g,"]]]]><![CDATA[>")}function Ft(t){return String(t).replace(/"/g,"&quot;").replace(/'/g,"&apos;")}function Gt(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function Ut(t,e){let n="";e.format&&(n="\n");const i=[];if(e.stopNodes&&Array.isArray(e.stopNodes))for(let t=0;t<e.stopNodes.length;t++){const n=e.stopNodes[t];"string"==typeof n?i.push(new K(n)):n instanceof K&&i.push(n)}const s=function(t,e){if(!Array.isArray(t)||0===t.length)return"1.0";const n=t[0];if("?xml"===Yt(n)){const t=n[":@"];if(t){const n=e.attributeNamePrefix+"version";if(t[n])return t[n]}}return"1.0"}(t,e);return Bt(t,e,n,new J,i,s)}function Bt(t,e,n,i,s,r){let o="",a=!1;if(e.maxNestedTags&&i.getDepth()>e.maxNestedTags)throw new Error("Maximum nested tags exceeded");if(!Array.isArray(t)){if(null!=t){let n=t.toString();return n=Jt(n,e),n}return""}for(let h=0;h<t.length;h++){const l=t[h],u=Yt(l);if(void 0===u)continue;const p=u===e.textNodeName||u===e.cdataPropName||u===e.commentPropName||"?"===u[0]?u:Gt(u,!1,e,i,r),c=Wt(l[":@"],e);i.push(p,c);const d=Zt(i,s);if(p===e.textNodeName){let t=l[u];d||(t=e.tagValueProcessor(p,t),t=Jt(t,e)),a&&(o+=n),o+=t,a=!1,i.pop();continue}if(p===e.cdataPropName){a&&(o+=n),o+=`<![CDATA[${Rt(l[u][0][e.textNodeName])}]]>`,a=!1,i.pop();continue}if(p===e.commentPropName){o+=n+`\x3c!--${kt(l[u][0][e.textNodeName])}--\x3e`,a=!0,i.pop();continue}if("?"===p[0]){o+=("?xml"===p?"":n)+`<${p}${qt(l[":@"],e,d,i,r)}?>`,a=!0,i.pop();continue}let f=n;""!==f&&(f+=e.indentBy);const g=n+`<${p}${qt(l[":@"],e,d,i,r)}`;let m;m=d?zt(l[u],e):Bt(l[u],e,f,i,s,r),-1!==e.unpairedTags.indexOf(p)?e.suppressUnpairedNode?o+=g+">":o+=g+"/>":m&&0!==m.length||!e.suppressEmptyNode?m&&m.endsWith(">")?o+=g+`>${m}${n}</${p}>`:(o+=g+">",m&&""!==n&&(m.includes("/>")||m.includes("</"))?o+=n+e.indentBy+m+n:o+=m,o+=`</${p}>`):o+=g+"/>",a=!0,i.pop()}return o}function Wt(t,e){if(!t||e.ignoreAttributes)return null;const n={};let i=!1;for(let s in t)Object.prototype.hasOwnProperty.call(t,s)&&(n[s.startsWith(e.attributeNamePrefix)?s.substr(e.attributeNamePrefix.length):s]=Ft(t[s]),i=!0);return i?n:null}function zt(t,e){if(!Array.isArray(t))return null!=t?t.toString():"";let n="";for(let i=0;i<t.length;i++){const s=t[i],r=Yt(s);if(r===e.textNodeName)n+=s[r];else if(r===e.cdataPropName)n+=s[r][0][e.textNodeName];else if(r===e.commentPropName)n+=s[r][0][e.textNodeName];else{if(r&&"?"===r[0])continue;if(r){const t=Xt(s[":@"],e),i=zt(s[r],e);i&&0!==i.length?n+=`<${r}${t}>${i}</${r}>`:n+=`<${r}${t}/>`}}}return n}function Xt(t,e){let n="";if(t&&!e.ignoreAttributes)for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;let s=t[i];!0===s&&e.suppressBooleanAttributes?n+=` ${i.substr(e.attributeNamePrefix.length)}`:n+=` ${i.substr(e.attributeNamePrefix.length)}="${Ft(s)}"`}return n}function Yt(t){const e=Object.keys(t);for(let n=0;n<e.length;n++){const i=e[n];if(Object.prototype.hasOwnProperty.call(t,i)&&":@"!==i)return i}}function qt(t,e,n,i,s){let r="";if(t&&!e.ignoreAttributes)for(let o in t){if(!Object.prototype.hasOwnProperty.call(t,o))continue;const a=o.substr(e.attributeNamePrefix.length),h=n?a:Gt(a,!0,e,i,s);let l;n?l=t[o]:(l=e.attributeValueProcessor(o,t[o]),l=Jt(l,e)),!0===l&&e.suppressBooleanAttributes?r+=` ${h}`:r+=` ${h}="${Ft(l)}"`}return r}function Zt(t,e){if(!e||0===e.length)return!1;for(let n=0;n<e.length;n++)if(t.matches(e[n]))return!0;return!1}function Jt(t,e){if(t&&t.length>0&&e.processEntities)for(let n=0;n<e.entities.length;n++){const i=e.entities[n];t=t.replace(i.regex,i.val)}return t}const Kt={attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,cdataPropName:!1,format:!1,indentBy:"  ",suppressEmptyNode:!1,suppressUnpairedNode:!0,suppressBooleanAttributes:!0,tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},preserveOrder:!1,commentPropName:!1,unpairedTags:[],entities:[{regex:new RegExp("&","g"),val:"&amp;"},{regex:new RegExp(">","g"),val:"&gt;"},{regex:new RegExp("<","g"),val:"&lt;"},{regex:new RegExp("'","g"),val:"&apos;"},{regex:new RegExp('"',"g"),val:"&quot;"}],processEntities:!0,stopNodes:[],oneListGroup:!1,maxNestedTags:100,jPath:!0,sanitizeName:!1};function Qt(t){if(this.options=Object.assign({},Kt,t),this.options.stopNodes&&Array.isArray(this.options.stopNodes)&&(this.options.stopNodes=this.options.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),this.stopNodeExpressions=[],this.options.stopNodes&&Array.isArray(this.options.stopNodes))for(let t=0;t<this.options.stopNodes.length;t++){const e=this.options.stopNodes[t];"string"==typeof e?this.stopNodeExpressions.push(new K(e)):e instanceof K&&this.stopNodeExpressions.push(e)}var e;!0===this.options.ignoreAttributes||this.options.attributesGroupName?this.isAttribute=function(){return!1}:(this.ignoreAttributesFn="function"==typeof(e=this.options.ignoreAttributes)?e:Array.isArray(e)?t=>{for(const n of e){if("string"==typeof n&&t===n)return!0;if(n instanceof RegExp&&n.test(t))return!0}}:()=>!1,this.attrPrefixLen=this.options.attributeNamePrefix.length,this.isAttribute=ne),this.processTextOrObjNode=te,this.options.format?(this.indentate=ee,this.tagEndChar=">\n",this.newLine="\n"):(this.indentate=function(){return""},this.tagEndChar=">",this.newLine="")}function Ht(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function te(t,e,n,i,s){const r=this.extractAttributes(t);if(i.push(e,r),this.checkStopNode(i)){const s=this.buildRawContent(t),r=this.buildAttributesForStopNode(t);return i.pop(),this.buildObjectNode(s,e,r,n)}const o=this.j2x(t,n+1,i,s);return i.pop(),"?"===e[0]?this.buildTextValNode("",e,o.attrStr,n,i):void 0!==t[this.options.textNodeName]&&1===Object.keys(t).length?this.buildTextValNode(t[this.options.textNodeName],e,o.attrStr,n,i):this.buildObjectNode(o.val,e,o.attrStr,n)}function ee(t){return this.options.indentBy.repeat(t)}function ne(t){return!(!t.startsWith(this.options.attributeNamePrefix)||t===this.options.textNodeName)&&t.substr(this.attrPrefixLen)}Qt.prototype.build=function(t){if(this.options.preserveOrder)return Ut(t,this.options);{Array.isArray(t)&&this.options.arrayNodeName&&this.options.arrayNodeName.length>1&&(t={[this.options.arrayNodeName]:t});const e=new J,n=function(t,e){const n=t["?xml"];if(n&&"object"==typeof n){if(e.attributesGroupName&&n[e.attributesGroupName]){const t=n[e.attributesGroupName][e.attributeNamePrefix+"version"];if(t)return t}const t=n[e.attributeNamePrefix+"version"];if(t)return t}return"1.0"}(t,this.options);return this.j2x(t,0,e,n).val}},Qt.prototype.j2x=function(t,e,n,i){let s="",r="";if(this.options.maxNestedTags&&n.getDepth()>=this.options.maxNestedTags)throw new Error("Maximum nested tags exceeded");const o=this.options.jPath?n.toString():n,a=this.checkStopNode(n);for(let h in t){if(!Object.prototype.hasOwnProperty.call(t,h))continue;const l=h===this.options.textNodeName||h===this.options.cdataPropName||h===this.options.commentPropName||this.options.attributesGroupName&&h===this.options.attributesGroupName||this.isAttribute(h)||"?"===h[0]?h:Ht(h,!1,this.options,n,i);if(void 0===t[h])this.isAttribute(h)&&(r+="");else if(null===t[h])this.isAttribute(h)||l===this.options.cdataPropName||l===this.options.commentPropName?r+="":"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if(t[h]instanceof Date)r+=this.buildTextValNode(t[h],l,"",e,n);else if("object"!=typeof t[h]){const u=this.isAttribute(h);if(u&&!this.ignoreAttributesFn(u,o)){const e=Ht(u,!0,this.options,n,i);s+=this.buildAttrPairStr(e,""+t[h],a)}else if(!u)if(h===this.options.textNodeName){let e=this.options.tagValueProcessor(h,""+t[h]);r+=this.replaceEntitiesValue(e)}else{n.push(l);const i=this.checkStopNode(n);if(n.pop(),i){const n=""+t[h];r+=""===n?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+n+"</"+l+this.tagEndChar}else r+=this.buildTextValNode(t[h],l,"",e,n)}}else if(Array.isArray(t[h])){const s=t[h].length;let o="",a="";for(let u=0;u<s;u++){const s=t[h][u];if(void 0===s);else if(null===s)"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if("object"==typeof s)if(this.options.oneListGroup){n.push(l);const t=this.j2x(s,e+1,n,i);n.pop(),o+=t.val,this.options.attributesGroupName&&s.hasOwnProperty(this.options.attributesGroupName)&&(a+=t.attrStr)}else o+=this.processTextOrObjNode(s,l,e,n,i);else if(this.options.oneListGroup){let t=this.options.tagValueProcessor(l,s);t=this.replaceEntitiesValue(t),o+=t}else{n.push(l);const t=this.checkStopNode(n);if(n.pop(),t){const t=""+s;o+=""===t?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+t+"</"+l+this.tagEndChar}else o+=this.buildTextValNode(s,l,"",e,n)}}this.options.oneListGroup&&(o=this.buildObjectNode(o,l,a,e)),r+=o}else if(this.options.attributesGroupName&&h===this.options.attributesGroupName){const e=Object.keys(t[h]),r=e.length;for(let o=0;o<r;o++){const r=Ht(e[o],!0,this.options,n,i);s+=this.buildAttrPairStr(r,""+t[h][e[o]],a)}}else r+=this.processTextOrObjNode(t[h],l,e,n,i)}return{attrStr:s,val:r}},Qt.prototype.buildAttrPairStr=function(t,e,n){return n||(e=this.options.attributeValueProcessor(t,""+e),e=this.replaceEntitiesValue(e)),this.options.suppressBooleanAttributes&&"true"===e?" "+t:" "+t+'="'+Ft(e)+'"'},Qt.prototype.extractAttributes=function(t){if(!t||"object"!=typeof t)return null;const e={};let n=!1;if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const i=t[this.options.attributesGroupName];for(let t in i)Object.prototype.hasOwnProperty.call(i,t)&&(e[t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t]=Ft(i[t]),n=!0)}else for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;const s=this.isAttribute(i);s&&(e[s]=Ft(t[i]),n=!0)}return n?e:null},Qt.prototype.buildRawContent=function(t){if("string"==typeof t)return t;if("object"!=typeof t||null===t)return String(t);if(void 0!==t[this.options.textNodeName])return t[this.options.textNodeName];let e="";for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;if(this.isAttribute(n))continue;if(this.options.attributesGroupName&&n===this.options.attributesGroupName)continue;const i=t[n];if(n===this.options.textNodeName)e+=i;else if(Array.isArray(i)){for(let t of i)if("string"==typeof t||"number"==typeof t)e+=`<${n}>${t}</${n}>`;else if("object"==typeof t&&null!==t){const i=this.buildRawContent(t),s=this.buildAttributesForStopNode(t);e+=""===i?`<${n}${s}/>`:`<${n}${s}>${i}</${n}>`}}else if("object"==typeof i&&null!==i){const t=this.buildRawContent(i),s=this.buildAttributesForStopNode(i);e+=""===t?`<${n}${s}/>`:`<${n}${s}>${t}</${n}>`}else e+=`<${n}>${i}</${n}>`}return e},Qt.prototype.buildAttributesForStopNode=function(t){if(!t||"object"!=typeof t)return"";let e="";if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const n=t[this.options.attributesGroupName];for(let t in n){if(!Object.prototype.hasOwnProperty.call(n,t))continue;const i=t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t,s=n[t];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}else for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;const i=this.isAttribute(n);if(i){const s=t[n];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}return e},Qt.prototype.buildObjectNode=function(t,e,n,i){if(""===t)return"?"===e[0]?this.indentate(i)+"<"+e+n+"?"+this.tagEndChar:this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar;if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s="</"+e+this.tagEndChar,r="";return"?"===e[0]&&(r="?",s=""),!n&&""!==n||-1!==t.indexOf("<")?!1!==this.options.commentPropName&&e===this.options.commentPropName&&0===r.length?this.indentate(i)+`\x3c!--${t}--\x3e`+this.newLine:this.indentate(i)+"<"+e+n+r+this.tagEndChar+t+this.indentate(i)+s:this.indentate(i)+"<"+e+n+r+">"+t+s}},Qt.prototype.closeTag=function(t){let e="";return-1!==this.options.unpairedTags.indexOf(t)?this.options.suppressUnpairedNode||(e="/"):e=this.options.suppressEmptyNode?"/":`></${t}`,e},Qt.prototype.checkStopNode=function(t){if(!this.stopNodeExpressions||0===this.stopNodeExpressions.length)return!1;for(let e=0;e<this.stopNodeExpressions.length;e++)if(t.matches(this.stopNodeExpressions[e]))return!0;return!1},Qt.prototype.buildTextValNode=function(t,e,n,i,s){if(!1!==this.options.cdataPropName&&e===this.options.cdataPropName){const e=Rt(t);return this.indentate(i)+`<![CDATA[${e}]]>`+this.newLine}if(!1!==this.options.commentPropName&&e===this.options.commentPropName){const e=kt(t);return this.indentate(i)+`\x3c!--${e}--\x3e`+this.newLine}if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s=this.options.tagValueProcessor(e,t);return s=this.replaceEntitiesValue(s),""===s?this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar:this.indentate(i)+"<"+e+n+">"+s+"</"+e+this.tagEndChar}},Qt.prototype.replaceEntitiesValue=function(t){if(t&&t.length>0&&this.options.processEntities)for(let e=0;e<this.options.entities.length;e++){const n=this.options.entities[e];t=t.replace(n.regex,n.val)}return t};const ie=Qt,se={validate:l};module.exports=e})();
 
 /***/ }),
 
-/***/ 317:
+/***/ 316:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59515,7 +59376,7 @@ var KnownEncryptionAlgorithmType;
 
 /***/ }),
 
-/***/ 318:
+/***/ 317:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -59744,7 +59605,7 @@ function replaceAll(value, searchValue, replaceValue) {
 
 /***/ }),
 
-/***/ 319:
+/***/ 318:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -59770,7 +59631,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(392);
+var import_exponentialRetryStrategy = __nccwpck_require__(391);
 var import_throttlingRetryStrategy = __nccwpck_require__(35);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_constants = __nccwpck_require__(48);
@@ -59790,7 +59651,7 @@ function defaultRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 320:
+/***/ 319:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59802,7 +59663,7 @@ exports.StorageRetryPolicyFactory = exports.NewRetryPolicyFactory = exports.Stor
 const StorageRetryPolicy_js_1 = __nccwpck_require__(79);
 Object.defineProperty(exports, "StorageRetryPolicy", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.StorageRetryPolicy; } }));
 Object.defineProperty(exports, "NewRetryPolicyFactory", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.NewRetryPolicyFactory; } }));
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(414);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(413);
 Object.defineProperty(exports, "StorageRetryPolicyType", ({ enumerable: true, get: function () { return StorageRetryPolicyType_js_1.StorageRetryPolicyType; } }));
 /**
  * StorageRetryPolicyFactory is a factory class helping generating {@link StorageRetryPolicy} objects.
@@ -59831,7 +59692,7 @@ exports.StorageRetryPolicyFactory = StorageRetryPolicyFactory;
 
 /***/ }),
 
-/***/ 321:
+/***/ 320:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59905,7 +59766,7 @@ function buildOutputs(result) {
 
 /***/ }),
 
-/***/ 322:
+/***/ 321:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -59952,25 +59813,25 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pythonDefaultJson = exports.buildOutputs = exports.detectMuslCcEnv = exports.detectUserLinkerEnv = exports.parseCacheShutdownOnIdleSeconds = exports.readRawInputs = void 0;
 exports.resolveSetup = resolveSetup;
 exports.applyResolveResult = applyResolveResult;
-const os = __importStar(__nccwpck_require__(379));
-const path = __importStar(__nccwpck_require__(503));
-const fs = __importStar(__nccwpck_require__(244));
-const core = __importStar(__nccwpck_require__(456));
-const cache_keys_js_1 = __nccwpck_require__(163);
-const log_utils_js_1 = __nccwpck_require__(349);
-const detect_musl_cc_js_1 = __nccwpck_require__(499);
+const os = __importStar(__nccwpck_require__(378));
+const path = __importStar(__nccwpck_require__(502));
+const fs = __importStar(__nccwpck_require__(243));
+const core = __importStar(__nccwpck_require__(455));
+const cache_keys_js_1 = __nccwpck_require__(162);
+const log_utils_js_1 = __nccwpck_require__(348);
+const detect_musl_cc_js_1 = __nccwpck_require__(498);
 Object.defineProperty(exports, "detectMuslCcEnv", ({ enumerable: true, get: function () { return detect_musl_cc_js_1.detectMuslCcEnv; } }));
-const build_outputs_js_1 = __nccwpck_require__(321);
+const build_outputs_js_1 = __nccwpck_require__(320);
 Object.defineProperty(exports, "buildOutputs", ({ enumerable: true, get: function () { return build_outputs_js_1.buildOutputs; } }));
-const raw_inputs_js_1 = __nccwpck_require__(430);
+const raw_inputs_js_1 = __nccwpck_require__(429);
 Object.defineProperty(exports, "readRawInputs", ({ enumerable: true, get: function () { return raw_inputs_js_1.readRawInputs; } }));
-const input_parsers_js_1 = __nccwpck_require__(413);
+const input_parsers_js_1 = __nccwpck_require__(412);
 Object.defineProperty(exports, "detectUserLinkerEnv", ({ enumerable: true, get: function () { return input_parsers_js_1.detectUserLinkerEnv; } }));
 Object.defineProperty(exports, "parseCacheShutdownOnIdleSeconds", ({ enumerable: true, get: function () { return input_parsers_js_1.parseCacheShutdownOnIdleSeconds; } }));
-const fetch_release_js_1 = __nccwpck_require__(144);
+const fetch_release_js_1 = __nccwpck_require__(143);
 const python_json_js_1 = __nccwpck_require__(11);
 Object.defineProperty(exports, "pythonDefaultJson", ({ enumerable: true, get: function () { return python_json_js_1.pythonDefaultJson; } }));
-const toolchain_js_1 = __nccwpck_require__(363);
+const toolchain_js_1 = __nccwpck_require__(362);
 const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
 const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
 const ALLOWED_LINKER_VALUES = [
@@ -60148,7 +60009,7 @@ async function resolveSetup(ctx, inputs, deps) {
     // so canonical_json_stringify is wrong; mirror Python's default separators
     // (", " and ": ") to match byte-for-byte.
     const signatureString = (0, python_json_js_1.pythonDefaultJson)(toolchainSignature);
-    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 269, 23));
+    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 268, 23));
     const digest = createHash("sha256").update(signatureString, "utf8").digest("hex").slice(0, 16);
     const runnerOs = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_OS"] ?? process.platform).toLowerCase());
     const runnerArch = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_ARCH"] ?? "unknown").toLowerCase());
@@ -60522,7 +60383,7 @@ async function applyResolveResult(result) {
 
 /***/ }),
 
-/***/ 323:
+/***/ 322:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60628,7 +60489,7 @@ function toArrayBuffer(source) {
 
 /***/ }),
 
-/***/ 324:
+/***/ 323:
 /***/ ((module) => {
 
 "use strict";
@@ -60733,7 +60594,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 325:
+/***/ 324:
 /***/ ((module) => {
 
 "use strict";
@@ -60741,7 +60602,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 326:
+/***/ 325:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -60760,7 +60621,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 327:
+/***/ 326:
 /***/ (function(module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -60799,12 +60660,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._readLinuxVersionFile = exports._getOsVersion = exports._findMatch = void 0;
-const semver = __importStar(__nccwpck_require__(176));
-const core_1 = __nccwpck_require__(456);
+const semver = __importStar(__nccwpck_require__(175));
+const core_1 = __nccwpck_require__(455);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
-const os = __nccwpck_require__(91);
-const cp = __nccwpck_require__(162);
+const os = __nccwpck_require__(90);
+const cp = __nccwpck_require__(161);
 const fs = __nccwpck_require__(526);
 function _findMatch(versionSpec, stable, candidates, archFilter) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -60896,7 +60757,7 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
-/***/ 328:
+/***/ 327:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -60926,7 +60787,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-const path = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(242));
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
  * replaced with /.
@@ -60965,7 +60826,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 329:
+/***/ 328:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -61073,7 +60934,7 @@ var WireType;
 
 /***/ }),
 
-/***/ 330:
+/***/ 329:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61086,15 +60947,15 @@ const core_util_1 = __nccwpck_require__(14);
 const core_auth_1 = __nccwpck_require__(509);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_2 = __nccwpck_require__(14);
-const storage_common_1 = __nccwpck_require__(271);
-const Clients_js_1 = __nccwpck_require__(182);
+const storage_common_1 = __nccwpck_require__(270);
+const Clients_js_1 = __nccwpck_require__(181);
 const Mutex_js_1 = __nccwpck_require__(513);
-const Pipeline_js_1 = __nccwpck_require__(180);
-const utils_common_js_1 = __nccwpck_require__(153);
-const core_xml_1 = __nccwpck_require__(191);
-const constants_js_1 = __nccwpck_require__(147);
+const Pipeline_js_1 = __nccwpck_require__(179);
+const utils_common_js_1 = __nccwpck_require__(152);
+const core_xml_1 = __nccwpck_require__(190);
+const constants_js_1 = __nccwpck_require__(146);
 const tracing_js_1 = __nccwpck_require__(31);
-const core_client_1 = __nccwpck_require__(437);
+const core_client_1 = __nccwpck_require__(436);
 /**
  * A BlobBatch represents an aggregated set of operations on blobs.
  * Currently, only `delete` and `setAccessTier` are supported.
@@ -61358,7 +61219,7 @@ function batchHeaderFilterPolicy() {
 
 /***/ }),
 
-/***/ 331:
+/***/ 330:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61367,17 +61228,17 @@ function batchHeaderFilterPolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = exports.AvroReadable = exports.AvroReader = void 0;
-var AvroReader_js_1 = __nccwpck_require__(418);
+var AvroReader_js_1 = __nccwpck_require__(417);
 Object.defineProperty(exports, "AvroReader", ({ enumerable: true, get: function () { return AvroReader_js_1.AvroReader; } }));
-var AvroReadable_js_1 = __nccwpck_require__(384);
+var AvroReadable_js_1 = __nccwpck_require__(383);
 Object.defineProperty(exports, "AvroReadable", ({ enumerable: true, get: function () { return AvroReadable_js_1.AvroReadable; } }));
-var AvroReadableFromStream_js_1 = __nccwpck_require__(247);
+var AvroReadableFromStream_js_1 = __nccwpck_require__(246);
 Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, get: function () { return AvroReadableFromStream_js_1.AvroReadableFromStream; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 332:
+/***/ 331:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61404,12 +61265,12 @@ __export(tracingPolicy_exports, {
 });
 module.exports = __toCommonJS(tracingPolicy_exports);
 var import_core_tracing = __nccwpck_require__(80);
-var import_constants = __nccwpck_require__(157);
-var import_userAgent = __nccwpck_require__(287);
-var import_log = __nccwpck_require__(181);
+var import_constants = __nccwpck_require__(156);
+var import_userAgent = __nccwpck_require__(286);
+var import_log = __nccwpck_require__(180);
 var import_core_util = __nccwpck_require__(14);
-var import_restError = __nccwpck_require__(350);
-var import_util = __nccwpck_require__(145);
+var import_restError = __nccwpck_require__(349);
+var import_util = __nccwpck_require__(144);
 const tracingPolicyName = "tracingPolicy";
 function tracingPolicy(options = {}) {
   const userAgentPromise = (0, import_userAgent.getUserAgentValue)(options.userAgentPrefix);
@@ -61523,7 +61384,7 @@ function tryProcessResponse(span, response) {
 
 /***/ }),
 
-/***/ 333:
+/***/ 332:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61569,7 +61430,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.markPhase = markPhase;
 exports.finishPhase = finishPhase;
-const core = __importStar(__nccwpck_require__(456));
+const core = __importStar(__nccwpck_require__(455));
 function phaseEnvName(name) {
     const cleaned = name.replace(/[^A-Za-z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase() || "PHASE";
     return `SETUP_SOLDR_PHASE_${cleaned}_START_MS`;
@@ -61613,7 +61474,7 @@ async function finishPhase(phase) {
 
 /***/ }),
 
-/***/ 334:
+/***/ 333:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61625,14 +61486,14 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher
-} = __nccwpck_require__(365)
-const Client = __nccwpck_require__(87)
+} = __nccwpck_require__(364)
+const Client = __nccwpck_require__(86)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(484)
+} = __nccwpck_require__(483)
 const util = __nccwpck_require__(69)
-const { kUrl, kInterceptors } = __nccwpck_require__(192)
-const buildConnector = __nccwpck_require__(261)
+const { kUrl, kInterceptors } = __nccwpck_require__(191)
+const buildConnector = __nccwpck_require__(260)
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -61729,7 +61590,7 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 335:
+/***/ 334:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61755,7 +61616,7 @@ __export(oauth2AuthenticationPolicy_exports, {
   oauth2AuthenticationPolicyName: () => oauth2AuthenticationPolicyName
 });
 module.exports = __toCommonJS(oauth2AuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(433);
+var import_checkInsecureConnection = __nccwpck_require__(432);
 const oauth2AuthenticationPolicyName = "oauth2AuthenticationPolicy";
 function oauth2AuthenticationPolicy(options) {
   return {
@@ -61781,7 +61642,7 @@ function oauth2AuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 336:
+/***/ 335:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61826,13 +61687,13 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureSoldr = ensureSoldr;
-const fs = __importStar(__nccwpck_require__(244));
-const os = __importStar(__nccwpck_require__(379));
-const path = __importStar(__nccwpck_require__(503));
-const core = __importStar(__nccwpck_require__(456));
+const fs = __importStar(__nccwpck_require__(243));
+const os = __importStar(__nccwpck_require__(378));
+const path = __importStar(__nccwpck_require__(502));
+const core = __importStar(__nccwpck_require__(455));
 const exec = __importStar(__nccwpck_require__(18));
 const tc = __importStar(__nccwpck_require__(517));
-const log_utils_js_1 = __nccwpck_require__(349);
+const log_utils_js_1 = __nccwpck_require__(348);
 function detectTarget() {
     const machine = process.arch;
     let arch;
@@ -62155,7 +62016,7 @@ async function ensureSoldr(opts) {
 
 /***/ }),
 
-/***/ 337:
+/***/ 336:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62181,9 +62042,9 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(282);
-var import_checkEnvironment = __nccwpck_require__(436);
-var import_httpHeaders = __nccwpck_require__(481);
+var import_bytesEncoding = __nccwpck_require__(281);
+var import_checkEnvironment = __nccwpck_require__(435);
+var import_httpHeaders = __nccwpck_require__(480);
 const formDataPolicyName = "formDataPolicy";
 function formDataToFormDataMap(formData) {
   const formDataMap = {};
@@ -62271,7 +62132,7 @@ async function prepareFormData(formData, request) {
 
 /***/ }),
 
-/***/ 338:
+/***/ 337:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62297,7 +62158,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_policies = __nccwpck_require__(281);
+var import_policies = __nccwpck_require__(280);
 const redirectPolicyName = import_policies.redirectPolicyName;
 function redirectPolicy(options = {}) {
   return (0, import_policies.redirectPolicy)(options);
@@ -62308,19 +62169,19 @@ function redirectPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 339:
+/***/ 338:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(192)
-const { URL } = __nccwpck_require__(84)
+const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(191)
+const { URL } = __nccwpck_require__(83)
 const Agent = __nccwpck_require__(5)
-const Pool = __nccwpck_require__(334)
+const Pool = __nccwpck_require__(333)
 const DispatcherBase = __nccwpck_require__(62)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(484)
-const buildConnector = __nccwpck_require__(261)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(483)
+const buildConnector = __nccwpck_require__(260)
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -62505,19 +62366,19 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 340:
+/***/ 339:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonReader = void 0;
-const json_typings_1 = __nccwpck_require__(391);
-const base64_1 = __nccwpck_require__(297);
-const reflection_info_1 = __nccwpck_require__(450);
+const json_typings_1 = __nccwpck_require__(390);
+const base64_1 = __nccwpck_require__(296);
+const reflection_info_1 = __nccwpck_require__(449);
 const pb_long_1 = __nccwpck_require__(115);
-const assert_1 = __nccwpck_require__(480);
-const reflection_long_convert_1 = __nccwpck_require__(156);
+const assert_1 = __nccwpck_require__(479);
+const reflection_long_convert_1 = __nccwpck_require__(155);
 /**
  * Reads proto3 messages in canonical JSON format using reflection information.
  *
@@ -62830,7 +62691,7 @@ exports.ReflectionJsonReader = ReflectionJsonReader;
 
 /***/ }),
 
-/***/ 341:
+/***/ 340:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -62846,7 +62707,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
-const os_1 = __nccwpck_require__(91);
+const os_1 = __nccwpck_require__(90);
 const fs_1 = __nccwpck_require__(526);
 const { access, appendFile, writeFile } = fs_1.promises;
 exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
@@ -63120,7 +62981,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 342:
+/***/ 341:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -63203,13 +63064,13 @@ exports.utf8read = utf8read;
 
 /***/ }),
 
-/***/ 343:
+/***/ 342:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 /* eslint-disable no-new-wrappers, no-eval, camelcase, operator-linebreak */
-module.exports = makeParserClass(__nccwpck_require__(422))
+module.exports = makeParserClass(__nccwpck_require__(421))
 module.exports.makeParserClass = makeParserClass
 
 class TomlError extends Error {
@@ -63230,10 +63091,10 @@ TomlError.wrap = err => {
 }
 module.exports.TomlError = TomlError
 
-const createDateTime = __nccwpck_require__(381)
-const createDateTimeFloat = __nccwpck_require__(169)
+const createDateTime = __nccwpck_require__(380)
+const createDateTimeFloat = __nccwpck_require__(168)
 const createDate = __nccwpck_require__(54)
-const createTime = __nccwpck_require__(345)
+const createTime = __nccwpck_require__(344)
 
 const CTRL_I = 0x09
 const CTRL_J = 0x0A
@@ -64590,7 +64451,7 @@ function makeParserClass (Parser) {
 
 /***/ }),
 
-/***/ 344:
+/***/ 343:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -64599,8 +64460,8 @@ function makeParserClass (Parser) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = createTracingClient;
-const instrumenter_js_1 = __nccwpck_require__(403);
-const tracingContext_js_1 = __nccwpck_require__(366);
+const instrumenter_js_1 = __nccwpck_require__(402);
+const tracingContext_js_1 = __nccwpck_require__(365);
 /**
  * Creates a new tracing client.
  *
@@ -64678,12 +64539,12 @@ function createTracingClient(options) {
 
 /***/ }),
 
-/***/ 345:
+/***/ 344:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(400)
+const f = __nccwpck_require__(399)
 
 class Time extends Date {
   constructor (value) {
@@ -64708,14 +64569,14 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 346:
+/***/ 345:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(122)
-const Pool = __nccwpck_require__(334)
+const { promisify } = __nccwpck_require__(121)
+const Pool = __nccwpck_require__(333)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
   kDispatches,
@@ -64725,10 +64586,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(467)
-const { MockInterceptor } = __nccwpck_require__(134)
-const Symbols = __nccwpck_require__(192)
-const { InvalidArgumentError } = __nccwpck_require__(484)
+} = __nccwpck_require__(466)
+const { MockInterceptor } = __nccwpck_require__(133)
+const Symbols = __nccwpck_require__(191)
+const { InvalidArgumentError } = __nccwpck_require__(483)
 
 /**
  * MockPool provides an API that extends the Pool to influence the mockDispatches.
@@ -64775,7 +64636,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 347:
+/***/ 346:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -64833,7 +64694,7 @@ exports.ClientStreamingCall = ClientStreamingCall;
 
 /***/ }),
 
-/***/ 348:
+/***/ 347:
 /***/ ((module) => {
 
 module.exports = function (xs, fn) {
@@ -64853,7 +64714,7 @@ var isArray = Array.isArray || function (xs) {
 
 /***/ }),
 
-/***/ 349:
+/***/ 348:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -64901,8 +64762,8 @@ exports.createLogger = createLogger;
 exports.colorForceEnvironment = colorForceEnvironment;
 exports.formatLogLine = formatLogLine;
 exports.isTimestampsEnabled = isTimestampsEnabled;
-const core = __importStar(__nccwpck_require__(456));
-const fs = __importStar(__nccwpck_require__(244));
+const core = __importStar(__nccwpck_require__(455));
+const fs = __importStar(__nccwpck_require__(243));
 function makeFileLogger(env) {
     const logPath = (env["SETUP_SOLDR_LOG"] ?? "").trim();
     if (!logPath)
@@ -65024,7 +64885,7 @@ function isTimestampsEnabled(env) {
 
 /***/ }),
 
-/***/ 350:
+/***/ 349:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65050,7 +64911,7 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_ts_http_runtime = __nccwpck_require__(88);
+var import_ts_http_runtime = __nccwpck_require__(87);
 const RestError = import_ts_http_runtime.RestError;
 function isRestError(e) {
   return (0, import_ts_http_runtime.isRestError)(e);
@@ -65061,21 +64922,21 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 351:
+/***/ 350:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { finished, PassThrough } = __nccwpck_require__(129)
+const { finished, PassThrough } = __nccwpck_require__(128)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(484)
+} = __nccwpck_require__(483)
 const util = __nccwpck_require__(69)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(186)
-const { AsyncResource } = __nccwpck_require__(426)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(185)
+const { AsyncResource } = __nccwpck_require__(425)
 const { addSignal, removeSignal } = __nccwpck_require__(102)
 
 class StreamHandler extends AsyncResource {
@@ -65289,7 +65150,7 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 352:
+/***/ 351:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65303,9 +65164,9 @@ module.exports = stream
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(212);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(437));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(177));
+const tslib_1 = __nccwpck_require__(211);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(436));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing BlockBlob operations. */
 class BlockBlobImpl {
@@ -65669,7 +65530,7 @@ const getBlockListOperationSpec = {
 
 /***/ }),
 
-/***/ 353:
+/***/ 352:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -65714,7 +65575,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 354:
+/***/ 353:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65724,7 +65585,7 @@ function decompressResponsePolicy() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GenericPollOperation = void 0;
 const operation_js_1 = __nccwpck_require__(51);
-const logger_js_1 = __nccwpck_require__(188);
+const logger_js_1 = __nccwpck_require__(187);
 const createStateProxy = () => ({
     initState: (config) => ({ config, isStarted: true }),
     setCanceled: (state) => (state.isCancelled = true),
@@ -65809,7 +65670,7 @@ exports.GenericPollOperation = GenericPollOperation;
 
 /***/ }),
 
-/***/ 355:
+/***/ 354:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -65856,7 +65717,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.versionTuple = versionTuple;
 exports.verifySoldr = verifySoldr;
 const exec = __importStar(__nccwpck_require__(18));
-const log_utils_js_1 = __nccwpck_require__(349);
+const log_utils_js_1 = __nccwpck_require__(348);
 function versionTuple(value) {
     const cleaned = value.trim().replace(/^v/, "");
     const parts = cleaned.split(".");
@@ -65952,7 +65813,7 @@ async function verifySoldr(opts) {
 
 /***/ }),
 
-/***/ 356:
+/***/ 355:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65975,7 +65836,7 @@ function ipRangeToString(ipRange) {
 
 /***/ }),
 
-/***/ 357:
+/***/ 356:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -66001,7 +65862,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(251);
+var import_userAgent = __nccwpck_require__(250);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -66023,7 +65884,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 358:
+/***/ 357:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66031,7 +65892,7 @@ function userAgentPolicy(options = {}) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getUserAgentString = void 0;
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const packageJson = __nccwpck_require__(465);
+const packageJson = __nccwpck_require__(464);
 /**
  * Ensure that this User Agent String is used in all HTTP calls so that we can monitor telemetry between different versions of this package
  */
@@ -66043,7 +65904,7 @@ exports.getUserAgentString = getUserAgentString;
 
 /***/ }),
 
-/***/ 359:
+/***/ 358:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66052,8 +65913,8 @@ exports.getUserAgentString = getUserAgentString;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BufferScheduler = void 0;
-const events_1 = __nccwpck_require__(466);
-const PooledBuffer_js_1 = __nccwpck_require__(367);
+const events_1 = __nccwpck_require__(465);
+const PooledBuffer_js_1 = __nccwpck_require__(366);
 /**
  * This class accepts a Node.js Readable stream as input, and keeps reading data
  * from the stream into the internal buffer structure, until it reaches maxBuffers.
@@ -66332,17 +66193,17 @@ exports.BufferScheduler = BufferScheduler;
 
 /***/ }),
 
-/***/ 360:
+/***/ 359:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { Blob, File: NativeFile } = __nccwpck_require__(117)
-const { types } = __nccwpck_require__(122)
+const { types } = __nccwpck_require__(121)
 const { kState } = __nccwpck_require__(15)
 const { isBlobLike } = __nccwpck_require__(512)
-const { webidl } = __nccwpck_require__(454)
+const { webidl } = __nccwpck_require__(453)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(25)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 const encoder = new TextEncoder()
@@ -66684,14 +66545,14 @@ module.exports = { File, FileLike, isFileLike }
 
 /***/ }),
 
-/***/ 361:
+/***/ 360:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const diagnosticsChannel = __nccwpck_require__(140)
-const { uid, states } = __nccwpck_require__(462)
+const diagnosticsChannel = __nccwpck_require__(139)
+const { uid, states } = __nccwpck_require__(461)
 const {
   kReadyState,
   kSentClose,
@@ -66699,12 +66560,12 @@ const {
   kReceivedClose
 } = __nccwpck_require__(97)
 const { fireEvent, failWebsocketConnection } = __nccwpck_require__(57)
-const { CloseEvent } = __nccwpck_require__(245)
-const { makeRequest } = __nccwpck_require__(83)
-const { fetching } = __nccwpck_require__(448)
+const { CloseEvent } = __nccwpck_require__(244)
+const { makeRequest } = __nccwpck_require__(82)
+const { fetching } = __nccwpck_require__(447)
 const { Headers } = __nccwpck_require__(511)
-const { getGlobalDispatcher } = __nccwpck_require__(373)
-const { kHeadersList } = __nccwpck_require__(192)
+const { getGlobalDispatcher } = __nccwpck_require__(372)
+const { kHeadersList } = __nccwpck_require__(191)
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -66714,7 +66575,7 @@ channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(286)
+  crypto = __nccwpck_require__(285)
 } catch {
 
 }
@@ -66983,7 +66844,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 362:
+/***/ 361:
 /***/ ((module) => {
 
 "use strict";
@@ -66999,7 +66860,7 @@ module.exports = (flag, argv = process.argv) => {
 
 /***/ }),
 
-/***/ 363:
+/***/ 362:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -67051,11 +66912,11 @@ exports.rustChannelManifestRelease = rustChannelManifestRelease;
 exports.resolveToolchainCacheChannel = resolveToolchainCacheChannel;
 exports.loadToolchainSpec = loadToolchainSpec;
 exports.systemRustupSatisfiesRequest = systemRustupSatisfiesRequest;
-const node_crypto_1 = __nccwpck_require__(269);
-const fs = __importStar(__nccwpck_require__(244));
-const path = __importStar(__nccwpck_require__(503));
-const toml = __importStar(__nccwpck_require__(397));
-const io = __importStar(__nccwpck_require__(289));
+const node_crypto_1 = __nccwpck_require__(268);
+const fs = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(502));
+const toml = __importStar(__nccwpck_require__(396));
+const io = __importStar(__nccwpck_require__(288));
 const exec = __importStar(__nccwpck_require__(18));
 const ROLLING_TOOLCHAIN_ALIASES = ["stable", "beta", "nightly"];
 /**
@@ -67341,7 +67202,7 @@ async function defaultWhich(cmd) {
 
 /***/ }),
 
-/***/ 364:
+/***/ 363:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67366,8 +67227,8 @@ __export(restError_exports, {
   createRestError: () => createRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_restError = __nccwpck_require__(442);
-var import_httpHeaders = __nccwpck_require__(481);
+var import_restError = __nccwpck_require__(441);
+var import_httpHeaders = __nccwpck_require__(480);
 function createRestError(messageOrResponse, response) {
   const resp = typeof messageOrResponse === "string" ? response : messageOrResponse;
   const internalError = resp.body?.error ?? resp.body;
@@ -67397,15 +67258,15 @@ function statusCodeToNumber(statusCode) {
 
 /***/ }),
 
-/***/ 365:
+/***/ 364:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const DispatcherBase = __nccwpck_require__(62)
-const FixedQueue = __nccwpck_require__(193)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(192)
+const FixedQueue = __nccwpck_require__(192)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(191)
 const PoolStats = __nccwpck_require__(22)
 
 const kClients = Symbol('clients')
@@ -67599,7 +67460,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 366:
+/***/ 365:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67659,7 +67520,7 @@ exports.TracingContextImpl = TracingContextImpl;
 
 /***/ }),
 
-/***/ 367:
+/***/ 366:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67668,9 +67529,9 @@ exports.TracingContextImpl = TracingContextImpl;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
-const tslib_1 = __nccwpck_require__(212);
-const BuffersStream_js_1 = __nccwpck_require__(382);
-const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(259));
+const tslib_1 = __nccwpck_require__(211);
+const BuffersStream_js_1 = __nccwpck_require__(381);
+const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(258));
 /**
  * maxBufferLength is max size of each buffer in the pooled buffers.
  */
@@ -67766,7 +67627,7 @@ exports.PooledBuffer = PooledBuffer;
 
 /***/ }),
 
-/***/ 368:
+/***/ 367:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -67815,10 +67676,10 @@ exports._internal = void 0;
 exports.selectCandidateFiles = selectCandidateFiles;
 exports.normalizeWorkspace = normalizeWorkspace;
 exports.normalizeSourceMtime = normalizeSourceMtime;
-const fs = __importStar(__nccwpck_require__(244));
-const path = __importStar(__nccwpck_require__(503));
+const fs = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(502));
 const exec = __importStar(__nccwpck_require__(18));
-const log_utils_js_1 = __nccwpck_require__(349);
+const log_utils_js_1 = __nccwpck_require__(348);
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 // Globs evaluated against the repo-relative POSIX path of each tracked file.
 const INCLUDE_GLOBS = [
@@ -68050,7 +67911,7 @@ exports._internal = {
 
 /***/ }),
 
-/***/ 369:
+/***/ 368:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68075,7 +67936,7 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_nodeHttpClient = __nccwpck_require__(439);
+var import_nodeHttpClient = __nccwpck_require__(438);
 function createDefaultHttpClient() {
   return (0, import_nodeHttpClient.createNodeHttpClient)();
 }
@@ -68086,14 +67947,14 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 370:
+/***/ 369:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { AsyncResource } = __nccwpck_require__(426)
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(484)
+const { AsyncResource } = __nccwpck_require__(425)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(483)
 const util = __nccwpck_require__(69)
 const { addSignal, removeSignal } = __nccwpck_require__(102)
 
@@ -68198,7 +68059,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 371:
+/***/ 370:
 /***/ ((module) => {
 
 /**
@@ -68367,7 +68228,7 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 372:
+/***/ 371:
 /***/ ((module) => {
 
 "use strict";
@@ -68375,7 +68236,7 @@ module.exports = require("node:util");
 
 /***/ }),
 
-/***/ 373:
+/***/ 372:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68384,7 +68245,7 @@ module.exports = require("node:util");
 // We include a version number for the Dispatcher API. In case of breaking changes,
 // this version number must be increased to avoid conflicts.
 const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
-const { InvalidArgumentError } = __nccwpck_require__(484)
+const { InvalidArgumentError } = __nccwpck_require__(483)
 const Agent = __nccwpck_require__(5)
 
 if (getGlobalDispatcher() === undefined) {
@@ -68415,13 +68276,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 374:
+/***/ 373:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(192)
+const { kClients } = __nccwpck_require__(191)
 const Agent = __nccwpck_require__(5)
 const {
   kAgent,
@@ -68433,14 +68294,14 @@ const {
   kGetNetConnect,
   kOptions,
   kFactory
-} = __nccwpck_require__(467)
-const MockClient = __nccwpck_require__(196)
-const MockPool = __nccwpck_require__(346)
+} = __nccwpck_require__(466)
+const MockClient = __nccwpck_require__(195)
+const MockPool = __nccwpck_require__(345)
 const { matchValue, buildMockOptions } = __nccwpck_require__(7)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(484)
-const Dispatcher = __nccwpck_require__(474)
-const Pluralizer = __nccwpck_require__(249)
-const PendingInterceptorsFormatter = __nccwpck_require__(229)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(483)
+const Dispatcher = __nccwpck_require__(473)
+const Pluralizer = __nccwpck_require__(248)
+const PendingInterceptorsFormatter = __nccwpck_require__(228)
 
 class FakeWeakRef {
   constructor (value) {
@@ -68594,7 +68455,7 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 375:
+/***/ 374:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68620,7 +68481,7 @@ __export(tlsPolicy_exports, {
   tlsPolicyName: () => tlsPolicyName
 });
 module.exports = __toCommonJS(tlsPolicy_exports);
-var import_policies = __nccwpck_require__(281);
+var import_policies = __nccwpck_require__(280);
 const tlsPolicyName = import_policies.tlsPolicyName;
 function tlsPolicy(tlsSettings) {
   return (0, import_policies.tlsPolicy)(tlsSettings);
@@ -68631,7 +68492,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 376:
+/***/ 375:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -68720,7 +68581,7 @@ exports.AccountSASServices = AccountSASServices;
 
 /***/ }),
 
-/***/ 377:
+/***/ 376:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68746,7 +68607,7 @@ __export(bearerAuthenticationPolicy_exports, {
   bearerAuthenticationPolicyName: () => bearerAuthenticationPolicyName
 });
 module.exports = __toCommonJS(bearerAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(433);
+var import_checkInsecureConnection = __nccwpck_require__(432);
 const bearerAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function bearerAuthenticationPolicy(options) {
   return {
@@ -68774,7 +68635,7 @@ function bearerAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 378:
+/***/ 377:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68783,7 +68644,7 @@ function bearerAuthenticationPolicy(options) {
 const {
   BalancedPoolMissingUpstreamError,
   InvalidArgumentError
-} = __nccwpck_require__(484)
+} = __nccwpck_require__(483)
 const {
   PoolBase,
   kClients,
@@ -68791,9 +68652,9 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(365)
-const Pool = __nccwpck_require__(334)
-const { kUrl, kInterceptors } = __nccwpck_require__(192)
+} = __nccwpck_require__(364)
+const Pool = __nccwpck_require__(333)
+const { kUrl, kInterceptors } = __nccwpck_require__(191)
 const { parseOrigin } = __nccwpck_require__(69)
 const kFactory = Symbol('factory')
 
@@ -68972,7 +68833,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 379:
+/***/ 378:
 /***/ ((module) => {
 
 "use strict";
@@ -68980,7 +68841,7 @@ module.exports = require("node:os");
 
 /***/ }),
 
-/***/ 380:
+/***/ 379:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -69024,7 +68885,7 @@ function operationOptionsToRequestParameters(options) {
 
 /***/ }),
 
-/***/ 381:
+/***/ 380:
 /***/ ((module) => {
 
 "use strict";
@@ -69042,7 +68903,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 382:
+/***/ 381:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69051,7 +68912,7 @@ module.exports = value => {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BuffersStream = void 0;
-const node_stream_1 = __nccwpck_require__(427);
+const node_stream_1 = __nccwpck_require__(426);
 /**
  * This class generates a readable stream from the data in an array of buffers.
  */
@@ -69150,15 +69011,15 @@ exports.BuffersStream = BuffersStream;
 
 /***/ }),
 
-/***/ 383:
+/***/ 382:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { parseSetCookie } = __nccwpck_require__(420)
-const { stringify } = __nccwpck_require__(405)
-const { webidl } = __nccwpck_require__(454)
+const { parseSetCookie } = __nccwpck_require__(419)
+const { stringify } = __nccwpck_require__(404)
+const { webidl } = __nccwpck_require__(453)
 const { Headers } = __nccwpck_require__(511)
 
 /**
@@ -69341,7 +69202,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 384:
+/***/ 383:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69357,7 +69218,7 @@ exports.AvroReadable = AvroReadable;
 
 /***/ }),
 
-/***/ 385:
+/***/ 384:
 /***/ ((module) => {
 
 "use strict";
@@ -69365,7 +69226,7 @@ module.exports = require("node:https");
 
 /***/ }),
 
-/***/ 386:
+/***/ 385:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69391,7 +69252,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(287);
+var import_userAgent = __nccwpck_require__(286);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -69412,17 +69273,17 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 387:
+/***/ 386:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const util = __nccwpck_require__(69)
-const { kBodyUsed } = __nccwpck_require__(192)
+const { kBodyUsed } = __nccwpck_require__(191)
 const assert = __nccwpck_require__(521)
-const { InvalidArgumentError } = __nccwpck_require__(484)
-const EE = __nccwpck_require__(466)
+const { InvalidArgumentError } = __nccwpck_require__(483)
+const EE = __nccwpck_require__(465)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
 
@@ -69641,7 +69502,7 @@ module.exports = RedirectHandler
 
 /***/ }),
 
-/***/ 388:
+/***/ 387:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69667,7 +69528,7 @@ function arraysEqual(a, b) {
 
 /***/ }),
 
-/***/ 389:
+/***/ 388:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69693,7 +69554,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_policies = __nccwpck_require__(281);
+var import_policies = __nccwpck_require__(280);
 const exponentialRetryPolicyName = import_policies.exponentialRetryPolicyName;
 function exponentialRetryPolicy(options = {}) {
   return (0, import_policies.exponentialRetryPolicy)(options);
@@ -69704,7 +69565,7 @@ function exponentialRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 390:
+/***/ 389:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -69739,7 +69600,7 @@ function randomUUID() {
 
 /***/ }),
 
-/***/ 391:
+/***/ 390:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69772,7 +69633,7 @@ exports.isJsonObject = isJsonObject;
 
 /***/ }),
 
-/***/ 392:
+/***/ 391:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69799,7 +69660,7 @@ __export(exponentialRetryStrategy_exports, {
   isSystemError: () => isSystemError
 });
 module.exports = __toCommonJS(exponentialRetryStrategy_exports);
-var import_delay = __nccwpck_require__(471);
+var import_delay = __nccwpck_require__(470);
 var import_throttlingRetryStrategy = __nccwpck_require__(35);
 const DEFAULT_CLIENT_RETRY_INTERVAL = 1e3;
 const DEFAULT_CLIENT_MAX_RETRY_INTERVAL = 1e3 * 64;
@@ -69845,7 +69706,7 @@ function isSystemError(err) {
 
 /***/ }),
 
-/***/ 393:
+/***/ 392:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69915,7 +69776,7 @@ exports.CacheScope = new CacheScope$Type();
 
 /***/ }),
 
-/***/ 394:
+/***/ 393:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69924,8 +69785,8 @@ exports.CacheScope = new CacheScope$Type();
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredential = void 0;
-const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(92);
-const Credential_js_1 = __nccwpck_require__(94);
+const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(91);
+const Credential_js_1 = __nccwpck_require__(93);
 /**
  * AnonymousCredential provides a credentialPolicyCreator member used to create
  * AnonymousCredentialPolicy objects. AnonymousCredentialPolicy is used with
@@ -69948,7 +69809,7 @@ exports.AnonymousCredential = AnonymousCredential;
 
 /***/ }),
 
-/***/ 395:
+/***/ 394:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69969,7 +69830,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 396:
+/***/ 395:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69979,7 +69840,7 @@ function getCachedDefaultHttpClient() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getStreamingResponseStatusCodes = getStreamingResponseStatusCodes;
 exports.getPathStringFromParameter = getPathStringFromParameter;
-const serializer_js_1 = __nccwpck_require__(476);
+const serializer_js_1 = __nccwpck_require__(475);
 /**
  * Gets the list of status codes for streaming responses.
  * @internal
@@ -70019,18 +69880,18 @@ function getPathStringFromParameter(parameter) {
 
 /***/ }),
 
-/***/ 397:
+/***/ 396:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-exports.parse = __nccwpck_require__(219)
-exports.stringify = __nccwpck_require__(294)
+exports.parse = __nccwpck_require__(218)
+exports.stringify = __nccwpck_require__(293)
 
 
 /***/ }),
 
-/***/ 398:
+/***/ 397:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70040,17 +69901,17 @@ exports.BlobServiceClient = void 0;
 const core_auth_1 = __nccwpck_require__(509);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(14);
-const Pipeline_js_1 = __nccwpck_require__(180);
+const Pipeline_js_1 = __nccwpck_require__(179);
 const ContainerClient_js_1 = __nccwpck_require__(64);
-const utils_common_js_1 = __nccwpck_require__(153);
-const storage_common_1 = __nccwpck_require__(271);
-const utils_common_js_2 = __nccwpck_require__(153);
+const utils_common_js_1 = __nccwpck_require__(152);
+const storage_common_1 = __nccwpck_require__(270);
+const utils_common_js_2 = __nccwpck_require__(152);
 const tracing_js_1 = __nccwpck_require__(31);
-const BlobBatchClient_js_1 = __nccwpck_require__(399);
-const StorageClient_js_1 = __nccwpck_require__(452);
+const BlobBatchClient_js_1 = __nccwpck_require__(398);
+const StorageClient_js_1 = __nccwpck_require__(451);
 const AccountSASPermissions_js_1 = __nccwpck_require__(58);
-const AccountSASSignatureValues_js_1 = __nccwpck_require__(284);
-const AccountSASServices_js_1 = __nccwpck_require__(376);
+const AccountSASSignatureValues_js_1 = __nccwpck_require__(283);
+const AccountSASServices_js_1 = __nccwpck_require__(375);
 /**
  * A BlobServiceClient represents a Client to the Azure Storage Blob service allowing you
  * to manipulate blob containers.
@@ -70743,7 +70604,7 @@ exports.BlobServiceClient = BlobServiceClient;
 
 /***/ }),
 
-/***/ 399:
+/***/ 398:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70752,14 +70613,14 @@ exports.BlobServiceClient = BlobServiceClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatchClient = void 0;
-const BatchResponseParser_js_1 = __nccwpck_require__(304);
-const BatchUtils_js_1 = __nccwpck_require__(253);
-const BlobBatch_js_1 = __nccwpck_require__(330);
+const BatchResponseParser_js_1 = __nccwpck_require__(303);
+const BatchUtils_js_1 = __nccwpck_require__(252);
+const BlobBatch_js_1 = __nccwpck_require__(329);
 const tracing_js_1 = __nccwpck_require__(31);
-const storage_common_1 = __nccwpck_require__(271);
-const StorageContextClient_js_1 = __nccwpck_require__(262);
-const Pipeline_js_1 = __nccwpck_require__(180);
-const utils_common_js_1 = __nccwpck_require__(153);
+const storage_common_1 = __nccwpck_require__(270);
+const StorageContextClient_js_1 = __nccwpck_require__(261);
+const Pipeline_js_1 = __nccwpck_require__(179);
+const utils_common_js_1 = __nccwpck_require__(152);
 /**
  * A BlobBatchClient allows you to make batched requests to the Azure Storage Blob service.
  *
@@ -70926,7 +70787,7 @@ exports.BlobBatchClient = BlobBatchClient;
 
 /***/ }),
 
-/***/ 400:
+/***/ 399:
 /***/ ((module) => {
 
 "use strict";
@@ -70940,15 +70801,15 @@ module.exports = (d, num) => {
 
 /***/ }),
 
-/***/ 401:
+/***/ 400:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const Decoder = __nccwpck_require__(42)
-const decodeText = __nccwpck_require__(270)
-const getLimit = __nccwpck_require__(479)
+const decodeText = __nccwpck_require__(269)
+const getLimit = __nccwpck_require__(478)
 
 const RE_CHARSET = /^charset$/i
 
@@ -71138,7 +70999,7 @@ module.exports = UrlEncoded
 
 /***/ }),
 
-/***/ 402:
+/***/ 401:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -71156,7 +71017,7 @@ exports.MESSAGE_TYPE = Symbol.for("protobuf-ts/message-type");
 
 /***/ }),
 
-/***/ 403:
+/***/ 402:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71168,7 +71029,7 @@ exports.createDefaultTracingSpan = createDefaultTracingSpan;
 exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
-const tracingContext_js_1 = __nccwpck_require__(366);
+const tracingContext_js_1 = __nccwpck_require__(365);
 const state_js_1 = __nccwpck_require__(95);
 function createDefaultTracingSpan() {
     return {
@@ -71232,17 +71093,17 @@ function getInstrumenter() {
 
 /***/ }),
 
-/***/ 404:
+/***/ 403:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
-const binary_format_contract_1 = __nccwpck_require__(329);
-const reflection_info_1 = __nccwpck_require__(450);
-const reflection_long_convert_1 = __nccwpck_require__(156);
-const reflection_scalar_default_1 = __nccwpck_require__(459);
+const binary_format_contract_1 = __nccwpck_require__(328);
+const reflection_info_1 = __nccwpck_require__(449);
+const reflection_long_convert_1 = __nccwpck_require__(155);
+const reflection_scalar_default_1 = __nccwpck_require__(458);
 /**
  * Reads proto3 messages in binary format using reflection information.
  *
@@ -71423,7 +71284,7 @@ exports.ReflectionBinaryReader = ReflectionBinaryReader;
 
 /***/ }),
 
-/***/ 405:
+/***/ 404:
 /***/ ((module) => {
 
 "use strict";
@@ -71705,7 +71566,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 406:
+/***/ 405:
 /***/ ((module) => {
 
 "use strict";
@@ -71713,15 +71574,15 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 407:
+/***/ 406:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseAsync
 
-const TOMLParser = __nccwpck_require__(343)
-const prettyError = __nccwpck_require__(273)
+const TOMLParser = __nccwpck_require__(342)
+const prettyError = __nccwpck_require__(272)
 
 function parseAsync (str, opts) {
   if (!opts) opts = {}
@@ -71751,7 +71612,7 @@ function parseAsync (str, opts) {
 
 /***/ }),
 
-/***/ 408:
+/***/ 407:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -71834,7 +71695,7 @@ function toPipelineResponse(compatResponse) {
 
 /***/ }),
 
-/***/ 409:
+/***/ 408:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -71860,7 +71721,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOptions = void 0;
-const core = __importStar(__nccwpck_require__(456));
+const core = __importStar(__nccwpck_require__(455));
 /**
  * Returns a copy with defaults filled in.
  */
@@ -71891,7 +71752,7 @@ exports.getOptions = getOptions;
 
 /***/ }),
 
-/***/ 410:
+/***/ 409:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71899,7 +71760,7 @@ exports.getOptions = getOptions;
 
 /* istanbul ignore file: only for Node 12 */
 
-const { kConnected, kSize } = __nccwpck_require__(192)
+const { kConnected, kSize } = __nccwpck_require__(191)
 
 class CompatWeakRef {
   constructor (value) {
@@ -71947,7 +71808,7 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 411:
+/***/ 410:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71959,7 +71820,7 @@ exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTie
 exports.toAccessTier = toAccessTier;
 exports.ensureCpkIfSpecified = ensureCpkIfSpecified;
 exports.getBlobServiceAccountAudience = getBlobServiceAccountAudience;
-const constants_js_1 = __nccwpck_require__(147);
+const constants_js_1 = __nccwpck_require__(146);
 /**
  * Represents the access tier on a blob.
  * For detailed information about block blob level tiering see {@link https://learn.microsoft.com/azure/storage/blobs/storage-blob-storage-tiers|Hot, cool and archive storage tiers.}
@@ -72075,19 +71936,19 @@ function getBlobServiceAccountAudience(storageAccountName) {
 
 /***/ }),
 
-/***/ 412:
+/***/ 411:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(427).Writable)
-const { inherits } = __nccwpck_require__(372)
+const WritableStream = (__nccwpck_require__(426).Writable)
+const { inherits } = __nccwpck_require__(371)
 const Dicer = __nccwpck_require__(13)
 
 const MultipartParser = __nccwpck_require__(0)
-const UrlencodedParser = __nccwpck_require__(401)
-const parseParams = __nccwpck_require__(189)
+const UrlencodedParser = __nccwpck_require__(400)
+const parseParams = __nccwpck_require__(188)
 
 function Busboy (opts) {
   if (!(this instanceof Busboy)) { return new Busboy(opts) }
@@ -72168,7 +72029,7 @@ module.exports.Dicer = Dicer
 
 /***/ }),
 
-/***/ 413:
+/***/ 412:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -72254,7 +72115,7 @@ function normalizeCompileCacheStats(raw) {
 
 /***/ }),
 
-/***/ 414:
+/***/ 413:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -72281,7 +72142,7 @@ var StorageRetryPolicyType;
 
 /***/ }),
 
-/***/ 415:
+/***/ 414:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -72323,7 +72184,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDetails = exports.isLinux = exports.isMacOS = exports.isWindows = exports.arch = exports.platform = void 0;
-const os_1 = __importDefault(__nccwpck_require__(91));
+const os_1 = __importDefault(__nccwpck_require__(90));
 const exec = __importStar(__nccwpck_require__(18));
 const getWindowsInfo = () => __awaiter(void 0, void 0, void 0, function* () {
     const { stdout: version } = yield exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Version"', undefined, {
@@ -72382,7 +72243,7 @@ exports.getDetails = getDetails;
 
 /***/ }),
 
-/***/ 416:
+/***/ 415:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -72490,15 +72351,15 @@ exports.parseProxyResponse = parseProxyResponse;
 
 /***/ }),
 
-/***/ 417:
+/***/ 416:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseStream
 
-const stream = __nccwpck_require__(129)
-const TOMLParser = __nccwpck_require__(343)
+const stream = __nccwpck_require__(128)
+const TOMLParser = __nccwpck_require__(342)
 
 function parseStream (stm) {
   if (stm) {
@@ -72578,7 +72439,7 @@ function parseTransform () {
 
 /***/ }),
 
-/***/ 418:
+/***/ 417:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72589,9 +72450,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReader = void 0;
 // TODO: Do a review of non-interfaces
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
-const AvroConstants_js_1 = __nccwpck_require__(225);
-const AvroParser_js_1 = __nccwpck_require__(296);
-const utils_common_js_1 = __nccwpck_require__(388);
+const AvroConstants_js_1 = __nccwpck_require__(224);
+const AvroParser_js_1 = __nccwpck_require__(295);
+const utils_common_js_1 = __nccwpck_require__(387);
 class AvroReader {
     _dataStream;
     _headerStream;
@@ -72705,7 +72566,7 @@ exports.AvroReader = AvroReader;
 
 /***/ }),
 
-/***/ 419:
+/***/ 418:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72715,13 +72576,13 @@ exports.CacheService = exports.GetCacheEntryDownloadURLResponse = exports.GetCac
 // @generated by protobuf-ts 2.9.1 with parameter long_type_string,client_none,generate_dependencies
 // @generated from protobuf file "results/api/v1/cache.proto" (package "github.actions.results.api.v1", syntax proto3)
 // tslint:disable
-const runtime_rpc_1 = __nccwpck_require__(172);
+const runtime_rpc_1 = __nccwpck_require__(171);
 const runtime_1 = __nccwpck_require__(19);
 const runtime_2 = __nccwpck_require__(19);
 const runtime_3 = __nccwpck_require__(19);
 const runtime_4 = __nccwpck_require__(19);
 const runtime_5 = __nccwpck_require__(19);
-const cachemetadata_1 = __nccwpck_require__(230);
+const cachemetadata_1 = __nccwpck_require__(229);
 // @generated message type with reflection information, may provide speed optimized methods
 class CreateCacheEntryRequest$Type extends runtime_5.MessageType {
     constructor() {
@@ -73114,14 +72975,14 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 
 /***/ }),
 
-/***/ 420:
+/***/ 419:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(126)
-const { isCTLExcludingHtab } = __nccwpck_require__(405)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(125)
+const { isCTLExcludingHtab } = __nccwpck_require__(404)
 const { collectASequenceOfCodePointsFast } = __nccwpck_require__(25)
 const assert = __nccwpck_require__(521)
 
@@ -73439,7 +73300,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 421:
+/***/ 420:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -73507,7 +73368,7 @@ exports.ServerCallContextController = ServerCallContextController;
 
 /***/ }),
 
-/***/ 422:
+/***/ 421:
 /***/ ((module) => {
 
 "use strict";
@@ -73642,7 +73503,7 @@ module.exports = Parser
 
 /***/ }),
 
-/***/ 423:
+/***/ 422:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73652,7 +73513,7 @@ exports.BlobDownloadResponse = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core_util_1 = __nccwpck_require__(14);
-const RetriableReadableStream_js_1 = __nccwpck_require__(488);
+const RetriableReadableStream_js_1 = __nccwpck_require__(487);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -74118,7 +73979,7 @@ exports.BlobDownloadResponse = BlobDownloadResponse;
 
 /***/ }),
 
-/***/ 424:
+/***/ 423:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -74163,7 +74024,7 @@ function storageRequestFailureDetailsParserPolicy() {
 
 /***/ }),
 
-/***/ 425:
+/***/ 424:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -74199,8 +74060,8 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(379));
-var import_node_process = __toESM(__nccwpck_require__(232));
+var import_node_os = __toESM(__nccwpck_require__(378));
+var import_node_process = __toESM(__nccwpck_require__(231));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -74223,7 +74084,7 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 426:
+/***/ 425:
 /***/ ((module) => {
 
 "use strict";
@@ -74231,7 +74092,7 @@ module.exports = require("async_hooks");
 
 /***/ }),
 
-/***/ 427:
+/***/ 426:
 /***/ ((module) => {
 
 "use strict";
@@ -74239,7 +74100,7 @@ module.exports = require("node:stream");
 
 /***/ }),
 
-/***/ 428:
+/***/ 427:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -74293,13 +74154,13 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DefaultGlobber = void 0;
-const core = __importStar(__nccwpck_require__(456));
+const core = __importStar(__nccwpck_require__(455));
 const fs = __importStar(__nccwpck_require__(526));
-const globOptionsHelper = __importStar(__nccwpck_require__(409));
-const path = __importStar(__nccwpck_require__(243));
+const globOptionsHelper = __importStar(__nccwpck_require__(408));
+const path = __importStar(__nccwpck_require__(242));
 const patternHelper = __importStar(__nccwpck_require__(43));
 const internal_match_kind_1 = __nccwpck_require__(523);
-const internal_pattern_1 = __nccwpck_require__(497);
+const internal_pattern_1 = __nccwpck_require__(496);
 const internal_search_state_1 = __nccwpck_require__(4);
 const IS_WINDOWS = process.platform === 'win32';
 class DefaultGlobber {
@@ -74481,7 +74342,7 @@ exports.DefaultGlobber = DefaultGlobber;
 
 /***/ }),
 
-/***/ 429:
+/***/ 428:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74491,7 +74352,7 @@ exports.DefaultGlobber = DefaultGlobber;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOperationArgumentValueFromParameter = getOperationArgumentValueFromParameter;
 exports.getOperationRequestInfo = getOperationRequestInfo;
-const state_js_1 = __nccwpck_require__(326);
+const state_js_1 = __nccwpck_require__(325);
 /**
  * @internal
  * Retrieves the value to use for a given operation argument
@@ -74586,7 +74447,7 @@ function getOperationRequestInfo(request) {
 
 /***/ }),
 
-/***/ 430:
+/***/ 429:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -74638,14 +74499,14 @@ function readRawInputs(env) {
 
 /***/ }),
 
-/***/ 431:
+/***/ 430:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(484)
-const { AsyncResource } = __nccwpck_require__(426)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(483)
+const { AsyncResource } = __nccwpck_require__(425)
 const util = __nccwpck_require__(69)
 const { addSignal, removeSignal } = __nccwpck_require__(102)
 const assert = __nccwpck_require__(521)
@@ -74751,14 +74612,14 @@ module.exports = upgrade
 
 /***/ }),
 
-/***/ 432:
+/***/ 431:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const os = __nccwpck_require__(91);
-const tty = __nccwpck_require__(179);
-const hasFlag = __nccwpck_require__(362);
+const os = __nccwpck_require__(90);
+const tty = __nccwpck_require__(178);
+const hasFlag = __nccwpck_require__(361);
 
 const {env} = process;
 
@@ -74894,7 +74755,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 433:
+/***/ 432:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -74919,7 +74780,7 @@ __export(checkInsecureConnection_exports, {
   ensureSecureConnection: () => ensureSecureConnection
 });
 module.exports = __toCommonJS(checkInsecureConnection_exports);
-var import_log = __nccwpck_require__(150);
+var import_log = __nccwpck_require__(149);
 let insecureConnectionWarningEmmitted = false;
 function allowInsecureConnection(request, options) {
   if (options.allowInsecureConnection && request.allowInsecureConnection) {
@@ -74956,14 +74817,14 @@ function ensureSecureConnection(request, options) {
 
 /***/ }),
 
-/***/ 434:
+/***/ 433:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CacheServiceClientProtobuf = exports.CacheServiceClientJSON = void 0;
-const cache_1 = __nccwpck_require__(419);
+const cache_1 = __nccwpck_require__(418);
 class CacheServiceClientJSON {
     constructor(rpc) {
         this.rpc = rpc;
@@ -75031,7 +74892,7 @@ exports.CacheServiceClientProtobuf = CacheServiceClientProtobuf;
 
 /***/ }),
 
-/***/ 435:
+/***/ 434:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -75080,7 +74941,7 @@ function decodeStringToString(value) {
 
 /***/ }),
 
-/***/ 436:
+/***/ 435:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -75125,7 +74986,7 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 
 /***/ }),
 
-/***/ 437:
+/***/ 436:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75134,31 +74995,31 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.authorizeRequestOnTenantChallenge = exports.authorizeRequestOnClaimChallenge = exports.serializationPolicyName = exports.serializationPolicy = exports.deserializationPolicyName = exports.deserializationPolicy = exports.XML_CHARKEY = exports.XML_ATTRKEY = exports.createClientPipeline = exports.ServiceClient = exports.MapperTypeNames = exports.createSerializer = void 0;
-var serializer_js_1 = __nccwpck_require__(476);
+var serializer_js_1 = __nccwpck_require__(475);
 Object.defineProperty(exports, "createSerializer", ({ enumerable: true, get: function () { return serializer_js_1.createSerializer; } }));
 Object.defineProperty(exports, "MapperTypeNames", ({ enumerable: true, get: function () { return serializer_js_1.MapperTypeNames; } }));
-var serviceClient_js_1 = __nccwpck_require__(309);
+var serviceClient_js_1 = __nccwpck_require__(308);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
-var pipeline_js_1 = __nccwpck_require__(279);
+var pipeline_js_1 = __nccwpck_require__(278);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
 var interfaces_js_1 = __nccwpck_require__(98);
 Object.defineProperty(exports, "XML_ATTRKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_ATTRKEY; } }));
 Object.defineProperty(exports, "XML_CHARKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_CHARKEY; } }));
-var deserializationPolicy_js_1 = __nccwpck_require__(85);
+var deserializationPolicy_js_1 = __nccwpck_require__(84);
 Object.defineProperty(exports, "deserializationPolicy", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicy; } }));
 Object.defineProperty(exports, "deserializationPolicyName", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicyName; } }));
-var serializationPolicy_js_1 = __nccwpck_require__(485);
+var serializationPolicy_js_1 = __nccwpck_require__(484);
 Object.defineProperty(exports, "serializationPolicy", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicy; } }));
 Object.defineProperty(exports, "serializationPolicyName", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicyName; } }));
 var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(110);
 Object.defineProperty(exports, "authorizeRequestOnClaimChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnClaimChallenge_js_1.authorizeRequestOnClaimChallenge; } }));
-var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(170);
+var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(169);
 Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnTenantChallenge_js_1.authorizeRequestOnTenantChallenge; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 438:
+/***/ 437:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -75198,9 +75059,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTar = exports.extractTar = exports.listTar = void 0;
 const exec_1 = __nccwpck_require__(18);
-const io = __importStar(__nccwpck_require__(289));
+const io = __importStar(__nccwpck_require__(288));
 const fs_1 = __nccwpck_require__(526);
-const path = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(242));
 const utils = __importStar(__nccwpck_require__(75));
 const constants_1 = __nccwpck_require__(45);
 const IS_WINDOWS = process.platform === 'win32';
@@ -75437,7 +75298,7 @@ exports.createTar = createTar;
 
 /***/ }),
 
-/***/ 439:
+/***/ 438:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -75473,15 +75334,15 @@ __export(nodeHttpClient_exports, {
   getBodyLength: () => getBodyLength
 });
 module.exports = __toCommonJS(nodeHttpClient_exports);
-var import_node_http = __toESM(__nccwpck_require__(258));
-var import_node_https = __toESM(__nccwpck_require__(385));
+var import_node_http = __toESM(__nccwpck_require__(257));
+var import_node_https = __toESM(__nccwpck_require__(384));
 var import_node_zlib = __toESM(__nccwpck_require__(514));
-var import_node_stream = __nccwpck_require__(427);
+var import_node_stream = __nccwpck_require__(426);
 var import_AbortError = __nccwpck_require__(10);
-var import_httpHeaders = __nccwpck_require__(481);
-var import_restError = __nccwpck_require__(442);
-var import_log = __nccwpck_require__(150);
-var import_sanitizer = __nccwpck_require__(120);
+var import_httpHeaders = __nccwpck_require__(480);
+var import_restError = __nccwpck_require__(441);
+var import_log = __nccwpck_require__(149);
+var import_sanitizer = __nccwpck_require__(119);
 const DEFAULT_TLS_SETTINGS = {};
 function isReadableStream(body) {
   return body && typeof body.pipe === "function";
@@ -75786,13 +75647,13 @@ function createNodeHttpClient() {
 
 /***/ }),
 
-/***/ 440:
+/***/ 439:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(454)
+const { webidl } = __nccwpck_require__(453)
 
 const kState = Symbol('ProgressEvent state')
 
@@ -75872,7 +75733,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 441:
+/***/ 440:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -75905,10 +75766,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const crypto = __importStar(__nccwpck_require__(286));
+const crypto = __importStar(__nccwpck_require__(285));
 const fs = __importStar(__nccwpck_require__(526));
-const os = __importStar(__nccwpck_require__(91));
-const utils_1 = __nccwpck_require__(500);
+const os = __importStar(__nccwpck_require__(90));
+const utils_1 = __nccwpck_require__(499);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -75941,7 +75802,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 442:
+/***/ 441:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -75967,9 +75828,9 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_error = __nccwpck_require__(152);
+var import_error = __nccwpck_require__(151);
 var import_inspect = __nccwpck_require__(1);
-var import_sanitizer = __nccwpck_require__(120);
+var import_sanitizer = __nccwpck_require__(119);
 const errorSanitizer = new import_sanitizer.Sanitizer();
 class RestError extends Error {
   /**
@@ -76043,7 +75904,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 443:
+/***/ 442:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -76096,7 +75957,7 @@ function wrapAbortSignalLike(abortSignalLike) {
 
 /***/ }),
 
-/***/ 444:
+/***/ 443:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76110,9 +75971,9 @@ function wrapAbortSignalLike(abortSignalLike) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(212);
+const tslib_1 = __nccwpck_require__(211);
 const coreHttpCompat = tslib_1.__importStar(__nccwpck_require__(72));
-const index_js_1 = __nccwpck_require__(272);
+const index_js_1 = __nccwpck_require__(271);
 class StorageClient extends coreHttpCompat.ExtendedServiceClient {
     url;
     version;
@@ -76169,7 +76030,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 445:
+/***/ 444:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76178,36 +76039,36 @@ exports.StorageClient = StorageClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = exports.StorageSharedKeyCredentialPolicy = exports.StorageSharedKeyCredential = exports.StorageRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = exports.Credential = exports.CredentialPolicy = exports.BaseRequestPolicy = exports.AnonymousCredentialPolicy = exports.AnonymousCredential = exports.StorageOAuthScopes = exports.newPipeline = exports.isPipelineLike = exports.Pipeline = exports.getBlobServiceAccountAudience = exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTier = exports.generateBlobSASQueryParameters = exports.generateAccountSASQueryParameters = void 0;
-const tslib_1 = __nccwpck_require__(212);
+const tslib_1 = __nccwpck_require__(211);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
-tslib_1.__exportStar(__nccwpck_require__(398), exports);
-tslib_1.__exportStar(__nccwpck_require__(182), exports);
+tslib_1.__exportStar(__nccwpck_require__(397), exports);
+tslib_1.__exportStar(__nccwpck_require__(181), exports);
 tslib_1.__exportStar(__nccwpck_require__(64), exports);
-tslib_1.__exportStar(__nccwpck_require__(201), exports);
+tslib_1.__exportStar(__nccwpck_require__(200), exports);
 tslib_1.__exportStar(__nccwpck_require__(58), exports);
 tslib_1.__exportStar(__nccwpck_require__(2), exports);
-tslib_1.__exportStar(__nccwpck_require__(376), exports);
-var AccountSASSignatureValues_js_1 = __nccwpck_require__(284);
+tslib_1.__exportStar(__nccwpck_require__(375), exports);
+var AccountSASSignatureValues_js_1 = __nccwpck_require__(283);
 Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(330), exports);
-tslib_1.__exportStar(__nccwpck_require__(399), exports);
-tslib_1.__exportStar(__nccwpck_require__(171), exports);
-tslib_1.__exportStar(__nccwpck_require__(498), exports);
+tslib_1.__exportStar(__nccwpck_require__(329), exports);
+tslib_1.__exportStar(__nccwpck_require__(398), exports);
+tslib_1.__exportStar(__nccwpck_require__(170), exports);
+tslib_1.__exportStar(__nccwpck_require__(497), exports);
 var BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(274), exports);
-var models_js_1 = __nccwpck_require__(411);
+tslib_1.__exportStar(__nccwpck_require__(273), exports);
+var models_js_1 = __nccwpck_require__(410);
 Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: function () { return models_js_1.BlockBlobTier; } }));
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
 Object.defineProperty(exports, "getBlobServiceAccountAudience", ({ enumerable: true, get: function () { return models_js_1.getBlobServiceAccountAudience; } }));
-var Pipeline_js_1 = __nccwpck_require__(180);
+var Pipeline_js_1 = __nccwpck_require__(179);
 Object.defineProperty(exports, "Pipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.Pipeline; } }));
 Object.defineProperty(exports, "isPipelineLike", ({ enumerable: true, get: function () { return Pipeline_js_1.isPipelineLike; } }));
 Object.defineProperty(exports, "newPipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.newPipeline; } }));
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return Pipeline_js_1.StorageOAuthScopes; } }));
-var storage_common_1 = __nccwpck_require__(271);
+var storage_common_1 = __nccwpck_require__(270);
 Object.defineProperty(exports, "AnonymousCredential", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredential; } }));
 Object.defineProperty(exports, "AnonymousCredentialPolicy", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredentialPolicy; } }));
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return storage_common_1.BaseRequestPolicy; } }));
@@ -76221,21 +76082,21 @@ Object.defineProperty(exports, "StorageSharedKeyCredentialPolicy", ({ enumerable
 Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
 tslib_1.__exportStar(__nccwpck_require__(520), exports);
-tslib_1.__exportStar(__nccwpck_require__(317), exports);
+tslib_1.__exportStar(__nccwpck_require__(316), exports);
 var log_js_1 = __nccwpck_require__(105);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 446:
+/***/ 445:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SPECIAL_HEADERS = exports.HEADER_STATE = exports.MINOR = exports.MAJOR = exports.CONNECTION_TOKEN_CHARS = exports.HEADER_CHARS = exports.TOKEN = exports.STRICT_TOKEN = exports.HEX = exports.URL_CHAR = exports.STRICT_URL_CHAR = exports.USERINFO_CHARS = exports.MARK = exports.ALPHANUM = exports.NUM = exports.HEX_MAP = exports.NUM_MAP = exports.ALPHA = exports.FINISH = exports.H_METHOD_MAP = exports.METHOD_MAP = exports.METHODS_RTSP = exports.METHODS_ICE = exports.METHODS_HTTP = exports.METHODS = exports.LENIENT_FLAGS = exports.FLAGS = exports.TYPE = exports.ERROR = void 0;
-const utils_1 = __nccwpck_require__(302);
+const utils_1 = __nccwpck_require__(301);
 // C headers
 var ERROR;
 (function (ERROR) {
@@ -76513,7 +76374,7 @@ exports.SPECIAL_HEADERS = {
 
 /***/ }),
 
-/***/ 447:
+/***/ 446:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76539,12 +76400,12 @@ __export(sendRequest_exports, {
   sendRequest: () => sendRequest
 });
 module.exports = __toCommonJS(sendRequest_exports);
-var import_restError = __nccwpck_require__(442);
-var import_httpHeaders = __nccwpck_require__(481);
+var import_restError = __nccwpck_require__(441);
+var import_httpHeaders = __nccwpck_require__(480);
 var import_pipelineRequest = __nccwpck_require__(113);
-var import_clientHelpers = __nccwpck_require__(487);
-var import_typeGuards = __nccwpck_require__(492);
-var import_multipart = __nccwpck_require__(264);
+var import_clientHelpers = __nccwpck_require__(486);
+var import_typeGuards = __nccwpck_require__(491);
+var import_multipart = __nccwpck_require__(263);
 async function sendRequest(method, url, pipeline, options = {}, customHttpClient) {
   const httpClient = customHttpClient ?? (0, import_clientHelpers.getCachedDefaultHttpsClient)();
   const request = buildPipelineRequest(method, url, options);
@@ -76697,7 +76558,7 @@ function createParseError(response, err) {
 
 /***/ }),
 
-/***/ 448:
+/***/ 447:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76713,8 +76574,8 @@ const {
   makeResponse
 } = __nccwpck_require__(41)
 const { Headers } = __nccwpck_require__(511)
-const { Request, makeRequest } = __nccwpck_require__(83)
-const zlib = __nccwpck_require__(406)
+const { Request, makeRequest } = __nccwpck_require__(82)
+const zlib = __nccwpck_require__(405)
 const {
   bytesMatch,
   makePolicyContainer,
@@ -76756,15 +76617,15 @@ const {
   subresourceSet,
   DOMException
 } = __nccwpck_require__(30)
-const { kHeadersList } = __nccwpck_require__(192)
-const EE = __nccwpck_require__(466)
-const { Readable, pipeline } = __nccwpck_require__(129)
+const { kHeadersList } = __nccwpck_require__(191)
+const EE = __nccwpck_require__(465)
+const { Readable, pipeline } = __nccwpck_require__(128)
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(69)
 const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(25)
-const { TransformStream } = __nccwpck_require__(252)
-const { getGlobalDispatcher } = __nccwpck_require__(373)
-const { webidl } = __nccwpck_require__(454)
-const { STATUS_CODES } = __nccwpck_require__(325)
+const { TransformStream } = __nccwpck_require__(251)
+const { getGlobalDispatcher } = __nccwpck_require__(372)
+const { webidl } = __nccwpck_require__(453)
+const { STATUS_CODES } = __nccwpck_require__(324)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
 /** @type {import('buffer').resolveObjectURL} */
@@ -78505,7 +78366,7 @@ async function httpNetworkFetch (
   // cancelAlgorithm set to cancelAlgorithm, highWaterMark set to
   // highWaterMark, and sizeAlgorithm set to sizeAlgorithm.
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(252).ReadableStream)
+    ReadableStream = (__nccwpck_require__(251).ReadableStream)
   }
 
   const stream = new ReadableStream(
@@ -78853,7 +78714,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 449:
+/***/ 448:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -78911,14 +78772,14 @@ exports.ServerStreamingCall = ServerStreamingCall;
 
 /***/ }),
 
-/***/ 450:
+/***/ 449:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.readMessageOption = exports.readFieldOption = exports.readFieldOptions = exports.normalizeFieldInfo = exports.RepeatType = exports.LongType = exports.ScalarType = void 0;
-const lower_camel_case_1 = __nccwpck_require__(451);
+const lower_camel_case_1 = __nccwpck_require__(450);
 /**
  * Scalar value types. This is a subset of field types declared by protobuf
  * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
@@ -79077,7 +78938,7 @@ exports.readMessageOption = readMessageOption;
 
 /***/ }),
 
-/***/ 451:
+/***/ 450:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -79120,7 +78981,7 @@ exports.lowerCamelCase = lowerCamelCase;
 
 /***/ }),
 
-/***/ 452:
+/***/ 451:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -79129,9 +78990,9 @@ exports.lowerCamelCase = lowerCamelCase;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const StorageContextClient_js_1 = __nccwpck_require__(262);
-const Pipeline_js_1 = __nccwpck_require__(180);
-const utils_common_js_1 = __nccwpck_require__(153);
+const StorageContextClient_js_1 = __nccwpck_require__(261);
+const Pipeline_js_1 = __nccwpck_require__(179);
+const utils_common_js_1 = __nccwpck_require__(152);
 /**
  * A StorageClient represents a based URL class for {@link BlobServiceClient}, {@link ContainerClient}
  * and etc.
@@ -79183,7 +79044,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 453:
+/***/ 452:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -79258,13 +79119,13 @@ function parseHeaderValueAsNumber(response, headerName) {
 
 /***/ }),
 
-/***/ 454:
+/***/ 453:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { types } = __nccwpck_require__(122)
+const { types } = __nccwpck_require__(121)
 const { hasOwn, toUSVString } = __nccwpck_require__(512)
 
 /** @type {import('../../types/webidl').Webidl} */
@@ -79912,15 +79773,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 455:
+/***/ 454:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /**
  * Module dependencies.
  */
 
-const tty = __nccwpck_require__(179);
-const util = __nccwpck_require__(122);
+const tty = __nccwpck_require__(178);
+const util = __nccwpck_require__(121);
 
 /**
  * This is the Node.js implementation of `debug()`.
@@ -79946,7 +79807,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = __nccwpck_require__(432);
+	const supportsColor = __nccwpck_require__(431);
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [
@@ -80154,7 +80015,7 @@ function init(debug) {
 	}
 }
 
-module.exports = __nccwpck_require__(141)(exports);
+module.exports = __nccwpck_require__(140)(exports);
 
 const {formatters} = module.exports;
 
@@ -80182,7 +80043,7 @@ formatters.O = function (v) {
 
 /***/ }),
 
-/***/ 456:
+/***/ 455:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -80222,11 +80083,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.platform = exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = exports.markdownSummary = exports.summary = exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(528);
-const file_command_1 = __nccwpck_require__(441);
-const utils_1 = __nccwpck_require__(500);
-const os = __importStar(__nccwpck_require__(91));
-const path = __importStar(__nccwpck_require__(243));
-const oidc_utils_1 = __nccwpck_require__(132);
+const file_command_1 = __nccwpck_require__(440);
+const utils_1 = __nccwpck_require__(499);
+const os = __importStar(__nccwpck_require__(90));
+const path = __importStar(__nccwpck_require__(242));
+const oidc_utils_1 = __nccwpck_require__(131);
 /**
  * The code to exit an action
  */
@@ -80511,29 +80372,29 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(341);
+var summary_1 = __nccwpck_require__(340);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(341);
+var summary_2 = __nccwpck_require__(340);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(328);
+var path_utils_1 = __nccwpck_require__(327);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
 /**
  * Platform utilities exports
  */
-exports.platform = __importStar(__nccwpck_require__(415));
+exports.platform = __importStar(__nccwpck_require__(414));
 //# sourceMappingURL=core.js.map
 
 /***/ }),
 
-/***/ 457:
+/***/ 456:
 /***/ ((module) => {
 
 "use strict";
@@ -80551,14 +80412,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 458:
+/***/ 457:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionEquals = void 0;
-const reflection_info_1 = __nccwpck_require__(450);
+const reflection_info_1 = __nccwpck_require__(449);
 /**
  * Determines whether two message of the same type have the same field values.
  * Checks for deep equality, traversing repeated fields, oneof groups, maps
@@ -80636,15 +80497,15 @@ function repeatedMsgEq(type, a, b) {
 
 /***/ }),
 
-/***/ 459:
+/***/ 458:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
-const reflection_info_1 = __nccwpck_require__(450);
-const reflection_long_convert_1 = __nccwpck_require__(156);
+const reflection_info_1 = __nccwpck_require__(449);
+const reflection_long_convert_1 = __nccwpck_require__(155);
 const pb_long_1 = __nccwpck_require__(115);
 /**
  * Creates the default value for a scalar type.
@@ -80681,7 +80542,7 @@ exports.reflectionScalarDefault = reflectionScalarDefault;
 
 /***/ }),
 
-/***/ 460:
+/***/ 459:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80719,7 +80580,7 @@ function storageCorrectContentLengthPolicy() {
 
 /***/ }),
 
-/***/ 461:
+/***/ 460:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -80764,7 +80625,7 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 462:
+/***/ 461:
 /***/ ((module) => {
 
 "use strict";
@@ -80823,7 +80684,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 463:
+/***/ 462:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -80848,7 +80709,7 @@ __export(debug_exports, {
   default: () => debug_default
 });
 module.exports = __toCommonJS(debug_exports);
-var import_log = __nccwpck_require__(483);
+var import_log = __nccwpck_require__(482);
 const debugEnvVariable = typeof process !== "undefined" && process.env && process.env.DEBUG || void 0;
 let enabledString;
 let enabledNamespaces = [];
@@ -81013,7 +80874,7 @@ var debug_default = debugObj;
 
 /***/ }),
 
-/***/ 464:
+/***/ 463:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* eslint-env browser */
@@ -81273,7 +81134,7 @@ function localstorage() {
 	}
 }
 
-module.exports = __nccwpck_require__(141)(exports);
+module.exports = __nccwpck_require__(140)(exports);
 
 const {formatters} = module.exports;
 
@@ -81292,7 +81153,7 @@ formatters.j = function (v) {
 
 /***/ }),
 
-/***/ 465:
+/***/ 464:
 /***/ ((module) => {
 
 "use strict";
@@ -81300,7 +81161,7 @@ module.exports = /*#__PURE__*/JSON.parse('{"name":"@actions/cache","version":"4.
 
 /***/ }),
 
-/***/ 466:
+/***/ 465:
 /***/ ((module) => {
 
 "use strict";
@@ -81308,7 +81169,7 @@ module.exports = require("events");
 
 /***/ }),
 
-/***/ 467:
+/***/ 466:
 /***/ ((module) => {
 
 "use strict";
@@ -81339,7 +81200,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 468:
+/***/ 467:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -81613,7 +81474,7 @@ var KnownStorageErrorCode;
 
 /***/ }),
 
-/***/ 469:
+/***/ 468:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -81640,7 +81501,7 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_policies = __nccwpck_require__(281);
+var import_policies = __nccwpck_require__(280);
 const proxyPolicyName = import_policies.proxyPolicyName;
 function getDefaultProxySettings(proxyUrl) {
   return (0, import_policies.getDefaultProxySettings)(proxyUrl);
@@ -81654,7 +81515,7 @@ function proxyPolicy(proxySettings, options) {
 
 /***/ }),
 
-/***/ 470:
+/***/ 469:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82234,7 +82095,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 471:
+/***/ 470:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -82259,7 +82120,7 @@ __export(delay_exports, {
   calculateRetryDelay: () => calculateRetryDelay
 });
 module.exports = __toCommonJS(delay_exports);
-var import_random = __nccwpck_require__(502);
+var import_random = __nccwpck_require__(501);
 function calculateRetryDelay(retryAttempt, config) {
   const exponentialDelay = config.retryDelayInMs * Math.pow(2, retryAttempt);
   const clampedDelay = Math.min(config.maxRetryDelayInMs, exponentialDelay);
@@ -82273,7 +82134,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 472:
+/***/ 471:
 /***/ ((module) => {
 
 "use strict";
@@ -82316,7 +82177,7 @@ module.exports = class DecoratorHandler {
 
 /***/ }),
 
-/***/ 473:
+/***/ 472:
 /***/ ((module) => {
 
 "use strict";
@@ -82338,13 +82199,13 @@ module.exports = function basename (path) {
 
 /***/ }),
 
-/***/ 474:
+/***/ 473:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = __nccwpck_require__(466)
+const EventEmitter = __nccwpck_require__(465)
 
 class Dispatcher extends EventEmitter {
   dispatch () {
@@ -82365,7 +82226,7 @@ module.exports = Dispatcher
 
 /***/ }),
 
-/***/ 475:
+/***/ 474:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82385,7 +82246,7 @@ exports.ServiceType = ServiceType;
 
 /***/ }),
 
-/***/ 476:
+/***/ 475:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82395,10 +82256,10 @@ exports.ServiceType = ServiceType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
-const tslib_1 = __nccwpck_require__(212);
-const base64 = tslib_1.__importStar(__nccwpck_require__(435));
+const tslib_1 = __nccwpck_require__(211);
+const base64 = tslib_1.__importStar(__nccwpck_require__(434));
 const interfaces_js_1 = __nccwpck_require__(98);
-const utils_js_1 = __nccwpck_require__(306);
+const utils_js_1 = __nccwpck_require__(305);
 class SerializerImpl {
     modelMappers;
     isXML;
@@ -83318,7 +83179,7 @@ exports.MapperTypeNames = {
 
 /***/ }),
 
-/***/ 477:
+/***/ 476:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -83333,18 +83194,18 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 
 /***/ }),
 
-/***/ 478:
+/***/ 477:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Writable } = __nccwpck_require__(129)
-const diagnosticsChannel = __nccwpck_require__(140)
-const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(462)
+const { Writable } = __nccwpck_require__(128)
+const diagnosticsChannel = __nccwpck_require__(139)
+const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(461)
 const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(97)
 const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(57)
-const { WebsocketFrameSend } = __nccwpck_require__(184)
+const { WebsocketFrameSend } = __nccwpck_require__(183)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -83685,7 +83546,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 479:
+/***/ 478:
 /***/ ((module) => {
 
 "use strict";
@@ -83709,7 +83570,7 @@ module.exports = function getLimit (limits, name, defaultLimit) {
 
 /***/ }),
 
-/***/ 480:
+/***/ 479:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -83760,7 +83621,7 @@ exports.assertFloat32 = assertFloat32;
 
 /***/ }),
 
-/***/ 481:
+/***/ 480:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -83873,11 +83734,11 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 482:
+/***/ 481:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __nccwpck_require__(348);
-var balanced = __nccwpck_require__(130);
+var concatMap = __nccwpck_require__(347);
+var balanced = __nccwpck_require__(129);
 
 module.exports = expandTop;
 
@@ -84083,7 +83944,7 @@ function expand(str, max, isTop) {
 
 /***/ }),
 
-/***/ 483:
+/***/ 482:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -84118,9 +83979,9 @@ __export(log_exports, {
   log: () => log
 });
 module.exports = __toCommonJS(log_exports);
-var import_node_os = __nccwpck_require__(379);
-var import_node_util = __toESM(__nccwpck_require__(372));
-var import_node_process = __toESM(__nccwpck_require__(232));
+var import_node_os = __nccwpck_require__(378);
+var import_node_util = __toESM(__nccwpck_require__(371));
+var import_node_process = __toESM(__nccwpck_require__(231));
 function log(message, ...args) {
   import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
 }
@@ -84131,7 +83992,7 @@ function log(message, ...args) {
 
 /***/ }),
 
-/***/ 484:
+/***/ 483:
 /***/ ((module) => {
 
 "use strict";
@@ -84369,7 +84230,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 485:
+/***/ 484:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84382,9 +84243,9 @@ exports.serializationPolicy = serializationPolicy;
 exports.serializeHeaders = serializeHeaders;
 exports.serializeRequestBody = serializeRequestBody;
 const interfaces_js_1 = __nccwpck_require__(98);
-const operationHelpers_js_1 = __nccwpck_require__(429);
-const serializer_js_1 = __nccwpck_require__(476);
-const interfaceHelpers_js_1 = __nccwpck_require__(396);
+const operationHelpers_js_1 = __nccwpck_require__(428);
+const serializer_js_1 = __nccwpck_require__(475);
+const interfaceHelpers_js_1 = __nccwpck_require__(395);
 /**
  * The programmatic identifier of the serializationPolicy.
  */
@@ -84533,19 +84394,19 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 /***/ }),
 
-/***/ 486:
+/***/ 485:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(504);
-var tls = __nccwpck_require__(501);
-var http = __nccwpck_require__(325);
+var net = __nccwpck_require__(503);
+var tls = __nccwpck_require__(500);
+var http = __nccwpck_require__(324);
 var https = __nccwpck_require__(70);
-var events = __nccwpck_require__(466);
+var events = __nccwpck_require__(465);
 var assert = __nccwpck_require__(521);
-var util = __nccwpck_require__(122);
+var util = __nccwpck_require__(121);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -84805,7 +84666,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 487:
+/***/ 486:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -84831,14 +84692,14 @@ __export(clientHelpers_exports, {
   getCachedDefaultHttpsClient: () => getCachedDefaultHttpsClient
 });
 module.exports = __toCommonJS(clientHelpers_exports);
-var import_defaultHttpClient = __nccwpck_require__(369);
-var import_createPipelineFromOptions = __nccwpck_require__(310);
-var import_apiVersionPolicy = __nccwpck_require__(223);
-var import_credentials = __nccwpck_require__(185);
-var import_apiKeyAuthenticationPolicy = __nccwpck_require__(86);
-var import_basicAuthenticationPolicy = __nccwpck_require__(151);
-var import_bearerAuthenticationPolicy = __nccwpck_require__(377);
-var import_oauth2AuthenticationPolicy = __nccwpck_require__(335);
+var import_defaultHttpClient = __nccwpck_require__(368);
+var import_createPipelineFromOptions = __nccwpck_require__(309);
+var import_apiVersionPolicy = __nccwpck_require__(222);
+var import_credentials = __nccwpck_require__(184);
+var import_apiKeyAuthenticationPolicy = __nccwpck_require__(85);
+var import_basicAuthenticationPolicy = __nccwpck_require__(150);
+var import_bearerAuthenticationPolicy = __nccwpck_require__(376);
+var import_oauth2AuthenticationPolicy = __nccwpck_require__(334);
 let cachedHttpClient;
 function createDefaultPipeline(options = {}) {
   const pipeline = (0, import_createPipelineFromOptions.createPipelineFromOptions)(options);
@@ -84878,7 +84739,7 @@ function getCachedDefaultHttpsClient() {
 
 /***/ }),
 
-/***/ 488:
+/***/ 487:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84887,8 +84748,8 @@ function getCachedDefaultHttpsClient() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetriableReadableStream = void 0;
-const abort_controller_1 = __nccwpck_require__(491);
-const node_stream_1 = __nccwpck_require__(427);
+const abort_controller_1 = __nccwpck_require__(490);
+const node_stream_1 = __nccwpck_require__(426);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -85016,6 +84877,21 @@ exports.RetriableReadableStream = RetriableReadableStream;
 
 /***/ }),
 
+/***/ 488:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.AbortError = void 0;
+var AbortError_js_1 = __nccwpck_require__(494);
+Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
 /***/ 489:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -85025,7 +84901,7 @@ exports.RetriableReadableStream = RetriableReadableStream;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(495);
+var AbortError_js_1 = __nccwpck_require__(492);
 Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
 //# sourceMappingURL=index.js.map
 
@@ -85047,21 +84923,6 @@ Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function 
 /***/ }),
 
 /***/ 491:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(494);
-Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
-//# sourceMappingURL=index.js.map
-
-/***/ }),
-
-/***/ 492:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -85111,6 +84972,44 @@ function isBlob(x) {
 0 && (0);
 //# sourceMappingURL=typeGuards.js.map
 
+
+/***/ }),
+
+/***/ 492:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.AbortError = void 0;
+/**
+ * This error is thrown when an asynchronous operation has been aborted.
+ * Check for this error by testing the `name` that the name property of the
+ * error matches `"AbortError"`.
+ *
+ * @example
+ * ```ts
+ * const controller = new AbortController();
+ * controller.abort();
+ * try {
+ *   doAsyncWork(controller.signal)
+ * } catch (e) {
+ *   if (e.name === 'AbortError') {
+ *     // handle abort error here.
+ *   }
+ * }
+ * ```
+ */
+class AbortError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "AbortError";
+    }
+}
+exports.AbortError = AbortError;
+//# sourceMappingURL=AbortError.js.map
 
 /***/ }),
 
@@ -85191,44 +85090,6 @@ exports.AbortError = AbortError;
 /***/ }),
 
 /***/ 495:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AbortError = void 0;
-/**
- * This error is thrown when an asynchronous operation has been aborted.
- * Check for this error by testing the `name` that the name property of the
- * error matches `"AbortError"`.
- *
- * @example
- * ```ts
- * const controller = new AbortController();
- * controller.abort();
- * try {
- *   doAsyncWork(controller.signal)
- * } catch (e) {
- *   if (e.name === 'AbortError') {
- *     // handle abort error here.
- *   }
- * }
- * ```
- */
-class AbortError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = "AbortError";
-    }
-}
-exports.AbortError = AbortError;
-//# sourceMappingURL=AbortError.js.map
-
-/***/ }),
-
-/***/ 496:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -85237,8 +85098,8 @@ exports.AbortError = AbortError;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQuickQueryStream = void 0;
-const node_stream_1 = __nccwpck_require__(427);
-const index_js_1 = __nccwpck_require__(331);
+const node_stream_1 = __nccwpck_require__(426);
+const index_js_1 = __nccwpck_require__(330);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -85355,7 +85216,7 @@ exports.BlobQuickQueryStream = BlobQuickQueryStream;
 
 /***/ }),
 
-/***/ 497:
+/***/ 496:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -85384,13 +85245,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
-const os = __importStar(__nccwpck_require__(91));
-const path = __importStar(__nccwpck_require__(243));
-const pathHelper = __importStar(__nccwpck_require__(218));
+const os = __importStar(__nccwpck_require__(90));
+const path = __importStar(__nccwpck_require__(242));
+const pathHelper = __importStar(__nccwpck_require__(217));
 const assert_1 = __importDefault(__nccwpck_require__(521));
-const minimatch_1 = __nccwpck_require__(123);
+const minimatch_1 = __nccwpck_require__(122);
 const internal_match_kind_1 = __nccwpck_require__(523);
-const internal_path_1 = __nccwpck_require__(119);
+const internal_path_1 = __nccwpck_require__(118);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, isImplicitPattern = false, segments, homedir) {
@@ -85617,7 +85478,7 @@ exports.Pattern = Pattern;
 
 /***/ }),
 
-/***/ 498:
+/***/ 497:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -85821,7 +85682,7 @@ exports.BlobSASPermissions = BlobSASPermissions;
 
 /***/ }),
 
-/***/ 499:
+/***/ 498:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -85874,8 +85735,8 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tripleToCcRsSuffix = tripleToCcRsSuffix;
 exports.detectMuslCcEnv = detectMuslCcEnv;
-const fs = __importStar(__nccwpck_require__(244));
-const path = __importStar(__nccwpck_require__(503));
+const fs = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(502));
 const MUSL_TRIPLE_RE = /^[a-z0-9_]+-unknown-linux-musl$/;
 function tripleToCcRsSuffix(triple) {
     return triple.replace(/-/g, "_");
@@ -85999,7 +85860,7 @@ function detectMuslCcEnv(env, deps) {
 
 /***/ }),
 
-/***/ 500:
+/***/ 499:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -86046,7 +85907,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 501:
+/***/ 500:
 /***/ ((module) => {
 
 "use strict";
@@ -86054,7 +85915,7 @@ module.exports = require("tls");
 
 /***/ }),
 
-/***/ 502:
+/***/ 501:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -86092,7 +85953,7 @@ function getRandomIntegerInclusive(min, max) {
 
 /***/ }),
 
-/***/ 503:
+/***/ 502:
 /***/ ((module) => {
 
 "use strict";
@@ -86100,7 +85961,7 @@ module.exports = require("node:path");
 
 /***/ }),
 
-/***/ 504:
+/***/ 503:
 /***/ ((module) => {
 
 "use strict";
@@ -86108,7 +85969,7 @@ module.exports = require("net");
 
 /***/ }),
 
-/***/ 505:
+/***/ 504:
 /***/ ((module) => {
 
 "use strict";
@@ -86116,20 +85977,20 @@ module.exports = require("timers");
 
 /***/ }),
 
-/***/ 506:
+/***/ 505:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Readable = __nccwpck_require__(127)
+const Readable = __nccwpck_require__(126)
 const {
   InvalidArgumentError,
   RequestAbortedError
-} = __nccwpck_require__(484)
+} = __nccwpck_require__(483)
 const util = __nccwpck_require__(69)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(186)
-const { AsyncResource } = __nccwpck_require__(426)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(185)
+const { AsyncResource } = __nccwpck_require__(425)
 const { addSignal, removeSignal } = __nccwpck_require__(102)
 
 class RequestHandler extends AsyncResource {
@@ -86304,7 +86165,7 @@ module.exports.RequestHandler = RequestHandler
 
 /***/ }),
 
-/***/ 507:
+/***/ 506:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -86351,14 +86212,14 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.shouldRefreshToolchain = shouldRefreshToolchain;
 exports.shouldSkipRefreshForExactHit = shouldSkipRefreshForExactHit;
 exports.ensureRustToolchain = ensureRustToolchain;
-const fs = __importStar(__nccwpck_require__(244));
-const os = __importStar(__nccwpck_require__(379));
-const path = __importStar(__nccwpck_require__(503));
-const core = __importStar(__nccwpck_require__(456));
+const fs = __importStar(__nccwpck_require__(243));
+const os = __importStar(__nccwpck_require__(378));
+const path = __importStar(__nccwpck_require__(502));
+const core = __importStar(__nccwpck_require__(455));
 const exec = __importStar(__nccwpck_require__(18));
-const io = __importStar(__nccwpck_require__(289));
+const io = __importStar(__nccwpck_require__(288));
 const tc = __importStar(__nccwpck_require__(517));
-const log_utils_js_1 = __nccwpck_require__(349);
+const log_utils_js_1 = __nccwpck_require__(348);
 function rustupInitTargetTriple() {
     const system = process.platform;
     const arch = process.arch;
@@ -86641,7 +86502,7 @@ async function ensureRustToolchain(opts) {
 
 /***/ }),
 
-/***/ 508:
+/***/ 507:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -86657,14 +86518,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TestTransport = void 0;
-const rpc_error_1 = __nccwpck_require__(173);
+const rpc_error_1 = __nccwpck_require__(172);
 const runtime_1 = __nccwpck_require__(19);
-const rpc_output_stream_1 = __nccwpck_require__(301);
-const rpc_options_1 = __nccwpck_require__(288);
+const rpc_output_stream_1 = __nccwpck_require__(300);
+const rpc_options_1 = __nccwpck_require__(287);
 const unary_call_1 = __nccwpck_require__(56);
-const server_streaming_call_1 = __nccwpck_require__(449);
-const client_streaming_call_1 = __nccwpck_require__(347);
-const duplex_streaming_call_1 = __nccwpck_require__(300);
+const server_streaming_call_1 = __nccwpck_require__(448);
+const client_streaming_call_1 = __nccwpck_require__(346);
+const duplex_streaming_call_1 = __nccwpck_require__(299);
 /**
  * Transport for testing.
  */
@@ -86970,6 +86831,164 @@ class TestInputStream {
 
 /***/ }),
 
+/***/ 508:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Passthrough soldr stub. Written when `enable: false` instead of
+// downloading the real soldr binary.
+//
+// The stub recognizes the small set of subcommands soldr-aware code paths
+// query (`version`, `cache`, `status`) and returns stub JSON so verify
+// and post don't crash. For anything else, it execs argv[1..] verbatim —
+// `soldr cargo build --release` runs as `cargo build --release`.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports._internal = void 0;
+exports.installPassthrough = installPassthrough;
+const fs = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(502));
+const STUB_VERSION = "passthrough";
+function bashStub() {
+    return `#!/usr/bin/env bash
+# setup-soldr passthrough stub (enable=false). Forwards \`soldr <tool>\`
+# to \`<tool>\` and returns stub JSON for soldr-aware subcommands.
+set -e
+if [ "$#" -eq 0 ]; then
+  echo "soldr passthrough stub: no arguments (setup-soldr was invoked with enable=false)" >&2
+  exit 0
+fi
+case "$1" in
+  version)
+    cat <<'JSON'
+{"soldr_version": "${STUB_VERSION}", "managed_zccache_version": null, "setup_soldr_passthrough": true}
+JSON
+    exit 0
+    ;;
+  cache)
+    cat <<'JSON'
+{"status": "ok", "soldr_version": "${STUB_VERSION}", "managed_zccache_version": null, "last_session": null, "rollups": null, "notes": ["setup-soldr enable=false: soldr passthrough stub"]}
+JSON
+    exit 0
+    ;;
+  status)
+    cat <<'JSON'
+{"status": "ok", "setup_soldr_passthrough": true}
+JSON
+    exit 0
+    ;;
+  stop)
+    # No daemon to stop in passthrough mode; report success so the
+    # post-step shutdown-cache helper doesn't log a noisy non-zero exit.
+    exit 0
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac
+`;
+}
+function cmdStub() {
+    // Windows .cmd shim. Note that newlines must be CRLF for cmd.exe to
+    // parse multi-line scripts reliably; we use \r\n explicitly.
+    const stubJsonVersion = `{"soldr_version": "${STUB_VERSION}", "managed_zccache_version": null, "setup_soldr_passthrough": true}`;
+    const stubJsonCache = `{"status": "ok", "soldr_version": "${STUB_VERSION}", "managed_zccache_version": null, "last_session": null, "rollups": null, "notes": ["setup-soldr enable=false: soldr passthrough stub"]}`;
+    const stubJsonStatus = `{"status": "ok", "setup_soldr_passthrough": true}`;
+    const lines = [
+        "@echo off",
+        "setlocal enableextensions",
+        'if "%~1"=="" (',
+        "  echo soldr passthrough stub: no arguments ^(setup-soldr was invoked with enable=false^) 1^>^&2",
+        "  exit /b 0",
+        ")",
+        'if /I "%~1"=="version" (',
+        `  echo ${stubJsonVersion}`,
+        "  exit /b 0",
+        ")",
+        'if /I "%~1"=="cache" (',
+        `  echo ${stubJsonCache}`,
+        "  exit /b 0",
+        ")",
+        'if /I "%~1"=="status" (',
+        `  echo ${stubJsonStatus}`,
+        "  exit /b 0",
+        ")",
+        'if /I "%~1"=="stop" exit /b 0',
+        'set "TOOL=%~1"',
+        "shift",
+        '"%TOOL%" %*',
+        "exit /b %ERRORLEVEL%",
+    ];
+    return lines.join("\r\n") + "\r\n";
+}
+/**
+ * Write a passthrough stub at `soldrPath`. On Unix this is a single
+ * bash script at `<binDir>/soldr`. On Windows we write TWO files:
+ *
+ *   - `soldrPath` (ends in `.cmd`) — for cmd.exe, PowerShell, and
+ *     @actions/exec calls that route through cross-spawn's .cmd
+ *     handling. This is the canonical SOLDR_BINARY.
+ *   - `<binDir>/soldr` (no extension) — a bash-flavored stub that Git
+ *     Bash / MSYS / WSL resolves when a workflow step running under
+ *     `shell: bash` invokes the literal `soldr` command. Without this
+ *     companion file, a bash script that runs `soldr cargo build` on
+ *     a Windows runner exits 127 with `soldr: command not found`,
+ *     because bash on Windows doesn't auto-append `.cmd` to PATH
+ *     lookups. See zccache CI run zackees/zccache#307.
+ */
+function installPassthrough(opts) {
+    const { soldrPath, isWindows, log } = opts;
+    fs.mkdirSync(path.dirname(soldrPath), { recursive: true });
+    if (isWindows) {
+        fs.writeFileSync(soldrPath, cmdStub(), "utf8");
+        const bashTwin = path.join(path.dirname(soldrPath), "soldr");
+        fs.writeFileSync(bashTwin, bashStub(), "utf8");
+        log(`setup-soldr: installed passthrough stubs at ${soldrPath} and ${bashTwin} (enable=false)`);
+    }
+    else {
+        fs.writeFileSync(soldrPath, bashStub(), { encoding: "utf8", mode: 0o755 });
+        log(`setup-soldr: installed passthrough stub at ${soldrPath} (enable=false)`);
+    }
+}
+// Exported for tests.
+exports._internal = { bashStub, cmdStub, STUB_VERSION };
+
+
+/***/ }),
+
 /***/ 509:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -86977,7 +86996,7 @@ class TestInputStream {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isTokenCredential = exports.isSASCredential = exports.AzureSASCredential = exports.isNamedKeyCredential = exports.AzureNamedKeyCredential = exports.isKeyCredential = exports.AzureKeyCredential = void 0;
-var azureKeyCredential_js_1 = __nccwpck_require__(292);
+var azureKeyCredential_js_1 = __nccwpck_require__(291);
 Object.defineProperty(exports, "AzureKeyCredential", ({ enumerable: true, get: function () { return azureKeyCredential_js_1.AzureKeyCredential; } }));
 var keyCredential_js_1 = __nccwpck_require__(38);
 Object.defineProperty(exports, "isKeyCredential", ({ enumerable: true, get: function () { return keyCredential_js_1.isKeyCredential; } }));
@@ -86987,7 +87006,7 @@ Object.defineProperty(exports, "isNamedKeyCredential", ({ enumerable: true, get:
 var azureSASCredential_js_1 = __nccwpck_require__(33);
 Object.defineProperty(exports, "AzureSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.AzureSASCredential; } }));
 Object.defineProperty(exports, "isSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.isSASCredential; } }));
-var tokenCredential_js_1 = __nccwpck_require__(242);
+var tokenCredential_js_1 = __nccwpck_require__(241);
 Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: function () { return tokenCredential_js_1.isTokenCredential; } }));
 //# sourceMappingURL=index.js.map
 
@@ -87002,9 +87021,9 @@ Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: fu
  */
 
 if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
-	module.exports = __nccwpck_require__(464);
+	module.exports = __nccwpck_require__(463);
 } else {
-	module.exports = __nccwpck_require__(455);
+	module.exports = __nccwpck_require__(454);
 }
 
 
@@ -87018,7 +87037,7 @@ if (typeof process === 'undefined' || process.type === 'renderer' || process.bro
 
 
 
-const { kHeadersList, kConstruct } = __nccwpck_require__(192)
+const { kHeadersList, kConstruct } = __nccwpck_require__(191)
 const { kGuard } = __nccwpck_require__(15)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 const {
@@ -87026,8 +87045,8 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(512)
-const util = __nccwpck_require__(122)
-const { webidl } = __nccwpck_require__(454)
+const util = __nccwpck_require__(121)
+const { webidl } = __nccwpck_require__(453)
 const assert = __nccwpck_require__(521)
 
 const kHeadersMap = Symbol('headers map')
@@ -87618,11 +87637,11 @@ module.exports = {
 
 
 const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(30)
-const { getGlobalOrigin } = __nccwpck_require__(138)
-const { performance } = __nccwpck_require__(315)
+const { getGlobalOrigin } = __nccwpck_require__(137)
+const { performance } = __nccwpck_require__(314)
 const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(69)
 const assert = __nccwpck_require__(521)
-const { isUint8Array } = __nccwpck_require__(195)
+const { isUint8Array } = __nccwpck_require__(194)
 
 let supportedHashes = []
 
@@ -87631,7 +87650,7 @@ let supportedHashes = []
 let crypto
 
 try {
-  crypto = __nccwpck_require__(286)
+  crypto = __nccwpck_require__(285)
   const possibleRelevantHashes = ['sha256', 'sha384', 'sha512']
   supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
 /* c8 ignore next 3 */
@@ -88584,7 +88603,7 @@ let ReadableStream = globalThis.ReadableStream
 
 function isReadableStreamLike (stream) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(252).ReadableStream)
+    ReadableStream = (__nccwpck_require__(251).ReadableStream)
   }
 
   return stream instanceof ReadableStream || (
@@ -88850,7 +88869,7 @@ module.exports = require("node:zlib");
 /***/ 515:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(486);
+module.exports = __nccwpck_require__(485);
 
 
 /***/ }),
@@ -88939,17 +88958,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.evaluateVersions = exports.isExplicitVersion = exports.findFromManifest = exports.getManifestFromRepo = exports.findAllVersions = exports.find = exports.cacheFile = exports.cacheDir = exports.extractZip = exports.extractXar = exports.extractTar = exports.extract7z = exports.downloadTool = exports.HTTPError = void 0;
-const core = __importStar(__nccwpck_require__(456));
-const io = __importStar(__nccwpck_require__(289));
-const crypto = __importStar(__nccwpck_require__(286));
+const core = __importStar(__nccwpck_require__(455));
+const io = __importStar(__nccwpck_require__(288));
+const crypto = __importStar(__nccwpck_require__(285));
 const fs = __importStar(__nccwpck_require__(526));
-const mm = __importStar(__nccwpck_require__(327));
-const os = __importStar(__nccwpck_require__(91));
-const path = __importStar(__nccwpck_require__(243));
-const httpm = __importStar(__nccwpck_require__(280));
-const semver = __importStar(__nccwpck_require__(176));
-const stream = __importStar(__nccwpck_require__(129));
-const util = __importStar(__nccwpck_require__(122));
+const mm = __importStar(__nccwpck_require__(326));
+const os = __importStar(__nccwpck_require__(90));
+const path = __importStar(__nccwpck_require__(242));
+const httpm = __importStar(__nccwpck_require__(279));
+const semver = __importStar(__nccwpck_require__(175));
+const stream = __importStar(__nccwpck_require__(128));
+const util = __importStar(__nccwpck_require__(121));
 const assert_1 = __nccwpck_require__(521);
 const exec_1 = __nccwpck_require__(18);
 const retry_helper_1 = __nccwpck_require__(9);
@@ -89599,7 +89618,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(392);
+var import_exponentialRetryStrategy = __nccwpck_require__(391);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_constants = __nccwpck_require__(48);
 const exponentialRetryPolicyName = "exponentialRetryPolicy";
@@ -89846,8 +89865,8 @@ function createEmptyPipeline() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SASQueryParameters = exports.SASProtocol = void 0;
-const SasIPRange_js_1 = __nccwpck_require__(356);
-const utils_common_js_1 = __nccwpck_require__(153);
+const SasIPRange_js_1 = __nccwpck_require__(355);
+const utils_common_js_1 = __nccwpck_require__(152);
 /**
  * Protocols for generated SAS.
  */
@@ -90349,9 +90368,9 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureShims = ensureShims;
-const fs = __importStar(__nccwpck_require__(244));
-const path = __importStar(__nccwpck_require__(503));
-const core = __importStar(__nccwpck_require__(456));
+const fs = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(502));
+const core = __importStar(__nccwpck_require__(455));
 // Tools that route through `soldr <tool>`:
 const ROUTED_TOOLS = ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"];
 // Unix bash shim template (per tool):
@@ -90414,20 +90433,20 @@ async function ensureShims(opts) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(402);
-const reflection_info_1 = __nccwpck_require__(450);
-const reflection_type_check_1 = __nccwpck_require__(285);
-const reflection_json_reader_1 = __nccwpck_require__(340);
-const reflection_json_writer_1 = __nccwpck_require__(89);
-const reflection_binary_reader_1 = __nccwpck_require__(404);
-const reflection_binary_writer_1 = __nccwpck_require__(183);
-const reflection_create_1 = __nccwpck_require__(202);
-const reflection_merge_partial_1 = __nccwpck_require__(135);
-const json_typings_1 = __nccwpck_require__(391);
-const json_format_contract_1 = __nccwpck_require__(237);
-const reflection_equals_1 = __nccwpck_require__(458);
-const binary_writer_1 = __nccwpck_require__(246);
-const binary_reader_1 = __nccwpck_require__(133);
+const message_type_contract_1 = __nccwpck_require__(401);
+const reflection_info_1 = __nccwpck_require__(449);
+const reflection_type_check_1 = __nccwpck_require__(284);
+const reflection_json_reader_1 = __nccwpck_require__(339);
+const reflection_json_writer_1 = __nccwpck_require__(88);
+const reflection_binary_reader_1 = __nccwpck_require__(403);
+const reflection_binary_writer_1 = __nccwpck_require__(182);
+const reflection_create_1 = __nccwpck_require__(201);
+const reflection_merge_partial_1 = __nccwpck_require__(134);
+const json_typings_1 = __nccwpck_require__(390);
+const json_format_contract_1 = __nccwpck_require__(236);
+const reflection_equals_1 = __nccwpck_require__(457);
+const binary_writer_1 = __nccwpck_require__(245);
+const binary_reader_1 = __nccwpck_require__(132);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
 const messageTypeDescriptor = baseDescriptors[message_type_contract_1.MESSAGE_TYPE] = {};
 /**
@@ -90712,8 +90731,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(91));
-const utils_1 = __nccwpck_require__(500);
+const os = __importStar(__nccwpck_require__(90));
+const utils_1 = __nccwpck_require__(499);
 /**
  * Commands
  *
@@ -90795,7 +90814,7 @@ function escapeProperty(s) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBeginCopyFromUrlPoller = void 0;
 const core_util_1 = __nccwpck_require__(14);
-const core_lro_1 = __nccwpck_require__(222);
+const core_lro_1 = __nccwpck_require__(221);
 /**
  * This is the poller returned by {@link BlobClient.beginCopyFromURL}.
  * This can not be instantiated directly outside of this package.
@@ -91030,7 +91049,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(81);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(94);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/src/lib/install-passthrough.ts
+++ b/src/lib/install-passthrough.ts
@@ -39,6 +39,11 @@ JSON
 JSON
     exit 0
     ;;
+  stop)
+    # No daemon to stop in passthrough mode; report success so the
+    # post-step shutdown-cache helper doesn't log a noisy non-zero exit.
+    exit 0
+    ;;
   *)
     exec "$@"
     ;;
@@ -71,6 +76,7 @@ function cmdStub(): string {
     `  echo ${stubJsonStatus}`,
     "  exit /b 0",
     ")",
+    'if /I "%~1"=="stop" exit /b 0',
     'set "TOOL=%~1"',
     "shift",
     '"%TOOL%" %*',
@@ -80,9 +86,19 @@ function cmdStub(): string {
 }
 
 /**
- * Write a passthrough stub at soldrPath. `soldrPath` is expected to end
- * in `.cmd` on Windows and have no extension on Unix; resolveSetup picks
- * the right name when `enable: false`.
+ * Write a passthrough stub at `soldrPath`. On Unix this is a single
+ * bash script at `<binDir>/soldr`. On Windows we write TWO files:
+ *
+ *   - `soldrPath` (ends in `.cmd`) — for cmd.exe, PowerShell, and
+ *     @actions/exec calls that route through cross-spawn's .cmd
+ *     handling. This is the canonical SOLDR_BINARY.
+ *   - `<binDir>/soldr` (no extension) — a bash-flavored stub that Git
+ *     Bash / MSYS / WSL resolves when a workflow step running under
+ *     `shell: bash` invokes the literal `soldr` command. Without this
+ *     companion file, a bash script that runs `soldr cargo build` on
+ *     a Windows runner exits 127 with `soldr: command not found`,
+ *     because bash on Windows doesn't auto-append `.cmd` to PATH
+ *     lookups. See zccache CI run zackees/zccache#307.
  */
 export function installPassthrough(opts: {
   soldrPath: string;
@@ -93,10 +109,15 @@ export function installPassthrough(opts: {
   fs.mkdirSync(path.dirname(soldrPath), { recursive: true });
   if (isWindows) {
     fs.writeFileSync(soldrPath, cmdStub(), "utf8");
+    const bashTwin = path.join(path.dirname(soldrPath), "soldr");
+    fs.writeFileSync(bashTwin, bashStub(), "utf8");
+    log(
+      `setup-soldr: installed passthrough stubs at ${soldrPath} and ${bashTwin} (enable=false)`,
+    );
   } else {
     fs.writeFileSync(soldrPath, bashStub(), { encoding: "utf8", mode: 0o755 });
+    log(`setup-soldr: installed passthrough stub at ${soldrPath} (enable=false)`);
   }
-  log(`setup-soldr: installed passthrough stub at ${soldrPath} (enable=false)`);
 }
 
 // Exported for tests.


### PR DESCRIPTION
## Summary
Two passthrough-mode (`enable: false`) bugs surfaced by [zackees/zccache#307](https://github.com/zackees/zccache/actions/runs/26126912250/job/76842804553?pr=307) on Windows runners using `shell: bash`:

1. `soldr cargo check --workspace` in a bash step exits **127 / `soldr: command not found`**. setup-soldr only wrote `<binDir>/soldr.cmd`; bash on Windows doesn't auto-append `.cmd` to PATH lookups, so a literal `soldr` invocation never finds the stub.
   **Fix:** on Windows also write a no-extension bash stub at `<binDir>/soldr` alongside `soldr.cmd`. Git Bash / MSYS / WSL resolve and execute it via its shebang. `.cmd` stays canonical for cmd/PowerShell/`@actions/exec`.

2. Post-step `shutdownCacheDaemons` calls `<soldrPath> stop`. The stub had no `stop` branch, fell through to the "exec the second arg" path, and produced a noisy `'"stop"' is not recognized` log. Already best-effort (didn't fail the run) but spammy.
   **Fix:** both stubs now recognize `stop` and exit 0 silently — no daemon in passthrough mode.

## Test plan
- [x] `npm run typecheck` clean
- [x] Full suite: 202 pass / 5 skipped (Unix-only bash tests) / 0 fail
- [x] New tests: Windows bash-twin creation; `stop` is a silent no-op on Unix
- [ ] CI green

## Release
After merge: tag `v0.8.0` and publish a GitHub release marked Latest. `v0` will auto-fast-forward via `update-v0-tag.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)