### PR TITLE
perf(cook): move restore into parallel block (gated on path safety)

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -19,7 +19,7 @@ const { inherits } = __nccwpck_require__(376)
 
 const Dicer = __nccwpck_require__(13)
 
-const parseParams = __nccwpck_require__(193)
+const parseParams = __nccwpck_require__(194)
 const decodeText = __nccwpck_require__(277)
 const basename = __nccwpck_require__(477)
 const getLimit = __nccwpck_require__(483)
@@ -472,14 +472,14 @@ exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = ex
 const core = __importStar(__nccwpck_require__(460));
 const http_client_1 = __nccwpck_require__(286);
 const storage_blob_1 = __nccwpck_require__(448);
-const buffer = __importStar(__nccwpck_require__(119));
+const buffer = __importStar(__nccwpck_require__(120));
 const fs = __importStar(__nccwpck_require__(532));
-const stream = __importStar(__nccwpck_require__(130));
-const util = __importStar(__nccwpck_require__(123));
+const stream = __importStar(__nccwpck_require__(131));
+const util = __importStar(__nccwpck_require__(124));
 const utils = __importStar(__nccwpck_require__(76));
 const constants_1 = __nccwpck_require__(45);
-const requestUtils_1 = __nccwpck_require__(261);
-const abort_controller_1 = __nccwpck_require__(229);
+const requestUtils_1 = __nccwpck_require__(262);
+const abort_controller_1 = __nccwpck_require__(230);
 /**
  * Pipes the body of a HTTP response to a stream
  *
@@ -840,12 +840,12 @@ exports.SearchState = SearchState;
 
 
 const { InvalidArgumentError } = __nccwpck_require__(488)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(196)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(197)
 const DispatcherBase = __nccwpck_require__(62)
 const Pool = __nccwpck_require__(338)
 const Client = __nccwpck_require__(88)
 const util = __nccwpck_require__(69)
-const createRedirectInterceptor = __nccwpck_require__(255)
+const createRedirectInterceptor = __nccwpck_require__(256)
 const { WeakRef, FinalizationRegistry } = __nccwpck_require__(415)()
 
 const kOnConnect = Symbol('onConnect')
@@ -1071,7 +1071,7 @@ function isNamedKeyCredential(credential) {
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(233)
+const { MockNotMatchedError } = __nccwpck_require__(234)
 const {
   kDispatches,
   kMockAgent,
@@ -1085,7 +1085,7 @@ const {
   types: {
     isPromise
   }
-} = __nccwpck_require__(123)
+} = __nccwpck_require__(124)
 
 function matchValue (match, value) {
   if (typeof match === 'string') {
@@ -1655,10 +1655,10 @@ function formatDefaultJson(value) {
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(156)
+const { kConstruct } = __nccwpck_require__(157)
 const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(80)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(69)
-const { kHeadersList } = __nccwpck_require__(196)
+const { kHeadersList } = __nccwpck_require__(197)
 const { webidl } = __nccwpck_require__(457)
 const { Response, cloneResponse } = __nccwpck_require__(41)
 const { Request } = __nccwpck_require__(84)
@@ -2504,10 +2504,10 @@ module.exports = {
 const WritableStream = (__nccwpck_require__(431).Writable)
 const inherits = (__nccwpck_require__(376).inherits)
 
-const StreamSearch = __nccwpck_require__(114)
+const StreamSearch = __nccwpck_require__(115)
 
 const PartStream = __nccwpck_require__(66)
-const HeaderParser = __nccwpck_require__(107)
+const HeaderParser = __nccwpck_require__(108)
 
 const DASH = 45
 const B_ONEDASH = Buffer.from('-')
@@ -2734,17 +2734,17 @@ exports.isObject = isObject;
 exports.randomUUID = randomUUID;
 exports.uint8ArrayToString = uint8ArrayToString;
 exports.stringToUint8Array = stringToUint8Array;
-const tslib_1 = __nccwpck_require__(217);
-const tspRuntime = tslib_1.__importStar(__nccwpck_require__(146));
-var aborterUtils_js_1 = __nccwpck_require__(100);
+const tslib_1 = __nccwpck_require__(218);
+const tspRuntime = tslib_1.__importStar(__nccwpck_require__(147));
+var aborterUtils_js_1 = __nccwpck_require__(101);
 Object.defineProperty(exports, "cancelablePromiseRace", ({ enumerable: true, get: function () { return aborterUtils_js_1.cancelablePromiseRace; } }));
-var createAbortablePromise_js_1 = __nccwpck_require__(260);
+var createAbortablePromise_js_1 = __nccwpck_require__(261);
 Object.defineProperty(exports, "createAbortablePromise", ({ enumerable: true, get: function () { return createAbortablePromise_js_1.createAbortablePromise; } }));
-var delay_js_1 = __nccwpck_require__(113);
+var delay_js_1 = __nccwpck_require__(114);
 Object.defineProperty(exports, "delay", ({ enumerable: true, get: function () { return delay_js_1.delay; } }));
-var error_js_1 = __nccwpck_require__(213);
+var error_js_1 = __nccwpck_require__(214);
 Object.defineProperty(exports, "getErrorMessage", ({ enumerable: true, get: function () { return error_js_1.getErrorMessage; } }));
-var typeGuards_js_1 = __nccwpck_require__(110);
+var typeGuards_js_1 = __nccwpck_require__(111);
 Object.defineProperty(exports, "isDefined", ({ enumerable: true, get: function () { return typeGuards_js_1.isDefined; } }));
 Object.defineProperty(exports, "isObjectWithProperties", ({ enumerable: true, get: function () { return typeGuards_js_1.isObjectWithProperties; } }));
 Object.defineProperty(exports, "objectHasProperty", ({ enumerable: true, get: function () { return typeGuards_js_1.objectHasProperty; } }));
@@ -2920,7 +2920,7 @@ module.exports = __toCommonJS(retryPolicy_exports);
 var import_helpers = __nccwpck_require__(456);
 var import_restError = __nccwpck_require__(445);
 var import_AbortError = __nccwpck_require__(10);
-var import_logger = __nccwpck_require__(246);
+var import_logger = __nccwpck_require__(247);
 var import_constants = __nccwpck_require__(48);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("ts-http-runtime retryPolicy");
 const retryPolicyName = "retryPolicy";
@@ -3077,8 +3077,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
-const string_decoder_1 = __nccwpck_require__(149);
-const tr = __importStar(__nccwpck_require__(125));
+const string_decoder_1 = __nccwpck_require__(150);
+const tr = __importStar(__nccwpck_require__(126));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -3178,19 +3178,19 @@ Object.defineProperty(exports, "WireType", ({ enumerable: true, get: function ()
 Object.defineProperty(exports, "mergeBinaryOptions", ({ enumerable: true, get: function () { return binary_format_contract_1.mergeBinaryOptions; } }));
 Object.defineProperty(exports, "UnknownFieldHandler", ({ enumerable: true, get: function () { return binary_format_contract_1.UnknownFieldHandler; } }));
 // Standard IBinaryReader implementation
-var binary_reader_1 = __nccwpck_require__(134);
+var binary_reader_1 = __nccwpck_require__(135);
 Object.defineProperty(exports, "BinaryReader", ({ enumerable: true, get: function () { return binary_reader_1.BinaryReader; } }));
 Object.defineProperty(exports, "binaryReadOptions", ({ enumerable: true, get: function () { return binary_reader_1.binaryReadOptions; } }));
 // Standard IBinaryWriter implementation
-var binary_writer_1 = __nccwpck_require__(251);
+var binary_writer_1 = __nccwpck_require__(252);
 Object.defineProperty(exports, "BinaryWriter", ({ enumerable: true, get: function () { return binary_writer_1.BinaryWriter; } }));
 Object.defineProperty(exports, "binaryWriteOptions", ({ enumerable: true, get: function () { return binary_writer_1.binaryWriteOptions; } }));
 // Int64 and UInt64 implementations required for the binary format
-var pb_long_1 = __nccwpck_require__(117);
+var pb_long_1 = __nccwpck_require__(118);
 Object.defineProperty(exports, "PbLong", ({ enumerable: true, get: function () { return pb_long_1.PbLong; } }));
 Object.defineProperty(exports, "PbULong", ({ enumerable: true, get: function () { return pb_long_1.PbULong; } }));
 // JSON format contracts, options for reading and writing, for example
-var json_format_contract_1 = __nccwpck_require__(242);
+var json_format_contract_1 = __nccwpck_require__(243);
 Object.defineProperty(exports, "jsonReadOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonReadOptions; } }));
 Object.defineProperty(exports, "jsonWriteOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonWriteOptions; } }));
 Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: function () { return json_format_contract_1.mergeJsonOptions; } }));
@@ -3212,17 +3212,17 @@ Object.defineProperty(exports, "readMessageOption", ({ enumerable: true, get: fu
 // Message operations via reflection
 var reflection_type_check_1 = __nccwpck_require__(291);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
-var reflection_create_1 = __nccwpck_require__(206);
+var reflection_create_1 = __nccwpck_require__(207);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
 var reflection_scalar_default_1 = __nccwpck_require__(463);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
-var reflection_merge_partial_1 = __nccwpck_require__(136);
+var reflection_merge_partial_1 = __nccwpck_require__(137);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
 var reflection_equals_1 = __nccwpck_require__(462);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
 var reflection_binary_reader_1 = __nccwpck_require__(409);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
-var reflection_binary_writer_1 = __nccwpck_require__(186);
+var reflection_binary_writer_1 = __nccwpck_require__(187);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
 var reflection_json_reader_1 = __nccwpck_require__(345);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
@@ -3231,7 +3231,7 @@ Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get:
 var reflection_contains_message_type_1 = __nccwpck_require__(50);
 Object.defineProperty(exports, "containsMessageType", ({ enumerable: true, get: function () { return reflection_contains_message_type_1.containsMessageType; } }));
 // Oneof helpers
-var oneof_1 = __nccwpck_require__(191);
+var oneof_1 = __nccwpck_require__(192);
 Object.defineProperty(exports, "isOneofGroup", ({ enumerable: true, get: function () { return oneof_1.isOneofGroup; } }));
 Object.defineProperty(exports, "setOneofValue", ({ enumerable: true, get: function () { return oneof_1.setOneofValue; } }));
 Object.defineProperty(exports, "getOneofValue", ({ enumerable: true, get: function () { return oneof_1.getOneofValue; } }));
@@ -3330,7 +3330,7 @@ const XML_CHARKEY = "_";
 /***/ 22:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(196)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(197)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -3421,15 +3421,15 @@ const {
   createDeferredPromise,
   fullyReadBody
 } = __nccwpck_require__(518)
-const { FormData } = __nccwpck_require__(208)
+const { FormData } = __nccwpck_require__(209)
 const { kState } = __nccwpck_require__(15)
 const { webidl } = __nccwpck_require__(457)
 const { DOMException, structuredClone } = __nccwpck_require__(30)
-const { Blob, File: NativeFile } = __nccwpck_require__(119)
-const { kBodyUsed } = __nccwpck_require__(196)
+const { Blob, File: NativeFile } = __nccwpck_require__(120)
+const { kBodyUsed } = __nccwpck_require__(197)
 const assert = __nccwpck_require__(527)
 const { isErrored } = __nccwpck_require__(69)
-const { isUint8Array, isArrayBuffer } = __nccwpck_require__(199)
+const { isUint8Array, isArrayBuffer } = __nccwpck_require__(200)
 const { File: UndiciFile } = __nccwpck_require__(365)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(25)
 
@@ -3451,7 +3451,7 @@ const textDecoder = new TextDecoder()
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 function extractBody (object, keepalive = false) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(257).ReadableStream)
+    ReadableStream = (__nccwpck_require__(258).ReadableStream)
   }
 
   // 1. Let stream be null.
@@ -3672,7 +3672,7 @@ function extractBody (object, keepalive = false) {
 function safelyExtractBody (object, keepalive = false) {
   if (!ReadableStream) {
     // istanbul ignore next
-    ReadableStream = (__nccwpck_require__(257).ReadableStream)
+    ReadableStream = (__nccwpck_require__(258).ReadableStream)
   }
 
   // To safely extract a body and a `Content-Type` value from
@@ -4030,7 +4030,7 @@ module.exports = {
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(527)
-const { atob } = __nccwpck_require__(119)
+const { atob } = __nccwpck_require__(120)
 const { isomorphicDecode } = __nccwpck_require__(518)
 
 const encoder = new TextEncoder()
@@ -4674,9 +4674,9 @@ module.exports = {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing AppendBlob operations. */
 class AppendBlobImpl {
@@ -5246,7 +5246,7 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tracingClient = void 0;
 const core_tracing_1 = __nccwpck_require__(82);
-const constants_js_1 = __nccwpck_require__(148);
+const constants_js_1 = __nccwpck_require__(149);
 /**
  * Creates a span using the global tracer.
  * @internal
@@ -5376,10 +5376,10 @@ const auth_1 = __nccwpck_require__(27);
 const fs = __importStar(__nccwpck_require__(532));
 const url_1 = __nccwpck_require__(85);
 const utils = __importStar(__nccwpck_require__(76));
-const uploadUtils_1 = __nccwpck_require__(160);
+const uploadUtils_1 = __nccwpck_require__(161);
 const downloadUtils_1 = __nccwpck_require__(3);
 const options_1 = __nccwpck_require__(266);
-const requestUtils_1 = __nccwpck_require__(261);
+const requestUtils_1 = __nccwpck_require__(262);
 const config_1 = __nccwpck_require__(37);
 const user_agent_1 = __nccwpck_require__(363);
 function getCacheApiUrl(resource) {
@@ -5835,9 +5835,9 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_https_proxy_agent = __nccwpck_require__(132);
-var import_http_proxy_agent = __nccwpck_require__(225);
-var import_log = __nccwpck_require__(151);
+var import_https_proxy_agent = __nccwpck_require__(133);
+var import_http_proxy_agent = __nccwpck_require__(226);
+var import_log = __nccwpck_require__(152);
 const HTTPS_PROXY = "HTTPS_PROXY";
 const HTTP_PROXY = "HTTP_PROXY";
 const ALL_PROXY = "ALL_PROXY";
@@ -6030,14 +6030,14 @@ const {
 } = __nccwpck_require__(30)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(15)
 const { webidl } = __nccwpck_require__(457)
-const { FormData } = __nccwpck_require__(208)
-const { getGlobalOrigin } = __nccwpck_require__(139)
+const { FormData } = __nccwpck_require__(209)
+const { getGlobalOrigin } = __nccwpck_require__(140)
 const { URLSerializer } = __nccwpck_require__(25)
-const { kHeadersList, kConstruct } = __nccwpck_require__(196)
+const { kHeadersList, kConstruct } = __nccwpck_require__(197)
 const assert = __nccwpck_require__(527)
-const { types } = __nccwpck_require__(123)
+const { types } = __nccwpck_require__(124)
 
-const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(257).ReadableStream)
+const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(258).ReadableStream)
 const textEncoder = new TextEncoder('utf-8')
 
 // https://fetch.spec.whatwg.org/#response-class
@@ -6671,7 +6671,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
-const pathHelper = __importStar(__nccwpck_require__(223));
+const pathHelper = __importStar(__nccwpck_require__(224));
 const internal_match_kind_1 = __nccwpck_require__(529);
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -6758,7 +6758,7 @@ exports.AzureLogger = void 0;
 exports.setLogLevel = setLogLevel;
 exports.getLogLevel = getLogLevel;
 exports.createClientLogger = createClientLogger;
-const logger_1 = __nccwpck_require__(147);
+const logger_1 = __nccwpck_require__(148);
 const context = (0, logger_1.createLoggerContext)({
     logLevelEnvVarName: "AZURE_LOG_LEVEL",
     namespace: "azure",
@@ -6910,9 +6910,9 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Blob operations. */
 class BlobImpl {
@@ -8062,8 +8062,8 @@ exports.containsMessageType = containsMessageType;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollHttpOperation = exports.isOperationError = exports.getResourceLocation = exports.getOperationStatus = exports.getOperationLocation = exports.initHttpOperation = exports.getStatusFromInitialResponse = exports.getErrorFromResponse = exports.parseRetryAfter = exports.inferLroMode = void 0;
-const operation_js_1 = __nccwpck_require__(140);
-const logger_js_1 = __nccwpck_require__(192);
+const operation_js_1 = __nccwpck_require__(141);
+const logger_js_1 = __nccwpck_require__(193);
 function getOperationLocationPollingUrl(inputs) {
     const { azureAsyncOperation, operationLocation } = inputs;
     return operationLocation !== null && operationLocation !== void 0 ? operationLocation : azureAsyncOperation;
@@ -8463,12 +8463,12 @@ const {
   kLastProgressEventFired
 } = __nccwpck_require__(461)
 const { ProgressEvent } = __nccwpck_require__(443)
-const { getEncoding } = __nccwpck_require__(97)
+const { getEncoding } = __nccwpck_require__(98)
 const { DOMException } = __nccwpck_require__(30)
 const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(25)
-const { types } = __nccwpck_require__(123)
-const { StringDecoder } = __nccwpck_require__(149)
-const { btoa } = __nccwpck_require__(119)
+const { types } = __nccwpck_require__(124)
+const { StringDecoder } = __nccwpck_require__(150)
+const { btoa } = __nccwpck_require__(120)
 
 /** @type {PropertyDescriptor} */
 const staticPropertyDescriptors = {
@@ -8980,9 +8980,9 @@ exports.UnaryCall = UnaryCall;
 "use strict";
 
 
-const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(98)
+const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(99)
 const { states, opcodes } = __nccwpck_require__(466)
-const { MessageEvent, ErrorEvent } = __nccwpck_require__(250)
+const { MessageEvent, ErrorEvent } = __nccwpck_require__(251)
 
 /* globals Blob */
 
@@ -9628,7 +9628,7 @@ const {
   ClientClosedError,
   InvalidArgumentError
 } = __nccwpck_require__(488)
-const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(196)
+const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(197)
 
 const kDestroyed = Symbol('destroyed')
 const kClosed = Symbol('closed')
@@ -9843,7 +9843,7 @@ __export(requestPolicyFactoryPolicy_exports, {
   requestPolicyFactoryPolicyName: () => requestPolicyFactoryPolicyName
 });
 module.exports = __toCommonJS(requestPolicyFactoryPolicy_exports);
-var import_util = __nccwpck_require__(109);
+var import_util = __nccwpck_require__(110);
 var import_response = __nccwpck_require__(413);
 var HttpPipelineLogLevel = /* @__PURE__ */ ((HttpPipelineLogLevel2) => {
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["ERROR"] = 1] = "ERROR";
@@ -9894,17 +9894,17 @@ function createRequestPolicyFactoryPolicy(factories) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const core_util_1 = __nccwpck_require__(14);
 const core_auth_1 = __nccwpck_require__(515);
 const storage_common_1 = __nccwpck_require__(278);
-const Pipeline_js_1 = __nccwpck_require__(183);
+const Pipeline_js_1 = __nccwpck_require__(184);
 const StorageClient_js_1 = __nccwpck_require__(455);
 const tracing_js_1 = __nccwpck_require__(31);
-const utils_common_js_1 = __nccwpck_require__(154);
+const utils_common_js_1 = __nccwpck_require__(155);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
-const BlobLeaseClient_js_1 = __nccwpck_require__(205);
-const Clients_js_1 = __nccwpck_require__(185);
+const BlobLeaseClient_js_1 = __nccwpck_require__(206);
+const Clients_js_1 = __nccwpck_require__(186);
 const BlobBatchClient_js_1 = __nccwpck_require__(403);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
@@ -11207,7 +11207,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.action3 = exports.action2 = exports.leaseId1 = exports.action1 = exports.proposedLeaseId = exports.duration = exports.action = exports.comp10 = exports.sourceLeaseId = exports.sourceContainerName = exports.comp9 = exports.deletedContainerVersion = exports.deletedContainerName = exports.comp8 = exports.containerAcl = exports.comp7 = exports.comp6 = exports.ifUnmodifiedSince = exports.ifModifiedSince = exports.leaseId = exports.preventEncryptionScopeOverride = exports.defaultEncryptionScope = exports.access = exports.metadata = exports.restype2 = exports.where = exports.comp5 = exports.multipartContentType = exports.contentLength = exports.comp4 = exports.body = exports.restype1 = exports.comp3 = exports.keyInfo = exports.include = exports.maxPageSize = exports.marker = exports.prefix = exports.comp2 = exports.comp1 = exports.accept1 = exports.requestId = exports.version = exports.timeoutInSeconds = exports.comp = exports.restype = exports.url = exports.accept = exports.blobServiceProperties = exports.contentType = void 0;
 exports.copySourceTags = exports.copySourceAuthorization = exports.sourceContentMD5 = exports.xMsRequiresSync = exports.legalHold1 = exports.sealBlob = exports.blobTagsString = exports.copySource = exports.sourceIfTags = exports.sourceIfNoneMatch = exports.sourceIfMatch = exports.sourceIfUnmodifiedSince = exports.sourceIfModifiedSince = exports.rehydratePriority = exports.tier = exports.comp14 = exports.encryptionScope = exports.legalHold = exports.comp13 = exports.immutabilityPolicyMode = exports.immutabilityPolicyExpiry = exports.comp12 = exports.blobContentDisposition = exports.blobContentLanguage = exports.blobContentEncoding = exports.blobContentMD5 = exports.blobContentType = exports.blobCacheControl = exports.expiresOn = exports.expiryOptions = exports.comp11 = exports.blobDeleteType = exports.deleteSnapshots = exports.ifTags = exports.ifNoneMatch = exports.ifMatch = exports.encryptionAlgorithm = exports.encryptionKeySha256 = exports.encryptionKey = exports.rangeGetContentCRC64 = exports.rangeGetContentMD5 = exports.range = exports.versionId = exports.snapshot = exports.delimiter = exports.startFrom = exports.include1 = exports.proposedLeaseId1 = exports.action4 = exports.breakPeriod = void 0;
 exports.listType = exports.comp25 = exports.blocks = exports.blockId = exports.comp24 = exports.copySourceBlobProperties = exports.blobType2 = exports.comp23 = exports.sourceRange1 = exports.appendPosition = exports.maxSize = exports.comp22 = exports.blobType1 = exports.comp21 = exports.sequenceNumberAction = exports.prevSnapshotUrl = exports.prevsnapshot = exports.comp20 = exports.range1 = exports.sourceContentCrc64 = exports.sourceRange = exports.sourceUrl = exports.pageWrite1 = exports.ifSequenceNumberEqualTo = exports.ifSequenceNumberLessThan = exports.ifSequenceNumberLessThanOrEqualTo = exports.pageWrite = exports.comp19 = exports.accept2 = exports.body1 = exports.contentType1 = exports.blobSequenceNumber = exports.blobContentLength = exports.blobType = exports.transactionalContentCrc64 = exports.transactionalContentMD5 = exports.tags = exports.ifNoneMatch1 = exports.ifMatch1 = exports.ifUnmodifiedSince1 = exports.ifModifiedSince1 = exports.comp18 = exports.comp17 = exports.queryRequest = exports.tier1 = exports.comp16 = exports.copyId = exports.copyActionAbortConstant = exports.comp15 = exports.fileRequestIntent = void 0;
-const mappers_js_1 = __nccwpck_require__(180);
+const mappers_js_1 = __nccwpck_require__(181);
 exports.contentType = {
     parameterPath: ["options", "contentType"],
     mapper: {
@@ -12921,8 +12921,8 @@ const ContainerSASPermissions_js_1 = __nccwpck_require__(281);
 const storage_common_1 = __nccwpck_require__(278);
 const SasIPRange_js_1 = __nccwpck_require__(361);
 const SASQueryParameters_js_1 = __nccwpck_require__(526);
-const constants_js_1 = __nccwpck_require__(148);
-const utils_common_js_1 = __nccwpck_require__(154);
+const constants_js_1 = __nccwpck_require__(149);
+const utils_common_js_1 = __nccwpck_require__(155);
 const storage_common_2 = __nccwpck_require__(278);
 function generateBlobSASQueryParameters(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName) {
     return generateBlobSASQueryParametersInternal(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName).sasQueryParameters;
@@ -13590,14 +13590,14 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 
 
 const assert = __nccwpck_require__(527)
-const { kDestroyed, kBodyUsed } = __nccwpck_require__(196)
+const { kDestroyed, kBodyUsed } = __nccwpck_require__(197)
 const { IncomingMessage } = __nccwpck_require__(329)
-const stream = __nccwpck_require__(130)
+const stream = __nccwpck_require__(131)
 const net = __nccwpck_require__(509)
 const { InvalidArgumentError } = __nccwpck_require__(488)
-const { Blob } = __nccwpck_require__(119)
-const nodeUtil = __nccwpck_require__(123)
-const { stringify } = __nccwpck_require__(129)
+const { Blob } = __nccwpck_require__(120)
+const nodeUtil = __nccwpck_require__(124)
+const { stringify } = __nccwpck_require__(130)
 const { headerNameLowerCasedRecord } = __nccwpck_require__(73)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
@@ -13967,7 +13967,7 @@ async function * convertIterableToBuffer (iterable) {
 let ReadableStream
 function ReadableStreamFrom (iterable) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(257).ReadableStream)
+    ReadableStream = (__nccwpck_require__(258).ReadableStream)
   }
 
   if (ReadableStream.from) {
@@ -14147,7 +14147,7 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(184);
+var import_log = __nccwpck_require__(185);
 var import_policies = __nccwpck_require__(287);
 const logPolicyName = import_policies.logPolicyName;
 function logPolicy(options = {}) {
@@ -14194,12 +14194,12 @@ __export(src_exports, {
   toHttpHeadersLike: () => import_util.toHttpHeadersLike
 });
 module.exports = __toCommonJS(src_exports);
-var import_extendedClient = __nccwpck_require__(216);
+var import_extendedClient = __nccwpck_require__(217);
 var import_response = __nccwpck_require__(413);
 var import_requestPolicyFactoryPolicy = __nccwpck_require__(63);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_httpClientAdapter = __nccwpck_require__(211);
-var import_util = __nccwpck_require__(109);
+var import_httpClientAdapter = __nccwpck_require__(212);
+var import_util = __nccwpck_require__(110);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -14373,7 +14373,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StatsCollector = void 0;
-const fs = __importStar(__nccwpck_require__(108));
+const fs = __importStar(__nccwpck_require__(109));
 const path = __importStar(__nccwpck_require__(508));
 const core = __importStar(__nccwpck_require__(460));
 function fmtBytes(n) {
@@ -14991,13 +14991,13 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
 const core = __importStar(__nccwpck_require__(460));
 const exec = __importStar(__nccwpck_require__(18));
-const glob = __importStar(__nccwpck_require__(168));
+const glob = __importStar(__nccwpck_require__(169));
 const io = __importStar(__nccwpck_require__(296));
 const crypto = __importStar(__nccwpck_require__(292));
 const fs = __importStar(__nccwpck_require__(532));
-const path = __importStar(__nccwpck_require__(248));
-const semver = __importStar(__nccwpck_require__(179));
-const util = __importStar(__nccwpck_require__(123));
+const path = __importStar(__nccwpck_require__(249));
+const semver = __importStar(__nccwpck_require__(180));
+const util = __importStar(__nccwpck_require__(124));
 const constants_1 = __nccwpck_require__(45);
 const versionSalt = '1.0';
 // From https://github.com/actions/toolkit/blob/main/packages/tool-cache/src/tool-cache.ts#L23
@@ -15187,7 +15187,7 @@ exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
 const node_crypto_1 = __nccwpck_require__(276);
 const constants_js_1 = __nccwpck_require__(36);
 const utils_common_js_1 = __nccwpck_require__(474);
-const SharedKeyComparator_js_1 = __nccwpck_require__(177);
+const SharedKeyComparator_js_1 = __nccwpck_require__(178);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
  */
@@ -15368,7 +15368,7 @@ exports.isGitRepo = isGitRepo;
 exports.listTrackedFiles = listTrackedFiles;
 exports.normalizeWorkspace = normalizeWorkspace;
 exports.normalizeSourceMtime = normalizeSourceMtime;
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const path = __importStar(__nccwpck_require__(508));
 const exec = __importStar(__nccwpck_require__(18));
 const log_utils_js_1 = __nccwpck_require__(354);
@@ -15952,9 +15952,9 @@ const {
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(15)
 const { webidl } = __nccwpck_require__(457)
-const { getGlobalOrigin } = __nccwpck_require__(139)
+const { getGlobalOrigin } = __nccwpck_require__(140)
 const { URLSerializer } = __nccwpck_require__(25)
-const { kHeadersList, kConstruct } = __nccwpck_require__(196)
+const { kHeadersList, kConstruct } = __nccwpck_require__(197)
 const assert = __nccwpck_require__(527)
 const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(470)
 
@@ -16443,7 +16443,7 @@ class Request {
 
       // 2. Set finalBody to the result of creating a proxy for inputBody.
       if (!TransformStream) {
-        TransformStream = (__nccwpck_require__(257).TransformStream)
+        TransformStream = (__nccwpck_require__(258).TransformStream)
       }
 
       // https://streams.spec.whatwg.org/#readablestream-create-a-proxy
@@ -16892,8 +16892,8 @@ module.exports = require("url");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.deserializationPolicyName = void 0;
 exports.deserializationPolicy = deserializationPolicy;
-const interfaces_js_1 = __nccwpck_require__(99);
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const interfaces_js_1 = __nccwpck_require__(100);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const serializer_js_1 = __nccwpck_require__(480);
 const operationHelpers_js_1 = __nccwpck_require__(433);
 const defaultJsonContentTypes = ["application/json", "text/json"];
@@ -17188,7 +17188,7 @@ function apiKeyAuthenticationPolicy(options) {
 const assert = __nccwpck_require__(527)
 const net = __nccwpck_require__(509)
 const http = __nccwpck_require__(329)
-const { pipeline } = __nccwpck_require__(130)
+const { pipeline } = __nccwpck_require__(131)
 const util = __nccwpck_require__(69)
 const timers = __nccwpck_require__(328)
 const Request = __nccwpck_require__(300)
@@ -17259,7 +17259,7 @@ const {
   kHTTP2BuildRequest,
   kHTTP2CopyHeaders,
   kHTTP1BuildRequest
-} = __nccwpck_require__(196)
+} = __nccwpck_require__(197)
 
 /** @type {import('http2')} */
 let http2
@@ -17292,7 +17292,7 @@ const kClosedResolve = Symbol('kClosedResolve')
 const channels = {}
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(141)
+  const diagnosticsChannel = __nccwpck_require__(142)
   channels.sendHeaders = diagnosticsChannel.channel('undici:client:sendHeaders')
   channels.beforeConnect = diagnosticsChannel.channel('undici:client:beforeConnect')
   channels.connectError = diagnosticsChannel.channel('undici:client:connectError')
@@ -17666,7 +17666,7 @@ function onHTTP2GoAway (code) {
 }
 
 const constants = __nccwpck_require__(449)
-const createRedirectInterceptor = __nccwpck_require__(255)
+const createRedirectInterceptor = __nccwpck_require__(256)
 const EMPTY_BUF = Buffer.alloc(0)
 
 async function lazyllhttp () {
@@ -19507,14 +19507,14 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 var import_AbortError = __nccwpck_require__(10);
-var import_logger = __nccwpck_require__(246);
+var import_logger = __nccwpck_require__(247);
 var import_httpHeaders = __nccwpck_require__(485);
-var import_pipelineRequest = __nccwpck_require__(115);
+var import_pipelineRequest = __nccwpck_require__(116);
 var import_pipeline = __nccwpck_require__(525);
 var import_restError = __nccwpck_require__(445);
 var import_bytesEncoding = __nccwpck_require__(288);
 var import_defaultHttpClient = __nccwpck_require__(373);
-var import_getClient = __nccwpck_require__(210);
+var import_getClient = __nccwpck_require__(211);
 var import_operationOptionHelpers = __nccwpck_require__(384);
 var import_restError2 = __nccwpck_require__(369);
 // Annotate the CommonJS export names for ESM import in node:
@@ -19532,7 +19532,7 @@ var import_restError2 = __nccwpck_require__(369);
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
 const base64_1 = __nccwpck_require__(304);
-const pb_long_1 = __nccwpck_require__(117);
+const pb_long_1 = __nccwpck_require__(118);
 const reflection_info_1 = __nccwpck_require__(453);
 const assert_1 = __nccwpck_require__(484);
 /**
@@ -19943,6 +19943,859 @@ exports.AnonymousCredentialPolicy = AnonymousCredentialPolicy;
 /***/ }),
 
 /***/ 94:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr entry point. Owned by Agent 2.
+//
+// Replaces the composite action's main-phase steps with a single JS
+// orchestrator. Calls the helpers in src/lib/* in the same order the
+// composite's steps fire.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(250));
+const os = __importStar(__nccwpck_require__(383));
+const path = __importStar(__nccwpck_require__(508));
+const core = __importStar(__nccwpck_require__(460));
+const cache = __importStar(__nccwpck_require__(216));
+const log_utils_js_1 = __nccwpck_require__(354);
+const resolve_setup_js_1 = __nccwpck_require__(190);
+const phase_timing_js_1 = __nccwpck_require__(337);
+const ensure_rust_toolchain_js_1 = __nccwpck_require__(512);
+const ensure_soldr_js_1 = __nccwpck_require__(340);
+const verify_soldr_js_1 = __nccwpck_require__(360);
+const install_passthrough_js_1 = __nccwpck_require__(514);
+const normalize_source_mtime_js_1 = __nccwpck_require__(79);
+const detect_shared_target_warning_js_1 = __nccwpck_require__(220);
+const ensure_shims_js_1 = __nccwpck_require__(530);
+const cache_compress_js_1 = __nccwpck_require__(493);
+const stats_collector_js_1 = __nccwpck_require__(74);
+const toolchain_snapshot_js_1 = __nccwpck_require__(459);
+const solo_toolchain_cache_js_1 = __nccwpck_require__(295);
+const cook_cache_js_1 = __nccwpck_require__(171);
+const soldr_mini_cache_js_1 = __nccwpck_require__(158);
+const diagnostics_js_1 = __nccwpck_require__(112);
+const source_mtime_snapshot_js_1 = __nccwpck_require__(408);
+/**
+ * Map (hit, matchedKey) → workflow-visible restore-status string.
+ * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
+ * for the `<layer>-cache-restore-status` outputs declared in action.yml.
+ */
+function deriveRestoreStatus(hit, matchedKey) {
+    if (hit)
+        return "exact-hit";
+    if (matchedKey.trim())
+        return "restore-key-hit";
+    return "miss";
+}
+function writeCacheKeysManifest(result, runnerTemp, log) {
+    if (!runnerTemp)
+        return;
+    const keys = [
+        result.setupCache.key,
+        result.buildCache.key,
+        result.targetCache.key,
+        result.cargoRegistryCache.key,
+    ].filter((k) => Boolean(k));
+    if (keys.length === 0)
+        return;
+    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
+    try {
+        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
+        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
+    }
+    catch (err) {
+        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+function isTruthy(value) {
+    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
+}
+function isFalsy(value) {
+    return FALSY.has(((value ?? "").trim().toLowerCase()));
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+function dirHasContent(p) {
+    try {
+        return fs.readdirSync(p).length > 0;
+    }
+    catch {
+        return false;
+    }
+}
+function buildActionContext() {
+    const env = process.env;
+    const logger = (0, log_utils_js_1.createLogger)(env);
+    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
+    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
+    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
+    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
+    const githubSha = env["GITHUB_SHA"]?.trim() || "";
+    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
+    const parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
+    return {
+        env: { ...env },
+        workspace,
+        runnerTemp,
+        runnerOs,
+        runnerArch,
+        githubSha,
+        githubToken,
+        parentSha,
+        logger,
+    };
+}
+async function restoreCacheSafe(paths, key, restoreKeys, logger) {
+    if (paths.length === 0 || !key) {
+        return { hit: false, matchedKey: "" };
+    }
+    try {
+        const matched = await cache.restoreCache(paths, key, restoreKeys);
+        return { hit: matched === key, matchedKey: matched ?? "" };
+    }
+    catch (err) {
+        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "" };
+    }
+}
+async function run() {
+    const ctx = buildActionContext();
+    const logger = ctx.logger;
+    await (0, phase_timing_js_1.markPhase)("action");
+    // ---- resolve ----
+    await (0, phase_timing_js_1.markPhase)("resolve");
+    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
+    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
+    await (0, resolve_setup_js_1.applyResolveResult)(result);
+    await (0, phase_timing_js_1.finishPhase)("resolve");
+    // Always emit the cache-keys manifest right after resolve so workflow
+    // steps that run between main and post (e.g. actions/upload-artifact)
+    // can read it. The four keys are fully determined by resolveSetup and
+    // never change later in the run.
+    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
+    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            logger,
+            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
+        });
+    }
+    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
+    if (dryRun) {
+        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
+        await (0, phase_timing_js_1.finishPhase)("action");
+        return;
+    }
+    // Persist resolve state for the post-job step.
+    core.saveState("resolveResult", JSON.stringify(result));
+    core.saveState("buildCacheMode", result.buildCache.mode);
+    core.saveState("logging", logging ? "true" : "false");
+    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
+    const statsMode = result.stats;
+    const debugMode = result.debugMode;
+    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
+    const statsCollector = new stats_collector_js_1.StatsCollector();
+    // ---- source-mtime-normalize ----
+    if (isTruthy(inputs.sourceMtimeNormalize)) {
+        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
+    }
+    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
+    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
+    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
+    core.saveState("setupCacheExactHit", "false");
+    core.saveState("setupCacheMatchedKey", "");
+    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
+    core.saveState("targetCacheExactHit", "false");
+    core.saveState("targetCacheMatchedKey", "");
+    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
+    core.saveState("buildCacheExactHit", "false");
+    core.saveState("buildCacheMatchedKey", "");
+    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
+    core.saveState("cargoRegistryCacheExactHit", "false");
+    core.saveState("cargoRegistryCacheMatchedKey", "");
+    // Pre-compute cook key + paths so cook restore can join the parallel
+    // block when safe. Cook RUN still happens in the cook phase later
+    // (it needs the soldr binary). Cook RESTORE just untars an archive
+    // into target/ — no soldr dependency.
+    const cookGate = (0, cook_cache_js_1.decideCookGate)({
+        prebuildDeps: inputs.prebuildDeps,
+        cacheUmbrella: cacheEnabled,
+        lockfilePath: result.targetCache.lockfilePath,
+    });
+    const cookEnabled = cookGate.enabled && result.enabled;
+    let cookFlags = [];
+    let cookKey = "";
+    let cookProjectRoot = "";
+    let cookTargetDir = "";
+    let cookArchive = "";
+    if (cookEnabled) {
+        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
+        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
+        const lockHash = result.targetCache.lockfileHash || "no-lock";
+        cookKey = (0, cook_cache_js_1.buildCookCacheKey)({
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            flagsHash,
+            lockHash,
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        });
+        cookProjectRoot = path.dirname(result.targetCache.targetPath);
+        cookTargetDir = result.targetCache.targetPath;
+        cookArchive = `${cookTargetDir}.tar.zst`;
+    }
+    // Cook restore can race with target-cache restore when target-cache is
+    // configured to write to target/ (i.e. `build-cache-mode: full`). In all
+    // other modes (`once`/`thin`), target-cache writes only the rust-plan
+    // bundle to a separate path — no conflict. Gate the parallel-join on
+    // path disjointness.
+    const targetCachePathsList = result.targetCache.paths
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    const cookCanParallelize = cookEnabled &&
+        !targetCachePathsList.some((p) => path.resolve(p) === path.resolve(cookTargetDir));
+    let cookRestoreResultParallel = null;
+    // ---- parallel restores ----
+    // setup-cache, target-cache, build-cache, cargo-registry, and (conditionally)
+    // cook-cache write to disjoint paths and have no inter-dependencies, so they
+    // run concurrently. Sequential previously: ~18s on warm runs. Parallel: ~8s.
+    // Cook restore joins when target-cache doesn't write target/ (i.e. modes
+    // other than `full`) — saves another ~5s when applicable.
+    //
+    // Layers that must stay sequential (wired below): solo-toolchain (writes
+    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
+    // install dir, must precede ensureSoldr), cook RUN (needs
+    // the soldr binary). Cargo-registry was previously after-cook — it's been
+    // moved into this parallel block because nothing the soldr install path
+    // touches depends on its hydrated cargo registry state.
+    await (0, phase_timing_js_1.markPhase)("parallel-restore");
+    let setupCacheExactHit = false;
+    const setupRestorePromise = (async () => {
+        if (!(cacheEnabled && result.setupCache.paths.length > 0))
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
+        setupCacheExactHit = restore.hit;
+        core.setOutput("cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("setup_cache_matched_key", restore.matchedKey);
+        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("setupCacheMatchedKey", restore.matchedKey);
+        // Expose for ensure_rust_toolchain to read via env. Must be visible by
+        // the time toolchain phase runs — guaranteed by the Promise.all below.
+        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
+        statsCollector.record({
+            label: "setup-cache", operation: "restore", hit: restore.hit,
+            key: result.setupCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.setupCache.restorePrefix],
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const targetRestorePromise = (async () => {
+        if (!result.targetCache.enabled)
+            return;
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (targetPaths.length === 0)
+            return;
+        const restoreKeys = [];
+        if (result.targetCache.restoreKeyParent)
+            restoreKeys.push(result.targetCache.restoreKeyParent);
+        if (result.targetCache.restoreKeyLock)
+            restoreKeys.push(result.targetCache.restoreKeyLock);
+        if (result.targetCache.restoreKeyLockfile)
+            restoreKeys.push(result.targetCache.restoreKeyLockfile);
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
+        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("target_cache_matched_key", restore.matchedKey);
+        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("targetCacheMatchedKey", restore.matchedKey);
+        statsCollector.record({
+            label: "target-cache", operation: "restore", hit: restore.hit,
+            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const buildRestorePromise = (async () => {
+        if (!buildCacheEnabled)
+            return;
+        const buildCachePath = result.buildCache.path;
+        const archivePath = `${buildCachePath}.tar.zst`;
+        const restoreKeys = [];
+        if (result.buildCache.restoreKeyParent)
+            restoreKeys.push(result.buildCache.restoreKeyParent);
+        if (result.buildCache.restoreKeyToolchain)
+            restoreKeys.push(result.buildCache.restoreKeyToolchain);
+        if (result.buildCache.restoreKeyOsArch)
+            restoreKeys.push(result.buildCache.restoreKeyOsArch);
+        const t0 = Date.now();
+        // @actions/cache hashes the `paths` array into a "version" key — save and
+        // restore MUST pass the same array or the lookup misses even when the
+        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
+        // restore must use the same single-path array. The decompression below
+        // unpacks archivePath → buildCachePath afterwards.
+        const restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
+        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("build_cache_matched_key", restore.matchedKey);
+        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("buildCacheMatchedKey", restore.matchedKey);
+        let buildArchiveBytes = null;
+        let buildInflatedBytes = null;
+        let buildFileCount = null;
+        if (fileExists(archivePath)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+            if (magic === "zstd" || magic === "gzip") {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath, debug: debugMode, log: debugLog });
+                    buildArchiveBytes = dr.archiveBytes;
+                    buildInflatedBytes = dr.inflatedBytes;
+                    buildFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
+        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
+        // dir on the cold side; if it's present after decompress, walk it and
+        // set each matching source file's mtime to what cold saw. The replay
+        // is gated by (size, content-hash) match so we never overwrite a
+        // genuinely modified file's mtime — that would underbuild.
+        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
+            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
+            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
+            if (snapshot) {
+                const rt0 = Date.now();
+                try {
+                    // Match the project-root selection that post.ts uses when
+                    // writing the snapshot — the parent of the resolved target-dir,
+                    // not the (outer) GITHUB_WORKSPACE.
+                    const projectRoot = path.dirname(result.targetCache.targetPath);
+                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
+                        workspace: projectRoot,
+                        snapshot,
+                        log: (msg) => logger.log(msg),
+                    });
+                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
+                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
+                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
+                }
+                catch (err) {
+                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+            else {
+                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
+            }
+        }
+        statsCollector.record({
+            label: "build-cache", operation: "restore", hit: restore.hit,
+            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    })();
+    // Cargo-registry restore moved here from after-cook. It writes only
+    // $CARGO_HOME/registry/ and has no dependency on soldr being installed;
+    // running it in parallel with target+build trims its ~5s off the critical
+    // path.
+    const cargoRegistryRestorePromise = (async () => {
+        if (!result.cargoRegistryCache.enabled)
+            return;
+        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe([registryArchive], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
+        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
+        let regArchiveBytes = null;
+        let regInflatedBytes = null;
+        let regFileCount = null;
+        if (fileExists(registryArchive)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
+            if (magic === "zstd" || magic === "gzip") {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({
+                        archivePath: registryArchive,
+                        targetDir: result.cargoRegistryCache.path,
+                        debug: debugMode, log: debugLog,
+                    });
+                    regArchiveBytes = dr.archiveBytes;
+                    regInflatedBytes = dr.inflatedBytes;
+                    regFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        statsCollector.record({
+            label: "cargo-registry", operation: "restore", hit: restore.hit,
+            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.cargoRegistryCache.restorePrefix],
+            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    })();
+    // Cook restore — joins the parallel block when target-cache won't be
+    // writing to the same target/ dir. See the gate computed above. When
+    // we skip this IIFE, the cook phase falls back to its sequential
+    // restore later.
+    const cookRestorePromise = (async () => {
+        if (!cookCanParallelize)
+            return;
+        logger.log(`cook: key=${cookKey} project=${cookProjectRoot} target=${cookTargetDir}`);
+        const t0 = Date.now();
+        const restore = await (0, cook_cache_js_1.restoreCookCache)({
+            exactKey: cookKey,
+            archivePath: cookArchive,
+            targetDir: cookTargetDir,
+            longWindow: 27,
+            debug: debugMode,
+            log: (msg) => logger.log(msg),
+        });
+        cookRestoreResultParallel = restore;
+        statsCollector.record({
+            label: "cook-cache", operation: "restore", hit: restore.hit,
+            key: cookKey, matchedKey: restore.matchedKey, restoreKeys: [],
+            archiveBytes: restore.archiveBytes || null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    })();
+    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
+    // try/catches, so this should only see rejections for genuine programming
+    // bugs.
+    await Promise.all([
+        setupRestorePromise,
+        targetRestorePromise,
+        buildRestorePromise,
+        cargoRegistryRestorePromise,
+        cookRestorePromise,
+    ]);
+    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
+    // ---- target-tree-cache (full mode) ----
+    // The bundle path is included in target-cache restore paths above when full
+    // mode is requested, so there's no separate restore here. We keep the phase
+    // marker for parity with the composite step ordering.
+    await (0, phase_timing_js_1.markPhase)("target-tree");
+    await (0, phase_timing_js_1.finishPhase)("target-tree");
+    // ---- toolchain ----
+    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
+    // toolchain install so we can see which inodes setup-soldr added on
+    // top of the runner image. When solo-toolchain-cache is opted in, a
+    // third snapshot is taken *before* the cache restore so the saved
+    // tarball captures the full above-runner state — not just the
+    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
+    // lifetime axis".
+    await (0, phase_timing_js_1.markPhase)("toolchain");
+    const snapshotRoots = [
+        path.join(result.rustupHome, "toolchains"),
+        path.join(result.cargoHome, "bin"),
+    ];
+    const soloRootMap = {
+        "rustup-toolchains": snapshotRoots[0],
+        "cargo-bin": snapshotRoots[1],
+    };
+    const soloEnabled = isTruthy(inputs.soloToolchainCache);
+    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "19");
+    let soloKeys = null;
+    let soloMatchedKey = "";
+    let soloExactHit = false;
+    // Pre-restore snapshot — only needed when solo cache is enabled, so
+    // we can compute the full save-diff (post-install vs runner-image,
+    // not vs post-restore baseline).
+    const preRestoreSnapshot = soloEnabled ? await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots) : null;
+    if (soloEnabled) {
+        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
+            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        });
+        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
+        const restoreT0 = Date.now();
+        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
+        const restored = await (0, solo_toolchain_cache_js_1.restoreSoloCache)({
+            keys: soloKeys,
+            rootMap: soloRootMap,
+            stagingDir,
+            log: (msg) => logger.log(msg),
+        });
+        soloMatchedKey = restored.matchedKey;
+        let verifiedMatch = true;
+        if (restored.verified && restored.matchedKey) {
+            const expected = result.toolchain.cacheChannel.trim();
+            // The rustup home is set up so `rustc` will resolve through the
+            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
+            // the cargo bin one.
+            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
+            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
+                expectedRelease: expected,
+                rustcCommand: rustcCmd,
+                log: (msg) => logger.log(msg),
+            });
+            verifiedMatch = verify.match;
+        }
+        soloExactHit = restored.hit && verifiedMatch;
+        core.saveState("soloToolchainEnabled", "true");
+        core.saveState("soloToolchainExactKey", soloKeys.exact);
+        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
+        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
+        core.saveState("soloToolchainLevel", soloLevel);
+        statsCollector.record({
+            label: "solo-toolchain-cache",
+            operation: "restore",
+            hit: soloExactHit,
+            key: soloKeys.exact,
+            matchedKey: soloMatchedKey,
+            restoreKeys: soloKeys.fallbacks,
+            archiveBytes: restored.restoredBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - restoreT0,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    else {
+        core.saveState("soloToolchainEnabled", "false");
+    }
+    const baselineSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
+    await (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({ resolveResult: result, setupCacheExactHit });
+    const postInstallSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
+    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
+    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
+    // When solo cache is enabled, also compute the save-diff (post-install
+    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
+    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
+        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
+        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
+        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
+        try {
+            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
+            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
+            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
+            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
+                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
+                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
+                `incremental-empty=${toolchainDiff.added.length === 0}`);
+        }
+        catch (err) {
+            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
+        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
+    if (ctx.runnerTemp) {
+        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
+        try {
+            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
+            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
+        }
+        catch (err) {
+            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    await (0, phase_timing_js_1.finishPhase)("toolchain");
+    // ---- install soldr ----
+    // Try the soldr-mini-cache before ensureSoldr fires the GH Releases fetch.
+    // On hit, the install dir is pre-populated and ensureSoldr's existing
+    // installedVersion() check short-circuits. On miss, ensureSoldr does its
+    // normal fetch and post.ts saves to the mini-cache.
+    await (0, phase_timing_js_1.markPhase)("install");
+    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
+    const miniInstallDir = path.dirname(result.soldrPath);
+    const miniArchive = `${miniInstallDir}.tar.zst`;
+    let miniHit = false;
+    let miniKey = "";
+    if (miniEnabled) {
+        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
+            hasRef: Boolean(result.soldrRef.trim()),
+            enable: result.enabled,
+            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
+        });
+        if (eligibility.eligible) {
+            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
+            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
+                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+                soldrVersion: version,
+            });
+            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir}`);
+            const miniT0 = Date.now();
+            const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
+                exactKey: miniKey,
+                installDir: miniInstallDir,
+                archivePath: miniArchive,
+                longWindow: 27,
+                debug: debugMode,
+                log: (msg) => logger.log(msg),
+            });
+            miniHit = restore.hit;
+            statsCollector.record({
+                label: "soldr-mini-cache",
+                operation: "restore",
+                hit: restore.hit,
+                key: miniKey,
+                matchedKey: restore.matchedKey,
+                restoreKeys: [],
+                archiveBytes: restore.archiveBytes || null,
+                inflatedBytes: null,
+                fileCount: null,
+                durationMs: Date.now() - miniT0,
+                timestamp: new Date().toISOString(),
+            });
+        }
+        else {
+            logger.log(`soldr-mini-cache: skipped — ${eligibility.reason}`);
+        }
+    }
+    else {
+        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
+    }
+    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
+    core.saveState("soldrMiniExactKey", miniKey);
+    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
+    core.saveState("soldrMiniInstallDir", miniInstallDir);
+    core.saveState("soldrMiniArchive", miniArchive);
+    if (result.enabled) {
+        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
+        // restored binary at the expected path with the expected version and
+        // short-circuits — no GH fetch.
+        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
+    }
+    else {
+        (0, install_passthrough_js_1.installPassthrough)({
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
+            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
+            "verbatim, and soldr-aware caching/observability is disabled.");
+    }
+    await (0, phase_timing_js_1.finishPhase)("install");
+    // Export SOLDR_BINARY so shims can exec it directly
+    core.exportVariable("SOLDR_BINARY", result.soldrPath);
+    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
+    // ---- shims ----
+    if (result.shimsEnabled) {
+        await (0, ensure_shims_js_1.ensureShims)({
+            shimsDir: result.shimsDir,
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+    }
+    // ---- verify ----
+    await (0, phase_timing_js_1.markPhase)("verify");
+    if (result.enabled) {
+        const verify = await (0, verify_soldr_js_1.verifySoldr)({
+            soldrPath: result.soldrPath,
+            buildCacheMode: result.buildCache.mode,
+            requireRustPlan: result.targetCache.enabled,
+        });
+        core.setOutput("soldr-version", verify.soldrVersion);
+        core.setOutput("soldr_version", verify.soldrVersion);
+    }
+    else {
+        core.setOutput("soldr-version", "passthrough");
+        core.setOutput("soldr_version", "passthrough");
+    }
+    await (0, phase_timing_js_1.finishPhase)("verify");
+    // ---- cook (prebuild-deps via cargo-chef) ----
+    // Long-lived deps tarball keyed on Cargo.lock content. When safe (see
+    // the cook gate above) the RESTORE happens in the parallel block; we
+    // pick up its result here and only run the actual cook step if the
+    // restore missed. In `build-cache-mode: full` workflows the restore
+    // can't safely parallelize, so we do it here sequentially.
+    // Failures here are logged but never fail the action — the user's
+    // own cargo build will still work without the cooked deps.
+    await (0, phase_timing_js_1.markPhase)("cook");
+    if (cookEnabled) {
+        let restore;
+        if (cookRestoreResultParallel) {
+            restore = cookRestoreResultParallel;
+        }
+        else {
+            // Sequential fallback path — used when target-cache writes to the same
+            // target/ dir (mode: full) and we couldn't safely parallelize.
+            logger.log(`cook: key=${cookKey} project=${cookProjectRoot} target=${cookTargetDir}`);
+            const cookT0 = Date.now();
+            restore = await (0, cook_cache_js_1.restoreCookCache)({
+                exactKey: cookKey,
+                archivePath: cookArchive,
+                targetDir: cookTargetDir,
+                longWindow: 27,
+                debug: debugMode,
+                log: (msg) => logger.log(msg),
+            });
+            statsCollector.record({
+                label: "cook-cache",
+                operation: "restore",
+                hit: restore.hit,
+                key: cookKey,
+                matchedKey: restore.matchedKey,
+                restoreKeys: [],
+                archiveBytes: restore.archiveBytes || null,
+                inflatedBytes: null,
+                fileCount: null,
+                durationMs: Date.now() - cookT0,
+                timestamp: new Date().toISOString(),
+            });
+        }
+        let cookRan = false;
+        if (!restore.hit) {
+            const runRes = await (0, cook_cache_js_1.runCook)({
+                soldrBinary: result.soldrPath,
+                projectRoot: cookProjectRoot,
+                flags: cookFlags,
+                log: (msg) => logger.log(msg),
+            });
+            cookRan = runRes.exitCode === 0;
+        }
+        else {
+            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
+        }
+        core.saveState("cookEnabled", "true");
+        core.saveState("cookExactKey", cookKey);
+        core.saveState("cookMatchedKey", restore.matchedKey);
+        core.saveState("cookHit", restore.hit ? "true" : "false");
+        core.saveState("cookRan", cookRan ? "true" : "false");
+        core.saveState("cookTargetDir", cookTargetDir);
+        core.saveState("cookLongWindow", "27");
+        core.saveState("cookCompressLevel", "19");
+    }
+    else {
+        logger.log(`cook: skipped - ${cookGate.reason}`);
+        core.saveState("cookEnabled", "false");
+    }
+    await (0, phase_timing_js_1.finishPhase)("cook");
+    // ---- shared-target warning ----
+    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
+        buildCacheEnabled,
+        effectiveTargetCacheEnabled: result.targetCache.enabled,
+        buildCacheMode: result.buildCache.mode,
+        targetDir: result.targetCache.targetPath,
+    });
+    // ---- stats report ----
+    statsCollector.report(statsMode, (msg) => logger.log(msg));
+    if (statsMode === "detailed") {
+        try {
+            await statsCollector.writeFiles(ctx.runnerTemp);
+            statsCollector.setGithubOutputs();
+        }
+        catch (err) {
+            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    core.saveState("statsCollector", statsCollector.serialize());
+    core.saveState("statsMode", statsMode);
+    core.saveState("compileCacheStats", result.compileCacheStats);
+    core.saveState("runnerTemp", ctx.runnerTemp);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            cacheOutcomes: statsCollector.snapshot(),
+            logger,
+        });
+    }
+    await (0, phase_timing_js_1.finishPhase)("action");
+    // dirHasContent is exported for tests; suppress unused warning here.
+    void dirHasContent;
+}
+// Auto-invoke only when this module is run as the main entry point. This lets
+// tests import `run` (and helpers) without triggering the side-effectful
+// orchestration. The dist/main.js produced by ncc is invoked directly by the
+// Actions runtime so the check trips and the action executes normally.
+if (typeof process !== "undefined" &&
+    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
+    // import.meta.url is the file URL of this module; argv[1] is the runner
+    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
+    // the dev path — we rely on the env-var opt-out for tests instead.
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    run().catch((err) => {
+        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        core.setFailed(`setup-soldr failed: ${message}`);
+    });
+}
+
+
+/***/ }),
+
+/***/ 95:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20294,7 +21147,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 95:
+/***/ 96:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20323,7 +21176,7 @@ exports.Credential = Credential;
 
 /***/ }),
 
-/***/ 96:
+/***/ 97:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20344,7 +21197,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 97:
+/***/ 98:
 /***/ ((module) => {
 
 "use strict";
@@ -20642,7 +21495,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 98:
+/***/ 99:
 /***/ ((module) => {
 
 "use strict";
@@ -20662,7 +21515,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 99:
+/***/ 100:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20683,7 +21536,7 @@ exports.XML_CHARKEY = "_";
 
 /***/ }),
 
-/***/ 100:
+/***/ 101:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20713,7 +21566,7 @@ async function cancelablePromiseRace(abortablePromiseBuilders, options) {
 
 /***/ }),
 
-/***/ 101:
+/***/ 102:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -20783,31 +21636,31 @@ __export(src_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(src_exports);
-var import_pipeline = __nccwpck_require__(245);
+var import_pipeline = __nccwpck_require__(246);
 var import_createPipelineFromOptions = __nccwpck_require__(282);
-var import_defaultHttpClient = __nccwpck_require__(236);
-var import_httpHeaders = __nccwpck_require__(243);
+var import_defaultHttpClient = __nccwpck_require__(237);
+var import_httpHeaders = __nccwpck_require__(244);
 var import_pipelineRequest = __nccwpck_require__(20);
 var import_restError = __nccwpck_require__(355);
-var import_decompressResponsePolicy = __nccwpck_require__(239);
+var import_decompressResponsePolicy = __nccwpck_require__(240);
 var import_exponentialRetryPolicy = __nccwpck_require__(393);
-var import_setClientRequestIdPolicy = __nccwpck_require__(150);
+var import_setClientRequestIdPolicy = __nccwpck_require__(151);
 var import_logPolicy = __nccwpck_require__(71);
 var import_multipartPolicy = __nccwpck_require__(273);
 var import_proxyPolicy = __nccwpck_require__(473);
 var import_redirectPolicy = __nccwpck_require__(342);
-var import_systemErrorRetryPolicy = __nccwpck_require__(220);
+var import_systemErrorRetryPolicy = __nccwpck_require__(221);
 var import_throttlingRetryPolicy = __nccwpck_require__(23);
-var import_retryPolicy = __nccwpck_require__(212);
+var import_retryPolicy = __nccwpck_require__(213);
 var import_tracingPolicy = __nccwpck_require__(336);
 var import_defaultRetryPolicy = __nccwpck_require__(55);
 var import_userAgentPolicy = __nccwpck_require__(390);
 var import_tlsPolicy = __nccwpck_require__(379);
 var import_formDataPolicy = __nccwpck_require__(270);
-var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(218);
-var import_ndJsonPolicy = __nccwpck_require__(240);
-var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(194);
-var import_agentPolicy = __nccwpck_require__(232);
+var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(219);
+var import_ndJsonPolicy = __nccwpck_require__(241);
+var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(195);
+var import_agentPolicy = __nccwpck_require__(233);
 var import_file = __nccwpck_require__(327);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -20815,7 +21668,7 @@ var import_file = __nccwpck_require__(327);
 
 /***/ }),
 
-/***/ 102:
+/***/ 103:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -20841,8 +21694,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(151);
-var import_sanitizer = __nccwpck_require__(121);
+var import_log = __nccwpck_require__(152);
+var import_sanitizer = __nccwpck_require__(122);
 const logPolicyName = "logPolicy";
 function logPolicy(options = {}) {
   const logger = options.logger ?? import_log.logger.info;
@@ -20871,7 +21724,7 @@ function logPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 103:
+/***/ 104:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const { addAbortListener } = __nccwpck_require__(69)
@@ -20932,7 +21785,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 104:
+/***/ 105:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20963,7 +21816,7 @@ function rangeToString(iRange) {
 
 /***/ }),
 
-/***/ 105:
+/***/ 106:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20973,7 +21826,7 @@ const {
   Readable,
   Duplex,
   PassThrough
-} = __nccwpck_require__(130)
+} = __nccwpck_require__(131)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
@@ -20981,7 +21834,7 @@ const {
 } = __nccwpck_require__(488)
 const util = __nccwpck_require__(69)
 const { AsyncResource } = __nccwpck_require__(430)
-const { addSignal, removeSignal } = __nccwpck_require__(103)
+const { addSignal, removeSignal } = __nccwpck_require__(104)
 const assert = __nccwpck_require__(527)
 
 const kResume = Symbol('resume')
@@ -21220,7 +22073,7 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 106:
+/***/ 107:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21238,17 +22091,17 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 
 /***/ }),
 
-/***/ 107:
+/***/ 108:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = (__nccwpck_require__(143).EventEmitter)
+const EventEmitter = (__nccwpck_require__(144).EventEmitter)
 const inherits = (__nccwpck_require__(376).inherits)
 const getLimit = __nccwpck_require__(483)
 
-const StreamSearch = __nccwpck_require__(114)
+const StreamSearch = __nccwpck_require__(115)
 
 const B_DCRLF = Buffer.from('\r\n\r\n')
 const RE_CRLF = /\r\n/g
@@ -21346,7 +22199,7 @@ module.exports = HeaderParser
 
 /***/ }),
 
-/***/ 108:
+/***/ 109:
 /***/ ((module) => {
 
 "use strict";
@@ -21354,7 +22207,7 @@ module.exports = require("node:fs/promises");
 
 /***/ }),
 
-/***/ 109:
+/***/ 110:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -21382,7 +22235,7 @@ __export(util_exports, {
   toWebResourceLike: () => toWebResourceLike
 });
 module.exports = __toCommonJS(util_exports);
-var import_core_rest_pipeline = __nccwpck_require__(101);
+var import_core_rest_pipeline = __nccwpck_require__(102);
 const originalRequestSymbol = /* @__PURE__ */ Symbol("Original PipelineRequest");
 const originalClientRequestSymbol = /* @__PURE__ */ Symbol.for("@azure/core-client original request");
 function toPipelineRequest(webResource, options = {}) {
@@ -21624,7 +22477,7 @@ class HttpHeaders {
 
 /***/ }),
 
-/***/ 110:
+/***/ 111:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21670,7 +22523,7 @@ function objectHasProperty(thing, property) {
 
 /***/ }),
 
-/***/ 111:
+/***/ 112:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -21726,8 +22579,8 @@ exports.redactValue = redactValue;
 exports.captureProcessSnapshot = captureProcessSnapshot;
 exports.dumpDiagnostics = dumpDiagnostics;
 exports.loggingEnabled = loggingEnabled;
-const fs = __importStar(__nccwpck_require__(249));
-const node_child_process_1 = __nccwpck_require__(198);
+const fs = __importStar(__nccwpck_require__(250));
+const node_child_process_1 = __nccwpck_require__(199);
 const compile_journal_js_1 = __nccwpck_require__(535);
 const ENV_KEY_PREFIXES = [
     "INPUT_",
@@ -22038,7 +22891,7 @@ function loggingEnabled(value) {
 
 /***/ }),
 
-/***/ 112:
+/***/ 113:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22121,7 +22974,7 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 
 /***/ }),
 
-/***/ 113:
+/***/ 114:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22131,8 +22984,8 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.delay = delay;
 exports.calculateRetryDelay = calculateRetryDelay;
-const createAbortablePromise_js_1 = __nccwpck_require__(260);
-const util_1 = __nccwpck_require__(146);
+const createAbortablePromise_js_1 = __nccwpck_require__(261);
+const util_1 = __nccwpck_require__(147);
 const StandardAbortMessage = "The delay was aborted.";
 /**
  * A wrapper for setTimeout that resolves a promise after timeInMs milliseconds.
@@ -22171,7 +23024,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 114:
+/***/ 115:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22203,7 +23056,7 @@ function calculateRetryDelay(retryAttempt, config) {
  * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
-const EventEmitter = (__nccwpck_require__(143).EventEmitter)
+const EventEmitter = (__nccwpck_require__(144).EventEmitter)
 const inherits = (__nccwpck_require__(376).inherits)
 
 function SBMH (needle) {
@@ -22407,7 +23260,7 @@ module.exports = SBMH
 
 /***/ }),
 
-/***/ 115:
+/***/ 116:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -22486,7 +23339,7 @@ function createPipelineRequest(options) {
 
 /***/ }),
 
-/***/ 116:
+/***/ 117:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -22523,7 +23376,7 @@ __export(userAgentPlatform_exports, {
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
 var import_node_os = __toESM(__nccwpck_require__(383));
-var import_node_process = __toESM(__nccwpck_require__(237));
+var import_node_process = __toESM(__nccwpck_require__(238));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -22546,14 +23399,14 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 117:
+/***/ 118:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PbLong = exports.PbULong = exports.detectBi = void 0;
-const goog_varint_1 = __nccwpck_require__(204);
+const goog_varint_1 = __nccwpck_require__(205);
 let BI;
 function detectBi() {
     const dv = new DataView(new ArrayBuffer(8));
@@ -22792,7 +23645,7 @@ PbLong.ZERO = new PbLong(0, 0);
 
 /***/ }),
 
-/***/ 118:
+/***/ 119:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22809,7 +23662,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 119:
+/***/ 120:
 /***/ ((module) => {
 
 "use strict";
@@ -22817,7 +23670,7 @@ module.exports = require("buffer");
 
 /***/ }),
 
-/***/ 120:
+/***/ 121:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -22846,8 +23699,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
-const path = __importStar(__nccwpck_require__(248));
-const pathHelper = __importStar(__nccwpck_require__(223));
+const path = __importStar(__nccwpck_require__(249));
+const pathHelper = __importStar(__nccwpck_require__(224));
 const assert_1 = __importDefault(__nccwpck_require__(527));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -22937,7 +23790,7 @@ exports.Path = Path;
 
 /***/ }),
 
-/***/ 121:
+/***/ 122:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -22962,7 +23815,7 @@ __export(sanitizer_exports, {
   Sanitizer: () => Sanitizer
 });
 module.exports = __toCommonJS(sanitizer_exports);
-var import_object = __nccwpck_require__(144);
+var import_object = __nccwpck_require__(145);
 const RedactedString = "REDACTED";
 const defaultAllowedHeaderNames = [
   "x-ms-client-request-id",
@@ -23111,7 +23964,7 @@ class Sanitizer {
 
 /***/ }),
 
-/***/ 122:
+/***/ 123:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -23128,7 +23981,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 123:
+/***/ 124:
 /***/ ((module) => {
 
 "use strict";
@@ -23136,13 +23989,13 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 124:
+/***/ 125:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
-var path = (function () { try { return __nccwpck_require__(248) } catch (e) {}}()) || {
+var path = (function () { try { return __nccwpck_require__(249) } catch (e) {}}()) || {
   sep: '/'
 }
 minimatch.sep = path.sep
@@ -24148,7 +25001,7 @@ function regExpEscape (s) {
 
 /***/ }),
 
-/***/ 125:
+/***/ 126:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -24185,10 +25038,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
 const os = __importStar(__nccwpck_require__(92));
 const events = __importStar(__nccwpck_require__(470));
-const child = __importStar(__nccwpck_require__(164));
-const path = __importStar(__nccwpck_require__(248));
+const child = __importStar(__nccwpck_require__(165));
+const path = __importStar(__nccwpck_require__(249));
 const io = __importStar(__nccwpck_require__(296));
-const ioUtil = __importStar(__nccwpck_require__(226));
+const ioUtil = __importStar(__nccwpck_require__(227));
 const timers_1 = __nccwpck_require__(510);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
@@ -24773,7 +25626,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 126:
+/***/ 127:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24785,7 +25638,7 @@ exports.StorageSharedKeyCredentialPolicy = void 0;
 const constants_js_1 = __nccwpck_require__(36);
 const utils_common_js_1 = __nccwpck_require__(474);
 const CredentialPolicy_js_1 = __nccwpck_require__(310);
-const SharedKeyComparator_js_1 = __nccwpck_require__(177);
+const SharedKeyComparator_js_1 = __nccwpck_require__(178);
 /**
  * StorageSharedKeyCredentialPolicy is a policy used to sign HTTP request with a shared key.
  */
@@ -24929,7 +25782,7 @@ exports.StorageSharedKeyCredentialPolicy = StorageSharedKeyCredentialPolicy;
 
 /***/ }),
 
-/***/ 127:
+/***/ 128:
 /***/ ((module) => {
 
 "use strict";
@@ -24949,7 +25802,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 128:
+/***/ 129:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24958,7 +25811,7 @@ module.exports = {
 
 
 const assert = __nccwpck_require__(527)
-const { Readable } = __nccwpck_require__(130)
+const { Readable } = __nccwpck_require__(131)
 const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(488)
 const util = __nccwpck_require__(69)
 const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(69)
@@ -25241,7 +26094,7 @@ function consumeEnd (consume) {
       resolve(dst.buffer)
     } else if (type === 'blob') {
       if (!Blob) {
-        Blob = (__nccwpck_require__(119).Blob)
+        Blob = (__nccwpck_require__(120).Blob)
       }
       resolve(new Blob(body, { type: stream[kContentType] }))
     }
@@ -25279,7 +26132,7 @@ function consumeFinish (consume, err) {
 
 /***/ }),
 
-/***/ 129:
+/***/ 130:
 /***/ ((module) => {
 
 "use strict";
@@ -25287,7 +26140,7 @@ module.exports = require("querystring");
 
 /***/ }),
 
-/***/ 130:
+/***/ 131:
 /***/ ((module) => {
 
 "use strict";
@@ -25295,7 +26148,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 131:
+/***/ 132:
 /***/ ((module) => {
 
 "use strict";
@@ -25365,7 +26218,7 @@ function range(a, b, str) {
 
 /***/ }),
 
-/***/ 132:
+/***/ 133:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -25402,7 +26255,7 @@ const net = __importStar(__nccwpck_require__(509));
 const tls = __importStar(__nccwpck_require__(506));
 const assert_1 = __importDefault(__nccwpck_require__(527));
 const debug_1 = __importDefault(__nccwpck_require__(516));
-const agent_base_1 = __nccwpck_require__(241);
+const agent_base_1 = __nccwpck_require__(242);
 const url_1 = __nccwpck_require__(85);
 const parse_proxy_response_1 = __nccwpck_require__(420);
 const debug = (0, debug_1.default)('https-proxy-agent');
@@ -25552,7 +26405,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 133:
+/***/ 134:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -25636,7 +26489,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 134:
+/***/ 135:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25644,8 +26497,8 @@ exports.OidcClient = OidcClient;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
 const binary_format_contract_1 = __nccwpck_require__(333);
-const pb_long_1 = __nccwpck_require__(117);
-const goog_varint_1 = __nccwpck_require__(204);
+const pb_long_1 = __nccwpck_require__(118);
+const goog_varint_1 = __nccwpck_require__(205);
 const defaultsRead = {
     readUnknownField: true,
     readerFactory: bytes => new BinaryReader(bytes),
@@ -25827,7 +26680,7 @@ exports.BinaryReader = BinaryReader;
 
 /***/ }),
 
-/***/ 135:
+/***/ 136:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26041,7 +26894,7 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 136:
+/***/ 137:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -26139,7 +26992,7 @@ exports.reflectionMergePartial = reflectionMergePartial;
 
 /***/ }),
 
-/***/ 137:
+/***/ 138:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26232,7 +27085,7 @@ async function parseXML(str, opts = {}) {
 
 /***/ }),
 
-/***/ 138:
+/***/ 139:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26240,14 +27093,14 @@ async function parseXML(str, opts = {}) {
 
 module.exports.request = __nccwpck_require__(511)
 module.exports.stream = __nccwpck_require__(356)
-module.exports.pipeline = __nccwpck_require__(105)
+module.exports.pipeline = __nccwpck_require__(106)
 module.exports.upgrade = __nccwpck_require__(434)
 module.exports.connect = __nccwpck_require__(374)
 
 
 /***/ }),
 
-/***/ 139:
+/***/ 140:
 /***/ ((module) => {
 
 "use strict";
@@ -26295,7 +27148,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 140:
+/***/ 141:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26304,7 +27157,7 @@ module.exports = {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollOperation = exports.initOperation = exports.deserializeState = void 0;
-const logger_js_1 = __nccwpck_require__(192);
+const logger_js_1 = __nccwpck_require__(193);
 const constants_js_1 = __nccwpck_require__(60);
 /**
  * Deserializes the state
@@ -26474,7 +27327,7 @@ exports.pollOperation = pollOperation;
 
 /***/ }),
 
-/***/ 141:
+/***/ 142:
 /***/ ((module) => {
 
 "use strict";
@@ -26482,7 +27335,7 @@ module.exports = require("diagnostics_channel");
 
 /***/ }),
 
-/***/ 142:
+/***/ 143:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -26781,7 +27634,7 @@ module.exports = setup;
 
 /***/ }),
 
-/***/ 143:
+/***/ 144:
 /***/ ((module) => {
 
 "use strict";
@@ -26789,7 +27642,7 @@ module.exports = require("node:events");
 
 /***/ }),
 
-/***/ 144:
+/***/ 145:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -26824,7 +27677,7 @@ function isObject(input) {
 
 /***/ }),
 
-/***/ 145:
+/***/ 146:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -26892,7 +27745,7 @@ async function resolveSoldrReleaseVersion(repo, version, ref, env, deps) {
 
 /***/ }),
 
-/***/ 146:
+/***/ 147:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26935,13 +27788,13 @@ __export(internal_exports, {
 module.exports = __toCommonJS(internal_exports);
 var import_delay = __nccwpck_require__(475);
 var import_random = __nccwpck_require__(507);
-var import_object = __nccwpck_require__(144);
-var import_error = __nccwpck_require__(153);
-var import_sha256 = __nccwpck_require__(201);
+var import_object = __nccwpck_require__(145);
+var import_error = __nccwpck_require__(154);
+var import_sha256 = __nccwpck_require__(202);
 var import_uuidUtils = __nccwpck_require__(394);
 var import_checkEnvironment = __nccwpck_require__(439);
 var import_bytesEncoding = __nccwpck_require__(288);
-var import_sanitizer = __nccwpck_require__(121);
+var import_sanitizer = __nccwpck_require__(122);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -26949,7 +27802,7 @@ var import_sanitizer = __nccwpck_require__(121);
 
 /***/ }),
 
-/***/ 147:
+/***/ 148:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26974,7 +27827,7 @@ __export(internal_exports, {
   createLoggerContext: () => import_logger.createLoggerContext
 });
 module.exports = __toCommonJS(internal_exports);
-var import_logger = __nccwpck_require__(246);
+var import_logger = __nccwpck_require__(247);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -26982,7 +27835,7 @@ var import_logger = __nccwpck_require__(246);
 
 /***/ }),
 
-/***/ 148:
+/***/ 149:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -27218,7 +28071,7 @@ exports.PathStylePorts = [
 
 /***/ }),
 
-/***/ 149:
+/***/ 150:
 /***/ ((module) => {
 
 "use strict";
@@ -27226,7 +28079,7 @@ module.exports = require("string_decoder");
 
 /***/ }),
 
-/***/ 150:
+/***/ 151:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -27270,7 +28123,7 @@ function setClientRequestIdPolicy(requestIdHeaderName = "x-ms-client-request-id"
 
 /***/ }),
 
-/***/ 151:
+/***/ 152:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -27295,7 +28148,7 @@ __export(log_exports, {
   logger: () => logger
 });
 module.exports = __toCommonJS(log_exports);
-var import_logger = __nccwpck_require__(246);
+var import_logger = __nccwpck_require__(247);
 const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -27304,7 +28157,7 @@ const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 
 /***/ }),
 
-/***/ 152:
+/***/ 153:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -27361,7 +28214,7 @@ function basicAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 153:
+/***/ 154:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -27386,7 +28239,7 @@ __export(error_exports, {
   isError: () => isError
 });
 module.exports = __toCommonJS(error_exports);
-var import_object = __nccwpck_require__(144);
+var import_object = __nccwpck_require__(145);
 function isError(e) {
   if ((0, import_object.isObject)(e)) {
     const hasName = typeof e.name === "string";
@@ -27402,7 +28255,7 @@ function isError(e) {
 
 /***/ }),
 
-/***/ 154:
+/***/ 155:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -27446,9 +28299,9 @@ exports.ConvertInternalResponseOfListBlobHierarchy = ConvertInternalResponseOfLi
 exports.ExtractPageRangeInfoItems = ExtractPageRangeInfoItems;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const core_util_1 = __nccwpck_require__(14);
-const constants_js_1 = __nccwpck_require__(148);
+const constants_js_1 = __nccwpck_require__(149);
 /**
  * Reserved URL characters must be properly escaped for Storage services like Blob or File.
  *
@@ -28216,7 +29069,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 155:
+/***/ 156:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28246,20 +29099,20 @@ exports.StorageBrowserPolicyFactory = StorageBrowserPolicyFactory;
 
 /***/ }),
 
-/***/ 156:
+/***/ 157:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(196).kConstruct)
+  kConstruct: (__nccwpck_require__(197).kConstruct)
 }
 
 
 /***/ }),
 
-/***/ 157:
+/***/ 158:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28323,10 +29176,10 @@ exports.buildMiniCacheKey = buildMiniCacheKey;
 exports.restoreMiniCache = restoreMiniCache;
 exports.saveMiniCache = saveMiniCache;
 exports.isEligibleForMiniCache = isEligibleForMiniCache;
-const fs = __importStar(__nccwpck_require__(249));
-const fsp = __importStar(__nccwpck_require__(108));
+const fs = __importStar(__nccwpck_require__(250));
+const fsp = __importStar(__nccwpck_require__(109));
 const path = __importStar(__nccwpck_require__(508));
-const cache = __importStar(__nccwpck_require__(215));
+const cache = __importStar(__nccwpck_require__(216));
 const cache_compress_js_1 = __nccwpck_require__(493);
 const MINI_KEY_PREFIX = "soldr-mini";
 /**
@@ -28501,7 +29354,7 @@ function isEligibleForMiniCache(opts) {
 
 /***/ }),
 
-/***/ 158:
+/***/ 159:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28533,7 +29386,7 @@ exports.reflectionLongConvert = reflectionLongConvert;
 
 /***/ }),
 
-/***/ 159:
+/***/ 160:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -28567,7 +29420,7 @@ const DEFAULT_RETRY_POLICY_COUNT = 3;
 
 /***/ }),
 
-/***/ 160:
+/***/ 161:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28741,7 +29594,7 @@ exports.uploadCacheArchiveSDK = uploadCacheArchiveSDK;
 
 /***/ }),
 
-/***/ 161:
+/***/ 162:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28814,7 +29667,7 @@ exports.req = req;
 
 /***/ }),
 
-/***/ 162:
+/***/ 163:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -28952,7 +29805,7 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 
 /***/ }),
 
-/***/ 163:
+/***/ 164:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28966,18 +29819,18 @@ const BalancedPool = __nccwpck_require__(382)
 const Agent = __nccwpck_require__(5)
 const util = __nccwpck_require__(69)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(138)
+const api = __nccwpck_require__(139)
 const buildConnector = __nccwpck_require__(267)
-const MockClient = __nccwpck_require__(200)
+const MockClient = __nccwpck_require__(201)
 const MockAgent = __nccwpck_require__(378)
 const MockPool = __nccwpck_require__(351)
-const mockErrors = __nccwpck_require__(233)
+const mockErrors = __nccwpck_require__(234)
 const ProxyAgent = __nccwpck_require__(343)
 const RetryHandler = __nccwpck_require__(275)
 const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(377)
 const DecoratorHandler = __nccwpck_require__(476)
 const RedirectHandler = __nccwpck_require__(391)
-const createRedirectInterceptor = __nccwpck_require__(255)
+const createRedirectInterceptor = __nccwpck_require__(256)
 
 let hasCrypto
 try {
@@ -29076,17 +29929,17 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   module.exports.Headers = __nccwpck_require__(517).Headers
   module.exports.Response = __nccwpck_require__(41).Response
   module.exports.Request = __nccwpck_require__(84).Request
-  module.exports.FormData = __nccwpck_require__(208).FormData
+  module.exports.FormData = __nccwpck_require__(209).FormData
   module.exports.File = __nccwpck_require__(365).File
-  module.exports.FileReader = __nccwpck_require__(94).FileReader
+  module.exports.FileReader = __nccwpck_require__(95).FileReader
 
-  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(139)
+  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(140)
 
   module.exports.setGlobalOrigin = setGlobalOrigin
   module.exports.getGlobalOrigin = getGlobalOrigin
 
   const { CacheStorage } = __nccwpck_require__(284)
-  const { kConstruct } = __nccwpck_require__(156)
+  const { kConstruct } = __nccwpck_require__(157)
 
   // Cache & CacheStorage are tightly coupled with fetch. Even if it may run
   // in an older version of Node, it doesn't have any use without fetch.
@@ -29127,7 +29980,7 @@ module.exports.mockErrors = mockErrors
 
 /***/ }),
 
-/***/ 164:
+/***/ 165:
 /***/ ((module) => {
 
 "use strict";
@@ -29135,7 +29988,7 @@ module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 165:
+/***/ 166:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29214,7 +30067,7 @@ exports.setupCachePaths = setupCachePaths;
 exports.setupCacheLayout = setupCacheLayout;
 exports.pathForOutput = pathForOutput;
 const node_crypto_1 = __nccwpck_require__(276);
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const path = __importStar(__nccwpck_require__(508));
 const TARGET_CACHE_PROFILES = ["thin-v1", "thin-v2"];
 const TARGET_CACHE_BOOL_TRUE = new Set(["true", "1", "yes", "on"]);
@@ -29591,7 +30444,7 @@ function pathForOutput(workspace, p) {
 
 /***/ }),
 
-/***/ 166:
+/***/ 167:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29604,18 +30457,18 @@ function pathForOutput(workspace, p) {
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(217);
-tslib_1.__exportStar(__nccwpck_require__(118), exports);
-tslib_1.__exportStar(__nccwpck_require__(181), exports);
-tslib_1.__exportStar(__nccwpck_require__(122), exports);
+const tslib_1 = __nccwpck_require__(218);
+tslib_1.__exportStar(__nccwpck_require__(119), exports);
+tslib_1.__exportStar(__nccwpck_require__(182), exports);
+tslib_1.__exportStar(__nccwpck_require__(123), exports);
 tslib_1.__exportStar(__nccwpck_require__(317), exports);
-tslib_1.__exportStar(__nccwpck_require__(209), exports);
+tslib_1.__exportStar(__nccwpck_require__(210), exports);
 tslib_1.__exportStar(__nccwpck_require__(272), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 167:
+/***/ 168:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29626,7 +30479,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageRetryPolicyName = void 0;
 exports.storageRetryPolicy = storageRetryPolicy;
 const abort_controller_1 = __nccwpck_require__(495);
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const core_util_1 = __nccwpck_require__(14);
 const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(326);
 const constants_js_1 = __nccwpck_require__(36);
@@ -29790,7 +30643,7 @@ function storageRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 168:
+/***/ 169:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29823,7 +30676,7 @@ exports.create = create;
 
 /***/ }),
 
-/***/ 169:
+/***/ 170:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29877,7 +30730,7 @@ exports.UserDelegationKeyCredential = UserDelegationKeyCredential;
 
 /***/ }),
 
-/***/ 170:
+/***/ 171:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29938,11 +30791,11 @@ exports.saveCookCache = saveCookCache;
 exports.parseCookFlags = parseCookFlags;
 exports.canonicalizeCookFlags = canonicalizeCookFlags;
 const node_crypto_1 = __nccwpck_require__(276);
-const fs = __importStar(__nccwpck_require__(249));
-const fsp = __importStar(__nccwpck_require__(108));
+const fs = __importStar(__nccwpck_require__(250));
+const fsp = __importStar(__nccwpck_require__(109));
 const path = __importStar(__nccwpck_require__(508));
 const exec = __importStar(__nccwpck_require__(18));
-const cache = __importStar(__nccwpck_require__(215));
+const cache = __importStar(__nccwpck_require__(216));
 const cache_compress_js_1 = __nccwpck_require__(493);
 const COOK_KEY_PREFIX = "cook";
 /**
@@ -30205,7 +31058,7 @@ function canonicalizeCookFlags(flags) {
 
 /***/ }),
 
-/***/ 171:
+/***/ 172:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30343,7 +31196,7 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 172:
+/***/ 173:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30375,7 +31228,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 173:
+/***/ 174:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30502,7 +31355,7 @@ function requestToOptions(request) {
 
 /***/ }),
 
-/***/ 174:
+/***/ 175:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30514,7 +31367,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 175:
+/***/ 176:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30529,7 +31382,7 @@ var reflection_info_1 = __nccwpck_require__(528);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
 Object.defineProperty(exports, "readMethodOption", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOption; } }));
 Object.defineProperty(exports, "readServiceOption", ({ enumerable: true, get: function () { return reflection_info_1.readServiceOption; } }));
-var rpc_error_1 = __nccwpck_require__(176);
+var rpc_error_1 = __nccwpck_require__(177);
 Object.defineProperty(exports, "RpcError", ({ enumerable: true, get: function () { return rpc_error_1.RpcError; } }));
 var rpc_options_1 = __nccwpck_require__(294);
 Object.defineProperty(exports, "mergeRpcOptions", ({ enumerable: true, get: function () { return rpc_options_1.mergeRpcOptions; } }));
@@ -30560,7 +31413,7 @@ Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: tru
 
 /***/ }),
 
-/***/ 176:
+/***/ 177:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30604,7 +31457,7 @@ exports.RpcError = RpcError;
 
 /***/ }),
 
-/***/ 177:
+/***/ 178:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30687,7 +31540,7 @@ function isLessThan(lhs, rhs) {
 
 /***/ }),
 
-/***/ 178:
+/***/ 179:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30699,7 +31552,7 @@ exports.LroEngine = void 0;
 const operation_js_1 = __nccwpck_require__(359);
 const constants_js_1 = __nccwpck_require__(60);
 const poller_js_1 = __nccwpck_require__(75);
-const operation_js_2 = __nccwpck_require__(140);
+const operation_js_2 = __nccwpck_require__(141);
 /**
  * The LRO Engine, a class that performs polling.
  */
@@ -30727,7 +31580,7 @@ exports.LroEngine = LroEngine;
 
 /***/ }),
 
-/***/ 179:
+/***/ 180:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -32377,7 +33230,7 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 180:
+/***/ 181:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -40720,7 +41573,7 @@ exports.BlockBlobGetBlockListExceptionHeaders = {
 
 /***/ }),
 
-/***/ 181:
+/***/ 182:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -40737,7 +41590,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 182:
+/***/ 183:
 /***/ ((module) => {
 
 "use strict";
@@ -40745,7 +41598,7 @@ module.exports = require("tty");
 
 /***/ }),
 
-/***/ 183:
+/***/ 184:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -40759,13 +41612,13 @@ exports.newPipeline = newPipeline;
 exports.getCoreClientOptions = getCoreClientOptions;
 exports.getCredentialFromPipeline = getCredentialFromPipeline;
 const core_http_compat_1 = __nccwpck_require__(72);
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const core_client_1 = __nccwpck_require__(440);
-const core_xml_1 = __nccwpck_require__(195);
+const core_xml_1 = __nccwpck_require__(196);
 const core_auth_1 = __nccwpck_require__(515);
-const log_js_1 = __nccwpck_require__(106);
+const log_js_1 = __nccwpck_require__(107);
 const storage_common_1 = __nccwpck_require__(278);
-const constants_js_1 = __nccwpck_require__(148);
+const constants_js_1 = __nccwpck_require__(149);
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return constants_js_1.StorageOAuthScopes; } }));
 /**
  * A helper to decide if a given argument satisfies the Pipeline contract
@@ -41029,7 +41882,7 @@ function isCoreHttpPolicyFactory(factory) {
 
 /***/ }),
 
-/***/ 184:
+/***/ 185:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -41062,7 +41915,7 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 
 /***/ }),
 
-/***/ 185:
+/***/ 186:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -41071,27 +41924,27 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobClient = exports.BlockBlobClient = exports.AppendBlobClient = exports.BlobClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const core_auth_1 = __nccwpck_require__(515);
 const core_util_1 = __nccwpck_require__(14);
 const core_util_2 = __nccwpck_require__(14);
 const BlobDownloadResponse_js_1 = __nccwpck_require__(427);
-const BlobQueryResponse_js_1 = __nccwpck_require__(202);
+const BlobQueryResponse_js_1 = __nccwpck_require__(203);
 const storage_common_1 = __nccwpck_require__(278);
 const models_js_1 = __nccwpck_require__(416);
 const PageBlobRangeResponse_js_1 = __nccwpck_require__(29);
-const Pipeline_js_1 = __nccwpck_require__(183);
+const Pipeline_js_1 = __nccwpck_require__(184);
 const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(536);
-const Range_js_1 = __nccwpck_require__(104);
+const Range_js_1 = __nccwpck_require__(105);
 const StorageClient_js_1 = __nccwpck_require__(455);
 const Batch_js_1 = __nccwpck_require__(91);
 const storage_common_2 = __nccwpck_require__(278);
-const constants_js_1 = __nccwpck_require__(148);
+const constants_js_1 = __nccwpck_require__(149);
 const tracing_js_1 = __nccwpck_require__(31);
-const utils_common_js_1 = __nccwpck_require__(154);
-const utils_js_1 = __nccwpck_require__(203);
+const utils_common_js_1 = __nccwpck_require__(155);
+const utils_js_1 = __nccwpck_require__(204);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
-const BlobLeaseClient_js_1 = __nccwpck_require__(205);
+const BlobLeaseClient_js_1 = __nccwpck_require__(206);
 /**
  * A BlobClient represents a URL to an Azure Storage blob; the blob may be a block blob,
  * append blob, or page blob.
@@ -43921,7 +44774,7 @@ exports.PageBlobClient = PageBlobClient;
 
 /***/ }),
 
-/***/ 186:
+/***/ 187:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -43931,7 +44784,7 @@ exports.ReflectionBinaryWriter = void 0;
 const binary_format_contract_1 = __nccwpck_require__(333);
 const reflection_info_1 = __nccwpck_require__(453);
 const assert_1 = __nccwpck_require__(484);
-const pb_long_1 = __nccwpck_require__(117);
+const pb_long_1 = __nccwpck_require__(118);
 /**
  * Writes proto3 messages in binary format using reflection information.
  *
@@ -44162,7 +45015,7 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 
 /***/ }),
 
-/***/ 187:
+/***/ 188:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44243,7 +45096,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 188:
+/***/ 189:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -44290,7 +45143,7 @@ function isApiKeyCredential(credential) {
 
 /***/ }),
 
-/***/ 189:
+/***/ 190:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -44339,9 +45192,9 @@ exports.resolveSetup = resolveSetup;
 exports.applyResolveResult = applyResolveResult;
 const os = __importStar(__nccwpck_require__(383));
 const path = __importStar(__nccwpck_require__(508));
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const core = __importStar(__nccwpck_require__(460));
-const cache_keys_js_1 = __nccwpck_require__(165);
+const cache_keys_js_1 = __nccwpck_require__(166);
 const log_utils_js_1 = __nccwpck_require__(354);
 const detect_musl_cc_js_1 = __nccwpck_require__(504);
 Object.defineProperty(exports, "detectMuslCcEnv", ({ enumerable: true, get: function () { return detect_musl_cc_js_1.detectMuslCcEnv; } }));
@@ -44349,11 +45202,11 @@ const build_outputs_js_1 = __nccwpck_require__(269);
 Object.defineProperty(exports, "buildOutputs", ({ enumerable: true, get: function () { return build_outputs_js_1.buildOutputs; } }));
 const raw_inputs_js_1 = __nccwpck_require__(344);
 Object.defineProperty(exports, "readRawInputs", ({ enumerable: true, get: function () { return raw_inputs_js_1.readRawInputs; } }));
-const input_parsers_js_1 = __nccwpck_require__(214);
+const input_parsers_js_1 = __nccwpck_require__(215);
 Object.defineProperty(exports, "detectUserLinkerEnv", ({ enumerable: true, get: function () { return input_parsers_js_1.detectUserLinkerEnv; } }));
 Object.defineProperty(exports, "parseCacheShutdownOnIdleSeconds", ({ enumerable: true, get: function () { return input_parsers_js_1.parseCacheShutdownOnIdleSeconds; } }));
 Object.defineProperty(exports, "parseRustBacktrace", ({ enumerable: true, get: function () { return input_parsers_js_1.parseRustBacktrace; } }));
-const fetch_release_js_1 = __nccwpck_require__(145);
+const fetch_release_js_1 = __nccwpck_require__(146);
 const python_json_js_1 = __nccwpck_require__(11);
 Object.defineProperty(exports, "pythonDefaultJson", ({ enumerable: true, get: function () { return python_json_js_1.pythonDefaultJson; } }));
 const toolchain_js_1 = __nccwpck_require__(368);
@@ -44921,7 +45774,7 @@ async function applyResolveResult(result) {
 
 /***/ }),
 
-/***/ 190:
+/***/ 191:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(527)
@@ -44974,7 +45827,7 @@ module.exports = { getResolveErrorBodyCallback }
 
 /***/ }),
 
-/***/ 191:
+/***/ 192:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -45096,7 +45949,7 @@ exports.getSelectedOneofValue = getSelectedOneofValue;
 
 /***/ }),
 
-/***/ 192:
+/***/ 193:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45115,7 +45968,7 @@ exports.logger = (0, logger_1.createClientLogger)("core-lro");
 
 /***/ }),
 
-/***/ 193:
+/***/ 194:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45319,7 +46172,7 @@ module.exports = parseParams
 
 /***/ }),
 
-/***/ 194:
+/***/ 195:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45345,8 +46198,8 @@ __export(auxiliaryAuthenticationHeaderPolicy_exports, {
   auxiliaryAuthenticationHeaderPolicyName: () => auxiliaryAuthenticationHeaderPolicyName
 });
 module.exports = __toCommonJS(auxiliaryAuthenticationHeaderPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(162);
-var import_log = __nccwpck_require__(184);
+var import_tokenCycler = __nccwpck_require__(163);
+var import_log = __nccwpck_require__(185);
 const auxiliaryAuthenticationHeaderPolicyName = "auxiliaryAuthenticationHeaderPolicy";
 const AUTHORIZATION_AUXILIARY_HEADER = "x-ms-authorization-auxiliary";
 async function sendAuthorizeRequest(options) {
@@ -45412,7 +46265,7 @@ function auxiliaryAuthenticationHeaderPolicy(options) {
 
 /***/ }),
 
-/***/ 195:
+/***/ 196:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45440,7 +46293,7 @@ __export(src_exports, {
   stringifyXML: () => import_xml.stringifyXML
 });
 module.exports = __toCommonJS(src_exports);
-var import_xml = __nccwpck_require__(137);
+var import_xml = __nccwpck_require__(138);
 var import_xml_common = __nccwpck_require__(21);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -45449,7 +46302,7 @@ var import_xml_common = __nccwpck_require__(21);
 
 /***/ }),
 
-/***/ 196:
+/***/ 197:
 /***/ ((module) => {
 
 module.exports = {
@@ -45519,7 +46372,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 197:
+/***/ 198:
 /***/ ((module) => {
 
 "use strict";
@@ -45644,7 +46497,7 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 198:
+/***/ 199:
 /***/ ((module) => {
 
 "use strict";
@@ -45652,7 +46505,7 @@ module.exports = require("node:child_process");
 
 /***/ }),
 
-/***/ 199:
+/***/ 200:
 /***/ ((module) => {
 
 "use strict";
@@ -45660,13 +46513,13 @@ module.exports = require("util/types");
 
 /***/ }),
 
-/***/ 200:
+/***/ 201:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(123)
+const { promisify } = __nccwpck_require__(124)
 const Client = __nccwpck_require__(88)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
@@ -45678,8 +46531,8 @@ const {
   kOriginalDispatch,
   kConnected
 } = __nccwpck_require__(471)
-const { MockInterceptor } = __nccwpck_require__(135)
-const Symbols = __nccwpck_require__(196)
+const { MockInterceptor } = __nccwpck_require__(136)
+const Symbols = __nccwpck_require__(197)
 const { InvalidArgumentError } = __nccwpck_require__(488)
 
 /**
@@ -45727,7 +46580,7 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 201:
+/***/ 202:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45768,7 +46621,7 @@ async function computeSha256Hash(content, encoding) {
 
 /***/ }),
 
-/***/ 202:
+/***/ 203:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46148,7 +47001,7 @@ exports.BlobQueryResponse = BlobQueryResponse;
 
 /***/ }),
 
-/***/ 203:
+/***/ 204:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46161,10 +47014,10 @@ exports.streamToBuffer = streamToBuffer;
 exports.streamToBuffer2 = streamToBuffer2;
 exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
-const tslib_1 = __nccwpck_require__(217);
-const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(249));
+const tslib_1 = __nccwpck_require__(218);
+const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(250));
 const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(376));
-const constants_js_1 = __nccwpck_require__(148);
+const constants_js_1 = __nccwpck_require__(149);
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
  *
@@ -46295,7 +47148,7 @@ exports.fsCreateReadStream = node_fs_1.default.createReadStream;
 
 /***/ }),
 
-/***/ 204:
+/***/ 205:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -46577,7 +47430,7 @@ exports.varint32read = varint32read;
 
 /***/ }),
 
-/***/ 205:
+/***/ 206:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46587,9 +47440,9 @@ exports.varint32read = varint32read;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobLeaseClient = void 0;
 const core_util_1 = __nccwpck_require__(14);
-const constants_js_1 = __nccwpck_require__(148);
+const constants_js_1 = __nccwpck_require__(149);
 const tracing_js_1 = __nccwpck_require__(31);
-const utils_common_js_1 = __nccwpck_require__(154);
+const utils_common_js_1 = __nccwpck_require__(155);
 /**
  * A client that manages leases for a {@link ContainerClient} or a {@link BlobClient}.
  */
@@ -46789,7 +47642,7 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 /***/ }),
 
-/***/ 206:
+/***/ 207:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46845,7 +47698,7 @@ exports.reflectionCreate = reflectionCreate;
 
 /***/ }),
 
-/***/ 207:
+/***/ 208:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46887,7 +47740,7 @@ function storageBrowserPolicy() {
 
 /***/ }),
 
-/***/ 208:
+/***/ 209:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46897,7 +47750,7 @@ const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(518)
 const { kState } = __nccwpck_require__(15)
 const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(365)
 const { webidl } = __nccwpck_require__(457)
-const { Blob, File: NativeFile } = __nccwpck_require__(119)
+const { Blob, File: NativeFile } = __nccwpck_require__(120)
 
 /** @type {globalThis['File']} */
 const File = NativeFile ?? UndiciFile
@@ -47160,7 +48013,7 @@ module.exports = { FormData }
 
 /***/ }),
 
-/***/ 209:
+/***/ 210:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -47177,7 +48030,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 210:
+/***/ 211:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47360,7 +48213,7 @@ function buildOperation(method, url, pipeline, options, allowInsecureConnection,
 
 /***/ }),
 
-/***/ 211:
+/***/ 212:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47386,7 +48239,7 @@ __export(httpClientAdapter_exports, {
 });
 module.exports = __toCommonJS(httpClientAdapter_exports);
 var import_response = __nccwpck_require__(413);
-var import_util = __nccwpck_require__(109);
+var import_util = __nccwpck_require__(110);
 function convertHttpClient(requestPolicyClient) {
   return {
     sendRequest: async (request) => {
@@ -47404,7 +48257,7 @@ function convertHttpClient(requestPolicyClient) {
 
 /***/ }),
 
-/***/ 212:
+/***/ 213:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47430,7 +48283,7 @@ __export(retryPolicy_exports, {
 });
 module.exports = __toCommonJS(retryPolicy_exports);
 var import_logger = __nccwpck_require__(44);
-var import_constants = __nccwpck_require__(159);
+var import_constants = __nccwpck_require__(160);
 var import_policies = __nccwpck_require__(287);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("core-rest-pipeline retryPolicy");
 function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAULT_RETRY_POLICY_COUNT }) {
@@ -47445,7 +48298,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 
 /***/ }),
 
-/***/ 213:
+/***/ 214:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47454,7 +48307,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getErrorMessage = getErrorMessage;
-const util_1 = __nccwpck_require__(146);
+const util_1 = __nccwpck_require__(147);
 /**
  * Given what is thought to be an error object, return the message if possible.
  * If the message is missing, returns a stringified version of the input.
@@ -47485,7 +48338,7 @@ function getErrorMessage(e) {
 
 /***/ }),
 
-/***/ 214:
+/***/ 215:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -47595,7 +48448,7 @@ function normalizeCompileCacheStats(raw) {
 
 /***/ }),
 
-/***/ 215:
+/***/ 216:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -47635,7 +48488,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.restoreCache = exports.isFeatureAvailable = exports.FinalizeCacheError = exports.ReserveCacheError = exports.ValidationError = void 0;
 const core = __importStar(__nccwpck_require__(460));
-const path = __importStar(__nccwpck_require__(248));
+const path = __importStar(__nccwpck_require__(249));
 const utils = __importStar(__nccwpck_require__(76));
 const cacheHttpClient = __importStar(__nccwpck_require__(34));
 const cacheTwirpClient = __importStar(__nccwpck_require__(61));
@@ -48121,7 +48974,7 @@ function saveCacheV2(paths, key, options, enableCrossOsArchive = false) {
 
 /***/ }),
 
-/***/ 216:
+/***/ 217:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48147,7 +49000,7 @@ __export(extendedClient_exports, {
 });
 module.exports = __toCommonJS(extendedClient_exports);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_core_rest_pipeline = __nccwpck_require__(101);
+var import_core_rest_pipeline = __nccwpck_require__(102);
 var import_core_client = __nccwpck_require__(440);
 var import_response = __nccwpck_require__(413);
 class ExtendedServiceClient extends import_core_client.ServiceClient {
@@ -48198,7 +49051,7 @@ class ExtendedServiceClient extends import_core_client.ServiceClient {
 
 /***/ }),
 
-/***/ 217:
+/***/ 218:
 /***/ ((module) => {
 
 /******************************************************************************
@@ -48656,7 +49509,7 @@ var __rewriteRelativeImportExtension;
 
 /***/ }),
 
-/***/ 218:
+/***/ 219:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48683,8 +49536,8 @@ __export(bearerTokenAuthenticationPolicy_exports, {
   parseChallenges: () => parseChallenges
 });
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(162);
-var import_log = __nccwpck_require__(184);
+var import_tokenCycler = __nccwpck_require__(163);
+var import_log = __nccwpck_require__(185);
 var import_restError = __nccwpck_require__(355);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
@@ -48875,7 +49728,7 @@ function getCaeChallengeClaims(challenges) {
 
 /***/ }),
 
-/***/ 219:
+/***/ 220:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -48924,7 +49777,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.targetDirHasCompiledArtifacts = targetDirHasCompiledArtifacts;
 exports.shouldEmitSharedTargetWarning = shouldEmitSharedTargetWarning;
 exports.detectSharedTargetWarning = detectSharedTargetWarning;
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const path = __importStar(__nccwpck_require__(508));
 const core = __importStar(__nccwpck_require__(460));
 const log_utils_js_1 = __nccwpck_require__(354);
@@ -49021,7 +49874,7 @@ async function detectSharedTargetWarning(opts) {
 
 /***/ }),
 
-/***/ 220:
+/***/ 221:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49058,7 +49911,7 @@ function systemErrorRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 221:
+/***/ 222:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49072,9 +49925,9 @@ function systemErrorRetryPolicy(options = {}) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Container operations. */
 class ContainerImpl {
@@ -49786,7 +50639,7 @@ const getAccountInfoOperationSpec = {
 
 /***/ }),
 
-/***/ 222:
+/***/ 223:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -49831,7 +50684,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 223:
+/***/ 224:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49860,7 +50713,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.safeTrimTrailingSeparator = exports.normalizeSeparators = exports.hasRoot = exports.hasAbsoluteRoot = exports.ensureAbsoluteRoot = exports.dirname = void 0;
-const path = __importStar(__nccwpck_require__(248));
+const path = __importStar(__nccwpck_require__(249));
 const assert_1 = __importDefault(__nccwpck_require__(527));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -50036,7 +50889,7 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 
 /***/ }),
 
-/***/ 224:
+/***/ 225:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50049,7 +50902,7 @@ module.exports.prettyError = __nccwpck_require__(280)
 
 /***/ }),
 
-/***/ 225:
+/***/ 226:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -50086,7 +50939,7 @@ const net = __importStar(__nccwpck_require__(509));
 const tls = __importStar(__nccwpck_require__(506));
 const debug_1 = __importDefault(__nccwpck_require__(516));
 const events_1 = __nccwpck_require__(470);
-const agent_base_1 = __nccwpck_require__(241);
+const agent_base_1 = __nccwpck_require__(242);
 const url_1 = __nccwpck_require__(85);
 const debug = (0, debug_1.default)('http-proxy-agent');
 /**
@@ -50204,7 +51057,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 226:
+/***/ 227:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -50241,7 +51094,7 @@ var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
 const fs = __importStar(__nccwpck_require__(532));
-const path = __importStar(__nccwpck_require__(248));
+const path = __importStar(__nccwpck_require__(249));
 _a = fs.promises
 // export const {open} = 'fs'
 , exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
@@ -50394,7 +51247,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 227:
+/***/ 228:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50403,7 +51256,7 @@ exports.getCmdPath = getCmdPath;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 var poller_js_1 = __nccwpck_require__(320);
 Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: function () { return poller_js_1.createHttpPoller; } }));
 /**
@@ -50418,14 +51271,14 @@ Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: fun
 // } from "./poller/models";
 // export { buildCreatePoller } from "./poller/poller";
 /** legacy */
-tslib_1.__exportStar(__nccwpck_require__(244), exports);
+tslib_1.__exportStar(__nccwpck_require__(245), exports);
 tslib_1.__exportStar(__nccwpck_require__(75), exports);
 tslib_1.__exportStar(__nccwpck_require__(40), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 228:
+/***/ 229:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -50471,7 +51324,7 @@ function apiVersionPolicy(options) {
 
 /***/ }),
 
-/***/ 229:
+/***/ 230:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50718,7 +51571,7 @@ exports.AbortSignal = AbortSignal;
 
 /***/ }),
 
-/***/ 230:
+/***/ 231:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50735,7 +51588,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 
 /***/ }),
 
-/***/ 231:
+/***/ 232:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50749,9 +51602,9 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Service operations. */
 class ServiceImpl {
@@ -51071,7 +51924,7 @@ const filterBlobsOperationSpec = {
 
 /***/ }),
 
-/***/ 232:
+/***/ 233:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51108,7 +51961,7 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 233:
+/***/ 234:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51133,13 +51986,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 234:
+/***/ 235:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Transform } = __nccwpck_require__(130)
+const { Transform } = __nccwpck_require__(131)
 const { Console } = __nccwpck_require__(32)
 
 /**
@@ -51181,7 +52034,7 @@ module.exports = class PendingInterceptorsFormatter {
 
 /***/ }),
 
-/***/ 235:
+/***/ 236:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51252,7 +52105,7 @@ exports.CacheMetadata = new CacheMetadata$Type();
 
 /***/ }),
 
-/***/ 236:
+/***/ 237:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51299,7 +52152,7 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 237:
+/***/ 238:
 /***/ ((module) => {
 
 "use strict";
@@ -51307,7 +52160,7 @@ module.exports = require("node:process");
 
 /***/ }),
 
-/***/ 238:
+/***/ 239:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51551,7 +52404,7 @@ function appendQueryParams(url, queryParams, sequenceParams, noOverwrite = false
 
 /***/ }),
 
-/***/ 239:
+/***/ 240:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51588,7 +52441,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 240:
+/***/ 241:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -51635,7 +52488,7 @@ function ndJsonPolicy() {
 
 /***/ }),
 
-/***/ 241:
+/***/ 242:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -51671,7 +52524,7 @@ exports.Agent = void 0;
 const net = __importStar(__nccwpck_require__(509));
 const http = __importStar(__nccwpck_require__(329));
 const https_1 = __nccwpck_require__(70);
-__exportStar(__nccwpck_require__(161), exports);
+__exportStar(__nccwpck_require__(162), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
 class Agent extends http.Agent {
     constructor(opts) {
@@ -51820,7 +52673,7 @@ exports.Agent = Agent;
 
 /***/ }),
 
-/***/ 242:
+/***/ 243:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -51863,7 +52716,7 @@ exports.mergeJsonOptions = mergeJsonOptions;
 
 /***/ }),
 
-/***/ 243:
+/***/ 244:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51898,7 +52751,7 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 244:
+/***/ 245:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51907,13 +52760,13 @@ function createHttpHeaders(rawHeaders) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-var lroEngine_js_1 = __nccwpck_require__(178);
+var lroEngine_js_1 = __nccwpck_require__(179);
 Object.defineProperty(exports, "LroEngine", ({ enumerable: true, get: function () { return lroEngine_js_1.LroEngine; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 245:
+/***/ 246:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51948,7 +52801,7 @@ function createEmptyPipeline() {
 
 /***/ }),
 
-/***/ 246:
+/***/ 247:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -52093,7 +52946,7 @@ function createClientLogger(namespace) {
 
 /***/ }),
 
-/***/ 247:
+/***/ 248:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -52140,7 +52993,7 @@ function isTokenCredential(credential) {
 
 /***/ }),
 
-/***/ 248:
+/***/ 249:
 /***/ ((module) => {
 
 "use strict";
@@ -52148,7 +53001,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 249:
+/***/ 250:
 /***/ ((module) => {
 
 "use strict";
@@ -52156,7 +53009,7 @@ module.exports = require("node:fs");
 
 /***/ }),
 
-/***/ 250:
+/***/ 251:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52467,15 +53320,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 251:
+/***/ 252:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryWriter = exports.binaryWriteOptions = void 0;
-const pb_long_1 = __nccwpck_require__(117);
-const goog_varint_1 = __nccwpck_require__(204);
+const pb_long_1 = __nccwpck_require__(118);
+const goog_varint_1 = __nccwpck_require__(205);
 const assert_1 = __nccwpck_require__(484);
 const defaultsWrite = {
     writeUnknownFields: true,
@@ -52707,7 +53560,7 @@ exports.BinaryWriter = BinaryWriter;
 
 /***/ }),
 
-/***/ 252:
+/***/ 253:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52718,7 +53571,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
 const AvroReadable_js_1 = __nccwpck_require__(388);
 const abort_controller_1 = __nccwpck_require__(496);
-const buffer_1 = __nccwpck_require__(119);
+const buffer_1 = __nccwpck_require__(120);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
 class AvroReadableFromStream extends AvroReadable_js_1.AvroReadable {
     _position;
@@ -52804,7 +53657,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 
 /***/ }),
 
-/***/ 253:
+/***/ 254:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52813,7 +53666,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 let _defaultHttpClient;
 function getCachedDefaultHttpClient() {
     if (!_defaultHttpClient) {
@@ -52825,7 +53678,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 254:
+/***/ 255:
 /***/ ((module) => {
 
 "use strict";
@@ -52862,7 +53715,7 @@ module.exports = class Pluralizer {
 
 /***/ }),
 
-/***/ 255:
+/***/ 256:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52891,7 +53744,7 @@ module.exports = createRedirectInterceptor
 
 /***/ }),
 
-/***/ 256:
+/***/ 257:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52945,7 +53798,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 257:
+/***/ 258:
 /***/ ((module) => {
 
 "use strict";
@@ -52953,7 +53806,7 @@ module.exports = require("stream/web");
 
 /***/ }),
 
-/***/ 258:
+/***/ 259:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52963,8 +53816,8 @@ module.exports = require("stream/web");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getBodyAsText = getBodyAsText;
 exports.utf8ByteLength = utf8ByteLength;
-const utils_js_1 = __nccwpck_require__(203);
-const constants_js_1 = __nccwpck_require__(148);
+const utils_js_1 = __nccwpck_require__(204);
+const constants_js_1 = __nccwpck_require__(149);
 async function getBodyAsText(batchResponse) {
     let buffer = Buffer.alloc(constants_js_1.BATCH_MAX_PAYLOAD_IN_BYTES);
     const responseLength = await (0, utils_js_1.streamToBuffer2)(batchResponse.readableStreamBody, buffer);
@@ -52979,7 +53832,7 @@ function utf8ByteLength(str) {
 
 /***/ }),
 
-/***/ 259:
+/***/ 260:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53030,7 +53883,7 @@ function wrapAbortSignalLikePolicy() {
 
 /***/ }),
 
-/***/ 260:
+/***/ 261:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53082,7 +53935,7 @@ function createAbortablePromise(buildPromise, options) {
 
 /***/ }),
 
-/***/ 261:
+/***/ 262:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -53226,803 +54079,6 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 
 /***/ }),
 
-/***/ 262:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// setup-soldr entry point. Owned by Agent 2.
-//
-// Replaces the composite action's main-phase steps with a single JS
-// orchestrator. Calls the helpers in src/lib/* in the same order the
-// composite's steps fire.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(249));
-const os = __importStar(__nccwpck_require__(383));
-const path = __importStar(__nccwpck_require__(508));
-const core = __importStar(__nccwpck_require__(460));
-const cache = __importStar(__nccwpck_require__(215));
-const log_utils_js_1 = __nccwpck_require__(354);
-const resolve_setup_js_1 = __nccwpck_require__(189);
-const phase_timing_js_1 = __nccwpck_require__(337);
-const ensure_rust_toolchain_js_1 = __nccwpck_require__(512);
-const ensure_soldr_js_1 = __nccwpck_require__(340);
-const verify_soldr_js_1 = __nccwpck_require__(360);
-const install_passthrough_js_1 = __nccwpck_require__(514);
-const normalize_source_mtime_js_1 = __nccwpck_require__(79);
-const detect_shared_target_warning_js_1 = __nccwpck_require__(219);
-const ensure_shims_js_1 = __nccwpck_require__(530);
-const cache_compress_js_1 = __nccwpck_require__(493);
-const stats_collector_js_1 = __nccwpck_require__(74);
-const toolchain_snapshot_js_1 = __nccwpck_require__(459);
-const solo_toolchain_cache_js_1 = __nccwpck_require__(295);
-const cook_cache_js_1 = __nccwpck_require__(170);
-const soldr_mini_cache_js_1 = __nccwpck_require__(157);
-const diagnostics_js_1 = __nccwpck_require__(111);
-const source_mtime_snapshot_js_1 = __nccwpck_require__(408);
-/**
- * Map (hit, matchedKey) → workflow-visible restore-status string.
- * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
- * for the `<layer>-cache-restore-status` outputs declared in action.yml.
- */
-function deriveRestoreStatus(hit, matchedKey) {
-    if (hit)
-        return "exact-hit";
-    if (matchedKey.trim())
-        return "restore-key-hit";
-    return "miss";
-}
-function writeCacheKeysManifest(result, runnerTemp, log) {
-    if (!runnerTemp)
-        return;
-    const keys = [
-        result.setupCache.key,
-        result.buildCache.key,
-        result.targetCache.key,
-        result.cargoRegistryCache.key,
-    ].filter((k) => Boolean(k));
-    if (keys.length === 0)
-        return;
-    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
-    try {
-        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
-        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
-    }
-    catch (err) {
-        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-const TRUTHY = new Set(["1", "true", "yes", "on"]);
-const FALSY = new Set(["0", "false", "no", "off"]);
-function isTruthy(value) {
-    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
-}
-function isFalsy(value) {
-    return FALSY.has(((value ?? "").trim().toLowerCase()));
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
-    }
-}
-function dirHasContent(p) {
-    try {
-        return fs.readdirSync(p).length > 0;
-    }
-    catch {
-        return false;
-    }
-}
-function buildActionContext() {
-    const env = process.env;
-    const logger = (0, log_utils_js_1.createLogger)(env);
-    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
-    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
-    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
-    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
-    const githubSha = env["GITHUB_SHA"]?.trim() || "";
-    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
-    const parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
-    return {
-        env: { ...env },
-        workspace,
-        runnerTemp,
-        runnerOs,
-        runnerArch,
-        githubSha,
-        githubToken,
-        parentSha,
-        logger,
-    };
-}
-async function restoreCacheSafe(paths, key, restoreKeys, logger) {
-    if (paths.length === 0 || !key) {
-        return { hit: false, matchedKey: "" };
-    }
-    try {
-        const matched = await cache.restoreCache(paths, key, restoreKeys);
-        return { hit: matched === key, matchedKey: matched ?? "" };
-    }
-    catch (err) {
-        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "" };
-    }
-}
-async function run() {
-    const ctx = buildActionContext();
-    const logger = ctx.logger;
-    await (0, phase_timing_js_1.markPhase)("action");
-    // ---- resolve ----
-    await (0, phase_timing_js_1.markPhase)("resolve");
-    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
-    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
-    await (0, resolve_setup_js_1.applyResolveResult)(result);
-    await (0, phase_timing_js_1.finishPhase)("resolve");
-    // Always emit the cache-keys manifest right after resolve so workflow
-    // steps that run between main and post (e.g. actions/upload-artifact)
-    // can read it. The four keys are fully determined by resolveSetup and
-    // never change later in the run.
-    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
-    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            logger,
-            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
-        });
-    }
-    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
-    if (dryRun) {
-        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
-        await (0, phase_timing_js_1.finishPhase)("action");
-        return;
-    }
-    // Persist resolve state for the post-job step.
-    core.saveState("resolveResult", JSON.stringify(result));
-    core.saveState("buildCacheMode", result.buildCache.mode);
-    core.saveState("logging", logging ? "true" : "false");
-    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
-    const statsMode = result.stats;
-    const debugMode = result.debugMode;
-    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
-    const statsCollector = new stats_collector_js_1.StatsCollector();
-    // ---- source-mtime-normalize ----
-    if (isTruthy(inputs.sourceMtimeNormalize)) {
-        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
-    }
-    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
-    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
-    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
-    core.saveState("setupCacheExactHit", "false");
-    core.saveState("setupCacheMatchedKey", "");
-    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
-    core.saveState("targetCacheExactHit", "false");
-    core.saveState("targetCacheMatchedKey", "");
-    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
-    core.saveState("buildCacheExactHit", "false");
-    core.saveState("buildCacheMatchedKey", "");
-    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
-    core.saveState("cargoRegistryCacheExactHit", "false");
-    core.saveState("cargoRegistryCacheMatchedKey", "");
-    // ---- parallel restores ----
-    // setup-cache, target-cache, build-cache, and cargo-registry write to
-    // disjoint paths and have no inter-dependencies, so they run concurrently.
-    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
-    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
-    //
-    // Layers that must stay sequential (wired below): solo-toolchain (writes
-    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
-    // install dir, must precede ensureSoldr), cook (writes target/ and needs
-    // the soldr binary). Cargo-registry was previously after-cook — it's been
-    // moved into this parallel block because nothing the soldr install path
-    // touches depends on its hydrated cargo registry state.
-    await (0, phase_timing_js_1.markPhase)("parallel-restore");
-    let setupCacheExactHit = false;
-    const setupRestorePromise = (async () => {
-        if (!(cacheEnabled && result.setupCache.paths.length > 0))
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
-        setupCacheExactHit = restore.hit;
-        core.setOutput("cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("setup_cache_matched_key", restore.matchedKey);
-        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("setupCacheMatchedKey", restore.matchedKey);
-        // Expose for ensure_rust_toolchain to read via env. Must be visible by
-        // the time toolchain phase runs — guaranteed by the Promise.all below.
-        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
-        statsCollector.record({
-            label: "setup-cache", operation: "restore", hit: restore.hit,
-            key: result.setupCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.setupCache.restorePrefix],
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const targetRestorePromise = (async () => {
-        if (!result.targetCache.enabled)
-            return;
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        if (targetPaths.length === 0)
-            return;
-        const restoreKeys = [];
-        if (result.targetCache.restoreKeyParent)
-            restoreKeys.push(result.targetCache.restoreKeyParent);
-        if (result.targetCache.restoreKeyLock)
-            restoreKeys.push(result.targetCache.restoreKeyLock);
-        if (result.targetCache.restoreKeyLockfile)
-            restoreKeys.push(result.targetCache.restoreKeyLockfile);
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
-        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("target_cache_matched_key", restore.matchedKey);
-        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("targetCacheMatchedKey", restore.matchedKey);
-        statsCollector.record({
-            label: "target-cache", operation: "restore", hit: restore.hit,
-            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const buildRestorePromise = (async () => {
-        if (!buildCacheEnabled)
-            return;
-        const buildCachePath = result.buildCache.path;
-        const archivePath = `${buildCachePath}.tar.zst`;
-        const restoreKeys = [];
-        if (result.buildCache.restoreKeyParent)
-            restoreKeys.push(result.buildCache.restoreKeyParent);
-        if (result.buildCache.restoreKeyToolchain)
-            restoreKeys.push(result.buildCache.restoreKeyToolchain);
-        if (result.buildCache.restoreKeyOsArch)
-            restoreKeys.push(result.buildCache.restoreKeyOsArch);
-        const t0 = Date.now();
-        // @actions/cache hashes the `paths` array into a "version" key — save and
-        // restore MUST pass the same array or the lookup misses even when the
-        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
-        // restore must use the same single-path array. The decompression below
-        // unpacks archivePath → buildCachePath afterwards.
-        const restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
-        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("build_cache_matched_key", restore.matchedKey);
-        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("buildCacheMatchedKey", restore.matchedKey);
-        let buildArchiveBytes = null;
-        let buildInflatedBytes = null;
-        let buildFileCount = null;
-        if (fileExists(archivePath)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-            if (magic === "zstd" || magic === "gzip") {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath, debug: debugMode, log: debugLog });
-                    buildArchiveBytes = dr.archiveBytes;
-                    buildInflatedBytes = dr.inflatedBytes;
-                    buildFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
-        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
-        // dir on the cold side; if it's present after decompress, walk it and
-        // set each matching source file's mtime to what cold saw. The replay
-        // is gated by (size, content-hash) match so we never overwrite a
-        // genuinely modified file's mtime — that would underbuild.
-        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
-            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
-            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
-            if (snapshot) {
-                const rt0 = Date.now();
-                try {
-                    // Match the project-root selection that post.ts uses when
-                    // writing the snapshot — the parent of the resolved target-dir,
-                    // not the (outer) GITHUB_WORKSPACE.
-                    const projectRoot = path.dirname(result.targetCache.targetPath);
-                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
-                        workspace: projectRoot,
-                        snapshot,
-                        log: (msg) => logger.log(msg),
-                    });
-                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
-                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
-                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
-                }
-                catch (err) {
-                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-            else {
-                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
-            }
-        }
-        statsCollector.record({
-            label: "build-cache", operation: "restore", hit: restore.hit,
-            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    })();
-    // Cargo-registry restore moved here from after-cook. It writes only
-    // $CARGO_HOME/registry/ and has no dependency on soldr being installed;
-    // running it in parallel with target+build trims its ~5s off the critical
-    // path.
-    const cargoRegistryRestorePromise = (async () => {
-        if (!result.cargoRegistryCache.enabled)
-            return;
-        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe([registryArchive], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
-        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
-        let regArchiveBytes = null;
-        let regInflatedBytes = null;
-        let regFileCount = null;
-        if (fileExists(registryArchive)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
-            if (magic === "zstd" || magic === "gzip") {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({
-                        archivePath: registryArchive,
-                        targetDir: result.cargoRegistryCache.path,
-                        debug: debugMode, log: debugLog,
-                    });
-                    regArchiveBytes = dr.archiveBytes;
-                    regInflatedBytes = dr.inflatedBytes;
-                    regFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        statsCollector.record({
-            label: "cargo-registry", operation: "restore", hit: restore.hit,
-            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.cargoRegistryCache.restorePrefix],
-            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    })();
-    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
-    // try/catches, so this should only see rejections for genuine programming
-    // bugs.
-    await Promise.all([
-        setupRestorePromise,
-        targetRestorePromise,
-        buildRestorePromise,
-        cargoRegistryRestorePromise,
-    ]);
-    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
-    // ---- target-tree-cache (full mode) ----
-    // The bundle path is included in target-cache restore paths above when full
-    // mode is requested, so there's no separate restore here. We keep the phase
-    // marker for parity with the composite step ordering.
-    await (0, phase_timing_js_1.markPhase)("target-tree");
-    await (0, phase_timing_js_1.finishPhase)("target-tree");
-    // ---- toolchain ----
-    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
-    // toolchain install so we can see which inodes setup-soldr added on
-    // top of the runner image. When solo-toolchain-cache is opted in, a
-    // third snapshot is taken *before* the cache restore so the saved
-    // tarball captures the full above-runner state — not just the
-    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
-    // lifetime axis".
-    await (0, phase_timing_js_1.markPhase)("toolchain");
-    const snapshotRoots = [
-        path.join(result.rustupHome, "toolchains"),
-        path.join(result.cargoHome, "bin"),
-    ];
-    const soloRootMap = {
-        "rustup-toolchains": snapshotRoots[0],
-        "cargo-bin": snapshotRoots[1],
-    };
-    const soloEnabled = isTruthy(inputs.soloToolchainCache);
-    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "19");
-    let soloKeys = null;
-    let soloMatchedKey = "";
-    let soloExactHit = false;
-    // Pre-restore snapshot — only needed when solo cache is enabled, so
-    // we can compute the full save-diff (post-install vs runner-image,
-    // not vs post-restore baseline).
-    const preRestoreSnapshot = soloEnabled ? await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots) : null;
-    if (soloEnabled) {
-        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
-            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        });
-        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
-        const restoreT0 = Date.now();
-        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
-        const restored = await (0, solo_toolchain_cache_js_1.restoreSoloCache)({
-            keys: soloKeys,
-            rootMap: soloRootMap,
-            stagingDir,
-            log: (msg) => logger.log(msg),
-        });
-        soloMatchedKey = restored.matchedKey;
-        let verifiedMatch = true;
-        if (restored.verified && restored.matchedKey) {
-            const expected = result.toolchain.cacheChannel.trim();
-            // The rustup home is set up so `rustc` will resolve through the
-            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
-            // the cargo bin one.
-            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
-            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
-                expectedRelease: expected,
-                rustcCommand: rustcCmd,
-                log: (msg) => logger.log(msg),
-            });
-            verifiedMatch = verify.match;
-        }
-        soloExactHit = restored.hit && verifiedMatch;
-        core.saveState("soloToolchainEnabled", "true");
-        core.saveState("soloToolchainExactKey", soloKeys.exact);
-        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
-        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
-        core.saveState("soloToolchainLevel", soloLevel);
-        statsCollector.record({
-            label: "solo-toolchain-cache",
-            operation: "restore",
-            hit: soloExactHit,
-            key: soloKeys.exact,
-            matchedKey: soloMatchedKey,
-            restoreKeys: soloKeys.fallbacks,
-            archiveBytes: restored.restoredBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - restoreT0,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else {
-        core.saveState("soloToolchainEnabled", "false");
-    }
-    const baselineSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
-    await (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({ resolveResult: result, setupCacheExactHit });
-    const postInstallSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
-    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
-    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
-    // When solo cache is enabled, also compute the save-diff (post-install
-    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
-    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
-        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
-        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
-        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
-        try {
-            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
-            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
-            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
-            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
-                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
-                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
-                `incremental-empty=${toolchainDiff.added.length === 0}`);
-        }
-        catch (err) {
-            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
-    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
-        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
-    if (ctx.runnerTemp) {
-        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
-        try {
-            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
-            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
-        }
-        catch (err) {
-            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    await (0, phase_timing_js_1.finishPhase)("toolchain");
-    // ---- install soldr ----
-    // Try the soldr-mini-cache before ensureSoldr fires the GH Releases fetch.
-    // On hit, the install dir is pre-populated and ensureSoldr's existing
-    // installedVersion() check short-circuits. On miss, ensureSoldr does its
-    // normal fetch and post.ts saves to the mini-cache.
-    await (0, phase_timing_js_1.markPhase)("install");
-    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
-    const miniInstallDir = path.dirname(result.soldrPath);
-    const miniArchive = `${miniInstallDir}.tar.zst`;
-    let miniHit = false;
-    let miniKey = "";
-    if (miniEnabled) {
-        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
-            hasRef: Boolean(result.soldrRef.trim()),
-            enable: result.enabled,
-            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
-        });
-        if (eligibility.eligible) {
-            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
-            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
-                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-                soldrVersion: version,
-            });
-            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir}`);
-            const miniT0 = Date.now();
-            const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
-                exactKey: miniKey,
-                installDir: miniInstallDir,
-                archivePath: miniArchive,
-                longWindow: 27,
-                debug: debugMode,
-                log: (msg) => logger.log(msg),
-            });
-            miniHit = restore.hit;
-            statsCollector.record({
-                label: "soldr-mini-cache",
-                operation: "restore",
-                hit: restore.hit,
-                key: miniKey,
-                matchedKey: restore.matchedKey,
-                restoreKeys: [],
-                archiveBytes: restore.archiveBytes || null,
-                inflatedBytes: null,
-                fileCount: null,
-                durationMs: Date.now() - miniT0,
-                timestamp: new Date().toISOString(),
-            });
-        }
-        else {
-            logger.log(`soldr-mini-cache: skipped — ${eligibility.reason}`);
-        }
-    }
-    else {
-        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
-    }
-    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
-    core.saveState("soldrMiniExactKey", miniKey);
-    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
-    core.saveState("soldrMiniInstallDir", miniInstallDir);
-    core.saveState("soldrMiniArchive", miniArchive);
-    if (result.enabled) {
-        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
-        // restored binary at the expected path with the expected version and
-        // short-circuits — no GH fetch.
-        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
-    }
-    else {
-        (0, install_passthrough_js_1.installPassthrough)({
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
-            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
-            "verbatim, and soldr-aware caching/observability is disabled.");
-    }
-    await (0, phase_timing_js_1.finishPhase)("install");
-    // Export SOLDR_BINARY so shims can exec it directly
-    core.exportVariable("SOLDR_BINARY", result.soldrPath);
-    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
-    // ---- shims ----
-    if (result.shimsEnabled) {
-        await (0, ensure_shims_js_1.ensureShims)({
-            shimsDir: result.shimsDir,
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-    }
-    // ---- verify ----
-    await (0, phase_timing_js_1.markPhase)("verify");
-    if (result.enabled) {
-        const verify = await (0, verify_soldr_js_1.verifySoldr)({
-            soldrPath: result.soldrPath,
-            buildCacheMode: result.buildCache.mode,
-            requireRustPlan: result.targetCache.enabled,
-        });
-        core.setOutput("soldr-version", verify.soldrVersion);
-        core.setOutput("soldr_version", verify.soldrVersion);
-    }
-    else {
-        core.setOutput("soldr-version", "passthrough");
-        core.setOutput("soldr_version", "passthrough");
-    }
-    await (0, phase_timing_js_1.finishPhase)("verify");
-    // ---- cook (prebuild-deps via cargo-chef) ----
-    // Long-lived deps tarball keyed on Cargo.lock content. Restores
-    // target/deps/ before the user's build so the first compile starts
-    // warm. Gated on Cargo.lock presence + cache umbrella + enable flag.
-    // Failures here are logged but never fail the action — the user's
-    // own cargo build will still work without the cooked deps.
-    await (0, phase_timing_js_1.markPhase)("cook");
-    const cookGate = (0, cook_cache_js_1.decideCookGate)({
-        prebuildDeps: inputs.prebuildDeps,
-        cacheUmbrella: cacheEnabled,
-        lockfilePath: result.targetCache.lockfilePath,
-    });
-    if (cookGate.enabled && result.enabled) {
-        const cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
-        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
-        const lockHash = result.targetCache.lockfileHash || "no-lock";
-        const cookKey = (0, cook_cache_js_1.buildCookCacheKey)({
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            flagsHash,
-            lockHash,
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        });
-        const projectRoot = path.dirname(result.targetCache.targetPath);
-        const cookTargetDir = result.targetCache.targetPath;
-        // CRITICAL: archive path must match what compressCache will write to
-        // during save (`${cacheDir}.tar.zst` — see cache-compress.ts:220).
-        // @actions/cache hashes the `paths` array into a "version" key — save
-        // and restore MUST pass the same array or the lookup misses even when
-        // the entry exists. Mirrors the build-cache pattern at main.ts:280.
-        const cookArchive = `${cookTargetDir}.tar.zst`;
-        logger.log(`cook: key=${cookKey} project=${projectRoot} target=${cookTargetDir}`);
-        const cookT0 = Date.now();
-        const restore = await (0, cook_cache_js_1.restoreCookCache)({
-            exactKey: cookKey,
-            archivePath: cookArchive,
-            targetDir: cookTargetDir,
-            longWindow: 27,
-            debug: debugMode,
-            log: (msg) => logger.log(msg),
-        });
-        let cookRan = false;
-        if (!restore.hit) {
-            const runRes = await (0, cook_cache_js_1.runCook)({
-                soldrBinary: result.soldrPath,
-                projectRoot,
-                flags: cookFlags,
-                log: (msg) => logger.log(msg),
-            });
-            cookRan = runRes.exitCode === 0;
-        }
-        else {
-            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
-        }
-        core.saveState("cookEnabled", "true");
-        core.saveState("cookExactKey", cookKey);
-        core.saveState("cookMatchedKey", restore.matchedKey);
-        core.saveState("cookHit", restore.hit ? "true" : "false");
-        core.saveState("cookRan", cookRan ? "true" : "false");
-        core.saveState("cookTargetDir", cookTargetDir);
-        core.saveState("cookLongWindow", "27");
-        core.saveState("cookCompressLevel", "19");
-        statsCollector.record({
-            label: "cook-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: cookKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - cookT0,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else {
-        logger.log(`cook: skipped - ${cookGate.reason}`);
-        core.saveState("cookEnabled", "false");
-    }
-    await (0, phase_timing_js_1.finishPhase)("cook");
-    // ---- shared-target warning ----
-    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
-        buildCacheEnabled,
-        effectiveTargetCacheEnabled: result.targetCache.enabled,
-        buildCacheMode: result.buildCache.mode,
-        targetDir: result.targetCache.targetPath,
-    });
-    // ---- stats report ----
-    statsCollector.report(statsMode, (msg) => logger.log(msg));
-    if (statsMode === "detailed") {
-        try {
-            await statsCollector.writeFiles(ctx.runnerTemp);
-            statsCollector.setGithubOutputs();
-        }
-        catch (err) {
-            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    core.saveState("statsCollector", statsCollector.serialize());
-    core.saveState("statsMode", statsMode);
-    core.saveState("compileCacheStats", result.compileCacheStats);
-    core.saveState("runnerTemp", ctx.runnerTemp);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            cacheOutcomes: statsCollector.snapshot(),
-            logger,
-        });
-    }
-    await (0, phase_timing_js_1.finishPhase)("action");
-    // dirHasContent is exported for tests; suppress unused warning here.
-    void dirHasContent;
-}
-// Auto-invoke only when this module is run as the main entry point. This lets
-// tests import `run` (and helpers) without triggering the side-effectful
-// orchestration. The dist/main.js produced by ncc is invoked directly by the
-// Actions runtime so the check trips and the action executes normally.
-if (typeof process !== "undefined" &&
-    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
-    // import.meta.url is the file URL of this module; argv[1] is the runner
-    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
-    // the dev path — we rely on the env-var opt-out for tests instead.
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.setFailed(`setup-soldr failed: ${message}`);
-    });
-}
-
-
-/***/ }),
-
 /***/ 263:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -54033,8 +54089,8 @@ if (typeof process !== "undefined" &&
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredential = void 0;
 const node_crypto_1 = __nccwpck_require__(276);
-const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(126);
-const Credential_js_1 = __nccwpck_require__(95);
+const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(127);
+const Credential_js_1 = __nccwpck_require__(96);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -54905,7 +54961,7 @@ exports.listEnumNumbers = listEnumNumbers;
 
 const assert = __nccwpck_require__(527)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(196)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(197)
 const { RequestRetryError } = __nccwpck_require__(488)
 const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(69)
 
@@ -55382,27 +55438,27 @@ module.exports = decodeText
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 tslib_1.__exportStar(__nccwpck_require__(364), exports);
-var cache_js_1 = __nccwpck_require__(253);
+var cache_js_1 = __nccwpck_require__(254);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
 tslib_1.__exportStar(__nccwpck_require__(83), exports);
-tslib_1.__exportStar(__nccwpck_require__(155), exports);
+tslib_1.__exportStar(__nccwpck_require__(156), exports);
 tslib_1.__exportStar(__nccwpck_require__(398), exports);
-tslib_1.__exportStar(__nccwpck_require__(95), exports);
+tslib_1.__exportStar(__nccwpck_require__(96), exports);
 tslib_1.__exportStar(__nccwpck_require__(263), exports);
 tslib_1.__exportStar(__nccwpck_require__(326), exports);
 var RequestPolicy_js_1 = __nccwpck_require__(46);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
 tslib_1.__exportStar(__nccwpck_require__(93), exports);
 tslib_1.__exportStar(__nccwpck_require__(310), exports);
-tslib_1.__exportStar(__nccwpck_require__(207), exports);
+tslib_1.__exportStar(__nccwpck_require__(208), exports);
 tslib_1.__exportStar(__nccwpck_require__(464), exports);
-tslib_1.__exportStar(__nccwpck_require__(167), exports);
-tslib_1.__exportStar(__nccwpck_require__(126), exports);
+tslib_1.__exportStar(__nccwpck_require__(168), exports);
+tslib_1.__exportStar(__nccwpck_require__(127), exports);
 tslib_1.__exportStar(__nccwpck_require__(78), exports);
 tslib_1.__exportStar(__nccwpck_require__(428), exports);
-tslib_1.__exportStar(__nccwpck_require__(169), exports);
+tslib_1.__exportStar(__nccwpck_require__(170), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -55420,9 +55476,9 @@ tslib_1.__exportStar(__nccwpck_require__(169), exports);
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(217);
-tslib_1.__exportStar(__nccwpck_require__(231), exports);
-tslib_1.__exportStar(__nccwpck_require__(221), exports);
+const tslib_1 = __nccwpck_require__(218);
+tslib_1.__exportStar(__nccwpck_require__(232), exports);
+tslib_1.__exportStar(__nccwpck_require__(222), exports);
 tslib_1.__exportStar(__nccwpck_require__(47), exports);
 tslib_1.__exportStar(__nccwpck_require__(283), exports);
 tslib_1.__exportStar(__nccwpck_require__(26), exports);
@@ -55728,20 +55784,20 @@ __export(createPipelineFromOptions_exports, {
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(71);
-var import_pipeline = __nccwpck_require__(245);
+var import_pipeline = __nccwpck_require__(246);
 var import_redirectPolicy = __nccwpck_require__(342);
 var import_userAgentPolicy = __nccwpck_require__(390);
 var import_multipartPolicy = __nccwpck_require__(273);
-var import_decompressResponsePolicy = __nccwpck_require__(239);
+var import_decompressResponsePolicy = __nccwpck_require__(240);
 var import_defaultRetryPolicy = __nccwpck_require__(55);
 var import_formDataPolicy = __nccwpck_require__(270);
 var import_core_util = __nccwpck_require__(14);
 var import_proxyPolicy = __nccwpck_require__(473);
-var import_setClientRequestIdPolicy = __nccwpck_require__(150);
-var import_agentPolicy = __nccwpck_require__(232);
+var import_setClientRequestIdPolicy = __nccwpck_require__(151);
+var import_agentPolicy = __nccwpck_require__(233);
 var import_tlsPolicy = __nccwpck_require__(379);
 var import_tracingPolicy = __nccwpck_require__(336);
-var import_wrapAbortSignalLikePolicy = __nccwpck_require__(259);
+var import_wrapAbortSignalLikePolicy = __nccwpck_require__(260);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_core_util.isNodeLike) {
@@ -55789,9 +55845,9 @@ function createPipelineFromOptions(options) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing PageBlob operations. */
 class PageBlobImpl {
@@ -56251,7 +56307,7 @@ const copyIncrementalOperationSpec = {
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(156)
+const { kConstruct } = __nccwpck_require__(157)
 const { Cache } = __nccwpck_require__(12)
 const { webidl } = __nccwpck_require__(457)
 const { kEnumerableProperty } = __nccwpck_require__(69)
@@ -56407,7 +56463,7 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createClientPipeline = createClientPipeline;
 const deserializationPolicy_js_1 = __nccwpck_require__(86);
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const serializationPolicy_js_1 = __nccwpck_require__(489);
 /**
  * Creates a new Pipeline for use with a Service Client.
@@ -56477,7 +56533,7 @@ const http = __importStar(__nccwpck_require__(329));
 const https = __importStar(__nccwpck_require__(70));
 const pm = __importStar(__nccwpck_require__(312));
 const tunnel = __importStar(__nccwpck_require__(521));
-const undici_1 = __nccwpck_require__(163);
+const undici_1 = __nccwpck_require__(164);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -57152,11 +57208,11 @@ var import_retryPolicy = __nccwpck_require__(16);
 var import_systemErrorRetryPolicy = __nccwpck_require__(28);
 var import_throttlingRetryPolicy = __nccwpck_require__(522);
 var import_formDataPolicy = __nccwpck_require__(341);
-var import_logPolicy = __nccwpck_require__(102);
-var import_multipartPolicy = __nccwpck_require__(171);
+var import_logPolicy = __nccwpck_require__(103);
+var import_multipartPolicy = __nccwpck_require__(172);
 var import_proxyPolicy = __nccwpck_require__(39);
 var import_redirectPolicy = __nccwpck_require__(318);
-var import_tlsPolicy = __nccwpck_require__(222);
+var import_tlsPolicy = __nccwpck_require__(223);
 var import_userAgentPolicy = __nccwpck_require__(362);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -57245,8 +57301,8 @@ const AccountSASResourceTypes_js_1 = __nccwpck_require__(2);
 const AccountSASServices_js_1 = __nccwpck_require__(380);
 const SasIPRange_js_1 = __nccwpck_require__(361);
 const SASQueryParameters_js_1 = __nccwpck_require__(526);
-const constants_js_1 = __nccwpck_require__(148);
-const utils_common_js_1 = __nccwpck_require__(154);
+const constants_js_1 = __nccwpck_require__(149);
+const utils_common_js_1 = __nccwpck_require__(155);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -57349,7 +57405,7 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
 const reflection_info_1 = __nccwpck_require__(453);
-const oneof_1 = __nccwpck_require__(191);
+const oneof_1 = __nccwpck_require__(192);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
     constructor(info) {
@@ -57613,8 +57669,8 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(116);
-var import_constants = __nccwpck_require__(159);
+var import_userAgentPlatform = __nccwpck_require__(117);
+var import_constants = __nccwpck_require__(160);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
   for (const [key, value] of telemetryInfo) {
@@ -57775,10 +57831,10 @@ exports.saveSoloCache = saveSoloCache;
 exports.restoreSoloCache = restoreSoloCache;
 exports.verifyRestoredToolchain = verifyRestoredToolchain;
 const node_crypto_1 = __nccwpck_require__(276);
-const fs = __importStar(__nccwpck_require__(249));
-const fsp = __importStar(__nccwpck_require__(108));
+const fs = __importStar(__nccwpck_require__(250));
+const fsp = __importStar(__nccwpck_require__(109));
 const path = __importStar(__nccwpck_require__(508));
-const cache = __importStar(__nccwpck_require__(215));
+const cache = __importStar(__nccwpck_require__(216));
 const exec = __importStar(__nccwpck_require__(18));
 const cache_compress_js_1 = __nccwpck_require__(493);
 /**
@@ -58142,8 +58198,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
 const assert_1 = __nccwpck_require__(527);
-const path = __importStar(__nccwpck_require__(248));
-const ioUtil = __importStar(__nccwpck_require__(226));
+const path = __importStar(__nccwpck_require__(249));
+const ioUtil = __importStar(__nccwpck_require__(227));
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -58507,11 +58563,11 @@ exports.maskSecretUrls = maskSecretUrls;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 tslib_1.__exportStar(__nccwpck_require__(472), exports);
 var storageClient_js_1 = __nccwpck_require__(447);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(166), exports);
+tslib_1.__exportStar(__nccwpck_require__(167), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -58577,7 +58633,7 @@ const {
   NotSupportedError
 } = __nccwpck_require__(488)
 const assert = __nccwpck_require__(527)
-const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(196)
+const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(197)
 const util = __nccwpck_require__(69)
 
 // tokenRegExp and headerCharRegex have been lifted from
@@ -58608,7 +58664,7 @@ const channels = {}
 let extractBody
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(141)
+  const diagnosticsChannel = __nccwpck_require__(142)
   channels.create = diagnosticsChannel.channel('undici:request:create')
   channels.bodySent = diagnosticsChannel.channel('undici:request:bodySent')
   channels.headers = diagnosticsChannel.channel('undici:request:headers')
@@ -59386,7 +59442,7 @@ function stringifyComplexTable (prefix, indent, key, value) {
 const { webidl } = __nccwpck_require__(457)
 const { DOMException } = __nccwpck_require__(30)
 const { URLSerializer } = __nccwpck_require__(25)
-const { getGlobalOrigin } = __nccwpck_require__(139)
+const { getGlobalOrigin } = __nccwpck_require__(140)
 const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(466)
 const {
   kWebSocketURL,
@@ -59396,14 +59452,14 @@ const {
   kResponse,
   kSentClose,
   kByteParser
-} = __nccwpck_require__(98)
+} = __nccwpck_require__(99)
 const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(57)
 const { establishWebSocketConnection } = __nccwpck_require__(366)
-const { WebsocketFrameSend } = __nccwpck_require__(187)
+const { WebsocketFrameSend } = __nccwpck_require__(188)
 const { ByteParser } = __nccwpck_require__(482)
 const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(69)
 const { getGlobalDispatcher } = __nccwpck_require__(377)
-const { types } = __nccwpck_require__(123)
+const { types } = __nccwpck_require__(124)
 
 let experimentalWarned = false
 
@@ -60512,7 +60568,7 @@ __export(concat_exports, {
   concat: () => concat
 });
 module.exports = __toCommonJS(concat_exports);
-var import_stream = __nccwpck_require__(130);
+var import_stream = __nccwpck_require__(131);
 var import_typeGuards = __nccwpck_require__(497);
 async function* streamAsyncIterator() {
   const reader = this.getReader();
@@ -60957,11 +61013,11 @@ exports.CredentialPolicy = CredentialPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BatchResponseParser = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const core_http_compat_1 = __nccwpck_require__(72);
-const constants_js_1 = __nccwpck_require__(148);
-const BatchUtils_js_1 = __nccwpck_require__(258);
-const log_js_1 = __nccwpck_require__(106);
+const constants_js_1 = __nccwpck_require__(149);
+const BatchUtils_js_1 = __nccwpck_require__(259);
+const log_js_1 = __nccwpck_require__(107);
 const HTTP_HEADER_DELIMITER = ": ";
 const SPACE_DELIMITER = " ";
 const NOT_FOUND = -1;
@@ -61353,7 +61409,7 @@ function flattenResponse(fullResponse, responseSpec) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.buildCreatePoller = void 0;
-const operation_js_1 = __nccwpck_require__(140);
+const operation_js_1 = __nccwpck_require__(141);
 const constants_js_1 = __nccwpck_require__(60);
 const core_util_1 = __nccwpck_require__(14);
 const createStateProxy = () => ({
@@ -61534,12 +61590,12 @@ exports.buildCreatePoller = buildCreatePoller;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const pipeline_js_1 = __nccwpck_require__(285);
 const utils_js_1 = __nccwpck_require__(313);
 const httpClientCache_js_1 = __nccwpck_require__(399);
 const operationHelpers_js_1 = __nccwpck_require__(433);
-const urlHelpers_js_1 = __nccwpck_require__(238);
+const urlHelpers_js_1 = __nccwpck_require__(239);
 const interfaceHelpers_js_1 = __nccwpck_require__(400);
 const log_js_1 = __nccwpck_require__(481);
 /**
@@ -61733,7 +61789,7 @@ __export(createPipelineFromOptions_exports, {
   createPipelineFromOptions: () => createPipelineFromOptions
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
-var import_logPolicy = __nccwpck_require__(102);
+var import_logPolicy = __nccwpck_require__(103);
 var import_pipeline = __nccwpck_require__(525);
 var import_redirectPolicy = __nccwpck_require__(318);
 var import_userAgentPolicy = __nccwpck_require__(362);
@@ -61743,8 +61799,8 @@ var import_formDataPolicy = __nccwpck_require__(341);
 var import_checkEnvironment = __nccwpck_require__(439);
 var import_proxyPolicy = __nccwpck_require__(39);
 var import_agentPolicy = __nccwpck_require__(465);
-var import_tlsPolicy = __nccwpck_require__(222);
-var import_multipartPolicy = __nccwpck_require__(171);
+var import_tlsPolicy = __nccwpck_require__(223);
+var import_multipartPolicy = __nccwpck_require__(172);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_checkEnvironment.isNodeLike) {
@@ -61817,7 +61873,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_log = __nccwpck_require__(151);
+var import_log = __nccwpck_require__(152);
 const redirectPolicyName = "redirectPolicy";
 const allowedRedirect = ["GET", "HEAD"];
 function redirectPolicy(options = {}) {
@@ -62552,12 +62608,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._readLinuxVersionFile = exports._getOsVersion = exports._findMatch = void 0;
-const semver = __importStar(__nccwpck_require__(179));
+const semver = __importStar(__nccwpck_require__(180));
 const core_1 = __nccwpck_require__(460);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
 const os = __nccwpck_require__(92);
-const cp = __nccwpck_require__(164);
+const cp = __nccwpck_require__(165);
 const fs = __nccwpck_require__(532);
 function _findMatch(versionSpec, stable, candidates, archFilter) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -62679,7 +62735,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-const path = __importStar(__nccwpck_require__(248));
+const path = __importStar(__nccwpck_require__(249));
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
  * replaced with /.
@@ -62837,15 +62893,15 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatch = void 0;
 const core_util_1 = __nccwpck_require__(14);
 const core_auth_1 = __nccwpck_require__(515);
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const core_util_2 = __nccwpck_require__(14);
 const storage_common_1 = __nccwpck_require__(278);
-const Clients_js_1 = __nccwpck_require__(185);
+const Clients_js_1 = __nccwpck_require__(186);
 const Mutex_js_1 = __nccwpck_require__(519);
-const Pipeline_js_1 = __nccwpck_require__(183);
-const utils_common_js_1 = __nccwpck_require__(154);
-const core_xml_1 = __nccwpck_require__(195);
-const constants_js_1 = __nccwpck_require__(148);
+const Pipeline_js_1 = __nccwpck_require__(184);
+const utils_common_js_1 = __nccwpck_require__(155);
+const core_xml_1 = __nccwpck_require__(196);
+const constants_js_1 = __nccwpck_require__(149);
 const tracing_js_1 = __nccwpck_require__(31);
 const core_client_1 = __nccwpck_require__(440);
 /**
@@ -63124,7 +63180,7 @@ var AvroReader_js_1 = __nccwpck_require__(422);
 Object.defineProperty(exports, "AvroReader", ({ enumerable: true, get: function () { return AvroReader_js_1.AvroReader; } }));
 var AvroReadable_js_1 = __nccwpck_require__(388);
 Object.defineProperty(exports, "AvroReadable", ({ enumerable: true, get: function () { return AvroReadable_js_1.AvroReadable; } }));
-var AvroReadableFromStream_js_1 = __nccwpck_require__(252);
+var AvroReadableFromStream_js_1 = __nccwpck_require__(253);
 Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, get: function () { return AvroReadableFromStream_js_1.AvroReadableFromStream; } }));
 //# sourceMappingURL=index.js.map
 
@@ -63157,12 +63213,12 @@ __export(tracingPolicy_exports, {
 });
 module.exports = __toCommonJS(tracingPolicy_exports);
 var import_core_tracing = __nccwpck_require__(82);
-var import_constants = __nccwpck_require__(159);
+var import_constants = __nccwpck_require__(160);
 var import_userAgent = __nccwpck_require__(293);
-var import_log = __nccwpck_require__(184);
+var import_log = __nccwpck_require__(185);
 var import_core_util = __nccwpck_require__(14);
 var import_restError = __nccwpck_require__(355);
-var import_util = __nccwpck_require__(146);
+var import_util = __nccwpck_require__(147);
 const tracingPolicyName = "tracingPolicy";
 function tracingPolicy(options = {}) {
   const userAgentPromise = (0, import_userAgent.getUserAgentValue)(options.userAgentPrefix);
@@ -63384,7 +63440,7 @@ const {
   InvalidArgumentError
 } = __nccwpck_require__(488)
 const util = __nccwpck_require__(69)
-const { kUrl, kInterceptors } = __nccwpck_require__(196)
+const { kUrl, kInterceptors } = __nccwpck_require__(197)
 const buildConnector = __nccwpck_require__(267)
 
 const kOptions = Symbol('options')
@@ -63579,7 +63635,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureSoldr = ensureSoldr;
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const os = __importStar(__nccwpck_require__(383));
 const path = __importStar(__nccwpck_require__(508));
 const core = __importStar(__nccwpck_require__(460));
@@ -64067,7 +64123,7 @@ function redirectPolicy(options = {}) {
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(196)
+const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(197)
 const { URL } = __nccwpck_require__(85)
 const Agent = __nccwpck_require__(5)
 const Pool = __nccwpck_require__(338)
@@ -64337,9 +64393,9 @@ exports.ReflectionJsonReader = void 0;
 const json_typings_1 = __nccwpck_require__(395);
 const base64_1 = __nccwpck_require__(304);
 const reflection_info_1 = __nccwpck_require__(453);
-const pb_long_1 = __nccwpck_require__(117);
+const pb_long_1 = __nccwpck_require__(118);
 const assert_1 = __nccwpck_require__(484);
-const reflection_long_convert_1 = __nccwpck_require__(158);
+const reflection_long_convert_1 = __nccwpck_require__(159);
 /**
  * Reads proto3 messages in canonical JSON format using reflection information.
  *
@@ -65053,7 +65109,7 @@ TomlError.wrap = err => {
 module.exports.TomlError = TomlError
 
 const createDateTime = __nccwpck_require__(385)
-const createDateTimeFloat = __nccwpck_require__(172)
+const createDateTimeFloat = __nccwpck_require__(173)
 const createDate = __nccwpck_require__(54)
 const createTime = __nccwpck_require__(350)
 
@@ -66536,7 +66592,7 @@ module.exports = value => {
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(123)
+const { promisify } = __nccwpck_require__(124)
 const Pool = __nccwpck_require__(338)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
@@ -66548,8 +66604,8 @@ const {
   kOriginalDispatch,
   kConnected
 } = __nccwpck_require__(471)
-const { MockInterceptor } = __nccwpck_require__(135)
-const Symbols = __nccwpck_require__(196)
+const { MockInterceptor } = __nccwpck_require__(136)
+const Symbols = __nccwpck_require__(197)
 const { InvalidArgumentError } = __nccwpck_require__(488)
 
 /**
@@ -66724,7 +66780,7 @@ exports.colorForceEnvironment = colorForceEnvironment;
 exports.formatLogLine = formatLogLine;
 exports.isTimestampsEnabled = isTimestampsEnabled;
 const core = __importStar(__nccwpck_require__(460));
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 function makeFileLogger(env) {
     const logPath = (env["SETUP_SOLDR_LOG"] ?? "").trim();
     if (!logPath)
@@ -66889,16 +66945,16 @@ function isRestError(e) {
 "use strict";
 
 
-const { finished, PassThrough } = __nccwpck_require__(130)
+const { finished, PassThrough } = __nccwpck_require__(131)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
 } = __nccwpck_require__(488)
 const util = __nccwpck_require__(69)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(190)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(191)
 const { AsyncResource } = __nccwpck_require__(430)
-const { addSignal, removeSignal } = __nccwpck_require__(103)
+const { addSignal, removeSignal } = __nccwpck_require__(104)
 
 class StreamHandler extends AsyncResource {
   constructor (opts, factory, callback) {
@@ -67125,9 +67181,9 @@ module.exports = stream
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing BlockBlob operations. */
 class BlockBlobImpl {
@@ -67546,7 +67602,7 @@ function decompressResponsePolicy() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GenericPollOperation = void 0;
 const operation_js_1 = __nccwpck_require__(51);
-const logger_js_1 = __nccwpck_require__(192);
+const logger_js_1 = __nccwpck_require__(193);
 const createStateProxy = () => ({
     initState: (config) => ({ config, isStarted: true }),
     setCanceled: (state) => (state.isCancelled = true),
@@ -67823,7 +67879,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(256);
+var import_userAgent = __nccwpck_require__(257);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -68160,8 +68216,8 @@ exports.BufferScheduler = BufferScheduler;
 "use strict";
 
 
-const { Blob, File: NativeFile } = __nccwpck_require__(119)
-const { types } = __nccwpck_require__(123)
+const { Blob, File: NativeFile } = __nccwpck_require__(120)
+const { types } = __nccwpck_require__(124)
 const { kState } = __nccwpck_require__(15)
 const { isBlobLike } = __nccwpck_require__(518)
 const { webidl } = __nccwpck_require__(457)
@@ -68512,21 +68568,21 @@ module.exports = { File, FileLike, isFileLike }
 "use strict";
 
 
-const diagnosticsChannel = __nccwpck_require__(141)
+const diagnosticsChannel = __nccwpck_require__(142)
 const { uid, states } = __nccwpck_require__(466)
 const {
   kReadyState,
   kSentClose,
   kByteParser,
   kReceivedClose
-} = __nccwpck_require__(98)
+} = __nccwpck_require__(99)
 const { fireEvent, failWebsocketConnection } = __nccwpck_require__(57)
-const { CloseEvent } = __nccwpck_require__(250)
+const { CloseEvent } = __nccwpck_require__(251)
 const { makeRequest } = __nccwpck_require__(84)
 const { fetching } = __nccwpck_require__(451)
 const { Headers } = __nccwpck_require__(517)
 const { getGlobalDispatcher } = __nccwpck_require__(377)
-const { kHeadersList } = __nccwpck_require__(196)
+const { kHeadersList } = __nccwpck_require__(197)
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -68874,7 +68930,7 @@ exports.resolveToolchainCacheChannel = resolveToolchainCacheChannel;
 exports.loadToolchainSpec = loadToolchainSpec;
 exports.systemRustupSatisfiesRequest = systemRustupSatisfiesRequest;
 const node_crypto_1 = __nccwpck_require__(276);
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const path = __importStar(__nccwpck_require__(508));
 const toml = __importStar(__nccwpck_require__(401));
 const io = __importStar(__nccwpck_require__(296));
@@ -69226,8 +69282,8 @@ function statusCodeToNumber(statusCode) {
 
 
 const DispatcherBase = __nccwpck_require__(62)
-const FixedQueue = __nccwpck_require__(197)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(196)
+const FixedQueue = __nccwpck_require__(198)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(197)
 const PoolStats = __nccwpck_require__(22)
 
 const kClients = Symbol('clients')
@@ -69490,7 +69546,7 @@ exports.TracingContextImpl = TracingContextImpl;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 const BuffersStream_js_1 = __nccwpck_require__(386);
 const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(265));
 /**
@@ -69633,7 +69689,7 @@ function createDefaultHttpClient() {
 const { AsyncResource } = __nccwpck_require__(430)
 const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(488)
 const util = __nccwpck_require__(69)
-const { addSignal, removeSignal } = __nccwpck_require__(103)
+const { addSignal, removeSignal } = __nccwpck_require__(104)
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -69959,7 +70015,7 @@ module.exports = {
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(196)
+const { kClients } = __nccwpck_require__(197)
 const Agent = __nccwpck_require__(5)
 const {
   kAgent,
@@ -69972,13 +70028,13 @@ const {
   kOptions,
   kFactory
 } = __nccwpck_require__(471)
-const MockClient = __nccwpck_require__(200)
+const MockClient = __nccwpck_require__(201)
 const MockPool = __nccwpck_require__(351)
 const { matchValue, buildMockOptions } = __nccwpck_require__(7)
 const { InvalidArgumentError, UndiciError } = __nccwpck_require__(488)
 const Dispatcher = __nccwpck_require__(478)
-const Pluralizer = __nccwpck_require__(254)
-const PendingInterceptorsFormatter = __nccwpck_require__(234)
+const Pluralizer = __nccwpck_require__(255)
+const PendingInterceptorsFormatter = __nccwpck_require__(235)
 
 class FakeWeakRef {
   constructor (value) {
@@ -70331,7 +70387,7 @@ const {
   kGetDispatcher
 } = __nccwpck_require__(370)
 const Pool = __nccwpck_require__(338)
-const { kUrl, kInterceptors } = __nccwpck_require__(196)
+const { kUrl, kInterceptors } = __nccwpck_require__(197)
 const { parseOrigin } = __nccwpck_require__(69)
 const kFactory = Symbol('factory')
 
@@ -70957,7 +71013,7 @@ function userAgentPolicy(options = {}) {
 
 
 const util = __nccwpck_require__(69)
-const { kBodyUsed } = __nccwpck_require__(196)
+const { kBodyUsed } = __nccwpck_require__(197)
 const assert = __nccwpck_require__(527)
 const { InvalidArgumentError } = __nccwpck_require__(488)
 const EE = __nccwpck_require__(470)
@@ -71463,7 +71519,7 @@ exports.CacheScope = new CacheScope$Type();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredential = void 0;
 const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(93);
-const Credential_js_1 = __nccwpck_require__(95);
+const Credential_js_1 = __nccwpck_require__(96);
 /**
  * AnonymousCredential provides a credentialPolicyCreator member used to create
  * AnonymousCredentialPolicy objects. AnonymousCredentialPolicy is used with
@@ -71495,7 +71551,7 @@ exports.AnonymousCredential = AnonymousCredential;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 let cachedHttpClient;
 function getCachedDefaultHttpClient() {
     if (!cachedHttpClient) {
@@ -71562,7 +71618,7 @@ function getPathStringFromParameter(parameter) {
 
 "use strict";
 
-exports.parse = __nccwpck_require__(224)
+exports.parse = __nccwpck_require__(225)
 exports.stringify = __nccwpck_require__(301)
 
 
@@ -71576,13 +71632,13 @@ exports.stringify = __nccwpck_require__(301)
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobServiceClient = void 0;
 const core_auth_1 = __nccwpck_require__(515);
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const core_util_1 = __nccwpck_require__(14);
-const Pipeline_js_1 = __nccwpck_require__(183);
+const Pipeline_js_1 = __nccwpck_require__(184);
 const ContainerClient_js_1 = __nccwpck_require__(64);
-const utils_common_js_1 = __nccwpck_require__(154);
+const utils_common_js_1 = __nccwpck_require__(155);
 const storage_common_1 = __nccwpck_require__(278);
-const utils_common_js_2 = __nccwpck_require__(154);
+const utils_common_js_2 = __nccwpck_require__(155);
 const tracing_js_1 = __nccwpck_require__(31);
 const BlobBatchClient_js_1 = __nccwpck_require__(403);
 const StorageClient_js_1 = __nccwpck_require__(455);
@@ -72291,13 +72347,13 @@ exports.BlobServiceClient = BlobServiceClient;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatchClient = void 0;
 const BatchResponseParser_js_1 = __nccwpck_require__(311);
-const BatchUtils_js_1 = __nccwpck_require__(258);
+const BatchUtils_js_1 = __nccwpck_require__(259);
 const BlobBatch_js_1 = __nccwpck_require__(334);
 const tracing_js_1 = __nccwpck_require__(31);
 const storage_common_1 = __nccwpck_require__(278);
 const StorageContextClient_js_1 = __nccwpck_require__(268);
-const Pipeline_js_1 = __nccwpck_require__(183);
-const utils_common_js_1 = __nccwpck_require__(154);
+const Pipeline_js_1 = __nccwpck_require__(184);
+const utils_common_js_1 = __nccwpck_require__(155);
 /**
  * A BlobBatchClient allows you to make batched requests to the Azure Storage Blob service.
  *
@@ -72707,7 +72763,7 @@ exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
 const tracingContext_js_1 = __nccwpck_require__(371);
-const state_js_1 = __nccwpck_require__(96);
+const state_js_1 = __nccwpck_require__(97);
 function createDefaultTracingSpan() {
     return {
         end: () => {
@@ -72835,7 +72891,7 @@ exports.snapshotSourceMtimes = snapshotSourceMtimes;
 exports.replaySourceMtimes = replaySourceMtimes;
 exports.writeSnapshotFile = writeSnapshotFile;
 exports.readSnapshotFile = readSnapshotFile;
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const path = __importStar(__nccwpck_require__(508));
 const node_crypto_1 = __nccwpck_require__(276);
 const normalize_source_mtime_js_1 = __nccwpck_require__(79);
@@ -73016,7 +73072,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
 const binary_format_contract_1 = __nccwpck_require__(333);
 const reflection_info_1 = __nccwpck_require__(453);
-const reflection_long_convert_1 = __nccwpck_require__(158);
+const reflection_long_convert_1 = __nccwpck_require__(159);
 const reflection_scalar_default_1 = __nccwpck_require__(463);
 /**
  * Reads proto3 messages in binary format using reflection information.
@@ -73552,8 +73608,8 @@ __export(response_exports, {
   toPipelineResponse: () => toPipelineResponse
 });
 module.exports = __toCommonJS(response_exports);
-var import_core_rest_pipeline = __nccwpck_require__(101);
-var import_util = __nccwpck_require__(109);
+var import_core_rest_pipeline = __nccwpck_require__(102);
+var import_util = __nccwpck_require__(110);
 const originalResponse = /* @__PURE__ */ Symbol("Original FullOperationResponse");
 function toCompatResponse(response, options) {
   let request = (0, import_util.toWebResourceLike)(response.request);
@@ -73674,7 +73730,7 @@ exports.getOptions = getOptions;
 
 /* istanbul ignore file: only for Node 12 */
 
-const { kConnected, kSize } = __nccwpck_require__(196)
+const { kConnected, kSize } = __nccwpck_require__(197)
 
 class CompatWeakRef {
   constructor (value) {
@@ -73734,7 +73790,7 @@ exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTie
 exports.toAccessTier = toAccessTier;
 exports.ensureCpkIfSpecified = ensureCpkIfSpecified;
 exports.getBlobServiceAccountAudience = getBlobServiceAccountAudience;
-const constants_js_1 = __nccwpck_require__(148);
+const constants_js_1 = __nccwpck_require__(149);
 /**
  * Represents the access tier on a blob.
  * For detailed information about block blob level tiering see {@link https://learn.microsoft.com/azure/storage/blobs/storage-blob-storage-tiers|Hot, cool and archive storage tiers.}
@@ -73862,7 +73918,7 @@ const Dicer = __nccwpck_require__(13)
 
 const MultipartParser = __nccwpck_require__(0)
 const UrlencodedParser = __nccwpck_require__(405)
-const parseParams = __nccwpck_require__(193)
+const parseParams = __nccwpck_require__(194)
 
 function Busboy (opts) {
   if (!(this instanceof Busboy)) { return new Busboy(opts) }
@@ -74186,7 +74242,7 @@ exports.parseProxyResponse = parseProxyResponse;
 
 module.exports = parseStream
 
-const stream = __nccwpck_require__(130)
+const stream = __nccwpck_require__(131)
 const TOMLParser = __nccwpck_require__(348)
 
 function parseStream (stm) {
@@ -74278,7 +74334,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReader = void 0;
 // TODO: Do a review of non-interfaces
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
-const AvroConstants_js_1 = __nccwpck_require__(230);
+const AvroConstants_js_1 = __nccwpck_require__(231);
 const AvroParser_js_1 = __nccwpck_require__(303);
 const utils_common_js_1 = __nccwpck_require__(392);
 class AvroReader {
@@ -74404,13 +74460,13 @@ exports.CacheService = exports.GetCacheEntryDownloadURLResponse = exports.GetCac
 // @generated by protobuf-ts 2.9.1 with parameter long_type_string,client_none,generate_dependencies
 // @generated from protobuf file "results/api/v1/cache.proto" (package "github.actions.results.api.v1", syntax proto3)
 // tslint:disable
-const runtime_rpc_1 = __nccwpck_require__(175);
+const runtime_rpc_1 = __nccwpck_require__(176);
 const runtime_1 = __nccwpck_require__(19);
 const runtime_2 = __nccwpck_require__(19);
 const runtime_3 = __nccwpck_require__(19);
 const runtime_4 = __nccwpck_require__(19);
 const runtime_5 = __nccwpck_require__(19);
-const cachemetadata_1 = __nccwpck_require__(235);
+const cachemetadata_1 = __nccwpck_require__(236);
 // @generated message type with reflection information, may provide speed optimized methods
 class CreateCacheEntryRequest$Type extends runtime_5.MessageType {
     constructor() {
@@ -74809,7 +74865,7 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(127)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(128)
 const { isCTLExcludingHtab } = __nccwpck_require__(410)
 const { collectASequenceOfCodePointsFast } = __nccwpck_require__(25)
 const assert = __nccwpck_require__(527)
@@ -75889,7 +75945,7 @@ __export(userAgentPlatform_exports, {
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
 var import_node_os = __toESM(__nccwpck_require__(383));
-var import_node_process = __toESM(__nccwpck_require__(237));
+var import_node_process = __toESM(__nccwpck_require__(238));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -75985,7 +76041,7 @@ exports.DefaultGlobber = void 0;
 const core = __importStar(__nccwpck_require__(460));
 const fs = __importStar(__nccwpck_require__(532));
 const globOptionsHelper = __importStar(__nccwpck_require__(414));
-const path = __importStar(__nccwpck_require__(248));
+const path = __importStar(__nccwpck_require__(249));
 const patternHelper = __importStar(__nccwpck_require__(43));
 const internal_match_kind_1 = __nccwpck_require__(529);
 const internal_pattern_1 = __nccwpck_require__(502);
@@ -76284,7 +76340,7 @@ function getOperationRequestInfo(request) {
 const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(488)
 const { AsyncResource } = __nccwpck_require__(430)
 const util = __nccwpck_require__(69)
-const { addSignal, removeSignal } = __nccwpck_require__(103)
+const { addSignal, removeSignal } = __nccwpck_require__(104)
 const assert = __nccwpck_require__(527)
 
 class UpgradeHandler extends AsyncResource {
@@ -76394,7 +76450,7 @@ module.exports = upgrade
 "use strict";
 
 const os = __nccwpck_require__(92);
-const tty = __nccwpck_require__(182);
+const tty = __nccwpck_require__(183);
 const hasFlag = __nccwpck_require__(367);
 
 const {env} = process;
@@ -76556,7 +76612,7 @@ __export(checkInsecureConnection_exports, {
   ensureSecureConnection: () => ensureSecureConnection
 });
 module.exports = __toCommonJS(checkInsecureConnection_exports);
-var import_log = __nccwpck_require__(151);
+var import_log = __nccwpck_require__(152);
 let insecureConnectionWarningEmmitted = false;
 function allowInsecureConnection(request, options) {
   if (options.allowInsecureConnection && request.allowInsecureConnection) {
@@ -76778,7 +76834,7 @@ var serviceClient_js_1 = __nccwpck_require__(315);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
 var pipeline_js_1 = __nccwpck_require__(285);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
-var interfaces_js_1 = __nccwpck_require__(99);
+var interfaces_js_1 = __nccwpck_require__(100);
 Object.defineProperty(exports, "XML_ATTRKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_ATTRKEY; } }));
 Object.defineProperty(exports, "XML_CHARKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_CHARKEY; } }));
 var deserializationPolicy_js_1 = __nccwpck_require__(86);
@@ -76787,9 +76843,9 @@ Object.defineProperty(exports, "deserializationPolicyName", ({ enumerable: true,
 var serializationPolicy_js_1 = __nccwpck_require__(489);
 Object.defineProperty(exports, "serializationPolicy", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicy; } }));
 Object.defineProperty(exports, "serializationPolicyName", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicyName; } }));
-var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(112);
+var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(113);
 Object.defineProperty(exports, "authorizeRequestOnClaimChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnClaimChallenge_js_1.authorizeRequestOnClaimChallenge; } }));
-var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(173);
+var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(174);
 Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnTenantChallenge_js_1.authorizeRequestOnTenantChallenge; } }));
 //# sourceMappingURL=index.js.map
 
@@ -76837,7 +76893,7 @@ exports.createTar = exports.extractTar = exports.listTar = void 0;
 const exec_1 = __nccwpck_require__(18);
 const io = __importStar(__nccwpck_require__(296));
 const fs_1 = __nccwpck_require__(532);
-const path = __importStar(__nccwpck_require__(248));
+const path = __importStar(__nccwpck_require__(249));
 const utils = __importStar(__nccwpck_require__(76));
 const constants_1 = __nccwpck_require__(45);
 const IS_WINDOWS = process.platform === 'win32';
@@ -77117,8 +77173,8 @@ var import_node_stream = __nccwpck_require__(431);
 var import_AbortError = __nccwpck_require__(10);
 var import_httpHeaders = __nccwpck_require__(485);
 var import_restError = __nccwpck_require__(445);
-var import_log = __nccwpck_require__(151);
-var import_sanitizer = __nccwpck_require__(121);
+var import_log = __nccwpck_require__(152);
+var import_sanitizer = __nccwpck_require__(122);
 const DEFAULT_TLS_SETTINGS = {};
 function isReadableStream(body) {
   return body && typeof body.pipe === "function";
@@ -77604,9 +77660,9 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_error = __nccwpck_require__(153);
+var import_error = __nccwpck_require__(154);
 var import_inspect = __nccwpck_require__(1);
-var import_sanitizer = __nccwpck_require__(121);
+var import_sanitizer = __nccwpck_require__(122);
 const errorSanitizer = new import_sanitizer.Sanitizer();
 class RestError extends Error {
   /**
@@ -77747,7 +77803,7 @@ function wrapAbortSignalLike(abortSignalLike) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 const coreHttpCompat = tslib_1.__importStar(__nccwpck_require__(72));
 const index_js_1 = __nccwpck_require__(279);
 class StorageClient extends coreHttpCompat.ExtendedServiceClient {
@@ -77815,13 +77871,13 @@ exports.StorageClient = StorageClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = exports.StorageSharedKeyCredentialPolicy = exports.StorageSharedKeyCredential = exports.StorageRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = exports.Credential = exports.CredentialPolicy = exports.BaseRequestPolicy = exports.AnonymousCredentialPolicy = exports.AnonymousCredential = exports.StorageOAuthScopes = exports.newPipeline = exports.isPipelineLike = exports.Pipeline = exports.getBlobServiceAccountAudience = exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTier = exports.generateBlobSASQueryParameters = exports.generateAccountSASQueryParameters = void 0;
-const tslib_1 = __nccwpck_require__(217);
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const tslib_1 = __nccwpck_require__(218);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
 tslib_1.__exportStar(__nccwpck_require__(402), exports);
-tslib_1.__exportStar(__nccwpck_require__(185), exports);
+tslib_1.__exportStar(__nccwpck_require__(186), exports);
 tslib_1.__exportStar(__nccwpck_require__(64), exports);
-tslib_1.__exportStar(__nccwpck_require__(205), exports);
+tslib_1.__exportStar(__nccwpck_require__(206), exports);
 tslib_1.__exportStar(__nccwpck_require__(58), exports);
 tslib_1.__exportStar(__nccwpck_require__(2), exports);
 tslib_1.__exportStar(__nccwpck_require__(380), exports);
@@ -77829,7 +77885,7 @@ var AccountSASSignatureValues_js_1 = __nccwpck_require__(290);
 Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
 tslib_1.__exportStar(__nccwpck_require__(334), exports);
 tslib_1.__exportStar(__nccwpck_require__(403), exports);
-tslib_1.__exportStar(__nccwpck_require__(174), exports);
+tslib_1.__exportStar(__nccwpck_require__(175), exports);
 tslib_1.__exportStar(__nccwpck_require__(503), exports);
 var BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
@@ -77839,7 +77895,7 @@ Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: functi
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
 Object.defineProperty(exports, "getBlobServiceAccountAudience", ({ enumerable: true, get: function () { return models_js_1.getBlobServiceAccountAudience; } }));
-var Pipeline_js_1 = __nccwpck_require__(183);
+var Pipeline_js_1 = __nccwpck_require__(184);
 Object.defineProperty(exports, "Pipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.Pipeline; } }));
 Object.defineProperty(exports, "isPipelineLike", ({ enumerable: true, get: function () { return Pipeline_js_1.isPipelineLike; } }));
 Object.defineProperty(exports, "newPipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.newPipeline; } }));
@@ -77859,7 +77915,7 @@ Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get:
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
 tslib_1.__exportStar(__nccwpck_require__(526), exports);
 tslib_1.__exportStar(__nccwpck_require__(323), exports);
-var log_js_1 = __nccwpck_require__(106);
+var log_js_1 = __nccwpck_require__(107);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
 
@@ -78178,7 +78234,7 @@ __export(sendRequest_exports, {
 module.exports = __toCommonJS(sendRequest_exports);
 var import_restError = __nccwpck_require__(445);
 var import_httpHeaders = __nccwpck_require__(485);
-var import_pipelineRequest = __nccwpck_require__(115);
+var import_pipelineRequest = __nccwpck_require__(116);
 var import_clientHelpers = __nccwpck_require__(491);
 var import_typeGuards = __nccwpck_require__(497);
 var import_multipart = __nccwpck_require__(271);
@@ -78393,12 +78449,12 @@ const {
   subresourceSet,
   DOMException
 } = __nccwpck_require__(30)
-const { kHeadersList } = __nccwpck_require__(196)
+const { kHeadersList } = __nccwpck_require__(197)
 const EE = __nccwpck_require__(470)
-const { Readable, pipeline } = __nccwpck_require__(130)
+const { Readable, pipeline } = __nccwpck_require__(131)
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(69)
 const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(25)
-const { TransformStream } = __nccwpck_require__(257)
+const { TransformStream } = __nccwpck_require__(258)
 const { getGlobalDispatcher } = __nccwpck_require__(377)
 const { webidl } = __nccwpck_require__(457)
 const { STATUS_CODES } = __nccwpck_require__(329)
@@ -79143,7 +79199,7 @@ function schemeFetch (fetchParams) {
     }
     case 'blob:': {
       if (!resolveObjectURL) {
-        resolveObjectURL = (__nccwpck_require__(119).resolveObjectURL)
+        resolveObjectURL = (__nccwpck_require__(120).resolveObjectURL)
       }
 
       // 1. Let blobURLEntry be request’s current URL’s blob URL entry.
@@ -80142,7 +80198,7 @@ async function httpNetworkFetch (
   // cancelAlgorithm set to cancelAlgorithm, highWaterMark set to
   // highWaterMark, and sizeAlgorithm set to sizeAlgorithm.
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(257).ReadableStream)
+    ReadableStream = (__nccwpck_require__(258).ReadableStream)
   }
 
   const stream = new ReadableStream(
@@ -80767,8 +80823,8 @@ exports.lowerCamelCase = lowerCamelCase;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
 const StorageContextClient_js_1 = __nccwpck_require__(268);
-const Pipeline_js_1 = __nccwpck_require__(183);
-const utils_common_js_1 = __nccwpck_require__(154);
+const Pipeline_js_1 = __nccwpck_require__(184);
+const utils_common_js_1 = __nccwpck_require__(155);
 /**
  * A StorageClient represents a based URL class for {@link BlobServiceClient}, {@link ContainerClient}
  * and etc.
@@ -80901,7 +80957,7 @@ function parseHeaderValueAsNumber(response, headerName) {
 "use strict";
 
 
-const { types } = __nccwpck_require__(123)
+const { types } = __nccwpck_require__(124)
 const { hasOwn, toUSVString } = __nccwpck_require__(518)
 
 /** @type {import('../../types/webidl').Webidl} */
@@ -81556,8 +81612,8 @@ module.exports = {
  * Module dependencies.
  */
 
-const tty = __nccwpck_require__(182);
-const util = __nccwpck_require__(123);
+const tty = __nccwpck_require__(183);
+const util = __nccwpck_require__(124);
 
 /**
  * This is the Node.js implementation of `debug()`.
@@ -81791,7 +81847,7 @@ function init(debug) {
 	}
 }
 
-module.exports = __nccwpck_require__(142)(exports);
+module.exports = __nccwpck_require__(143)(exports);
 
 const {formatters} = module.exports;
 
@@ -81873,7 +81929,7 @@ exports.walkSnapshot = walkSnapshot;
 exports.diffSnapshots = diffSnapshots;
 exports.diffStats = diffStats;
 exports.serializeManifest = serializeManifest;
-const fs = __importStar(__nccwpck_require__(108));
+const fs = __importStar(__nccwpck_require__(109));
 const path = __importStar(__nccwpck_require__(508));
 function entryKey(root, relpath) {
     return `${root}#${relpath}`;
@@ -82028,8 +82084,8 @@ const command_1 = __nccwpck_require__(534);
 const file_command_1 = __nccwpck_require__(444);
 const utils_1 = __nccwpck_require__(505);
 const os = __importStar(__nccwpck_require__(92));
-const path = __importStar(__nccwpck_require__(248));
-const oidc_utils_1 = __nccwpck_require__(133);
+const path = __importStar(__nccwpck_require__(249));
+const oidc_utils_1 = __nccwpck_require__(134);
 /**
  * The code to exit an action
  */
@@ -82447,8 +82503,8 @@ function repeatedMsgEq(type, a, b) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
 const reflection_info_1 = __nccwpck_require__(453);
-const reflection_long_convert_1 = __nccwpck_require__(158);
-const pb_long_1 = __nccwpck_require__(117);
+const reflection_long_convert_1 = __nccwpck_require__(159);
+const pb_long_1 = __nccwpck_require__(118);
 /**
  * Creates the default value for a scalar type.
  */
@@ -83076,7 +83132,7 @@ function localstorage() {
 	}
 }
 
-module.exports = __nccwpck_require__(142)(exports);
+module.exports = __nccwpck_require__(143)(exports);
 
 const {formatters} = module.exports;
 
@@ -83492,7 +83548,7 @@ exports.attachCredential = attachCredential;
 exports.httpAuthorizationToString = httpAuthorizationToString;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(102);
 const core_util_1 = __nccwpck_require__(14);
 const constants_js_1 = __nccwpck_require__(36);
 /**
@@ -84198,9 +84254,9 @@ exports.ServiceType = ServiceType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(218);
 const base64 = tslib_1.__importStar(__nccwpck_require__(438));
-const interfaces_js_1 = __nccwpck_require__(99);
+const interfaces_js_1 = __nccwpck_require__(100);
 const utils_js_1 = __nccwpck_require__(313);
 class SerializerImpl {
     modelMappers;
@@ -85142,12 +85198,12 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 "use strict";
 
 
-const { Writable } = __nccwpck_require__(130)
-const diagnosticsChannel = __nccwpck_require__(141)
+const { Writable } = __nccwpck_require__(131)
+const diagnosticsChannel = __nccwpck_require__(142)
 const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(466)
-const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(98)
+const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(99)
 const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(57)
-const { WebsocketFrameSend } = __nccwpck_require__(187)
+const { WebsocketFrameSend } = __nccwpck_require__(188)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -85680,7 +85736,7 @@ function createHttpHeaders(rawHeaders) {
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var concatMap = __nccwpck_require__(353);
-var balanced = __nccwpck_require__(131);
+var balanced = __nccwpck_require__(132);
 
 module.exports = expandTop;
 
@@ -85923,7 +85979,7 @@ __export(log_exports, {
 module.exports = __toCommonJS(log_exports);
 var import_node_os = __nccwpck_require__(383);
 var import_node_util = __toESM(__nccwpck_require__(376));
-var import_node_process = __toESM(__nccwpck_require__(237));
+var import_node_process = __toESM(__nccwpck_require__(238));
 function log(message, ...args) {
   import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
 }
@@ -86184,7 +86240,7 @@ exports.serializationPolicyName = void 0;
 exports.serializationPolicy = serializationPolicy;
 exports.serializeHeaders = serializeHeaders;
 exports.serializeRequestBody = serializeRequestBody;
-const interfaces_js_1 = __nccwpck_require__(99);
+const interfaces_js_1 = __nccwpck_require__(100);
 const operationHelpers_js_1 = __nccwpck_require__(433);
 const serializer_js_1 = __nccwpck_require__(480);
 const interfaceHelpers_js_1 = __nccwpck_require__(400);
@@ -86348,7 +86404,7 @@ var http = __nccwpck_require__(329);
 var https = __nccwpck_require__(70);
 var events = __nccwpck_require__(470);
 var assert = __nccwpck_require__(527);
-var util = __nccwpck_require__(123);
+var util = __nccwpck_require__(124);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -86636,10 +86692,10 @@ __export(clientHelpers_exports, {
 module.exports = __toCommonJS(clientHelpers_exports);
 var import_defaultHttpClient = __nccwpck_require__(373);
 var import_createPipelineFromOptions = __nccwpck_require__(316);
-var import_apiVersionPolicy = __nccwpck_require__(228);
-var import_credentials = __nccwpck_require__(188);
+var import_apiVersionPolicy = __nccwpck_require__(229);
+var import_credentials = __nccwpck_require__(189);
 var import_apiKeyAuthenticationPolicy = __nccwpck_require__(87);
-var import_basicAuthenticationPolicy = __nccwpck_require__(152);
+var import_basicAuthenticationPolicy = __nccwpck_require__(153);
 var import_bearerAuthenticationPolicy = __nccwpck_require__(381);
 var import_oauth2AuthenticationPolicy = __nccwpck_require__(339);
 let cachedHttpClient;
@@ -86870,7 +86926,7 @@ exports.walkDirSize = walkDirSize;
 exports.detectCompressMagic = detectCompressMagic;
 exports.decompressCache = decompressCache;
 exports.compressCache = compressCache;
-const fs = __importStar(__nccwpck_require__(108));
+const fs = __importStar(__nccwpck_require__(109));
 const path = __importStar(__nccwpck_require__(508));
 const core = __importStar(__nccwpck_require__(460));
 const exec = __importStar(__nccwpck_require__(18));
@@ -87090,7 +87146,7 @@ function parseLevel(value) {
  * Bubbles non-zero exit codes from either side.
  */
 async function runPipe(producer, consumer) {
-    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 198, 23));
+    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 199, 23));
     const [pCmd, pArgs] = producer;
     const [cCmd, cArgs] = consumer;
     await new Promise((resolve, reject) => {
@@ -87499,12 +87555,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
 const os = __importStar(__nccwpck_require__(92));
-const path = __importStar(__nccwpck_require__(248));
-const pathHelper = __importStar(__nccwpck_require__(223));
+const path = __importStar(__nccwpck_require__(249));
+const pathHelper = __importStar(__nccwpck_require__(224));
 const assert_1 = __importDefault(__nccwpck_require__(527));
-const minimatch_1 = __nccwpck_require__(124);
+const minimatch_1 = __nccwpck_require__(125);
 const internal_match_kind_1 = __nccwpck_require__(529);
-const internal_path_1 = __nccwpck_require__(120);
+const internal_path_1 = __nccwpck_require__(121);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, isImplicitPattern = false, segments, homedir) {
@@ -87988,7 +88044,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tripleToCcRsSuffix = tripleToCcRsSuffix;
 exports.detectMuslCcEnv = detectMuslCcEnv;
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const path = __importStar(__nccwpck_require__(508));
 const MUSL_TRIPLE_RE = /^[a-z0-9_]+-unknown-linux-musl$/;
 function tripleToCcRsSuffix(triple) {
@@ -88236,15 +88292,15 @@ module.exports = require("timers");
 "use strict";
 
 
-const Readable = __nccwpck_require__(128)
+const Readable = __nccwpck_require__(129)
 const {
   InvalidArgumentError,
   RequestAbortedError
 } = __nccwpck_require__(488)
 const util = __nccwpck_require__(69)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(190)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(191)
 const { AsyncResource } = __nccwpck_require__(430)
-const { addSignal, removeSignal } = __nccwpck_require__(103)
+const { addSignal, removeSignal } = __nccwpck_require__(104)
 
 class RequestHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -88465,7 +88521,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.shouldRefreshToolchain = shouldRefreshToolchain;
 exports.shouldSkipRefreshForExactHit = shouldSkipRefreshForExactHit;
 exports.ensureRustToolchain = ensureRustToolchain;
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const os = __importStar(__nccwpck_require__(383));
 const path = __importStar(__nccwpck_require__(508));
 const core = __importStar(__nccwpck_require__(460));
@@ -88771,7 +88827,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TestTransport = void 0;
-const rpc_error_1 = __nccwpck_require__(176);
+const rpc_error_1 = __nccwpck_require__(177);
 const runtime_1 = __nccwpck_require__(19);
 const rpc_output_stream_1 = __nccwpck_require__(308);
 const rpc_options_1 = __nccwpck_require__(294);
@@ -89132,7 +89188,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._internal = void 0;
 exports.installPassthrough = installPassthrough;
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const path = __importStar(__nccwpck_require__(508));
 const STUB_VERSION = "passthrough";
 function bashStub() {
@@ -89259,7 +89315,7 @@ Object.defineProperty(exports, "isNamedKeyCredential", ({ enumerable: true, get:
 var azureSASCredential_js_1 = __nccwpck_require__(33);
 Object.defineProperty(exports, "AzureSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.AzureSASCredential; } }));
 Object.defineProperty(exports, "isSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.isSASCredential; } }));
-var tokenCredential_js_1 = __nccwpck_require__(247);
+var tokenCredential_js_1 = __nccwpck_require__(248);
 Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: function () { return tokenCredential_js_1.isTokenCredential; } }));
 //# sourceMappingURL=index.js.map
 
@@ -89290,7 +89346,7 @@ if (typeof process === 'undefined' || process.type === 'renderer' || process.bro
 
 
 
-const { kHeadersList, kConstruct } = __nccwpck_require__(196)
+const { kHeadersList, kConstruct } = __nccwpck_require__(197)
 const { kGuard } = __nccwpck_require__(15)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 const {
@@ -89298,7 +89354,7 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(518)
-const util = __nccwpck_require__(123)
+const util = __nccwpck_require__(124)
 const { webidl } = __nccwpck_require__(457)
 const assert = __nccwpck_require__(527)
 
@@ -89890,11 +89946,11 @@ module.exports = {
 
 
 const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(30)
-const { getGlobalOrigin } = __nccwpck_require__(139)
+const { getGlobalOrigin } = __nccwpck_require__(140)
 const { performance } = __nccwpck_require__(321)
 const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(69)
 const assert = __nccwpck_require__(527)
-const { isUint8Array } = __nccwpck_require__(199)
+const { isUint8Array } = __nccwpck_require__(200)
 
 let supportedHashes = []
 
@@ -90856,7 +90912,7 @@ let ReadableStream = globalThis.ReadableStream
 
 function isReadableStreamLike (stream) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(257).ReadableStream)
+    ReadableStream = (__nccwpck_require__(258).ReadableStream)
   }
 
   return stream instanceof ReadableStream || (
@@ -91217,11 +91273,11 @@ const crypto = __importStar(__nccwpck_require__(292));
 const fs = __importStar(__nccwpck_require__(532));
 const mm = __importStar(__nccwpck_require__(331));
 const os = __importStar(__nccwpck_require__(92));
-const path = __importStar(__nccwpck_require__(248));
+const path = __importStar(__nccwpck_require__(249));
 const httpm = __importStar(__nccwpck_require__(286));
-const semver = __importStar(__nccwpck_require__(179));
-const stream = __importStar(__nccwpck_require__(130));
-const util = __importStar(__nccwpck_require__(123));
+const semver = __importStar(__nccwpck_require__(180));
+const stream = __importStar(__nccwpck_require__(131));
+const util = __importStar(__nccwpck_require__(124));
 const assert_1 = __nccwpck_require__(527);
 const exec_1 = __nccwpck_require__(18);
 const retry_helper_1 = __nccwpck_require__(9);
@@ -92119,7 +92175,7 @@ function createEmptyPipeline() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SASQueryParameters = exports.SASProtocol = void 0;
 const SasIPRange_js_1 = __nccwpck_require__(361);
-const utils_common_js_1 = __nccwpck_require__(154);
+const utils_common_js_1 = __nccwpck_require__(155);
 /**
  * Protocols for generated SAS.
  */
@@ -92621,7 +92677,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureShims = ensureShims;
-const fs = __importStar(__nccwpck_require__(249));
+const fs = __importStar(__nccwpck_require__(250));
 const path = __importStar(__nccwpck_require__(508));
 const core = __importStar(__nccwpck_require__(460));
 // Tools that route through `soldr <tool>`:
@@ -92692,14 +92748,14 @@ const reflection_type_check_1 = __nccwpck_require__(291);
 const reflection_json_reader_1 = __nccwpck_require__(345);
 const reflection_json_writer_1 = __nccwpck_require__(90);
 const reflection_binary_reader_1 = __nccwpck_require__(409);
-const reflection_binary_writer_1 = __nccwpck_require__(186);
-const reflection_create_1 = __nccwpck_require__(206);
-const reflection_merge_partial_1 = __nccwpck_require__(136);
+const reflection_binary_writer_1 = __nccwpck_require__(187);
+const reflection_create_1 = __nccwpck_require__(207);
+const reflection_merge_partial_1 = __nccwpck_require__(137);
 const json_typings_1 = __nccwpck_require__(395);
-const json_format_contract_1 = __nccwpck_require__(242);
+const json_format_contract_1 = __nccwpck_require__(243);
 const reflection_equals_1 = __nccwpck_require__(462);
-const binary_writer_1 = __nccwpck_require__(251);
-const binary_reader_1 = __nccwpck_require__(134);
+const binary_writer_1 = __nccwpck_require__(252);
+const binary_reader_1 = __nccwpck_require__(135);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
 const messageTypeDescriptor = baseDescriptors[message_type_contract_1.MESSAGE_TYPE] = {};
 /**
@@ -93114,8 +93170,8 @@ exports.readJournal = readJournal;
 exports.summarize = summarize;
 exports.formatJournalSection = formatJournalSection;
 exports.formatRollupsSection = formatRollupsSection;
-const fs = __importStar(__nccwpck_require__(249));
-const diagnostics_js_1 = __nccwpck_require__(111);
+const fs = __importStar(__nccwpck_require__(250));
+const diagnostics_js_1 = __nccwpck_require__(112);
 const SLOWEST_TOP_N = 20;
 /**
  * Read a `last-session.jsonl` file. Returns `null` if it doesn't exist
@@ -93418,7 +93474,7 @@ function formatRollupsSection(report) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBeginCopyFromUrlPoller = void 0;
 const core_util_1 = __nccwpck_require__(14);
-const core_lro_1 = __nccwpck_require__(227);
+const core_lro_1 = __nccwpck_require__(228);
 /**
  * This is the poller returned by {@link BlobClient.beginCopyFromURL}.
  * This can not be instantiated directly outside of this package.
@@ -93653,7 +93709,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(262);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(94);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/src/main.ts
+++ b/src/main.ts
@@ -226,15 +226,63 @@ export async function run(): Promise<void> {
   core.saveState("cargoRegistryCacheExactHit", "false");
   core.saveState("cargoRegistryCacheMatchedKey", "");
 
+  // Pre-compute cook key + paths so cook restore can join the parallel
+  // block when safe. Cook RUN still happens in the cook phase later
+  // (it needs the soldr binary). Cook RESTORE just untars an archive
+  // into target/ — no soldr dependency.
+  const cookGate = decideCookGate({
+    prebuildDeps: inputs.prebuildDeps,
+    cacheUmbrella: cacheEnabled,
+    lockfilePath: result.targetCache.lockfilePath,
+  });
+  const cookEnabled = cookGate.enabled && result.enabled;
+  let cookFlags: string[] = [];
+  let cookKey = "";
+  let cookProjectRoot = "";
+  let cookTargetDir = "";
+  let cookArchive = "";
+  if (cookEnabled) {
+    cookFlags = canonicalizeCookFlags(parseCookFlags(inputs.prebuildDepsFlags));
+    const flagsHash = hashCookFlags(cookFlags);
+    const lockHash = result.targetCache.lockfileHash || "no-lock";
+    cookKey = buildCookCacheKey({
+      runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+      runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+      libc: detectLibc(),
+      rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+      flagsHash,
+      lockHash,
+      soldrVersion:
+        result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+    });
+    cookProjectRoot = path.dirname(result.targetCache.targetPath);
+    cookTargetDir = result.targetCache.targetPath;
+    cookArchive = `${cookTargetDir}.tar.zst`;
+  }
+  // Cook restore can race with target-cache restore when target-cache is
+  // configured to write to target/ (i.e. `build-cache-mode: full`). In all
+  // other modes (`once`/`thin`), target-cache writes only the rust-plan
+  // bundle to a separate path — no conflict. Gate the parallel-join on
+  // path disjointness.
+  const targetCachePathsList = result.targetCache.paths
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const cookCanParallelize =
+    cookEnabled &&
+    !targetCachePathsList.some((p) => path.resolve(p) === path.resolve(cookTargetDir));
+  let cookRestoreResultParallel: { hit: boolean; matchedKey: string; archiveBytes: number } | null = null;
+
   // ---- parallel restores ----
-  // setup-cache, target-cache, build-cache, and cargo-registry write to
-  // disjoint paths and have no inter-dependencies, so they run concurrently.
-  // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
-  // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
+  // setup-cache, target-cache, build-cache, cargo-registry, and (conditionally)
+  // cook-cache write to disjoint paths and have no inter-dependencies, so they
+  // run concurrently. Sequential previously: ~18s on warm runs. Parallel: ~8s.
+  // Cook restore joins when target-cache doesn't write target/ (i.e. modes
+  // other than `full`) — saves another ~5s when applicable.
   //
   // Layers that must stay sequential (wired below): solo-toolchain (writes
   // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
-  // install dir, must precede ensureSoldr), cook (writes target/ and needs
+  // install dir, must precede ensureSoldr), cook RUN (needs
   // the soldr binary). Cargo-registry was previously after-cook — it's been
   // moved into this parallel block because nothing the soldr install path
   // touches depends on its hydrated cargo registry state.
@@ -434,6 +482,31 @@ export async function run(): Promise<void> {
     });
   })();
 
+  // Cook restore — joins the parallel block when target-cache won't be
+  // writing to the same target/ dir. See the gate computed above. When
+  // we skip this IIFE, the cook phase falls back to its sequential
+  // restore later.
+  const cookRestorePromise = (async (): Promise<void> => {
+    if (!cookCanParallelize) return;
+    logger.log(`cook: key=${cookKey} project=${cookProjectRoot} target=${cookTargetDir}`);
+    const t0 = Date.now();
+    const restore = await restoreCookCache({
+      exactKey: cookKey,
+      archivePath: cookArchive,
+      targetDir: cookTargetDir,
+      longWindow: 27,
+      debug: debugMode,
+      log: (msg) => logger.log(msg),
+    });
+    cookRestoreResultParallel = restore;
+    statsCollector.record({
+      label: "cook-cache", operation: "restore", hit: restore.hit,
+      key: cookKey, matchedKey: restore.matchedKey, restoreKeys: [],
+      archiveBytes: restore.archiveBytes || null, inflatedBytes: null, fileCount: null,
+      durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+    });
+  })();
+
   // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
   // try/catches, so this should only see rejections for genuine programming
   // bugs.
@@ -442,6 +515,7 @@ export async function run(): Promise<void> {
     targetRestorePromise,
     buildRestorePromise,
     cargoRegistryRestorePromise,
+    cookRestorePromise,
   ]);
   await finishPhase("parallel-restore");
 
@@ -702,54 +776,50 @@ export async function run(): Promise<void> {
   await finishPhase("verify");
 
   // ---- cook (prebuild-deps via cargo-chef) ----
-  // Long-lived deps tarball keyed on Cargo.lock content. Restores
-  // target/deps/ before the user's build so the first compile starts
-  // warm. Gated on Cargo.lock presence + cache umbrella + enable flag.
+  // Long-lived deps tarball keyed on Cargo.lock content. When safe (see
+  // the cook gate above) the RESTORE happens in the parallel block; we
+  // pick up its result here and only run the actual cook step if the
+  // restore missed. In `build-cache-mode: full` workflows the restore
+  // can't safely parallelize, so we do it here sequentially.
   // Failures here are logged but never fail the action — the user's
   // own cargo build will still work without the cooked deps.
   await markPhase("cook");
-  const cookGate = decideCookGate({
-    prebuildDeps: inputs.prebuildDeps,
-    cacheUmbrella: cacheEnabled,
-    lockfilePath: result.targetCache.lockfilePath,
-  });
-  if (cookGate.enabled && result.enabled) {
-    const cookFlags = canonicalizeCookFlags(parseCookFlags(inputs.prebuildDepsFlags));
-    const flagsHash = hashCookFlags(cookFlags);
-    const lockHash = result.targetCache.lockfileHash || "no-lock";
-    const cookKey = buildCookCacheKey({
-      runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-      runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-      libc: detectLibc(),
-      rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-      flagsHash,
-      lockHash,
-      soldrVersion:
-        result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-    });
-    const projectRoot = path.dirname(result.targetCache.targetPath);
-    const cookTargetDir = result.targetCache.targetPath;
-    // CRITICAL: archive path must match what compressCache will write to
-    // during save (`${cacheDir}.tar.zst` — see cache-compress.ts:220).
-    // @actions/cache hashes the `paths` array into a "version" key — save
-    // and restore MUST pass the same array or the lookup misses even when
-    // the entry exists. Mirrors the build-cache pattern at main.ts:280.
-    const cookArchive = `${cookTargetDir}.tar.zst`;
-    logger.log(`cook: key=${cookKey} project=${projectRoot} target=${cookTargetDir}`);
-    const cookT0 = Date.now();
-    const restore = await restoreCookCache({
-      exactKey: cookKey,
-      archivePath: cookArchive,
-      targetDir: cookTargetDir,
-      longWindow: 27,
-      debug: debugMode,
-      log: (msg) => logger.log(msg),
-    });
+  if (cookEnabled) {
+    let restore: { hit: boolean; matchedKey: string; archiveBytes: number };
+    if (cookRestoreResultParallel) {
+      restore = cookRestoreResultParallel;
+    } else {
+      // Sequential fallback path — used when target-cache writes to the same
+      // target/ dir (mode: full) and we couldn't safely parallelize.
+      logger.log(`cook: key=${cookKey} project=${cookProjectRoot} target=${cookTargetDir}`);
+      const cookT0 = Date.now();
+      restore = await restoreCookCache({
+        exactKey: cookKey,
+        archivePath: cookArchive,
+        targetDir: cookTargetDir,
+        longWindow: 27,
+        debug: debugMode,
+        log: (msg) => logger.log(msg),
+      });
+      statsCollector.record({
+        label: "cook-cache",
+        operation: "restore",
+        hit: restore.hit,
+        key: cookKey,
+        matchedKey: restore.matchedKey,
+        restoreKeys: [],
+        archiveBytes: restore.archiveBytes || null,
+        inflatedBytes: null,
+        fileCount: null,
+        durationMs: Date.now() - cookT0,
+        timestamp: new Date().toISOString(),
+      });
+    }
     let cookRan = false;
     if (!restore.hit) {
       const runRes = await runCook({
         soldrBinary: result.soldrPath,
-        projectRoot,
+        projectRoot: cookProjectRoot,
         flags: cookFlags,
         log: (msg) => logger.log(msg),
       });
@@ -765,19 +835,6 @@ export async function run(): Promise<void> {
     core.saveState("cookTargetDir", cookTargetDir);
     core.saveState("cookLongWindow", "27");
     core.saveState("cookCompressLevel", "19");
-    statsCollector.record({
-      label: "cook-cache",
-      operation: "restore",
-      hit: restore.hit,
-      key: cookKey,
-      matchedKey: restore.matchedKey,
-      restoreKeys: [],
-      archiveBytes: restore.archiveBytes || null,
-      inflatedBytes: null,
-      fileCount: null,
-      durationMs: Date.now() - cookT0,
-      timestamp: new Date().toISOString(),
-    });
   } else {
     logger.log(`cook: skipped - ${cookGate.reason}`);
     core.saveState("cookEnabled", "false");


### PR DESCRIPTION
## Summary

Cook RESTORE is just \`cache.restoreCache\` + \`decompressCache\` into \`target/\` — no soldr binary needed. Moving it from its sequential position (after install + verify) into the parallel-restore block saves another **~5s on warm-hit runs**.

## Safety gate

Cook restore writes to \`result.targetCache.targetPath\`. target-cache restore ALSO writes there when \`build-cache-mode: full\`. To avoid concurrent tar extractions racing on the same directory:

\`\`\`ts
cookCanParallelize =
  cookEnabled &&
  !targetCachePathsList.some(p => path.resolve(p) === path.resolve(cookTargetDir));
\`\`\`

- \`once\`/\`thin\` (the default mode in the demo + most workflows): target-cache writes only the rust-plan bundle to a separate path → cook **joins the parallel block**.
- \`full\` mode: target-cache writes target/ → cook **stays sequential** in the cook phase. No regression.

## Cook RUN stays in cook phase

The actual \`soldr cook\` invocation (which DOES need the soldr binary on PATH) remains in the cook phase, gated on restore-miss. On hit, the cook phase is just a state-saveState pass.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 294/294 (Linux container; all platforms)
- [x] \`npm run build\` in node:22-bookworm Docker
- [ ] After merge: post-merge demo shows cook restore overlapping target/build/cargo-registry in parallel-restore phase. Setup Soldr step drops ~25s → ~20s on warm-hit runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)