### PR TITLE
feat(demo): upload zccache logs as artifacts, enable ACTIONS_STEP_DEBUG

### DIFF
--- a/.github/workflows/zccache-build-demo.yml
+++ b/.github/workflows/zccache-build-demo.yml
@@ -127,6 +127,8 @@ jobs:
     if: ${{ inputs.run_mode == 'Purge cache and run cold build before warm build' }}
     needs: purge-demo-caches
     runs-on: ubuntu-24.04
+    env:
+      ACTIONS_STEP_DEBUG: true
 
     steps:
       - name: Checkout setup-soldr action
@@ -244,6 +246,14 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      - name: Upload zccache logs (cold)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: zccache-logs-cold
+          path: ${{ steps.setup.outputs.build-cache-path }}/logs/
+          if-no-files-found: ignore
+
   warm-build:
     name: Warm zccache build with checked-out setup-soldr
     needs:
@@ -251,6 +261,8 @@ jobs:
       - cold-build
     if: ${{ always() && (inputs.run_mode != 'Purge cache and run cold build before warm build' || needs.cold-build.result == 'success') }}
     runs-on: ubuntu-24.04
+    env:
+      ACTIONS_STEP_DEBUG: true
 
     steps:
       - name: Checkout setup-soldr action
@@ -367,3 +379,11 @@ jobs:
           path: ${{ runner.temp }}/setup-soldr-cache-keys.txt
           if-no-files-found: warn
           retention-days: 7
+
+      - name: Upload zccache logs (warm)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: zccache-logs-warm
+          path: ${{ steps.setup.outputs.build-cache-path }}/logs/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- Adds `ACTIONS_STEP_DEBUG: true` to both `cold-build` and `warm-build` job envs — enables GitHub Actions' own debug logging layer on top of the existing `debug: "true"` / `stats: detailed` inputs
- Adds `Upload zccache logs` steps (`if: always()`) in both jobs to capture `last-session.log` and `last-session-stats.json` from `build-cache-path/logs/` as downloadable artifacts (`zccache-logs-cold`, `zccache-logs-warm`)
- Uses `if-no-files-found: ignore` so the step is a no-op on cold runs where the log dir doesn't yet exist

## What gets uploaded

```
build-cache-path/logs/
  last-session.log
  last-session-stats.json
```

Artifact names: `zccache-logs-cold` and `zccache-logs-warm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)