### PR TITLE
chore(version): bump default soldr 0.7.26 -> 0.7.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.26`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.28`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -104,7 +104,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.26`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.28`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -168,7 +168,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.26`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.28`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action keeps using the runner's existing `CARGO_HOME` unless `CARGO_HOME` is already set by the workflow. When `RUSTUP_HOME` is not explicitly set, setup-soldr prefers the runner's existing rustup home if it already satisfies the requested toolchain/components/targets; otherwise it falls back to a managed `RUSTUP_HOME` under the action cache root and rehydrates that state on later warm runs.

--- a/__tests__/diagnostics.test.ts
+++ b/__tests__/diagnostics.test.ts
@@ -21,7 +21,7 @@ function captureLogger(): { logger: Logger; lines: string[] } {
 function fixtureRawInputs(): RawInputs {
   return {
     enable: "true",
-    version: "0.7.26",
+    version: "0.7.28",
     repo: "zackees/soldr",
     ref: "",
     cache: "true",
@@ -108,7 +108,7 @@ test("dumpDiagnostics includes parsed RawInputs", () => {
   const body = lines.join("\n");
   assert.match(body, /\[raw_inputs/);
   assert.match(body, /cacheKeySuffix="zccache-demo"/);
-  assert.match(body, /version="0\.7\.26"/);
+  assert.match(body, /version="0\.7\.28"/);
 });
 
 test("dumpDiagnostics redacts token-shaped env values", () => {

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.24.
+    description: Soldr version or tag to install. Defaults to 0.7.28.
     required: false
-    default: "0.7.26"
+    default: "0.7.28"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary
- Bump default Soldr version from `0.7.26` to `0.7.28` (latest stable on PyPI / `zackees/soldr` releases — pulls in 0.7.27 and 0.7.28).
- Fix stale `description: Defaults to 0.7.24` line in `action.yml` that was already out of sync with the actual default.
- Update README references (intro line, inputs table, notes) and the `diagnostics.test.ts` fixture + assertion.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (255 tests; 250 pass, 5 skipped, 0 fail)
- [ ] After merge: move the floating `v0` tag to the new `main` commit and push it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)