### PR TITLE
docs: add CLAUDE.md with PR-branch workflow rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# setup-soldr — Claude instructions
+
+## Change workflow
+
+All changes land via a feature branch and PR — never commit directly to `main`. Merge to `main` only after CI passes (the PR is the unit of "on success"). This matches the repo's history of numbered bump/feature PRs (e.g. `#128`).
+
+Floating major tags (e.g. `v0`) are moved to point at the new `main` commit only after the PR is merged, then pushed.


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` documenting the convention this repo already follows: changes land via a feature branch and PR (never direct to `main`), merged after CI passes.
- Notes that floating major tags (e.g. `v0`) are moved to the new `main` commit only after the PR is merged, then pushed.

## Test plan
- [x] No code changes; doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)