### PR TITLE
perf(cook): generalize skip to any lockfile-level target-cache match

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -14,14 +14,14 @@
 //  * support limits.fieldNameSize
 //     -- this will require modifications to utils.parseParams
 
-const { Readable } = __nccwpck_require__(430)
-const { inherits } = __nccwpck_require__(375)
+const { Readable } = __nccwpck_require__(431)
+const { inherits } = __nccwpck_require__(376)
 
 const Dicer = __nccwpck_require__(13)
 
 const parseParams = __nccwpck_require__(193)
 const decodeText = __nccwpck_require__(276)
-const basename = __nccwpck_require__(476)
+const basename = __nccwpck_require__(477)
 const getLimit = __nccwpck_require__(483)
 
 const RE_BOUNDARY = /^boundary$/i
@@ -340,7 +340,7 @@ __export(inspect_exports, {
   custom: () => custom
 });
 module.exports = __toCommonJS(inspect_exports);
-var import_node_util = __nccwpck_require__(375);
+var import_node_util = __nccwpck_require__(376);
 const custom = import_node_util.inspect.custom;
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -469,9 +469,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = exports.downloadCacheHttpClient = exports.DownloadProgress = void 0;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const http_client_1 = __nccwpck_require__(285);
-const storage_blob_1 = __nccwpck_require__(447);
+const storage_blob_1 = __nccwpck_require__(448);
 const buffer = __importStar(__nccwpck_require__(119));
 const fs = __importStar(__nccwpck_require__(532));
 const stream = __importStar(__nccwpck_require__(130));
@@ -842,11 +842,11 @@ exports.SearchState = SearchState;
 const { InvalidArgumentError } = __nccwpck_require__(488)
 const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(196)
 const DispatcherBase = __nccwpck_require__(62)
-const Pool = __nccwpck_require__(337)
+const Pool = __nccwpck_require__(338)
 const Client = __nccwpck_require__(88)
 const util = __nccwpck_require__(69)
 const createRedirectInterceptor = __nccwpck_require__(255)
-const { WeakRef, FinalizationRegistry } = __nccwpck_require__(414)()
+const { WeakRef, FinalizationRegistry } = __nccwpck_require__(415)()
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -1078,9 +1078,9 @@ const {
   kOriginalDispatch,
   kOrigin,
   kGetNetConnect
-} = __nccwpck_require__(470)
+} = __nccwpck_require__(471)
 const { buildURL, nop } = __nccwpck_require__(69)
-const { STATUS_CODES } = __nccwpck_require__(328)
+const { STATUS_CODES } = __nccwpck_require__(329)
 const {
   types: {
     isPromise
@@ -1510,7 +1510,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetryHelper = void 0;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 /**
  * Internal class for retries
  */
@@ -1659,14 +1659,14 @@ const { kConstruct } = __nccwpck_require__(156)
 const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(80)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(69)
 const { kHeadersList } = __nccwpck_require__(196)
-const { webidl } = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(457)
 const { Response, cloneResponse } = __nccwpck_require__(41)
 const { Request } = __nccwpck_require__(84)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(15)
-const { fetching } = __nccwpck_require__(450)
+const { fetching } = __nccwpck_require__(451)
 const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(518)
 const assert = __nccwpck_require__(527)
-const { getGlobalDispatcher } = __nccwpck_require__(376)
+const { getGlobalDispatcher } = __nccwpck_require__(377)
 
 /**
  * @see https://w3c.github.io/ServiceWorker/#dfn-cache-batch-operation
@@ -2501,8 +2501,8 @@ module.exports = {
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(430).Writable)
-const inherits = (__nccwpck_require__(375).inherits)
+const WritableStream = (__nccwpck_require__(431).Writable)
+const inherits = (__nccwpck_require__(376).inherits)
 
 const StreamSearch = __nccwpck_require__(114)
 
@@ -2917,8 +2917,8 @@ __export(retryPolicy_exports, {
   retryPolicy: () => retryPolicy
 });
 module.exports = __toCommonJS(retryPolicy_exports);
-var import_helpers = __nccwpck_require__(455);
-var import_restError = __nccwpck_require__(444);
+var import_helpers = __nccwpck_require__(456);
+var import_restError = __nccwpck_require__(445);
 var import_AbortError = __nccwpck_require__(10);
 var import_logger = __nccwpck_require__(246);
 var import_constants = __nccwpck_require__(48);
@@ -3162,7 +3162,7 @@ exports.getExecOutput = getExecOutput;
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Convenience JSON typings and corresponding type guards
-var json_typings_1 = __nccwpck_require__(394);
+var json_typings_1 = __nccwpck_require__(395);
 Object.defineProperty(exports, "typeofJsonValue", ({ enumerable: true, get: function () { return json_typings_1.typeofJsonValue; } }));
 Object.defineProperty(exports, "isJsonObject", ({ enumerable: true, get: function () { return json_typings_1.isJsonObject; } }));
 // Base 64 encoding
@@ -3170,10 +3170,10 @@ var base64_1 = __nccwpck_require__(303);
 Object.defineProperty(exports, "base64decode", ({ enumerable: true, get: function () { return base64_1.base64decode; } }));
 Object.defineProperty(exports, "base64encode", ({ enumerable: true, get: function () { return base64_1.base64encode; } }));
 // UTF8 encoding
-var protobufjs_utf8_1 = __nccwpck_require__(345);
+var protobufjs_utf8_1 = __nccwpck_require__(346);
 Object.defineProperty(exports, "utf8read", ({ enumerable: true, get: function () { return protobufjs_utf8_1.utf8read; } }));
 // Binary format contracts, options for reading and writing, for example
-var binary_format_contract_1 = __nccwpck_require__(332);
+var binary_format_contract_1 = __nccwpck_require__(333);
 Object.defineProperty(exports, "WireType", ({ enumerable: true, get: function () { return binary_format_contract_1.WireType; } }));
 Object.defineProperty(exports, "mergeBinaryOptions", ({ enumerable: true, get: function () { return binary_format_contract_1.mergeBinaryOptions; } }));
 Object.defineProperty(exports, "UnknownFieldHandler", ({ enumerable: true, get: function () { return binary_format_contract_1.UnknownFieldHandler; } }));
@@ -3195,13 +3195,13 @@ Object.defineProperty(exports, "jsonReadOptions", ({ enumerable: true, get: func
 Object.defineProperty(exports, "jsonWriteOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonWriteOptions; } }));
 Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: function () { return json_format_contract_1.mergeJsonOptions; } }));
 // Message type contract
-var message_type_contract_1 = __nccwpck_require__(405);
+var message_type_contract_1 = __nccwpck_require__(406);
 Object.defineProperty(exports, "MESSAGE_TYPE", ({ enumerable: true, get: function () { return message_type_contract_1.MESSAGE_TYPE; } }));
 // Message type implementation via reflection
 var message_type_1 = __nccwpck_require__(531);
 Object.defineProperty(exports, "MessageType", ({ enumerable: true, get: function () { return message_type_1.MessageType; } }));
 // Reflection info, generated by the plugin, exposed to the user, used by reflection ops
-var reflection_info_1 = __nccwpck_require__(452);
+var reflection_info_1 = __nccwpck_require__(453);
 Object.defineProperty(exports, "ScalarType", ({ enumerable: true, get: function () { return reflection_info_1.ScalarType; } }));
 Object.defineProperty(exports, "LongType", ({ enumerable: true, get: function () { return reflection_info_1.LongType; } }));
 Object.defineProperty(exports, "RepeatType", ({ enumerable: true, get: function () { return reflection_info_1.RepeatType; } }));
@@ -3214,17 +3214,17 @@ var reflection_type_check_1 = __nccwpck_require__(290);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
 var reflection_create_1 = __nccwpck_require__(206);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
-var reflection_scalar_default_1 = __nccwpck_require__(462);
+var reflection_scalar_default_1 = __nccwpck_require__(463);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
 var reflection_merge_partial_1 = __nccwpck_require__(136);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
-var reflection_equals_1 = __nccwpck_require__(461);
+var reflection_equals_1 = __nccwpck_require__(462);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
-var reflection_binary_reader_1 = __nccwpck_require__(408);
+var reflection_binary_reader_1 = __nccwpck_require__(409);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
 var reflection_binary_writer_1 = __nccwpck_require__(186);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
-var reflection_json_reader_1 = __nccwpck_require__(343);
+var reflection_json_reader_1 = __nccwpck_require__(344);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
 var reflection_json_writer_1 = __nccwpck_require__(90);
 Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get: function () { return reflection_json_writer_1.ReflectionJsonWriter; } }));
@@ -3244,7 +3244,7 @@ Object.defineProperty(exports, "listEnumNames", ({ enumerable: true, get: functi
 Object.defineProperty(exports, "listEnumNumbers", ({ enumerable: true, get: function () { return enum_object_1.listEnumNumbers; } }));
 Object.defineProperty(exports, "isEnumObject", ({ enumerable: true, get: function () { return enum_object_1.isEnumObject; } }));
 // lowerCamelCase() is exported for plugin, rpc-runtime and other rpc packages
-var lower_camel_case_1 = __nccwpck_require__(453);
+var lower_camel_case_1 = __nccwpck_require__(454);
 Object.defineProperty(exports, "lowerCamelCase", ({ enumerable: true, get: function () { return lower_camel_case_1.lowerCamelCase; } }));
 // assertion functions are exported for plugin, may also be useful to user
 var assert_1 = __nccwpck_require__(484);
@@ -3411,7 +3411,7 @@ function throttlingRetryPolicy(options = {}) {
 "use strict";
 
 
-const Busboy = __nccwpck_require__(416)
+const Busboy = __nccwpck_require__(417)
 const util = __nccwpck_require__(69)
 const {
   ReadableStreamFrom,
@@ -3423,14 +3423,14 @@ const {
 } = __nccwpck_require__(518)
 const { FormData } = __nccwpck_require__(208)
 const { kState } = __nccwpck_require__(15)
-const { webidl } = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(457)
 const { DOMException, structuredClone } = __nccwpck_require__(30)
 const { Blob, File: NativeFile } = __nccwpck_require__(119)
 const { kBodyUsed } = __nccwpck_require__(196)
 const assert = __nccwpck_require__(527)
 const { isErrored } = __nccwpck_require__(69)
 const { isUint8Array, isArrayBuffer } = __nccwpck_require__(199)
-const { File: UndiciFile } = __nccwpck_require__(364)
+const { File: UndiciFile } = __nccwpck_require__(365)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(25)
 
 let random
@@ -4675,7 +4675,7 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
 const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(439));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing AppendBlob operations. */
@@ -5009,7 +5009,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(395);
+var import_exponentialRetryStrategy = __nccwpck_require__(396);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_constants = __nccwpck_require__(48);
 const systemErrorRetryPolicyName = "systemErrorRetryPolicy";
@@ -5083,7 +5083,7 @@ function rangeResponseFromModel(response) {
 "use strict";
 
 
-const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(318)
+const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(319)
 
 const corsSafeListedMethods = ['GET', 'HEAD', 'POST']
 const corsSafeListedMethodsSet = new Set(corsSafeListedMethods)
@@ -5370,7 +5370,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.reserveCache = exports.downloadCache = exports.getCacheEntry = void 0;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const http_client_1 = __nccwpck_require__(285);
 const auth_1 = __nccwpck_require__(27);
 const fs = __importStar(__nccwpck_require__(532));
@@ -5381,7 +5381,7 @@ const downloadUtils_1 = __nccwpck_require__(3);
 const options_1 = __nccwpck_require__(265);
 const requestUtils_1 = __nccwpck_require__(261);
 const config_1 = __nccwpck_require__(37);
-const user_agent_1 = __nccwpck_require__(361);
+const user_agent_1 = __nccwpck_require__(362);
 function getCacheApiUrl(resource) {
     const baseUrl = (0, config_1.getCacheServiceURL)();
     if (!baseUrl) {
@@ -5620,7 +5620,7 @@ __export(throttlingRetryStrategy_exports, {
   throttlingRetryStrategy: () => throttlingRetryStrategy
 });
 module.exports = __toCommonJS(throttlingRetryStrategy_exports);
-var import_helpers = __nccwpck_require__(455);
+var import_helpers = __nccwpck_require__(456);
 const RetryAfterHeader = "Retry-After";
 const AllRetryAfterHeaders = ["retry-after-ms", "x-ms-retry-after-ms", RetryAfterHeader];
 function getRetryAfterInMs(response) {
@@ -6029,7 +6029,7 @@ const {
   DOMException
 } = __nccwpck_require__(30)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(15)
-const { webidl } = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(457)
 const { FormData } = __nccwpck_require__(208)
 const { getGlobalOrigin } = __nccwpck_require__(139)
 const { URLSerializer } = __nccwpck_require__(25)
@@ -6911,7 +6911,7 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
 const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(439));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Blob operations. */
@@ -7985,7 +7985,7 @@ exports.StorageBrowserPolicy = void 0;
 const RequestPolicy_js_1 = __nccwpck_require__(46);
 const core_util_1 = __nccwpck_require__(14);
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(473);
+const utils_common_js_1 = __nccwpck_require__(474);
 /**
  * StorageBrowserPolicy will handle differences between Node.js and browser runtime, including:
  *
@@ -8038,7 +8038,7 @@ exports.StorageBrowserPolicy = StorageBrowserPolicy;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.containsMessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(405);
+const message_type_contract_1 = __nccwpck_require__(406);
 /**
  * Check if the provided object is a proto message.
  *
@@ -8461,8 +8461,8 @@ const {
   kResult,
   kAborted,
   kLastProgressEventFired
-} = __nccwpck_require__(460)
-const { ProgressEvent } = __nccwpck_require__(442)
+} = __nccwpck_require__(461)
+const { ProgressEvent } = __nccwpck_require__(443)
 const { getEncoding } = __nccwpck_require__(97)
 const { DOMException } = __nccwpck_require__(30)
 const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(25)
@@ -8854,7 +8854,7 @@ module.exports = {
 
 "use strict";
 
-const f = __nccwpck_require__(403)
+const f = __nccwpck_require__(404)
 const DateTime = global.Date
 
 class Date extends DateTime {
@@ -8981,7 +8981,7 @@ exports.UnaryCall = UnaryCall;
 
 
 const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(98)
-const { states, opcodes } = __nccwpck_require__(465)
+const { states, opcodes } = __nccwpck_require__(466)
 const { MessageEvent, ErrorEvent } = __nccwpck_require__(250)
 
 /* globals Blob */
@@ -9463,14 +9463,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.internalCacheTwirpClient = void 0;
-const core_1 = __nccwpck_require__(459);
-const user_agent_1 = __nccwpck_require__(361);
+const core_1 = __nccwpck_require__(460);
+const user_agent_1 = __nccwpck_require__(362);
 const errors_1 = __nccwpck_require__(305);
 const config_1 = __nccwpck_require__(37);
 const cacheUtils_1 = __nccwpck_require__(76);
 const auth_1 = __nccwpck_require__(27);
 const http_client_1 = __nccwpck_require__(285);
-const cache_twirp_client_1 = __nccwpck_require__(436);
+const cache_twirp_client_1 = __nccwpck_require__(437);
 const util_1 = __nccwpck_require__(296);
 /**
  * This class is a wrapper around the CacheServiceClientJSON class generated by Twirp.
@@ -9622,7 +9622,7 @@ exports.internalCacheTwirpClient = internalCacheTwirpClient;
 "use strict";
 
 
-const Dispatcher = __nccwpck_require__(477)
+const Dispatcher = __nccwpck_require__(478)
 const {
   ClientDestroyedError,
   ClientClosedError,
@@ -9844,7 +9844,7 @@ __export(requestPolicyFactoryPolicy_exports, {
 });
 module.exports = __toCommonJS(requestPolicyFactoryPolicy_exports);
 var import_util = __nccwpck_require__(109);
-var import_response = __nccwpck_require__(412);
+var import_response = __nccwpck_require__(413);
 var HttpPipelineLogLevel = /* @__PURE__ */ ((HttpPipelineLogLevel2) => {
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["ERROR"] = 1] = "ERROR";
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["INFO"] = 3] = "INFO";
@@ -9899,13 +9899,13 @@ const core_util_1 = __nccwpck_require__(14);
 const core_auth_1 = __nccwpck_require__(515);
 const storage_common_1 = __nccwpck_require__(277);
 const Pipeline_js_1 = __nccwpck_require__(183);
-const StorageClient_js_1 = __nccwpck_require__(454);
+const StorageClient_js_1 = __nccwpck_require__(455);
 const tracing_js_1 = __nccwpck_require__(31);
 const utils_common_js_1 = __nccwpck_require__(154);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
 const BlobLeaseClient_js_1 = __nccwpck_require__(205);
 const Clients_js_1 = __nccwpck_require__(185);
-const BlobBatchClient_js_1 = __nccwpck_require__(402);
+const BlobBatchClient_js_1 = __nccwpck_require__(403);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
  */
@@ -12883,8 +12883,8 @@ exports.listType = {
 "use strict";
 
 
-const inherits = (__nccwpck_require__(375).inherits)
-const ReadableStream = (__nccwpck_require__(430).Readable)
+const inherits = (__nccwpck_require__(376).inherits)
+const ReadableStream = (__nccwpck_require__(431).Readable)
 
 function PartStream (opts) {
   ReadableStream.call(this, opts)
@@ -12919,7 +12919,7 @@ exports.generateBlobSASQueryParametersInternal = generateBlobSASQueryParametersI
 const BlobSASPermissions_js_1 = __nccwpck_require__(503);
 const ContainerSASPermissions_js_1 = __nccwpck_require__(280);
 const storage_common_1 = __nccwpck_require__(277);
-const SasIPRange_js_1 = __nccwpck_require__(359);
+const SasIPRange_js_1 = __nccwpck_require__(360);
 const SASQueryParameters_js_1 = __nccwpck_require__(526);
 const constants_js_1 = __nccwpck_require__(148);
 const utils_common_js_1 = __nccwpck_require__(154);
@@ -13591,7 +13591,7 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 
 const assert = __nccwpck_require__(527)
 const { kDestroyed, kBodyUsed } = __nccwpck_require__(196)
-const { IncomingMessage } = __nccwpck_require__(328)
+const { IncomingMessage } = __nccwpck_require__(329)
 const stream = __nccwpck_require__(130)
 const net = __nccwpck_require__(509)
 const { InvalidArgumentError } = __nccwpck_require__(488)
@@ -14195,7 +14195,7 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 var import_extendedClient = __nccwpck_require__(216);
-var import_response = __nccwpck_require__(412);
+var import_response = __nccwpck_require__(413);
 var import_requestPolicyFactoryPolicy = __nccwpck_require__(63);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
 var import_httpClientAdapter = __nccwpck_require__(211);
@@ -14375,7 +14375,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StatsCollector = void 0;
 const fs = __importStar(__nccwpck_require__(108));
 const path = __importStar(__nccwpck_require__(508));
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 function fmtBytes(n) {
     if (n === null)
         return "-";
@@ -14989,7 +14989,7 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const exec = __importStar(__nccwpck_require__(18));
 const glob = __importStar(__nccwpck_require__(168));
 const io = __importStar(__nccwpck_require__(295));
@@ -15186,7 +15186,7 @@ exports.storageSharedKeyCredentialPolicyName = void 0;
 exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
 const node_crypto_1 = __nccwpck_require__(275);
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(473);
+const utils_common_js_1 = __nccwpck_require__(474);
 const SharedKeyComparator_js_1 = __nccwpck_require__(177);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
@@ -15371,7 +15371,7 @@ exports.normalizeSourceMtime = normalizeSourceMtime;
 const fs = __importStar(__nccwpck_require__(249));
 const path = __importStar(__nccwpck_require__(508));
 const exec = __importStar(__nccwpck_require__(18));
-const log_utils_js_1 = __nccwpck_require__(352);
+const log_utils_js_1 = __nccwpck_require__(353);
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 // Globs evaluated against the repo-relative POSIX path of each tracked file.
 const INCLUDE_GLOBS = [
@@ -15673,9 +15673,9 @@ exports.NewRetryPolicyFactory = NewRetryPolicyFactory;
 const abort_controller_1 = __nccwpck_require__(495);
 const RequestPolicy_js_1 = __nccwpck_require__(46);
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(473);
+const utils_common_js_1 = __nccwpck_require__(474);
 const log_js_1 = __nccwpck_require__(17);
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(417);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(418);
 /**
  * A factory method used to generated a RetryPolicy factory.
  *
@@ -15900,9 +15900,9 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = exports.useInstrumenter = void 0;
-var instrumenter_js_1 = __nccwpck_require__(406);
+var instrumenter_js_1 = __nccwpck_require__(407);
 Object.defineProperty(exports, "useInstrumenter", ({ enumerable: true, get: function () { return instrumenter_js_1.useInstrumenter; } }));
-var tracingClient_js_1 = __nccwpck_require__(347);
+var tracingClient_js_1 = __nccwpck_require__(348);
 Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: function () { return tracingClient_js_1.createTracingClient; } }));
 //# sourceMappingURL=index.js.map
 
@@ -15930,7 +15930,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 const { extractBody, mixinBody, cloneBody } = __nccwpck_require__(24)
 const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(517)
-const { FinalizationRegistry } = __nccwpck_require__(414)()
+const { FinalizationRegistry } = __nccwpck_require__(415)()
 const util = __nccwpck_require__(69)
 const {
   isValidHTTPToken,
@@ -15951,12 +15951,12 @@ const {
 } = __nccwpck_require__(30)
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(15)
-const { webidl } = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(457)
 const { getGlobalOrigin } = __nccwpck_require__(139)
 const { URLSerializer } = __nccwpck_require__(25)
 const { kHeadersList, kConstruct } = __nccwpck_require__(196)
 const assert = __nccwpck_require__(527)
-const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(469)
+const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(470)
 
 let TransformStream = globalThis.TransformStream
 
@@ -16894,8 +16894,8 @@ exports.deserializationPolicyName = void 0;
 exports.deserializationPolicy = deserializationPolicy;
 const interfaces_js_1 = __nccwpck_require__(99);
 const core_rest_pipeline_1 = __nccwpck_require__(101);
-const serializer_js_1 = __nccwpck_require__(479);
-const operationHelpers_js_1 = __nccwpck_require__(432);
+const serializer_js_1 = __nccwpck_require__(480);
+const operationHelpers_js_1 = __nccwpck_require__(433);
 const defaultJsonContentTypes = ["application/json", "text/json"];
 const defaultXmlContentTypes = ["application/xml", "application/atom+xml"];
 /**
@@ -17149,7 +17149,7 @@ __export(apiKeyAuthenticationPolicy_exports, {
   apiKeyAuthenticationPolicyName: () => apiKeyAuthenticationPolicyName
 });
 module.exports = __toCommonJS(apiKeyAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(435);
+var import_checkInsecureConnection = __nccwpck_require__(436);
 const apiKeyAuthenticationPolicyName = "apiKeyAuthenticationPolicy";
 function apiKeyAuthenticationPolicy(options) {
   return {
@@ -17187,10 +17187,10 @@ function apiKeyAuthenticationPolicy(options) {
 
 const assert = __nccwpck_require__(527)
 const net = __nccwpck_require__(509)
-const http = __nccwpck_require__(328)
+const http = __nccwpck_require__(329)
 const { pipeline } = __nccwpck_require__(130)
 const util = __nccwpck_require__(69)
-const timers = __nccwpck_require__(327)
+const timers = __nccwpck_require__(328)
 const Request = __nccwpck_require__(299)
 const DispatcherBase = __nccwpck_require__(62)
 const {
@@ -17665,7 +17665,7 @@ function onHTTP2GoAway (code) {
   resume(client)
 }
 
-const constants = __nccwpck_require__(448)
+const constants = __nccwpck_require__(449)
 const createRedirectInterceptor = __nccwpck_require__(255)
 const EMPTY_BUF = Buffer.alloc(0)
 
@@ -19511,12 +19511,12 @@ var import_logger = __nccwpck_require__(246);
 var import_httpHeaders = __nccwpck_require__(485);
 var import_pipelineRequest = __nccwpck_require__(115);
 var import_pipeline = __nccwpck_require__(525);
-var import_restError = __nccwpck_require__(444);
+var import_restError = __nccwpck_require__(445);
 var import_bytesEncoding = __nccwpck_require__(287);
-var import_defaultHttpClient = __nccwpck_require__(372);
+var import_defaultHttpClient = __nccwpck_require__(373);
 var import_getClient = __nccwpck_require__(210);
-var import_operationOptionHelpers = __nccwpck_require__(383);
-var import_restError2 = __nccwpck_require__(368);
+var import_operationOptionHelpers = __nccwpck_require__(384);
+var import_restError2 = __nccwpck_require__(369);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -19533,7 +19533,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
 const base64_1 = __nccwpck_require__(303);
 const pb_long_1 = __nccwpck_require__(117);
-const reflection_info_1 = __nccwpck_require__(452);
+const reflection_info_1 = __nccwpck_require__(453);
 const assert_1 = __nccwpck_require__(484);
 /**
  * Writes proto3 messages in canonical JSON format using reflection
@@ -19773,7 +19773,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Batch = void 0;
 // In browser, during webpack or browserify bundling, this module will be replaced by 'events'
 // https://github.com/Gozala/events
-const events_1 = __nccwpck_require__(469);
+const events_1 = __nccwpck_require__(470);
 /**
  * States for Batch.
  */
@@ -19959,8 +19959,8 @@ const {
   kResult,
   kEvents,
   kAborted
-} = __nccwpck_require__(460)
-const { webidl } = __nccwpck_require__(456)
+} = __nccwpck_require__(461)
+const { webidl } = __nccwpck_require__(457)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 
 class FileReader extends EventTarget {
@@ -20788,27 +20788,27 @@ var import_createPipelineFromOptions = __nccwpck_require__(281);
 var import_defaultHttpClient = __nccwpck_require__(236);
 var import_httpHeaders = __nccwpck_require__(243);
 var import_pipelineRequest = __nccwpck_require__(20);
-var import_restError = __nccwpck_require__(353);
+var import_restError = __nccwpck_require__(354);
 var import_decompressResponsePolicy = __nccwpck_require__(239);
-var import_exponentialRetryPolicy = __nccwpck_require__(392);
+var import_exponentialRetryPolicy = __nccwpck_require__(393);
 var import_setClientRequestIdPolicy = __nccwpck_require__(150);
 var import_logPolicy = __nccwpck_require__(71);
 var import_multipartPolicy = __nccwpck_require__(272);
-var import_proxyPolicy = __nccwpck_require__(472);
-var import_redirectPolicy = __nccwpck_require__(340);
+var import_proxyPolicy = __nccwpck_require__(473);
+var import_redirectPolicy = __nccwpck_require__(341);
 var import_systemErrorRetryPolicy = __nccwpck_require__(220);
 var import_throttlingRetryPolicy = __nccwpck_require__(23);
 var import_retryPolicy = __nccwpck_require__(212);
-var import_tracingPolicy = __nccwpck_require__(335);
+var import_tracingPolicy = __nccwpck_require__(336);
 var import_defaultRetryPolicy = __nccwpck_require__(55);
-var import_userAgentPolicy = __nccwpck_require__(389);
-var import_tlsPolicy = __nccwpck_require__(378);
+var import_userAgentPolicy = __nccwpck_require__(390);
+var import_tlsPolicy = __nccwpck_require__(379);
 var import_formDataPolicy = __nccwpck_require__(269);
 var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(218);
 var import_ndJsonPolicy = __nccwpck_require__(240);
 var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(194);
 var import_agentPolicy = __nccwpck_require__(232);
-var import_file = __nccwpck_require__(326);
+var import_file = __nccwpck_require__(327);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 
@@ -20980,7 +20980,7 @@ const {
   RequestAbortedError
 } = __nccwpck_require__(488)
 const util = __nccwpck_require__(69)
-const { AsyncResource } = __nccwpck_require__(429)
+const { AsyncResource } = __nccwpck_require__(430)
 const { addSignal, removeSignal } = __nccwpck_require__(103)
 const assert = __nccwpck_require__(527)
 
@@ -21245,7 +21245,7 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 
 
 const EventEmitter = (__nccwpck_require__(143).EventEmitter)
-const inherits = (__nccwpck_require__(375).inherits)
+const inherits = (__nccwpck_require__(376).inherits)
 const getLimit = __nccwpck_require__(483)
 
 const StreamSearch = __nccwpck_require__(114)
@@ -22048,8 +22048,8 @@ function loggingEnabled(value) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseCAEChallenge = parseCAEChallenge;
 exports.authorizeRequestOnClaimChallenge = authorizeRequestOnClaimChallenge;
-const log_js_1 = __nccwpck_require__(480);
-const base64_js_1 = __nccwpck_require__(437);
+const log_js_1 = __nccwpck_require__(481);
+const base64_js_1 = __nccwpck_require__(438);
 /**
  * Converts: `Bearer a="b", c="d", Bearer d="e", f="g"`.
  * Into: `[ { a: 'b', c: 'd' }, { d: 'e', f: 'g' } ]`.
@@ -22204,7 +22204,7 @@ function calculateRetryDelay(retryAttempt, config) {
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
 const EventEmitter = (__nccwpck_require__(143).EventEmitter)
-const inherits = (__nccwpck_require__(375).inherits)
+const inherits = (__nccwpck_require__(376).inherits)
 
 function SBMH (needle) {
   if (typeof needle === 'string') {
@@ -22433,7 +22433,7 @@ __export(pipelineRequest_exports, {
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
 var import_httpHeaders = __nccwpck_require__(485);
-var import_uuidUtils = __nccwpck_require__(393);
+var import_uuidUtils = __nccwpck_require__(394);
 class PipelineRequestImpl {
   url;
   method;
@@ -22522,7 +22522,7 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(382));
+var import_node_os = __toESM(__nccwpck_require__(383));
 var import_node_process = __toESM(__nccwpck_require__(237));
 function getHeaderName() {
   return "User-Agent";
@@ -24184,7 +24184,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
 const os = __importStar(__nccwpck_require__(92));
-const events = __importStar(__nccwpck_require__(469));
+const events = __importStar(__nccwpck_require__(470));
 const child = __importStar(__nccwpck_require__(164));
 const path = __importStar(__nccwpck_require__(248));
 const io = __importStar(__nccwpck_require__(295));
@@ -24783,7 +24783,7 @@ class ExecState extends events.EventEmitter {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredentialPolicy = void 0;
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(473);
+const utils_common_js_1 = __nccwpck_require__(474);
 const CredentialPolicy_js_1 = __nccwpck_require__(309);
 const SharedKeyComparator_js_1 = __nccwpck_require__(177);
 /**
@@ -25404,7 +25404,7 @@ const assert_1 = __importDefault(__nccwpck_require__(527));
 const debug_1 = __importDefault(__nccwpck_require__(516));
 const agent_base_1 = __nccwpck_require__(241);
 const url_1 = __nccwpck_require__(85);
-const parse_proxy_response_1 = __nccwpck_require__(419);
+const parse_proxy_response_1 = __nccwpck_require__(420);
 const debug = (0, debug_1.default)('https-proxy-agent');
 const setServernameFromNonIpHost = (options) => {
     if (options.servername === undefined &&
@@ -25570,7 +25570,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
 const http_client_1 = __nccwpck_require__(285);
 const auth_1 = __nccwpck_require__(27);
-const core_1 = __nccwpck_require__(459);
+const core_1 = __nccwpck_require__(460);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -25643,7 +25643,7 @@ exports.OidcClient = OidcClient;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
-const binary_format_contract_1 = __nccwpck_require__(332);
+const binary_format_contract_1 = __nccwpck_require__(333);
 const pb_long_1 = __nccwpck_require__(117);
 const goog_varint_1 = __nccwpck_require__(204);
 const defaultsRead = {
@@ -25841,7 +25841,7 @@ const {
   kDefaultTrailers,
   kContentLength,
   kMockDispatch
-} = __nccwpck_require__(470)
+} = __nccwpck_require__(471)
 const { InvalidArgumentError } = __nccwpck_require__(488)
 const { buildURL } = __nccwpck_require__(69)
 
@@ -26165,7 +26165,7 @@ __export(xml_exports, {
   stringifyXML: () => stringifyXML
 });
 module.exports = __toCommonJS(xml_exports);
-var import_fast_xml_parser = __nccwpck_require__(321);
+var import_fast_xml_parser = __nccwpck_require__(322);
 var import_xml_common = __nccwpck_require__(21);
 function getCommonOptions(options) {
   return {
@@ -26239,10 +26239,10 @@ async function parseXML(str, opts = {}) {
 
 
 module.exports.request = __nccwpck_require__(511)
-module.exports.stream = __nccwpck_require__(354)
+module.exports.stream = __nccwpck_require__(355)
 module.exports.pipeline = __nccwpck_require__(105)
-module.exports.upgrade = __nccwpck_require__(433)
-module.exports.connect = __nccwpck_require__(373)
+module.exports.upgrade = __nccwpck_require__(434)
+module.exports.connect = __nccwpck_require__(374)
 
 
 /***/ }),
@@ -26498,7 +26498,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(374);
+	createDebug.humanize = __nccwpck_require__(375);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -26933,13 +26933,13 @@ __export(internal_exports, {
   uint8ArrayToString: () => import_bytesEncoding.uint8ArrayToString
 });
 module.exports = __toCommonJS(internal_exports);
-var import_delay = __nccwpck_require__(474);
+var import_delay = __nccwpck_require__(475);
 var import_random = __nccwpck_require__(507);
 var import_object = __nccwpck_require__(144);
 var import_error = __nccwpck_require__(153);
 var import_sha256 = __nccwpck_require__(201);
-var import_uuidUtils = __nccwpck_require__(393);
-var import_checkEnvironment = __nccwpck_require__(438);
+var import_uuidUtils = __nccwpck_require__(394);
+var import_checkEnvironment = __nccwpck_require__(439);
 var import_bytesEncoding = __nccwpck_require__(287);
 var import_sanitizer = __nccwpck_require__(121);
 // Annotate the CommonJS export names for ESM import in node:
@@ -27331,7 +27331,7 @@ __export(basicAuthenticationPolicy_exports, {
 });
 module.exports = __toCommonJS(basicAuthenticationPolicy_exports);
 var import_bytesEncoding = __nccwpck_require__(287);
-var import_checkInsecureConnection = __nccwpck_require__(435);
+var import_checkInsecureConnection = __nccwpck_require__(436);
 const basicAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function basicAuthenticationPolicy(options) {
   return {
@@ -28508,7 +28508,7 @@ function isEligibleForMiniCache(opts) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionLongConvert = void 0;
-const reflection_info_1 = __nccwpck_require__(452);
+const reflection_info_1 = __nccwpck_require__(453);
 /**
  * Utility method to convert a PbLong or PbUlong to a JavaScript
  * representation during runtime.
@@ -28606,8 +28606,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.uploadCacheArchiveSDK = exports.UploadProgress = void 0;
-const core = __importStar(__nccwpck_require__(459));
-const storage_blob_1 = __nccwpck_require__(447);
+const core = __importStar(__nccwpck_require__(460));
+const storage_blob_1 = __nccwpck_require__(448);
 const errors_1 = __nccwpck_require__(305);
 /**
  * Class for tracking the upload state and displaying stats.
@@ -28771,7 +28771,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.req = exports.json = exports.toBuffer = void 0;
-const http = __importStar(__nccwpck_require__(328));
+const http = __importStar(__nccwpck_require__(329));
 const https = __importStar(__nccwpck_require__(70));
 async function toBuffer(stream) {
     let length = 0;
@@ -28959,24 +28959,24 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 
 
 const Client = __nccwpck_require__(88)
-const Dispatcher = __nccwpck_require__(477)
+const Dispatcher = __nccwpck_require__(478)
 const errors = __nccwpck_require__(488)
-const Pool = __nccwpck_require__(337)
-const BalancedPool = __nccwpck_require__(381)
+const Pool = __nccwpck_require__(338)
+const BalancedPool = __nccwpck_require__(382)
 const Agent = __nccwpck_require__(5)
 const util = __nccwpck_require__(69)
 const { InvalidArgumentError } = errors
 const api = __nccwpck_require__(138)
 const buildConnector = __nccwpck_require__(266)
 const MockClient = __nccwpck_require__(200)
-const MockAgent = __nccwpck_require__(377)
-const MockPool = __nccwpck_require__(349)
+const MockAgent = __nccwpck_require__(378)
+const MockPool = __nccwpck_require__(350)
 const mockErrors = __nccwpck_require__(233)
-const ProxyAgent = __nccwpck_require__(341)
+const ProxyAgent = __nccwpck_require__(342)
 const RetryHandler = __nccwpck_require__(274)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(376)
-const DecoratorHandler = __nccwpck_require__(475)
-const RedirectHandler = __nccwpck_require__(390)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(377)
+const DecoratorHandler = __nccwpck_require__(476)
+const RedirectHandler = __nccwpck_require__(391)
 const createRedirectInterceptor = __nccwpck_require__(255)
 
 let hasCrypto
@@ -29060,7 +29060,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   let fetchImpl = null
   module.exports.fetch = async function fetch (resource) {
     if (!fetchImpl) {
-      fetchImpl = (__nccwpck_require__(450).fetch)
+      fetchImpl = (__nccwpck_require__(451).fetch)
     }
 
     try {
@@ -29077,7 +29077,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   module.exports.Response = __nccwpck_require__(41).Response
   module.exports.Request = __nccwpck_require__(84).Request
   module.exports.FormData = __nccwpck_require__(208).FormData
-  module.exports.File = __nccwpck_require__(364).File
+  module.exports.File = __nccwpck_require__(365).File
   module.exports.FileReader = __nccwpck_require__(94).FileReader
 
   const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(139)
@@ -29094,7 +29094,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
 }
 
 if (util.nodeMajor >= 16) {
-  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(386)
+  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(387)
 
   module.exports.deleteCookie = deleteCookie
   module.exports.getCookies = getCookies
@@ -29608,7 +29608,7 @@ const tslib_1 = __nccwpck_require__(217);
 tslib_1.__exportStar(__nccwpck_require__(118), exports);
 tslib_1.__exportStar(__nccwpck_require__(181), exports);
 tslib_1.__exportStar(__nccwpck_require__(122), exports);
-tslib_1.__exportStar(__nccwpck_require__(316), exports);
+tslib_1.__exportStar(__nccwpck_require__(317), exports);
 tslib_1.__exportStar(__nccwpck_require__(209), exports);
 tslib_1.__exportStar(__nccwpck_require__(271), exports);
 //# sourceMappingURL=index.js.map
@@ -29628,9 +29628,9 @@ exports.storageRetryPolicy = storageRetryPolicy;
 const abort_controller_1 = __nccwpck_require__(495);
 const core_rest_pipeline_1 = __nccwpck_require__(101);
 const core_util_1 = __nccwpck_require__(14);
-const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(325);
+const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(326);
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(473);
+const utils_common_js_1 = __nccwpck_require__(474);
 const log_js_1 = __nccwpck_require__(17);
 /**
  * Name of the {@link storageRetryPolicy}
@@ -29806,7 +29806,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.create = void 0;
-const internal_globber_1 = __nccwpck_require__(431);
+const internal_globber_1 = __nccwpck_require__(432);
 /**
  * Constructs a globber
  *
@@ -30233,7 +30233,7 @@ __export(multipartPolicy_exports, {
 module.exports = __toCommonJS(multipartPolicy_exports);
 var import_bytesEncoding = __nccwpck_require__(287);
 var import_typeGuards = __nccwpck_require__(497);
-var import_uuidUtils = __nccwpck_require__(393);
+var import_uuidUtils = __nccwpck_require__(394);
 var import_concat = __nccwpck_require__(304);
 function generateBoundary() {
   return `----AzSDKFormBoundary${(0, import_uuidUtils.randomUUID)()}`;
@@ -30348,7 +30348,7 @@ function multipartPolicy() {
 
 "use strict";
 
-const f = __nccwpck_require__(403)
+const f = __nccwpck_require__(404)
 
 class FloatingDateTime extends Date {
   constructor (value) {
@@ -30523,7 +30523,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Note: we do not use `export * from ...` to help tree shakers,
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-var service_type_1 = __nccwpck_require__(478);
+var service_type_1 = __nccwpck_require__(479);
 Object.defineProperty(exports, "ServiceType", ({ enumerable: true, get: function () { return service_type_1.ServiceType; } }));
 var reflection_info_1 = __nccwpck_require__(528);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
@@ -30542,9 +30542,9 @@ Object.defineProperty(exports, "Deferred", ({ enumerable: true, get: function ()
 Object.defineProperty(exports, "DeferredState", ({ enumerable: true, get: function () { return deferred_1.DeferredState; } }));
 var duplex_streaming_call_1 = __nccwpck_require__(306);
 Object.defineProperty(exports, "DuplexStreamingCall", ({ enumerable: true, get: function () { return duplex_streaming_call_1.DuplexStreamingCall; } }));
-var client_streaming_call_1 = __nccwpck_require__(350);
+var client_streaming_call_1 = __nccwpck_require__(351);
 Object.defineProperty(exports, "ClientStreamingCall", ({ enumerable: true, get: function () { return client_streaming_call_1.ClientStreamingCall; } }));
-var server_streaming_call_1 = __nccwpck_require__(451);
+var server_streaming_call_1 = __nccwpck_require__(452);
 Object.defineProperty(exports, "ServerStreamingCall", ({ enumerable: true, get: function () { return server_streaming_call_1.ServerStreamingCall; } }));
 var unary_call_1 = __nccwpck_require__(56);
 Object.defineProperty(exports, "UnaryCall", ({ enumerable: true, get: function () { return unary_call_1.UnaryCall; } }));
@@ -30554,7 +30554,7 @@ Object.defineProperty(exports, "stackDuplexStreamingInterceptors", ({ enumerable
 Object.defineProperty(exports, "stackClientStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackClientStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackServerStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackServerStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackUnaryInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackUnaryInterceptors; } }));
-var server_call_context_1 = __nccwpck_require__(424);
+var server_call_context_1 = __nccwpck_require__(425);
 Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: true, get: function () { return server_call_context_1.ServerCallContextController; } }));
 
 
@@ -30696,7 +30696,7 @@ function isLessThan(lhs, rhs) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-const operation_js_1 = __nccwpck_require__(357);
+const operation_js_1 = __nccwpck_require__(358);
 const constants_js_1 = __nccwpck_require__(60);
 const poller_js_1 = __nccwpck_require__(75);
 const operation_js_2 = __nccwpck_require__(140);
@@ -40760,7 +40760,7 @@ exports.getCoreClientOptions = getCoreClientOptions;
 exports.getCredentialFromPipeline = getCredentialFromPipeline;
 const core_http_compat_1 = __nccwpck_require__(72);
 const core_rest_pipeline_1 = __nccwpck_require__(101);
-const core_client_1 = __nccwpck_require__(439);
+const core_client_1 = __nccwpck_require__(440);
 const core_xml_1 = __nccwpck_require__(195);
 const core_auth_1 = __nccwpck_require__(515);
 const log_js_1 = __nccwpck_require__(106);
@@ -41075,15 +41075,15 @@ const core_rest_pipeline_1 = __nccwpck_require__(101);
 const core_auth_1 = __nccwpck_require__(515);
 const core_util_1 = __nccwpck_require__(14);
 const core_util_2 = __nccwpck_require__(14);
-const BlobDownloadResponse_js_1 = __nccwpck_require__(426);
+const BlobDownloadResponse_js_1 = __nccwpck_require__(427);
 const BlobQueryResponse_js_1 = __nccwpck_require__(202);
 const storage_common_1 = __nccwpck_require__(277);
-const models_js_1 = __nccwpck_require__(415);
+const models_js_1 = __nccwpck_require__(416);
 const PageBlobRangeResponse_js_1 = __nccwpck_require__(29);
 const Pipeline_js_1 = __nccwpck_require__(183);
 const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(536);
 const Range_js_1 = __nccwpck_require__(104);
-const StorageClient_js_1 = __nccwpck_require__(454);
+const StorageClient_js_1 = __nccwpck_require__(455);
 const Batch_js_1 = __nccwpck_require__(91);
 const storage_common_2 = __nccwpck_require__(277);
 const constants_js_1 = __nccwpck_require__(148);
@@ -43928,8 +43928,8 @@ exports.PageBlobClient = PageBlobClient;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryWriter = void 0;
-const binary_format_contract_1 = __nccwpck_require__(332);
-const reflection_info_1 = __nccwpck_require__(452);
+const binary_format_contract_1 = __nccwpck_require__(333);
+const reflection_info_1 = __nccwpck_require__(453);
 const assert_1 = __nccwpck_require__(484);
 const pb_long_1 = __nccwpck_require__(117);
 /**
@@ -44168,7 +44168,7 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 "use strict";
 
 
-const { maxUnsigned16Bit } = __nccwpck_require__(465)
+const { maxUnsigned16Bit } = __nccwpck_require__(466)
 
 /** @type {import('crypto')} */
 let crypto
@@ -44337,17 +44337,17 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pythonDefaultJson = exports.buildOutputs = exports.detectMuslCcEnv = exports.detectUserLinkerEnv = exports.parseRustBacktrace = exports.parseCacheShutdownOnIdleSeconds = exports.readRawInputs = void 0;
 exports.resolveSetup = resolveSetup;
 exports.applyResolveResult = applyResolveResult;
-const os = __importStar(__nccwpck_require__(382));
+const os = __importStar(__nccwpck_require__(383));
 const path = __importStar(__nccwpck_require__(508));
 const fs = __importStar(__nccwpck_require__(249));
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const cache_keys_js_1 = __nccwpck_require__(165);
-const log_utils_js_1 = __nccwpck_require__(352);
+const log_utils_js_1 = __nccwpck_require__(353);
 const detect_musl_cc_js_1 = __nccwpck_require__(504);
 Object.defineProperty(exports, "detectMuslCcEnv", ({ enumerable: true, get: function () { return detect_musl_cc_js_1.detectMuslCcEnv; } }));
 const build_outputs_js_1 = __nccwpck_require__(268);
 Object.defineProperty(exports, "buildOutputs", ({ enumerable: true, get: function () { return build_outputs_js_1.buildOutputs; } }));
-const raw_inputs_js_1 = __nccwpck_require__(342);
+const raw_inputs_js_1 = __nccwpck_require__(343);
 Object.defineProperty(exports, "readRawInputs", ({ enumerable: true, get: function () { return raw_inputs_js_1.readRawInputs; } }));
 const input_parsers_js_1 = __nccwpck_require__(214);
 Object.defineProperty(exports, "detectUserLinkerEnv", ({ enumerable: true, get: function () { return input_parsers_js_1.detectUserLinkerEnv; } }));
@@ -44356,7 +44356,7 @@ Object.defineProperty(exports, "parseRustBacktrace", ({ enumerable: true, get: f
 const fetch_release_js_1 = __nccwpck_require__(145);
 const python_json_js_1 = __nccwpck_require__(11);
 Object.defineProperty(exports, "pythonDefaultJson", ({ enumerable: true, get: function () { return python_json_js_1.pythonDefaultJson; } }));
-const toolchain_js_1 = __nccwpck_require__(367);
+const toolchain_js_1 = __nccwpck_require__(368);
 const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
 const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
 const ALLOWED_LINKER_VALUES = [
@@ -45677,7 +45677,7 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(470)
+} = __nccwpck_require__(471)
 const { MockInterceptor } = __nccwpck_require__(135)
 const Symbols = __nccwpck_require__(196)
 const { InvalidArgumentError } = __nccwpck_require__(488)
@@ -46163,7 +46163,7 @@ exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
 const tslib_1 = __nccwpck_require__(217);
 const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(249));
-const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(375));
+const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(376));
 const constants_js_1 = __nccwpck_require__(148);
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
@@ -46796,8 +46796,8 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionCreate = void 0;
-const reflection_scalar_default_1 = __nccwpck_require__(462);
-const message_type_contract_1 = __nccwpck_require__(405);
+const reflection_scalar_default_1 = __nccwpck_require__(463);
+const message_type_contract_1 = __nccwpck_require__(406);
 /**
  * Creates an instance of the generic message, using the field
  * information.
@@ -46857,7 +46857,7 @@ exports.storageBrowserPolicyName = void 0;
 exports.storageBrowserPolicy = storageBrowserPolicy;
 const core_util_1 = __nccwpck_require__(14);
 const constants_js_1 = __nccwpck_require__(36);
-const utils_common_js_1 = __nccwpck_require__(473);
+const utils_common_js_1 = __nccwpck_require__(474);
 /**
  * The programmatic identifier of the StorageBrowserPolicy.
  */
@@ -46895,8 +46895,8 @@ function storageBrowserPolicy() {
 
 const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(518)
 const { kState } = __nccwpck_require__(15)
-const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(364)
-const { webidl } = __nccwpck_require__(456)
+const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(365)
+const { webidl } = __nccwpck_require__(457)
 const { Blob, File: NativeFile } = __nccwpck_require__(119)
 
 /** @type {globalThis['File']} */
@@ -47203,9 +47203,9 @@ __export(getClient_exports, {
 });
 module.exports = __toCommonJS(getClient_exports);
 var import_clientHelpers = __nccwpck_require__(491);
-var import_sendRequest = __nccwpck_require__(449);
-var import_urlHelpers = __nccwpck_require__(323);
-var import_checkEnvironment = __nccwpck_require__(438);
+var import_sendRequest = __nccwpck_require__(450);
+var import_urlHelpers = __nccwpck_require__(324);
+var import_checkEnvironment = __nccwpck_require__(439);
 function getClient(endpoint, clientOptions = {}) {
   const pipeline = clientOptions.pipeline ?? (0, import_clientHelpers.createDefaultPipeline)(clientOptions);
   if (clientOptions.additionalPolicies?.length) {
@@ -47385,7 +47385,7 @@ __export(httpClientAdapter_exports, {
   convertHttpClient: () => convertHttpClient
 });
 module.exports = __toCommonJS(httpClientAdapter_exports);
-var import_response = __nccwpck_require__(412);
+var import_response = __nccwpck_require__(413);
 var import_util = __nccwpck_require__(109);
 function convertHttpClient(requestPolicyClient) {
   return {
@@ -47634,13 +47634,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.restoreCache = exports.isFeatureAvailable = exports.FinalizeCacheError = exports.ReserveCacheError = exports.ValidationError = void 0;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const path = __importStar(__nccwpck_require__(248));
 const utils = __importStar(__nccwpck_require__(76));
 const cacheHttpClient = __importStar(__nccwpck_require__(34));
 const cacheTwirpClient = __importStar(__nccwpck_require__(61));
 const config_1 = __nccwpck_require__(37);
-const tar_1 = __nccwpck_require__(440);
+const tar_1 = __nccwpck_require__(441);
 const http_client_1 = __nccwpck_require__(285);
 class ValidationError extends Error {
     constructor(message) {
@@ -48148,8 +48148,8 @@ __export(extendedClient_exports, {
 module.exports = __toCommonJS(extendedClient_exports);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
 var import_core_rest_pipeline = __nccwpck_require__(101);
-var import_core_client = __nccwpck_require__(439);
-var import_response = __nccwpck_require__(412);
+var import_core_client = __nccwpck_require__(440);
+var import_response = __nccwpck_require__(413);
 class ExtendedServiceClient extends import_core_client.ServiceClient {
   constructor(options) {
     super(options);
@@ -48685,7 +48685,7 @@ __export(bearerTokenAuthenticationPolicy_exports, {
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
 var import_tokenCycler = __nccwpck_require__(162);
 var import_log = __nccwpck_require__(184);
-var import_restError = __nccwpck_require__(353);
+var import_restError = __nccwpck_require__(354);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
   try {
@@ -48926,8 +48926,8 @@ exports.shouldEmitSharedTargetWarning = shouldEmitSharedTargetWarning;
 exports.detectSharedTargetWarning = detectSharedTargetWarning;
 const fs = __importStar(__nccwpck_require__(249));
 const path = __importStar(__nccwpck_require__(508));
-const core = __importStar(__nccwpck_require__(459));
-const log_utils_js_1 = __nccwpck_require__(352);
+const core = __importStar(__nccwpck_require__(460));
+const log_utils_js_1 = __nccwpck_require__(353);
 const WARNING_MESSAGE = "setup-soldr detected a pre-populated shared target directory; a " +
     "subsequent `soldr cargo build` using the same `--target-dir` may fail " +
     "with a missing .rmeta error - see README 'Known limitations'.";
@@ -49073,7 +49073,7 @@ function systemErrorRetryPolicy(options = {}) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
 const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(439));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Container operations. */
@@ -50042,8 +50042,8 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 "use strict";
 
 module.exports = __nccwpck_require__(288)
-module.exports.async = __nccwpck_require__(411)
-module.exports.stream = __nccwpck_require__(420)
+module.exports.async = __nccwpck_require__(412)
+module.exports.stream = __nccwpck_require__(421)
 module.exports.prettyError = __nccwpck_require__(279)
 
 
@@ -50085,7 +50085,7 @@ exports.HttpProxyAgent = void 0;
 const net = __importStar(__nccwpck_require__(509));
 const tls = __importStar(__nccwpck_require__(506));
 const debug_1 = __importDefault(__nccwpck_require__(516));
-const events_1 = __nccwpck_require__(469);
+const events_1 = __nccwpck_require__(470);
 const agent_base_1 = __nccwpck_require__(241);
 const url_1 = __nccwpck_require__(85);
 const debug = (0, debug_1.default)('http-proxy-agent');
@@ -50404,7 +50404,7 @@ exports.getCmdPath = getCmdPath;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
 const tslib_1 = __nccwpck_require__(217);
-var poller_js_1 = __nccwpck_require__(319);
+var poller_js_1 = __nccwpck_require__(320);
 Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: function () { return poller_js_1.createHttpPoller; } }));
 /**
  * This can be uncommented to expose the protocol-agnostic poller
@@ -50750,7 +50750,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
 const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(439));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Service operations. */
@@ -51193,7 +51193,7 @@ const runtime_2 = __nccwpck_require__(19);
 const runtime_3 = __nccwpck_require__(19);
 const runtime_4 = __nccwpck_require__(19);
 const runtime_5 = __nccwpck_require__(19);
-const cachescope_1 = __nccwpck_require__(396);
+const cachescope_1 = __nccwpck_require__(397);
 // @generated message type with reflection information, may provide speed optimized methods
 class CacheMetadata$Type extends runtime_5.MessageType {
     constructor() {
@@ -51278,7 +51278,7 @@ __export(defaultHttpClient_exports, {
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
 var import_ts_http_runtime = __nccwpck_require__(89);
-var import_wrapAbortSignal = __nccwpck_require__(445);
+var import_wrapAbortSignal = __nccwpck_require__(446);
 function createDefaultHttpClient() {
   const client = (0, import_ts_http_runtime.createDefaultHttpClient)();
   return {
@@ -51317,8 +51317,8 @@ module.exports = require("node:process");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRequestUrl = getRequestUrl;
 exports.appendQueryParams = appendQueryParams;
-const operationHelpers_js_1 = __nccwpck_require__(432);
-const interfaceHelpers_js_1 = __nccwpck_require__(399);
+const operationHelpers_js_1 = __nccwpck_require__(433);
+const interfaceHelpers_js_1 = __nccwpck_require__(400);
 const CollectionFormatToDelimiterMap = {
     CSV: ",",
     SSV: " ",
@@ -51669,7 +51669,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Agent = void 0;
 const net = __importStar(__nccwpck_require__(509));
-const http = __importStar(__nccwpck_require__(328));
+const http = __importStar(__nccwpck_require__(329));
 const https_1 = __nccwpck_require__(70);
 __exportStar(__nccwpck_require__(161), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
@@ -51987,7 +51987,7 @@ __export(logger_exports, {
   setLogLevel: () => setLogLevel
 });
 module.exports = __toCommonJS(logger_exports);
-var import_debug = __toESM(__nccwpck_require__(466));
+var import_debug = __toESM(__nccwpck_require__(467));
 const TYPESPEC_RUNTIME_LOG_LEVELS = ["verbose", "info", "warning", "error"];
 const levelMap = {
   verbose: 400,
@@ -52162,9 +52162,9 @@ module.exports = require("node:fs");
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(457)
 const { kEnumerableProperty } = __nccwpck_require__(69)
-const { MessagePort } = __nccwpck_require__(318)
+const { MessagePort } = __nccwpck_require__(319)
 
 /**
  * @see https://html.spec.whatwg.org/multipage/comms.html#messageevent
@@ -52716,7 +52716,7 @@ exports.BinaryWriter = BinaryWriter;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
-const AvroReadable_js_1 = __nccwpck_require__(387);
+const AvroReadable_js_1 = __nccwpck_require__(388);
 const abort_controller_1 = __nccwpck_require__(496);
 const buffer_1 = __nccwpck_require__(119);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
@@ -52868,7 +52868,7 @@ module.exports = class Pluralizer {
 "use strict";
 
 
-const RedirectHandler = __nccwpck_require__(390)
+const RedirectHandler = __nccwpck_require__(391)
 
 function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections }) {
   return (dispatch) => {
@@ -52917,7 +52917,7 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(428);
+var import_userAgentPlatform = __nccwpck_require__(429);
 var import_constants = __nccwpck_require__(48);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
@@ -53005,7 +53005,7 @@ __export(wrapAbortSignalLikePolicy_exports, {
   wrapAbortSignalLikePolicyName: () => wrapAbortSignalLikePolicyName
 });
 module.exports = __toCommonJS(wrapAbortSignalLikePolicy_exports);
-var import_wrapAbortSignal = __nccwpck_require__(445);
+var import_wrapAbortSignal = __nccwpck_require__(446);
 const wrapAbortSignalLikePolicyName = "wrapAbortSignalLikePolicy";
 function wrapAbortSignalLikePolicy() {
   return {
@@ -53121,7 +53121,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.retryHttpClientResponse = exports.retryTypedResponse = exports.retry = exports.isRetryableStatusCode = exports.isServerErrorStatusCode = exports.isSuccessStatusCode = void 0;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const http_client_1 = __nccwpck_require__(285);
 const constants_1 = __nccwpck_require__(45);
 function isSuccessStatusCode(statusCode) {
@@ -53331,7 +53331,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDownloadOptions = exports.getUploadOptions = void 0;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 /**
  * Returns a copy of the upload options with defaults filled in.
  *
@@ -53828,7 +53828,7 @@ __export(multipart_exports, {
   buildMultipartBody: () => buildMultipartBody
 });
 module.exports = __toCommonJS(multipart_exports);
-var import_restError = __nccwpck_require__(444);
+var import_restError = __nccwpck_require__(445);
 var import_httpHeaders = __nccwpck_require__(485);
 var import_bytesEncoding = __nccwpck_require__(287);
 var import_typeGuards = __nccwpck_require__(497);
@@ -53984,7 +53984,7 @@ __export(multipartPolicy_exports, {
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
 var import_policies = __nccwpck_require__(286);
-var import_file = __nccwpck_require__(326);
+var import_file = __nccwpck_require__(327);
 const multipartPolicyName = import_policies.multipartPolicyName;
 function multipartPolicy() {
   const tspPolicy = (0, import_policies.multipartPolicy)();
@@ -54586,25 +54586,25 @@ module.exports = decodeText
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
 const tslib_1 = __nccwpck_require__(217);
-tslib_1.__exportStar(__nccwpck_require__(362), exports);
+tslib_1.__exportStar(__nccwpck_require__(363), exports);
 var cache_js_1 = __nccwpck_require__(253);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
 tslib_1.__exportStar(__nccwpck_require__(83), exports);
 tslib_1.__exportStar(__nccwpck_require__(155), exports);
-tslib_1.__exportStar(__nccwpck_require__(397), exports);
+tslib_1.__exportStar(__nccwpck_require__(398), exports);
 tslib_1.__exportStar(__nccwpck_require__(95), exports);
 tslib_1.__exportStar(__nccwpck_require__(262), exports);
-tslib_1.__exportStar(__nccwpck_require__(325), exports);
+tslib_1.__exportStar(__nccwpck_require__(326), exports);
 var RequestPolicy_js_1 = __nccwpck_require__(46);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
 tslib_1.__exportStar(__nccwpck_require__(93), exports);
 tslib_1.__exportStar(__nccwpck_require__(309), exports);
 tslib_1.__exportStar(__nccwpck_require__(207), exports);
-tslib_1.__exportStar(__nccwpck_require__(463), exports);
+tslib_1.__exportStar(__nccwpck_require__(464), exports);
 tslib_1.__exportStar(__nccwpck_require__(167), exports);
 tslib_1.__exportStar(__nccwpck_require__(126), exports);
 tslib_1.__exportStar(__nccwpck_require__(78), exports);
-tslib_1.__exportStar(__nccwpck_require__(427), exports);
+tslib_1.__exportStar(__nccwpck_require__(428), exports);
 tslib_1.__exportStar(__nccwpck_require__(169), exports);
 //# sourceMappingURL=index.js.map
 
@@ -54629,7 +54629,7 @@ tslib_1.__exportStar(__nccwpck_require__(221), exports);
 tslib_1.__exportStar(__nccwpck_require__(47), exports);
 tslib_1.__exportStar(__nccwpck_require__(282), exports);
 tslib_1.__exportStar(__nccwpck_require__(26), exports);
-tslib_1.__exportStar(__nccwpck_require__(355), exports);
+tslib_1.__exportStar(__nccwpck_require__(356), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -54932,18 +54932,18 @@ __export(createPipelineFromOptions_exports, {
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(71);
 var import_pipeline = __nccwpck_require__(245);
-var import_redirectPolicy = __nccwpck_require__(340);
-var import_userAgentPolicy = __nccwpck_require__(389);
+var import_redirectPolicy = __nccwpck_require__(341);
+var import_userAgentPolicy = __nccwpck_require__(390);
 var import_multipartPolicy = __nccwpck_require__(272);
 var import_decompressResponsePolicy = __nccwpck_require__(239);
 var import_defaultRetryPolicy = __nccwpck_require__(55);
 var import_formDataPolicy = __nccwpck_require__(269);
 var import_core_util = __nccwpck_require__(14);
-var import_proxyPolicy = __nccwpck_require__(472);
+var import_proxyPolicy = __nccwpck_require__(473);
 var import_setClientRequestIdPolicy = __nccwpck_require__(150);
 var import_agentPolicy = __nccwpck_require__(232);
-var import_tlsPolicy = __nccwpck_require__(378);
-var import_tracingPolicy = __nccwpck_require__(335);
+var import_tlsPolicy = __nccwpck_require__(379);
+var import_tracingPolicy = __nccwpck_require__(336);
 var import_wrapAbortSignalLikePolicy = __nccwpck_require__(259);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
@@ -54993,7 +54993,7 @@ function createPipelineFromOptions(options) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
 const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(439));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing PageBlob operations. */
@@ -55456,7 +55456,7 @@ const copyIncrementalOperationSpec = {
 
 const { kConstruct } = __nccwpck_require__(156)
 const { Cache } = __nccwpck_require__(12)
-const { webidl } = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(457)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 
 class CacheStorage {
@@ -55676,7 +55676,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
-const http = __importStar(__nccwpck_require__(328));
+const http = __importStar(__nccwpck_require__(329));
 const https = __importStar(__nccwpck_require__(70));
 const pm = __importStar(__nccwpck_require__(311));
 const tunnel = __importStar(__nccwpck_require__(521));
@@ -56347,20 +56347,20 @@ __export(internal_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(internal_exports);
-var import_agentPolicy = __nccwpck_require__(464);
-var import_decompressResponsePolicy = __nccwpck_require__(356);
-var import_defaultRetryPolicy = __nccwpck_require__(324);
+var import_agentPolicy = __nccwpck_require__(465);
+var import_decompressResponsePolicy = __nccwpck_require__(357);
+var import_defaultRetryPolicy = __nccwpck_require__(325);
 var import_exponentialRetryPolicy = __nccwpck_require__(524);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_systemErrorRetryPolicy = __nccwpck_require__(28);
 var import_throttlingRetryPolicy = __nccwpck_require__(522);
-var import_formDataPolicy = __nccwpck_require__(339);
+var import_formDataPolicy = __nccwpck_require__(340);
 var import_logPolicy = __nccwpck_require__(102);
 var import_multipartPolicy = __nccwpck_require__(171);
 var import_proxyPolicy = __nccwpck_require__(39);
-var import_redirectPolicy = __nccwpck_require__(317);
+var import_redirectPolicy = __nccwpck_require__(318);
 var import_tlsPolicy = __nccwpck_require__(222);
-var import_userAgentPolicy = __nccwpck_require__(360);
+var import_userAgentPolicy = __nccwpck_require__(361);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -56414,7 +56414,7 @@ function stringToUint8Array(value, format) {
 
 module.exports = parseString
 
-const TOMLParser = __nccwpck_require__(346)
+const TOMLParser = __nccwpck_require__(347)
 const prettyError = __nccwpck_require__(279)
 
 function parseString (str) {
@@ -56445,8 +56445,8 @@ exports.generateAccountSASQueryParameters = generateAccountSASQueryParameters;
 exports.generateAccountSASQueryParametersInternal = generateAccountSASQueryParametersInternal;
 const AccountSASPermissions_js_1 = __nccwpck_require__(58);
 const AccountSASResourceTypes_js_1 = __nccwpck_require__(2);
-const AccountSASServices_js_1 = __nccwpck_require__(379);
-const SasIPRange_js_1 = __nccwpck_require__(359);
+const AccountSASServices_js_1 = __nccwpck_require__(380);
+const SasIPRange_js_1 = __nccwpck_require__(360);
 const SASQueryParameters_js_1 = __nccwpck_require__(526);
 const constants_js_1 = __nccwpck_require__(148);
 const utils_common_js_1 = __nccwpck_require__(154);
@@ -56551,7 +56551,7 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
-const reflection_info_1 = __nccwpck_require__(452);
+const reflection_info_1 = __nccwpck_require__(453);
 const oneof_1 = __nccwpck_require__(191);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
@@ -57622,7 +57622,7 @@ function copyFile(srcFile, destFile, force) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.maskSecretUrls = exports.maskSigUrl = void 0;
-const core_1 = __nccwpck_require__(459);
+const core_1 = __nccwpck_require__(460);
 /**
  * Masks the `sig` parameter in a URL and sets it as a secret.
  *
@@ -57711,8 +57711,8 @@ exports.maskSecretUrls = maskSecretUrls;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
 const tslib_1 = __nccwpck_require__(217);
-tslib_1.__exportStar(__nccwpck_require__(471), exports);
-var storageClient_js_1 = __nccwpck_require__(446);
+tslib_1.__exportStar(__nccwpck_require__(472), exports);
+var storageClient_js_1 = __nccwpck_require__(447);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
 tslib_1.__exportStar(__nccwpck_require__(166), exports);
 //# sourceMappingURL=index.js.map
@@ -58586,11 +58586,11 @@ function stringifyComplexTable (prefix, indent, key, value) {
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(457)
 const { DOMException } = __nccwpck_require__(30)
 const { URLSerializer } = __nccwpck_require__(25)
 const { getGlobalOrigin } = __nccwpck_require__(139)
-const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(465)
+const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(466)
 const {
   kWebSocketURL,
   kReadyState,
@@ -58601,11 +58601,11 @@ const {
   kByteParser
 } = __nccwpck_require__(98)
 const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(57)
-const { establishWebSocketConnection } = __nccwpck_require__(365)
+const { establishWebSocketConnection } = __nccwpck_require__(366)
 const { WebsocketFrameSend } = __nccwpck_require__(187)
-const { ByteParser } = __nccwpck_require__(481)
+const { ByteParser } = __nccwpck_require__(482)
 const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(69)
-const { getGlobalDispatcher } = __nccwpck_require__(376)
+const { getGlobalDispatcher } = __nccwpck_require__(377)
 const { types } = __nccwpck_require__(123)
 
 let experimentalWarned = false
@@ -60407,6 +60407,856 @@ class DecodedURL extends URL {
 /***/ }),
 
 /***/ 312:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr entry point. Owned by Agent 2.
+//
+// Replaces the composite action's main-phase steps with a single JS
+// orchestrator. Calls the helpers in src/lib/* in the same order the
+// composite's steps fire.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(249));
+const os = __importStar(__nccwpck_require__(383));
+const path = __importStar(__nccwpck_require__(508));
+const core = __importStar(__nccwpck_require__(460));
+const cache = __importStar(__nccwpck_require__(215));
+const log_utils_js_1 = __nccwpck_require__(353);
+const resolve_setup_js_1 = __nccwpck_require__(189);
+const phase_timing_js_1 = __nccwpck_require__(337);
+const ensure_rust_toolchain_js_1 = __nccwpck_require__(512);
+const ensure_soldr_js_1 = __nccwpck_require__(364);
+const verify_soldr_js_1 = __nccwpck_require__(359);
+const install_passthrough_js_1 = __nccwpck_require__(514);
+const normalize_source_mtime_js_1 = __nccwpck_require__(79);
+const detect_shared_target_warning_js_1 = __nccwpck_require__(219);
+const ensure_shims_js_1 = __nccwpck_require__(530);
+const cache_compress_js_1 = __nccwpck_require__(493);
+const stats_collector_js_1 = __nccwpck_require__(74);
+const toolchain_snapshot_js_1 = __nccwpck_require__(459);
+const solo_toolchain_cache_js_1 = __nccwpck_require__(294);
+const cook_cache_js_1 = __nccwpck_require__(170);
+const soldr_mini_cache_js_1 = __nccwpck_require__(157);
+const diagnostics_js_1 = __nccwpck_require__(111);
+const source_mtime_snapshot_js_1 = __nccwpck_require__(408);
+/**
+ * Map (hit, matchedKey) → workflow-visible restore-status string.
+ * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
+ * for the `<layer>-cache-restore-status` outputs declared in action.yml.
+ */
+function deriveRestoreStatus(hit, matchedKey) {
+    if (hit)
+        return "exact-hit";
+    if (matchedKey.trim())
+        return "restore-key-hit";
+    return "miss";
+}
+function writeCacheKeysManifest(result, runnerTemp, log) {
+    if (!runnerTemp)
+        return;
+    const keys = [
+        result.setupCache.key,
+        result.buildCache.key,
+        result.targetCache.key,
+        result.cargoRegistryCache.key,
+    ].filter((k) => Boolean(k));
+    if (keys.length === 0)
+        return;
+    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
+    try {
+        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
+        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
+    }
+    catch (err) {
+        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+function isTruthy(value) {
+    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
+}
+function isFalsy(value) {
+    return FALSY.has(((value ?? "").trim().toLowerCase()));
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+function dirHasContent(p) {
+    try {
+        return fs.readdirSync(p).length > 0;
+    }
+    catch {
+        return false;
+    }
+}
+function buildActionContext() {
+    const env = process.env;
+    const logger = (0, log_utils_js_1.createLogger)(env);
+    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
+    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
+    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
+    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
+    const githubSha = env["GITHUB_SHA"]?.trim() || "";
+    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
+    const parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
+    return {
+        env: { ...env },
+        workspace,
+        runnerTemp,
+        runnerOs,
+        runnerArch,
+        githubSha,
+        githubToken,
+        parentSha,
+        logger,
+    };
+}
+async function restoreCacheSafe(paths, key, restoreKeys, logger) {
+    if (paths.length === 0 || !key) {
+        return { hit: false, matchedKey: "" };
+    }
+    try {
+        const matched = await cache.restoreCache(paths, key, restoreKeys);
+        return { hit: matched === key, matchedKey: matched ?? "" };
+    }
+    catch (err) {
+        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "" };
+    }
+}
+async function run() {
+    const ctx = buildActionContext();
+    const logger = ctx.logger;
+    await (0, phase_timing_js_1.markPhase)("action");
+    // ---- resolve ----
+    await (0, phase_timing_js_1.markPhase)("resolve");
+    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
+    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
+    await (0, resolve_setup_js_1.applyResolveResult)(result);
+    await (0, phase_timing_js_1.finishPhase)("resolve");
+    // Always emit the cache-keys manifest right after resolve so workflow
+    // steps that run between main and post (e.g. actions/upload-artifact)
+    // can read it. The four keys are fully determined by resolveSetup and
+    // never change later in the run.
+    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
+    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            logger,
+            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
+        });
+    }
+    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
+    if (dryRun) {
+        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
+        await (0, phase_timing_js_1.finishPhase)("action");
+        return;
+    }
+    // Persist resolve state for the post-job step.
+    core.saveState("resolveResult", JSON.stringify(result));
+    core.saveState("buildCacheMode", result.buildCache.mode);
+    core.saveState("logging", logging ? "true" : "false");
+    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
+    const statsMode = result.stats;
+    const debugMode = result.debugMode;
+    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
+    const statsCollector = new stats_collector_js_1.StatsCollector();
+    // ---- source-mtime-normalize ----
+    if (isTruthy(inputs.sourceMtimeNormalize)) {
+        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
+    }
+    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
+    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
+    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
+    core.saveState("setupCacheExactHit", "false");
+    core.saveState("setupCacheMatchedKey", "");
+    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
+    core.saveState("targetCacheExactHit", "false");
+    core.saveState("targetCacheMatchedKey", "");
+    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
+    core.saveState("buildCacheExactHit", "false");
+    core.saveState("buildCacheMatchedKey", "");
+    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
+    core.saveState("cargoRegistryCacheExactHit", "false");
+    core.saveState("cargoRegistryCacheMatchedKey", "");
+    // ---- parallel restores ----
+    // setup-cache, target-cache, build-cache, and cargo-registry write to
+    // disjoint paths and have no inter-dependencies, so they run concurrently.
+    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
+    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
+    //
+    // Layers that must stay sequential (wired below): solo-toolchain (writes
+    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
+    // install dir, must precede ensureSoldr), cook (writes target/ and needs
+    // the soldr binary). Cargo-registry was previously after-cook — it's been
+    // moved into this parallel block because nothing the soldr install path
+    // touches depends on its hydrated cargo registry state.
+    await (0, phase_timing_js_1.markPhase)("parallel-restore");
+    let setupCacheExactHit = false;
+    // Capture target-cache match status so we can skip the redundant cook restore.
+    // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
+    // (~2.5 GB inflated) also contains compiled deps. When target-cache matched
+    // at the lockfile/shape/toolchain level (exact OR parent-SHA OR lock-prefix
+    // fallback), we have target/deps/ already populated with identical content —
+    // cook restore would just overwrite. Skipping saves ~5–10 s per warm run.
+    // A looser restoreKeyLockfile-only match (different shape) is NOT enough to
+    // skip cook, since cook output may differ across shapes.
+    let targetCacheMatchedKey = "";
+    const setupRestorePromise = (async () => {
+        if (!(cacheEnabled && result.setupCache.paths.length > 0))
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
+        setupCacheExactHit = restore.hit;
+        core.setOutput("cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("setup_cache_matched_key", restore.matchedKey);
+        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("setupCacheMatchedKey", restore.matchedKey);
+        // Expose for ensure_rust_toolchain to read via env. Must be visible by
+        // the time toolchain phase runs — guaranteed by the Promise.all below.
+        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
+        statsCollector.record({
+            label: "setup-cache", operation: "restore", hit: restore.hit,
+            key: result.setupCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.setupCache.restorePrefix],
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const targetRestorePromise = (async () => {
+        if (!result.targetCache.enabled)
+            return;
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (targetPaths.length === 0)
+            return;
+        const restoreKeys = [];
+        if (result.targetCache.restoreKeyParent)
+            restoreKeys.push(result.targetCache.restoreKeyParent);
+        if (result.targetCache.restoreKeyLock)
+            restoreKeys.push(result.targetCache.restoreKeyLock);
+        if (result.targetCache.restoreKeyLockfile)
+            restoreKeys.push(result.targetCache.restoreKeyLockfile);
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
+        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("target_cache_matched_key", restore.matchedKey);
+        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("targetCacheMatchedKey", restore.matchedKey);
+        targetCacheMatchedKey = restore.matchedKey;
+        statsCollector.record({
+            label: "target-cache", operation: "restore", hit: restore.hit,
+            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const buildRestorePromise = (async () => {
+        if (!buildCacheEnabled)
+            return;
+        const buildCachePath = result.buildCache.path;
+        const archivePath = `${buildCachePath}.tar.zst`;
+        const restoreKeys = [];
+        if (result.buildCache.restoreKeyParent)
+            restoreKeys.push(result.buildCache.restoreKeyParent);
+        if (result.buildCache.restoreKeyToolchain)
+            restoreKeys.push(result.buildCache.restoreKeyToolchain);
+        if (result.buildCache.restoreKeyOsArch)
+            restoreKeys.push(result.buildCache.restoreKeyOsArch);
+        const t0 = Date.now();
+        // @actions/cache hashes the `paths` array into a "version" key — save and
+        // restore MUST pass the same array or the lookup misses even when the
+        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
+        // restore must use the same single-path array. The decompression below
+        // unpacks archivePath → buildCachePath afterwards.
+        const restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
+        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("build_cache_matched_key", restore.matchedKey);
+        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("buildCacheMatchedKey", restore.matchedKey);
+        let buildArchiveBytes = null;
+        let buildInflatedBytes = null;
+        let buildFileCount = null;
+        if (fileExists(archivePath)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+            if (magic === "zstd" || magic === "gzip") {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath, debug: debugMode, log: debugLog });
+                    buildArchiveBytes = dr.archiveBytes;
+                    buildInflatedBytes = dr.inflatedBytes;
+                    buildFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
+        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
+        // dir on the cold side; if it's present after decompress, walk it and
+        // set each matching source file's mtime to what cold saw. The replay
+        // is gated by (size, content-hash) match so we never overwrite a
+        // genuinely modified file's mtime — that would underbuild.
+        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
+            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
+            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
+            if (snapshot) {
+                const rt0 = Date.now();
+                try {
+                    // Match the project-root selection that post.ts uses when
+                    // writing the snapshot — the parent of the resolved target-dir,
+                    // not the (outer) GITHUB_WORKSPACE.
+                    const projectRoot = path.dirname(result.targetCache.targetPath);
+                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
+                        workspace: projectRoot,
+                        snapshot,
+                        log: (msg) => logger.log(msg),
+                    });
+                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
+                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
+                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
+                }
+                catch (err) {
+                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+            else {
+                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
+            }
+        }
+        statsCollector.record({
+            label: "build-cache", operation: "restore", hit: restore.hit,
+            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    })();
+    // Cargo-registry restore moved here from after-cook. It writes only
+    // $CARGO_HOME/registry/ and has no dependency on soldr being installed;
+    // running it in parallel with target+build trims its ~5s off the critical
+    // path.
+    const cargoRegistryRestorePromise = (async () => {
+        if (!result.cargoRegistryCache.enabled)
+            return;
+        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe([registryArchive], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
+        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
+        let regArchiveBytes = null;
+        let regInflatedBytes = null;
+        let regFileCount = null;
+        if (fileExists(registryArchive)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
+            if (magic === "zstd" || magic === "gzip") {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({
+                        archivePath: registryArchive,
+                        targetDir: result.cargoRegistryCache.path,
+                        debug: debugMode, log: debugLog,
+                    });
+                    regArchiveBytes = dr.archiveBytes;
+                    regInflatedBytes = dr.inflatedBytes;
+                    regFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        statsCollector.record({
+            label: "cargo-registry", operation: "restore", hit: restore.hit,
+            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.cargoRegistryCache.restorePrefix],
+            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    })();
+    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
+    // try/catches, so this should only see rejections for genuine programming
+    // bugs.
+    await Promise.all([
+        setupRestorePromise,
+        targetRestorePromise,
+        buildRestorePromise,
+        cargoRegistryRestorePromise,
+    ]);
+    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
+    // ---- target-tree-cache (full mode) ----
+    // The bundle path is included in target-cache restore paths above when full
+    // mode is requested, so there's no separate restore here. We keep the phase
+    // marker for parity with the composite step ordering.
+    await (0, phase_timing_js_1.markPhase)("target-tree");
+    await (0, phase_timing_js_1.finishPhase)("target-tree");
+    // Kick off cook restore in the background. It overlaps with the
+    // sequential toolchain + soldr install + shims + verify steps that
+    // follow. By the time the cook phase runs, the restore is done — we
+    // just await the promise. Saves ~5–7 s of warm-build wall clock.
+    //
+    // Why this is safe (vs the disastrous PR #145 which added cook to the
+    // BIG parallel block): cook now races with SMALL ops (rust install
+    // ~1–2 s, soldr install ~2–3 s, shims/verify ~1–2 s). Those don't
+    // contend on disk write bandwidth the way target/build/cargo-registry
+    // restores did. Cook's 2.5 GB tar write becomes the long pole and
+    // hides behind the small ops.
+    //
+    // SAFETY: when target-cache writes to target/ (build-cache-mode: full),
+    // cook restore would race with target-cache restore on the same dir.
+    // The parallel-restore block above already finished target-cache, but
+    // we still want a runtime gate just in case the mode changes.
+    const cookGate = (0, cook_cache_js_1.decideCookGate)({
+        prebuildDeps: inputs.prebuildDeps,
+        cacheUmbrella: cacheEnabled,
+        lockfilePath: result.targetCache.lockfilePath,
+    });
+    const cookActive = cookGate.enabled && result.enabled;
+    let cookFlags = [];
+    let cookKey = "";
+    let cookProjectRoot = "";
+    let cookTargetDir = "";
+    let cookArchive = "";
+    let cookRestoreT0 = Date.now();
+    let cookRestorePromise = null;
+    // Skip cook restore when target-cache matched at the lockfile/shape level.
+    // restoreKeyLock = `${prefix}-${targetInputsHash}-${suffix}-` where
+    // targetInputsHash = sha256(toolchain, lockfile, manifest, shape). A
+    // matchedKey starting with restoreKeyLock means the cached entry was built
+    // with the same toolchain + lockfile + shape — its target/deps/ matches
+    // what cook would restore. Covers:
+    //   - exact hit  (matchedKey === current key, also startsWith restoreKeyLock)
+    //   - parent-SHA hit (matchedKey === restoreKeyParent, also startsWith)
+    //   - lock-prefix fallback (any saved entry with same lockfile+shape)
+    // Does NOT cover restoreKeyLockfile fallback (shorter prefix that drops
+    // shape) — different shape may mean different cook output, so cook still
+    // runs there as the safety net.
+    const targetCacheLockMatch = !!targetCacheMatchedKey &&
+        !!result.targetCache.restoreKeyLock &&
+        targetCacheMatchedKey.startsWith(result.targetCache.restoreKeyLock);
+    const cookSkippedDueToTargetHit = cookActive && targetCacheLockMatch;
+    if (cookActive && !cookSkippedDueToTargetHit) {
+        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
+        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
+        const lockHash = result.targetCache.lockfileHash || "no-lock";
+        cookKey = (0, cook_cache_js_1.buildCookCacheKey)({
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            flagsHash,
+            lockHash,
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        });
+        cookProjectRoot = path.dirname(result.targetCache.targetPath);
+        cookTargetDir = result.targetCache.targetPath;
+        cookArchive = `${cookTargetDir}.tar.zst`;
+        logger.log(`cook: key=${cookKey} starting background restore concurrent with install`);
+        cookRestoreT0 = Date.now();
+        cookRestorePromise = (0, cook_cache_js_1.restoreCookCache)({
+            exactKey: cookKey,
+            archivePath: cookArchive,
+            targetDir: cookTargetDir,
+            longWindow: 27,
+            debug: debugMode,
+            log: (msg) => logger.log(msg),
+        });
+    }
+    // ---- toolchain ----
+    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
+    // toolchain install so we can see which inodes setup-soldr added on
+    // top of the runner image. When solo-toolchain-cache is opted in, a
+    // third snapshot is taken *before* the cache restore so the saved
+    // tarball captures the full above-runner state — not just the
+    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
+    // lifetime axis".
+    await (0, phase_timing_js_1.markPhase)("toolchain");
+    const snapshotRoots = [
+        path.join(result.rustupHome, "toolchains"),
+        path.join(result.cargoHome, "bin"),
+    ];
+    const soloRootMap = {
+        "rustup-toolchains": snapshotRoots[0],
+        "cargo-bin": snapshotRoots[1],
+    };
+    const soloEnabled = isTruthy(inputs.soloToolchainCache);
+    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "19");
+    let soloKeys = null;
+    let soloMatchedKey = "";
+    let soloExactHit = false;
+    // Pre-restore snapshot — only needed when solo cache is enabled, so
+    // we can compute the full save-diff (post-install vs runner-image,
+    // not vs post-restore baseline).
+    const preRestoreSnapshot = soloEnabled ? await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots) : null;
+    if (soloEnabled) {
+        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
+            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        });
+        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
+        const restoreT0 = Date.now();
+        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
+        const restored = await (0, solo_toolchain_cache_js_1.restoreSoloCache)({
+            keys: soloKeys,
+            rootMap: soloRootMap,
+            stagingDir,
+            log: (msg) => logger.log(msg),
+        });
+        soloMatchedKey = restored.matchedKey;
+        let verifiedMatch = true;
+        if (restored.verified && restored.matchedKey) {
+            const expected = result.toolchain.cacheChannel.trim();
+            // The rustup home is set up so `rustc` will resolve through the
+            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
+            // the cargo bin one.
+            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
+            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
+                expectedRelease: expected,
+                rustcCommand: rustcCmd,
+                log: (msg) => logger.log(msg),
+            });
+            verifiedMatch = verify.match;
+        }
+        soloExactHit = restored.hit && verifiedMatch;
+        core.saveState("soloToolchainEnabled", "true");
+        core.saveState("soloToolchainExactKey", soloKeys.exact);
+        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
+        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
+        core.saveState("soloToolchainLevel", soloLevel);
+        statsCollector.record({
+            label: "solo-toolchain-cache",
+            operation: "restore",
+            hit: soloExactHit,
+            key: soloKeys.exact,
+            matchedKey: soloMatchedKey,
+            restoreKeys: soloKeys.fallbacks,
+            archiveBytes: restored.restoredBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - restoreT0,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    else {
+        core.saveState("soloToolchainEnabled", "false");
+    }
+    const baselineSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
+    await (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({ resolveResult: result, setupCacheExactHit });
+    const postInstallSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
+    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
+    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
+    // When solo cache is enabled, also compute the save-diff (post-install
+    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
+    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
+        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
+        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
+        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
+        try {
+            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
+            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
+            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
+            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
+                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
+                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
+                `incremental-empty=${toolchainDiff.added.length === 0}`);
+        }
+        catch (err) {
+            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
+        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
+    if (ctx.runnerTemp) {
+        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
+        try {
+            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
+            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
+        }
+        catch (err) {
+            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    await (0, phase_timing_js_1.finishPhase)("toolchain");
+    // ---- install soldr ----
+    // Try the soldr-mini-cache before ensureSoldr fires the GH Releases fetch.
+    // On hit, the install dir is pre-populated and ensureSoldr's existing
+    // installedVersion() check short-circuits. On miss, ensureSoldr does its
+    // normal fetch and post.ts saves to the mini-cache.
+    await (0, phase_timing_js_1.markPhase)("install");
+    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
+    const miniInstallDir = path.dirname(result.soldrPath);
+    const miniArchive = `${miniInstallDir}.tar.zst`;
+    let miniHit = false;
+    let miniKey = "";
+    if (miniEnabled) {
+        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
+            hasRef: Boolean(result.soldrRef.trim()),
+            enable: result.enabled,
+            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
+        });
+        if (eligibility.eligible) {
+            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
+            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
+                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+                soldrVersion: version,
+            });
+            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir}`);
+            const miniT0 = Date.now();
+            const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
+                exactKey: miniKey,
+                installDir: miniInstallDir,
+                archivePath: miniArchive,
+                longWindow: 27,
+                debug: debugMode,
+                log: (msg) => logger.log(msg),
+            });
+            miniHit = restore.hit;
+            statsCollector.record({
+                label: "soldr-mini-cache",
+                operation: "restore",
+                hit: restore.hit,
+                key: miniKey,
+                matchedKey: restore.matchedKey,
+                restoreKeys: [],
+                archiveBytes: restore.archiveBytes || null,
+                inflatedBytes: null,
+                fileCount: null,
+                durationMs: Date.now() - miniT0,
+                timestamp: new Date().toISOString(),
+            });
+        }
+        else {
+            logger.log(`soldr-mini-cache: skipped — ${eligibility.reason}`);
+        }
+    }
+    else {
+        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
+    }
+    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
+    core.saveState("soldrMiniExactKey", miniKey);
+    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
+    core.saveState("soldrMiniInstallDir", miniInstallDir);
+    core.saveState("soldrMiniArchive", miniArchive);
+    if (result.enabled) {
+        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
+        // restored binary at the expected path with the expected version and
+        // short-circuits — no GH fetch.
+        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
+    }
+    else {
+        (0, install_passthrough_js_1.installPassthrough)({
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
+            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
+            "verbatim, and soldr-aware caching/observability is disabled.");
+    }
+    await (0, phase_timing_js_1.finishPhase)("install");
+    // Export SOLDR_BINARY so shims can exec it directly
+    core.exportVariable("SOLDR_BINARY", result.soldrPath);
+    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
+    // ---- shims ----
+    if (result.shimsEnabled) {
+        await (0, ensure_shims_js_1.ensureShims)({
+            shimsDir: result.shimsDir,
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+    }
+    // ---- verify ----
+    await (0, phase_timing_js_1.markPhase)("verify");
+    if (result.enabled) {
+        const verify = await (0, verify_soldr_js_1.verifySoldr)({
+            soldrPath: result.soldrPath,
+            buildCacheMode: result.buildCache.mode,
+            requireRustPlan: result.targetCache.enabled,
+        });
+        core.setOutput("soldr-version", verify.soldrVersion);
+        core.setOutput("soldr_version", verify.soldrVersion);
+    }
+    else {
+        core.setOutput("soldr-version", "passthrough");
+        core.setOutput("soldr_version", "passthrough");
+    }
+    await (0, phase_timing_js_1.finishPhase)("verify");
+    // ---- cook (prebuild-deps via cargo-chef) ----
+    // The RESTORE was kicked off as a background promise right after the
+    // parallel-restore block above — we just await its result here. The
+    // RUN (actual cargo-chef invocation) still happens in this phase if
+    // the restore missed.
+    // Failures here are logged but never fail the action — the user's
+    // own cargo build will still work without the cooked deps.
+    await (0, phase_timing_js_1.markPhase)("cook");
+    if (cookActive && cookRestorePromise) {
+        const restore = await cookRestorePromise;
+        statsCollector.record({
+            label: "cook-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: cookKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        let cookRan = false;
+        if (!restore.hit) {
+            const runRes = await (0, cook_cache_js_1.runCook)({
+                soldrBinary: result.soldrPath,
+                projectRoot: cookProjectRoot,
+                flags: cookFlags,
+                log: (msg) => logger.log(msg),
+            });
+            cookRan = runRes.exitCode === 0;
+        }
+        else {
+            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
+        }
+        core.saveState("cookEnabled", "true");
+        core.saveState("cookExactKey", cookKey);
+        core.saveState("cookMatchedKey", restore.matchedKey);
+        core.saveState("cookHit", restore.hit ? "true" : "false");
+        core.saveState("cookRan", cookRan ? "true" : "false");
+        core.saveState("cookTargetDir", cookTargetDir);
+        core.saveState("cookLongWindow", "27");
+        core.saveState("cookCompressLevel", "19");
+    }
+    else if (cookSkippedDueToTargetHit) {
+        logger.log(`cook: skipped - target-cache matched at lockfile/shape level (matched=${targetCacheMatchedKey}); cook output would be redundant`);
+        core.saveState("cookEnabled", "false");
+    }
+    else {
+        logger.log(`cook: skipped - ${cookGate.reason}`);
+        core.saveState("cookEnabled", "false");
+    }
+    await (0, phase_timing_js_1.finishPhase)("cook");
+    // ---- shared-target warning ----
+    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
+        buildCacheEnabled,
+        effectiveTargetCacheEnabled: result.targetCache.enabled,
+        buildCacheMode: result.buildCache.mode,
+        targetDir: result.targetCache.targetPath,
+    });
+    // ---- stats report ----
+    statsCollector.report(statsMode, (msg) => logger.log(msg));
+    if (statsMode === "detailed") {
+        try {
+            await statsCollector.writeFiles(ctx.runnerTemp);
+            statsCollector.setGithubOutputs();
+        }
+        catch (err) {
+            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    core.saveState("statsCollector", statsCollector.serialize());
+    core.saveState("statsMode", statsMode);
+    core.saveState("compileCacheStats", result.compileCacheStats);
+    core.saveState("runnerTemp", ctx.runnerTemp);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            cacheOutcomes: statsCollector.snapshot(),
+            logger,
+        });
+    }
+    await (0, phase_timing_js_1.finishPhase)("action");
+    // dirHasContent is exported for tests; suppress unused warning here.
+    void dirHasContent;
+}
+// Auto-invoke only when this module is run as the main entry point. This lets
+// tests import `run` (and helpers) without triggering the side-effectful
+// orchestration. The dist/main.js produced by ncc is invoked directly by the
+// Actions runtime so the check trips and the action executes normally.
+if (typeof process !== "undefined" &&
+    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
+    // import.meta.url is the file URL of this module; argv[1] is the runner
+    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
+    // the dev path — we rely on the env-var opt-out for tests instead.
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    run().catch((err) => {
+        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        core.setFailed(`setup-soldr failed: ${message}`);
+    });
+}
+
+
+/***/ }),
+
+/***/ 313:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -60547,7 +61397,7 @@ function flattenResponse(fullResponse, responseSpec) {
 
 /***/ }),
 
-/***/ 313:
+/***/ 314:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60728,7 +61578,7 @@ exports.buildCreatePoller = buildCreatePoller;
 
 /***/ }),
 
-/***/ 314:
+/***/ 315:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60739,12 +61589,12 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
 const core_rest_pipeline_1 = __nccwpck_require__(101);
 const pipeline_js_1 = __nccwpck_require__(284);
-const utils_js_1 = __nccwpck_require__(312);
-const httpClientCache_js_1 = __nccwpck_require__(398);
-const operationHelpers_js_1 = __nccwpck_require__(432);
+const utils_js_1 = __nccwpck_require__(313);
+const httpClientCache_js_1 = __nccwpck_require__(399);
+const operationHelpers_js_1 = __nccwpck_require__(433);
 const urlHelpers_js_1 = __nccwpck_require__(238);
-const interfaceHelpers_js_1 = __nccwpck_require__(399);
-const log_js_1 = __nccwpck_require__(480);
+const interfaceHelpers_js_1 = __nccwpck_require__(400);
+const log_js_1 = __nccwpck_require__(481);
 /**
  * Initializes a new instance of the ServiceClient.
  */
@@ -60911,7 +61761,7 @@ function getCredentialScopes(options) {
 
 /***/ }),
 
-/***/ 315:
+/***/ 316:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60938,14 +61788,14 @@ __export(createPipelineFromOptions_exports, {
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(102);
 var import_pipeline = __nccwpck_require__(525);
-var import_redirectPolicy = __nccwpck_require__(317);
-var import_userAgentPolicy = __nccwpck_require__(360);
-var import_decompressResponsePolicy = __nccwpck_require__(356);
-var import_defaultRetryPolicy = __nccwpck_require__(324);
-var import_formDataPolicy = __nccwpck_require__(339);
-var import_checkEnvironment = __nccwpck_require__(438);
+var import_redirectPolicy = __nccwpck_require__(318);
+var import_userAgentPolicy = __nccwpck_require__(361);
+var import_decompressResponsePolicy = __nccwpck_require__(357);
+var import_defaultRetryPolicy = __nccwpck_require__(325);
+var import_formDataPolicy = __nccwpck_require__(340);
+var import_checkEnvironment = __nccwpck_require__(439);
 var import_proxyPolicy = __nccwpck_require__(39);
-var import_agentPolicy = __nccwpck_require__(464);
+var import_agentPolicy = __nccwpck_require__(465);
 var import_tlsPolicy = __nccwpck_require__(222);
 var import_multipartPolicy = __nccwpck_require__(171);
 function createPipelineFromOptions(options) {
@@ -60977,7 +61827,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 316:
+/***/ 317:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -60994,7 +61844,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 317:
+/***/ 318:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61066,7 +61916,7 @@ async function handleRedirect(next, response, maxRetries, allowCrossOriginRedire
 
 /***/ }),
 
-/***/ 318:
+/***/ 319:
 /***/ ((module) => {
 
 "use strict";
@@ -61074,7 +61924,7 @@ module.exports = require("worker_threads");
 
 /***/ }),
 
-/***/ 319:
+/***/ 320:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61084,7 +61934,7 @@ module.exports = require("worker_threads");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
 const operation_js_1 = __nccwpck_require__(51);
-const poller_js_1 = __nccwpck_require__(313);
+const poller_js_1 = __nccwpck_require__(314);
 /**
  * Creates a poller that can be used to poll a long-running operation.
  * @param lro - Description of the long-running operation
@@ -61129,7 +61979,7 @@ exports.createHttpPoller = createHttpPoller;
 
 /***/ }),
 
-/***/ 320:
+/***/ 321:
 /***/ ((module) => {
 
 "use strict";
@@ -61137,14 +61987,14 @@ module.exports = require("perf_hooks");
 
 /***/ }),
 
-/***/ 321:
+/***/ 322:
 /***/ ((module) => {
 
 (()=>{"use strict";var t={d:(e,n)=>{for(var i in n)t.o(n,i)&&!t.o(e,i)&&Object.defineProperty(e,i,{enumerable:!0,get:n[i]})},o:(t,e)=>Object.prototype.hasOwnProperty.call(t,e),r:t=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(t,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(t,"__esModule",{value:!0})}},e={};t.r(e),t.d(e,{XMLBuilder:()=>ie,XMLParser:()=>Lt,XMLValidator:()=>se});const n=":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD",i=new RegExp("^["+n+"]["+n+"\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$");function s(t,e){const n=[];let i=e.exec(t);for(;i;){const s=[];s.startIndex=e.lastIndex-i[0].length;const r=i.length;for(let t=0;t<r;t++)s.push(i[t]);n.push(s),i=e.exec(t)}return n}const r=function(t){return!(null==i.exec(t))},o=["hasOwnProperty","toString","valueOf","__defineGetter__","__defineSetter__","__lookupGetter__","__lookupSetter__"],a=["__proto__","constructor","prototype"],h={allowBooleanAttributes:!1,unpairedTags:[]};function l(t,e){e=Object.assign({},h,e);const n=[];let i=!1,s=!1;"\ufeff"===t[0]&&(t=t.substr(1));for(let r=0;r<t.length;r++)if("<"===t[r]&&"?"===t[r+1]){if(r+=2,r=p(t,r),r.err)return r}else{if("<"!==t[r]){if(u(t[r]))continue;return b("InvalidChar","char '"+t[r]+"' is not expected.",w(t,r))}{let o=r;if(r++,"!"===t[r]){r=c(t,r);continue}{let a=!1;"/"===t[r]&&(a=!0,r++);let h="";for(;r<t.length&&">"!==t[r]&&" "!==t[r]&&"\t"!==t[r]&&"\n"!==t[r]&&"\r"!==t[r];r++)h+=t[r];if(h=h.trim(),"/"===h[h.length-1]&&(h=h.substring(0,h.length-1),r--),!E(h)){let e;return e=0===h.trim().length?"Invalid space after '<'.":"Tag '"+h+"' is an invalid name.",b("InvalidTag",e,w(t,r))}const l=g(t,r);if(!1===l)return b("InvalidAttr","Attributes for '"+h+"' have open quote.",w(t,r));let d=l.value;if(r=l.index,"/"===d[d.length-1]){const n=r-d.length;d=d.substring(0,d.length-1);const s=x(d,e);if(!0!==s)return b(s.err.code,s.err.msg,w(t,n+s.err.line));i=!0}else if(a){if(!l.tagClosed)return b("InvalidTag","Closing tag '"+h+"' doesn't have proper closing.",w(t,r));if(d.trim().length>0)return b("InvalidTag","Closing tag '"+h+"' can't have attributes or invalid starting.",w(t,o));if(0===n.length)return b("InvalidTag","Closing tag '"+h+"' has not been opened.",w(t,o));{const e=n.pop();if(h!==e.tagName){let n=w(t,e.tagStartPos);return b("InvalidTag","Expected closing tag '"+e.tagName+"' (opened in line "+n.line+", col "+n.col+") instead of closing tag '"+h+"'.",w(t,o))}0==n.length&&(s=!0)}}else{const a=x(d,e);if(!0!==a)return b(a.err.code,a.err.msg,w(t,r-d.length+a.err.line));if(!0===s)return b("InvalidXml","Multiple possible root nodes found.",w(t,r));-1!==e.unpairedTags.indexOf(h)||n.push({tagName:h,tagStartPos:o}),i=!0}for(r++;r<t.length;r++)if("<"===t[r]){if("!"===t[r+1]){r++,r=c(t,r);continue}if("?"!==t[r+1])break;if(r=p(t,++r),r.err)return r}else if("&"===t[r]){const e=N(t,r);if(-1==e)return b("InvalidChar","char '&' is not expected.",w(t,r));r=e}else if(!0===s&&!u(t[r]))return b("InvalidXml","Extra text at the end",w(t,r));"<"===t[r]&&r--}}}return i?1==n.length?b("InvalidTag","Unclosed tag '"+n[0].tagName+"'.",w(t,n[0].tagStartPos)):!(n.length>0)||b("InvalidXml","Invalid '"+JSON.stringify(n.map(t=>t.tagName),null,4).replace(/\r?\n/g,"")+"' found.",{line:1,col:1}):b("InvalidXml","Start tag expected.",1)}function u(t){return" "===t||"\t"===t||"\n"===t||"\r"===t}function p(t,e){const n=e;for(;e<t.length;e++)if("?"==t[e]||" "==t[e]){const i=t.substr(n,e-n);if(e>5&&"xml"===i)return b("InvalidXml","XML declaration allowed only at the start of the document.",w(t,e));if("?"==t[e]&&">"==t[e+1]){e++;break}continue}return e}function c(t,e){if(t.length>e+5&&"-"===t[e+1]&&"-"===t[e+2]){for(e+=3;e<t.length;e++)if("-"===t[e]&&"-"===t[e+1]&&">"===t[e+2]){e+=2;break}}else if(t.length>e+8&&"D"===t[e+1]&&"O"===t[e+2]&&"C"===t[e+3]&&"T"===t[e+4]&&"Y"===t[e+5]&&"P"===t[e+6]&&"E"===t[e+7]){let n=1;for(e+=8;e<t.length;e++)if("<"===t[e])n++;else if(">"===t[e]&&(n--,0===n))break}else if(t.length>e+9&&"["===t[e+1]&&"C"===t[e+2]&&"D"===t[e+3]&&"A"===t[e+4]&&"T"===t[e+5]&&"A"===t[e+6]&&"["===t[e+7])for(e+=8;e<t.length;e++)if("]"===t[e]&&"]"===t[e+1]&&">"===t[e+2]){e+=2;break}return e}const d='"',f="'";function g(t,e){let n="",i="",s=!1;for(;e<t.length;e++){if(t[e]===d||t[e]===f)""===i?i=t[e]:i!==t[e]||(i="");else if(">"===t[e]&&""===i){s=!0;break}n+=t[e]}return""===i&&{value:n,index:e,tagClosed:s}}const m=new RegExp("(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['\"])(([\\s\\S])*?)\\5)?","g");function x(t,e){const n=s(t,m),i={};for(let t=0;t<n.length;t++){if(0===n[t][1].length)return b("InvalidAttr","Attribute '"+n[t][2]+"' has no space in starting.",v(n[t]));if(void 0!==n[t][3]&&void 0===n[t][4])return b("InvalidAttr","Attribute '"+n[t][2]+"' is without value.",v(n[t]));if(void 0===n[t][3]&&!e.allowBooleanAttributes)return b("InvalidAttr","boolean attribute '"+n[t][2]+"' is not allowed.",v(n[t]));const s=n[t][2];if(!y(s))return b("InvalidAttr","Attribute '"+s+"' is an invalid name.",v(n[t]));if(Object.prototype.hasOwnProperty.call(i,s))return b("InvalidAttr","Attribute '"+s+"' is repeated.",v(n[t]));i[s]=1}return!0}function N(t,e){if(";"===t[++e])return-1;if("#"===t[e])return function(t,e){let n=/\d/;for("x"===t[e]&&(e++,n=/[\da-fA-F]/);e<t.length;e++){if(";"===t[e])return e;if(!t[e].match(n))break}return-1}(t,++e);let n=0;for(;e<t.length;e++,n++)if(!(t[e].match(/\w/)&&n<20)){if(";"===t[e])break;return-1}return e}function b(t,e,n){return{err:{code:t,msg:e,line:n.line||n,col:n.col}}}function y(t){return r(t)}function E(t){return r(t)}function w(t,e){const n=t.substring(0,e).split(/\r?\n/);return{line:n.length,col:n[n.length-1].length+1}}function v(t){return t.startIndex+t[1].length}const S=t=>o.includes(t)?"__"+t:t,_={preserveOrder:!1,attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,removeNSPrefix:!1,allowBooleanAttributes:!1,parseTagValue:!0,parseAttributeValue:!1,trimValues:!0,cdataPropName:!1,numberParseOptions:{hex:!0,leadingZeros:!0,eNotation:!0},tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},stopNodes:[],alwaysCreateTextNode:!1,isArray:()=>!1,commentPropName:!1,unpairedTags:[],processEntities:!0,htmlEntities:!1,entityDecoder:null,ignoreDeclaration:!1,ignorePiTags:!1,transformTagName:!1,transformAttributeName:!1,updateTag:function(t,e,n){return t},captureMetaData:!1,maxNestedTags:100,strictReservedNames:!0,jPath:!0,onDangerousProperty:S};function A(t,e){if("string"!=typeof t)return;const n=t.toLowerCase();if(o.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);if(a.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`)}function T(t,e){return"boolean"==typeof t?{enabled:t,maxEntitySize:1e4,maxExpansionDepth:1e4,maxTotalExpansions:1/0,maxExpandedLength:1e5,maxEntityCount:1e3,allowedTags:null,tagFilter:null,appliesTo:"all"}:"object"==typeof t&&null!==t?{enabled:!1!==t.enabled,maxEntitySize:Math.max(1,t.maxEntitySize??1e4),maxExpansionDepth:Math.max(1,t.maxExpansionDepth??1e4),maxTotalExpansions:Math.max(1,t.maxTotalExpansions??1/0),maxExpandedLength:Math.max(1,t.maxExpandedLength??1e5),maxEntityCount:Math.max(1,t.maxEntityCount??1e3),allowedTags:t.allowedTags??null,tagFilter:t.tagFilter??null,appliesTo:t.appliesTo??"all"}:T(!0)}const C=function(t){const e=Object.assign({},_,t),n=[{value:e.attributeNamePrefix,name:"attributeNamePrefix"},{value:e.attributesGroupName,name:"attributesGroupName"},{value:e.textNodeName,name:"textNodeName"},{value:e.cdataPropName,name:"cdataPropName"},{value:e.commentPropName,name:"commentPropName"}];for(const{value:t,name:e}of n)t&&A(t,e);return null===e.onDangerousProperty&&(e.onDangerousProperty=S),e.processEntities=T(e.processEntities,e.htmlEntities),e.unpairedTagsSet=new Set(e.unpairedTags),e.stopNodes&&Array.isArray(e.stopNodes)&&(e.stopNodes=e.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),e};let P;P="function"!=typeof Symbol?"@@xmlMetadata":Symbol("XML Node Metadata");class ${constructor(t){this.tagname=t,this.child=[],this[":@"]=Object.create(null)}add(t,e){"__proto__"===t&&(t="#__proto__"),this.child.push({[t]:e})}addChild(t,e){"__proto__"===t.tagname&&(t.tagname="#__proto__"),t[":@"]&&Object.keys(t[":@"]).length>0?this.child.push({[t.tagname]:t.child,":@":t[":@"]}):this.child.push({[t.tagname]:t.child}),void 0!==e&&(this.child[this.child.length-1][P]={startIndex:e})}static getMetaDataSymbol(){return P}}const O=":A-Za-z_À-ÖØ-öø-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�",I=":A-Za-z_À-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�𐀀-󯿿",V=I+"\\-\\.\\d·̀-ͯ҇‿-⁀",D=(t,e,n="")=>{const i=`[${t.replace(":","")}][${e.replace(":","")}]*`;return{name:new RegExp(`^[${t}][${e}]*$`,n),ncName:new RegExp(`^${i}$`,n),qName:new RegExp(`^${i}(?::${i})?$`,n),nmToken:new RegExp(`^[${e}]+$`,n),nmTokens:new RegExp(`^[${e}]+(?:\\s+[${e}]+)*$`,n)}},M=D(O,O+"\\-\\.\\d·̀-ͯ‿-⁀"),j=D(I,V,"u"),L=(t,{xmlVersion:e="1.0"}={})=>((t="1.0")=>"1.1"===t?j:M)(e).qName.test(t);class k{constructor(t,e){this.suppressValidationErr=!t,this.options=t,this.xmlVersion=e||1}setXmlVersion(t=1){this.xmlVersion=t}readDocType(t,e){const n=Object.create(null);let i=0;if("O"!==t[e+3]||"C"!==t[e+4]||"T"!==t[e+5]||"Y"!==t[e+6]||"P"!==t[e+7]||"E"!==t[e+8])throw new Error("Invalid Tag instead of DOCTYPE");{e+=9;let s=1,r=!1,o=!1,a="";for(;e<t.length;e++)if("<"!==t[e]||o)if(">"===t[e]){if(o?"-"===t[e-1]&&"-"===t[e-2]&&(o=!1,s--):s--,0===s)break}else"["===t[e]?r=!0:a+=t[e];else{if(r&&F(t,"!ENTITY",e)){let s,r;if(e+=7,[s,r,e]=this.readEntityExp(t,e+1,this.suppressValidationErr),-1===r.indexOf("&")){if(!1!==this.options.enabled&&null!=this.options.maxEntityCount&&i>=this.options.maxEntityCount)throw new Error(`Entity count (${i+1}) exceeds maximum allowed (${this.options.maxEntityCount})`);n[s]=r,i++}}else if(r&&F(t,"!ELEMENT",e)){e+=8;const{index:n}=this.readElementExp(t,e+1);e=n}else if(r&&F(t,"!ATTLIST",e))e+=8;else if(r&&F(t,"!NOTATION",e)){e+=9;const{index:n}=this.readNotationExp(t,e+1,this.suppressValidationErr);e=n}else{if(!F(t,"!--",e))throw new Error("Invalid DOCTYPE");o=!0}s++,a=""}if(0!==s)throw new Error("Unclosed DOCTYPE")}return{entities:n,i:e}}readEntityExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e])&&'"'!==t[e]&&"'"!==t[e];)e++;let i=t.substring(n,e);if(G(i,{xmlVersion:this.xmlVersion}),e=R(t,e),!this.suppressValidationErr){if("SYSTEM"===t.substring(e,e+6).toUpperCase())throw new Error("External entities are not supported");if("%"===t[e])throw new Error("Parameter entities are not supported")}let s="";if([e,s]=this.readIdentifierVal(t,e,"entity"),!1!==this.options.enabled&&null!=this.options.maxEntitySize&&s.length>this.options.maxEntitySize)throw new Error(`Entity "${i}" size (${s.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`);return[i,s,--e]}readNotationExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);!this.suppressValidationErr&&G(i,{xmlVersion:this.xmlVersion}),e=R(t,e);const s=t.substring(e,e+6).toUpperCase();if(!this.suppressValidationErr&&"SYSTEM"!==s&&"PUBLIC"!==s)throw new Error(`Expected SYSTEM or PUBLIC, found "${s}"`);e+=s.length,e=R(t,e);let r=null,o=null;if("PUBLIC"===s)[e,r]=this.readIdentifierVal(t,e,"publicIdentifier"),'"'!==t[e=R(t,e)]&&"'"!==t[e]||([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"));else if("SYSTEM"===s&&([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"),!this.suppressValidationErr&&!o))throw new Error("Missing mandatory system identifier for SYSTEM notation");return{notationName:i,publicIdentifier:r,systemIdentifier:o,index:--e}}readIdentifierVal(t,e,n){let i="";const s=t[e];if('"'!==s&&"'"!==s)throw new Error(`Expected quoted string, found "${s}"`);const r=++e;for(;e<t.length&&t[e]!==s;)e++;if(i=t.substring(r,e),t[e]!==s)throw new Error(`Unterminated ${n} value`);return[++e,i]}readElementExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);if(!this.suppressValidationErr&&!L(i,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid element name: "${i}"`);let s="";if("E"===t[e=R(t,e)]&&F(t,"MPTY",e))e+=4;else if("A"===t[e]&&F(t,"NY",e))e+=2;else if("("===t[e]){const n=++e;for(;e<t.length&&")"!==t[e];)e++;if(s=t.substring(n,e),")"!==t[e])throw new Error("Unterminated content model")}else if(!this.suppressValidationErr)throw new Error(`Invalid Element Expression, found "${t[e]}"`);return{elementName:i,contentModel:s.trim(),index:e}}readAttlistExp(t,e){let n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);for(G(i,{xmlVersion:this.xmlVersion}),n=e=R(t,e);e<t.length&&!/\s/.test(t[e]);)e++;let s=t.substring(n,e);if(!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid attribute name: "${s}"`);e=R(t,e);let r="";if("NOTATION"===t.substring(e,e+8).toUpperCase()){if(r="NOTATION","("!==t[e=R(t,e+=8)])throw new Error(`Expected '(', found "${t[e]}"`);e++;let n=[];for(;e<t.length&&")"!==t[e];){const i=e;for(;e<t.length&&"|"!==t[e]&&")"!==t[e];)e++;let s=t.substring(i,e);if(s=s.trim(),!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid notation name: "${s}"`);n.push(s),"|"===t[e]&&(e++,e=R(t,e))}if(")"!==t[e])throw new Error("Unterminated list of notations");e++,r+=" ("+n.join("|")+")"}else{const n=e;for(;e<t.length&&!/\s/.test(t[e]);)e++;r+=t.substring(n,e);const i=["CDATA","ID","IDREF","IDREFS","ENTITY","ENTITIES","NMTOKEN","NMTOKENS"];if(!this.suppressValidationErr&&!i.includes(r.toUpperCase()))throw new Error(`Invalid attribute type: "${r}"`)}e=R(t,e);let o="";return"#REQUIRED"===t.substring(e,e+8).toUpperCase()?(o="#REQUIRED",e+=8):"#IMPLIED"===t.substring(e,e+7).toUpperCase()?(o="#IMPLIED",e+=7):[e,o]=this.readIdentifierVal(t,e,"ATTLIST"),{elementName:i,attributeName:s,attributeType:r,defaultValue:o,index:e}}}const R=(t,e)=>{for(;e<t.length&&/\s/.test(t[e]);)e++;return e};function F(t,e,n){for(let i=0;i<e.length;i++)if(e[i]!==t[n+i+1])return!1;return!0}function G(t,e){if(L(t,{xmlVersion:e}))return t;throw new Error(`Invalid entity name ${t}`)}const U=/^[-+]?0x[a-fA-F0-9]+$/,B=/^0b[01]+$/,W=/^0o[0-7]+$/,z=/^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/,X={hex:!0,binary:!1,octal:!1,leadingZeros:!0,decimalPoint:".",eNotation:!0,infinity:"original"};const Y=/^([-+])?(0*)(\d*(\.\d*)?[eE][-\+]?\d+)$/;function q(t,e){const n=t.trim();if(2!==e&&8!==e||(t=n.substring(2)),parseInt)return parseInt(t,e);if(Number.parseInt)return Number.parseInt(t,e);if(window&&window.parseInt)return window.parseInt(t,e);throw new Error("parseInt, Number.parseInt, window.parseInt are not supported")}class Z{constructor(t){this._matcher=t}get separator(){return this._matcher.separator}getCurrentTag(){const t=this._matcher.path;return t.length>0?t[t.length-1].tag:void 0}getCurrentNamespace(){const t=this._matcher.path;return t.length>0?t[t.length-1].namespace:void 0}getAttrValue(t){const e=this._matcher.path;if(0!==e.length)return e[e.length-1].values?.[t]}hasAttr(t){const e=this._matcher.path;if(0===e.length)return!1;const n=e[e.length-1];return void 0!==n.values&&t in n.values}getPosition(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].position??0}getCounter(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this._matcher.path.length}toString(t,e=!0){return this._matcher.toString(t,e)}toArray(){return this._matcher.path.map(t=>t.tag)}matches(t){return this._matcher.matches(t)}matchesAny(t){return t.matchesAny(this._matcher)}}class J{constructor(t={}){this.separator=t.separator||".",this.path=[],this.siblingStacks=[],this._pathStringCache=null,this._view=new Z(this)}push(t,e=null,n=null){this._pathStringCache=null,this.path.length>0&&(this.path[this.path.length-1].values=void 0);const i=this.path.length;this.siblingStacks[i]||(this.siblingStacks[i]=new Map);const s=this.siblingStacks[i],r=n?`${n}:${t}`:t,o=s.get(r)||0;let a=0;for(const t of s.values())a+=t;s.set(r,o+1);const h={tag:t,position:a,counter:o};null!=n&&(h.namespace=n),null!=e&&(h.values=e),this.path.push(h)}pop(){if(0===this.path.length)return;this._pathStringCache=null;const t=this.path.pop();return this.siblingStacks.length>this.path.length+1&&(this.siblingStacks.length=this.path.length+1),t}updateCurrent(t){if(this.path.length>0){const e=this.path[this.path.length-1];null!=t&&(e.values=t)}}getCurrentTag(){return this.path.length>0?this.path[this.path.length-1].tag:void 0}getCurrentNamespace(){return this.path.length>0?this.path[this.path.length-1].namespace:void 0}getAttrValue(t){if(0!==this.path.length)return this.path[this.path.length-1].values?.[t]}hasAttr(t){if(0===this.path.length)return!1;const e=this.path[this.path.length-1];return void 0!==e.values&&t in e.values}getPosition(){return 0===this.path.length?-1:this.path[this.path.length-1].position??0}getCounter(){return 0===this.path.length?-1:this.path[this.path.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this.path.length}toString(t,e=!0){const n=t||this.separator;if(n===this.separator&&!0===e){if(null!==this._pathStringCache)return this._pathStringCache;const t=this.path.map(t=>t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n);return this._pathStringCache=t,t}return this.path.map(t=>e&&t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n)}toArray(){return this.path.map(t=>t.tag)}reset(){this._pathStringCache=null,this.path=[],this.siblingStacks=[]}matches(t){const e=t.segments;return 0!==e.length&&(t.hasDeepWildcard()?this._matchWithDeepWildcard(e):this._matchSimple(e))}_matchSimple(t){if(this.path.length!==t.length)return!1;for(let e=0;e<t.length;e++)if(!this._matchSegment(t[e],this.path[e],e===this.path.length-1))return!1;return!0}_matchWithDeepWildcard(t){let e=this.path.length-1,n=t.length-1;for(;n>=0&&e>=0;){const i=t[n];if("deep-wildcard"===i.type){if(n--,n<0)return!0;const i=t[n];let s=!1;for(let t=e;t>=0;t--)if(this._matchSegment(i,this.path[t],t===this.path.length-1)){e=t-1,n--,s=!0;break}if(!s)return!1}else{if(!this._matchSegment(i,this.path[e],e===this.path.length-1))return!1;e--,n--}}return n<0}_matchSegment(t,e,n){if("*"!==t.tag&&t.tag!==e.tag)return!1;if(void 0!==t.namespace&&"*"!==t.namespace&&t.namespace!==e.namespace)return!1;if(void 0!==t.attrName){if(!n)return!1;if(!e.values||!(t.attrName in e.values))return!1;if(void 0!==t.attrValue&&String(e.values[t.attrName])!==String(t.attrValue))return!1}if(void 0!==t.position){if(!n)return!1;const i=e.counter??0;if("first"===t.position&&0!==i)return!1;if("odd"===t.position&&i%2!=1)return!1;if("even"===t.position&&i%2!=0)return!1;if("nth"===t.position&&i!==t.positionValue)return!1}return!0}matchesAny(t){return t.matchesAny(this)}snapshot(){return{path:this.path.map(t=>({...t})),siblingStacks:this.siblingStacks.map(t=>new Map(t))}}restore(t){this._pathStringCache=null,this.path=t.path.map(t=>({...t})),this.siblingStacks=t.siblingStacks.map(t=>new Map(t))}readOnly(){return this._view}}class K{constructor(t,e={},n){this.pattern=t,this.separator=e.separator||".",this.segments=this._parse(t),this.data=n,this._hasDeepWildcard=this.segments.some(t=>"deep-wildcard"===t.type),this._hasAttributeCondition=this.segments.some(t=>void 0!==t.attrName),this._hasPositionSelector=this.segments.some(t=>void 0!==t.position)}_parse(t){const e=[];let n=0,i="";for(;n<t.length;)t[n]===this.separator?n+1<t.length&&t[n+1]===this.separator?(i.trim()&&(e.push(this._parseSegment(i.trim())),i=""),e.push({type:"deep-wildcard"}),n+=2):(i.trim()&&e.push(this._parseSegment(i.trim())),i="",n++):(i+=t[n],n++);return i.trim()&&e.push(this._parseSegment(i.trim())),e}_parseSegment(t){const e={type:"tag"};let n=null,i=t;const s=t.match(/^([^\[]+)(\[[^\]]*\])(.*)$/);if(s&&(i=s[1]+s[3],s[2])){const t=s[2].slice(1,-1);t&&(n=t)}let r,o,a=i;if(i.includes("::")){const e=i.indexOf("::");if(r=i.substring(0,e).trim(),a=i.substring(e+2).trim(),!r)throw new Error(`Invalid namespace in pattern: ${t}`)}let h=null;if(a.includes(":")){const t=a.lastIndexOf(":"),e=a.substring(0,t).trim(),n=a.substring(t+1).trim();["first","last","odd","even"].includes(n)||/^nth\(\d+\)$/.test(n)?(o=e,h=n):o=a}else o=a;if(!o)throw new Error(`Invalid segment pattern: ${t}`);if(e.tag=o,r&&(e.namespace=r),n)if(n.includes("=")){const t=n.indexOf("=");e.attrName=n.substring(0,t).trim(),e.attrValue=n.substring(t+1).trim()}else e.attrName=n.trim();if(h){const t=h.match(/^nth\((\d+)\)$/);t?(e.position="nth",e.positionValue=parseInt(t[1],10)):e.position=h}return e}get length(){return this.segments.length}hasDeepWildcard(){return this._hasDeepWildcard}hasAttributeCondition(){return this._hasAttributeCondition}hasPositionSelector(){return this._hasPositionSelector}toString(){return this.pattern}}class Q{constructor(){this._byDepthAndTag=new Map,this._wildcardByDepth=new Map,this._deepWildcards=[],this._patterns=new Set,this._sealed=!1}add(t){if(this._sealed)throw new TypeError("ExpressionSet is sealed. Create a new ExpressionSet to add more expressions.");if(this._patterns.has(t.pattern))return this;if(this._patterns.add(t.pattern),t.hasDeepWildcard())return this._deepWildcards.push(t),this;const e=t.length,n=t.segments[t.segments.length-1],i=n?.tag;if(i&&"*"!==i){const n=`${e}:${i}`;this._byDepthAndTag.has(n)||this._byDepthAndTag.set(n,[]),this._byDepthAndTag.get(n).push(t)}else this._wildcardByDepth.has(e)||this._wildcardByDepth.set(e,[]),this._wildcardByDepth.get(e).push(t);return this}addAll(t){for(const e of t)this.add(e);return this}has(t){return this._patterns.has(t.pattern)}get size(){return this._patterns.size}seal(){return this._sealed=!0,this}get isSealed(){return this._sealed}matchesAny(t){return null!==this.findMatch(t)}findMatch(t){const e=t.getDepth(),n=`${e}:${t.getCurrentTag()}`,i=this._byDepthAndTag.get(n);if(i)for(let e=0;e<i.length;e++)if(t.matches(i[e]))return i[e];const s=this._wildcardByDepth.get(e);if(s)for(let e=0;e<s.length;e++)if(t.matches(s[e]))return s[e];for(let e=0;e<this._deepWildcards.length;e++)if(t.matches(this._deepWildcards[e]))return this._deepWildcards[e];return null}}const H={cent:"¢",pound:"£",curren:"¤",yen:"¥",euro:"€",dollar:"$",euro:"€",fnof:"ƒ",inr:"₹",af:"؋",birr:"ብር",peso:"₱",rub:"₽",won:"₩",yuan:"¥",cedil:"¸"},tt={amp:"&",apos:"'",gt:">",lt:"<",quot:'"'},et={nbsp:" ",copy:"©",reg:"®",trade:"™",mdash:"—",ndash:"–",hellip:"…",laquo:"«",raquo:"»",lsquo:"‘",rsquo:"’",ldquo:"“",rdquo:"”",bull:"•",para:"¶",sect:"§",deg:"°",frac12:"½",frac14:"¼",frac34:"¾"},nt=new Set("!?\\\\/[]$%{}^&*()<>|+");function it(t){if("#"===t[0])throw new Error(`[EntityReplacer] Invalid character '#' in entity name: "${t}"`);for(const e of t)if(nt.has(e))throw new Error(`[EntityReplacer] Invalid character '${e}' in entity name: "${t}"`);return t}function st(...t){const e=Object.create(null);for(const n of t)if(n)for(const t of Object.keys(n)){const i=n[t];if("string"==typeof i)e[t]=i;else if(i&&"object"==typeof i&&void 0!==i.val){const n=i.val;"string"==typeof n&&(e[t]=n)}}return e}const rt="external",ot="base",at="all",ht=Object.freeze({allow:0,leave:1,remove:2,throw:3}),lt=new Set([9,10,13]);class ut{constructor(t={}){var e;this._limit=t.limit||{},this._maxTotalExpansions=this._limit.maxTotalExpansions||0,this._maxExpandedLength=this._limit.maxExpandedLength||0,this._postCheck="function"==typeof t.postCheck?t.postCheck:t=>t,this._limitTiers=(e=this._limit.applyLimitsTo??rt)&&e!==rt?e===at?new Set([at]):e===ot?new Set([ot]):Array.isArray(e)?new Set(e):new Set([rt]):new Set([rt]),this._numericAllowed=t.numericAllowed??!0,this._baseMap=st(tt,t.namedEntities||null),this._externalMap=Object.create(null),this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this._removeSet=new Set(t.remove&&Array.isArray(t.remove)?t.remove:[]),this._leaveSet=new Set(t.leave&&Array.isArray(t.leave)?t.leave:[]);const n=function(t){if(!t)return{xmlVersion:1,onLevel:ht.allow,nullLevel:ht.remove};const e=1.1===t.xmlVersion?1.1:1,n=ht[t.onNCR]??ht.allow,i=ht[t.nullNCR]??ht.remove;return{xmlVersion:e,onLevel:n,nullLevel:Math.max(i,ht.remove)}}(t.ncr);this._ncrXmlVersion=n.xmlVersion,this._ncrOnLevel=n.onLevel,this._ncrNullLevel=n.nullLevel}setExternalEntities(t){if(t)for(const e of Object.keys(t))it(e);this._externalMap=st(t)}addExternalEntity(t,e){it(t),"string"==typeof e&&-1===e.indexOf("&")&&(this._externalMap[t]=e)}addInputEntities(t){this._totalExpansions=0,this._expandedLength=0,this._inputMap=st(t)}reset(){return this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this}setXmlVersion(t){this._ncrXmlVersion=1.1===t?1.1:1}decode(t){if("string"!=typeof t||0===t.length)return t;const e=t,n=[],i=t.length;let s=0,r=0;const o=this._maxTotalExpansions>0,a=this._maxExpandedLength>0,h=o||a;for(;r<i;){if(38!==t.charCodeAt(r)){r++;continue}let e=r+1;for(;e<i&&59!==t.charCodeAt(e)&&e-r<=32;)e++;if(e>=i||59!==t.charCodeAt(e)){r++;continue}const l=t.slice(r+1,e);if(0===l.length){r++;continue}let u,p;if(this._removeSet.has(l))u="",void 0===p&&(p=rt);else{if(this._leaveSet.has(l)){r++;continue}if(35===l.charCodeAt(0)){const t=this._resolveNCR(l);if(void 0===t){r++;continue}u=t,p=ot}else{const t=this._resolveName(l);u=t?.value,p=t?.tier}}if(void 0!==u){if(r>s&&n.push(t.slice(s,r)),n.push(u),s=e+1,r=s,h&&this._tierCounts(p)){if(o&&(this._totalExpansions++,this._totalExpansions>this._maxTotalExpansions))throw new Error(`[EntityReplacer] Entity expansion count limit exceeded: ${this._totalExpansions} > ${this._maxTotalExpansions}`);if(a){const t=u.length-(l.length+2);if(t>0&&(this._expandedLength+=t,this._expandedLength>this._maxExpandedLength))throw new Error(`[EntityReplacer] Expanded content length limit exceeded: ${this._expandedLength} > ${this._maxExpandedLength}`)}}}else r++}s<i&&n.push(t.slice(s));const l=0===n.length?t:n.join("");return this._postCheck(l,e)}_tierCounts(t){return!!this._limitTiers.has(at)||this._limitTiers.has(t)}_resolveName(t){return t in this._inputMap?{value:this._inputMap[t],tier:rt}:t in this._externalMap?{value:this._externalMap[t],tier:rt}:t in this._baseMap?{value:this._baseMap[t],tier:ot}:void 0}_classifyNCR(t){return 0===t?this._ncrNullLevel:t>=55296&&t<=57343||1===this._ncrXmlVersion&&t>=1&&t<=31&&!lt.has(t)?ht.remove:-1}_applyNCRAction(t,e,n){switch(t){case ht.allow:return String.fromCodePoint(n);case ht.remove:return"";case ht.leave:return;case ht.throw:throw new Error(`[EntityDecoder] Prohibited numeric character reference &${e}; (U+${n.toString(16).toUpperCase().padStart(4,"0")})`);default:return String.fromCodePoint(n)}}_resolveNCR(t){const e=t.charCodeAt(1);let n;if(n=120===e||88===e?parseInt(t.slice(2),16):parseInt(t.slice(1),10),Number.isNaN(n)||n<0||n>1114111)return;const i=this._classifyNCR(n);if(!this._numericAllowed&&i<ht.remove)return;const s=-1===i?this._ncrOnLevel:Math.max(this._ncrOnLevel,i);return this._applyNCRAction(s,t,n)}}function pt(t,e){if(!t)return{};const n=e.attributesGroupName?t[e.attributesGroupName]:t;if(!n)return{};const i={};for(const t in n)t.startsWith(e.attributeNamePrefix)?i[t.substring(e.attributeNamePrefix.length)]=n[t]:i[t]=n[t];return i}function ct(t){if(!t||"string"!=typeof t)return;const e=t.indexOf(":");if(-1!==e&&e>0){const n=t.substring(0,e);if("xmlns"!==n)return n}}class dt{constructor(t,e){var n;this.options=t,this.currentNode=null,this.tagsNodeStack=[],this.parseXml=Nt,this.parseTextData=ft,this.resolveNameSpace=gt,this.buildAttributesMap=xt,this.isItStopNode=wt,this.replaceEntitiesValue=yt,this.readStopNodeData=At,this.saveTextToParentTag=Et,this.addChild=bt,this.ignoreAttributesFn="function"==typeof(n=this.options.ignoreAttributes)?n:Array.isArray(n)?t=>{for(const e of n){if("string"==typeof e&&t===e)return!0;if(e instanceof RegExp&&e.test(t))return!0}}:()=>!1,this.entityExpansionCount=0,this.currentExpandedLength=0;let i={...tt};this.options.entityDecoder?this.entityDecoder=this.options.entityDecoder:("object"==typeof this.options.htmlEntities?i=this.options.htmlEntities:!0===this.options.htmlEntities&&(i={...et,...H}),this.entityDecoder=new ut({namedEntities:{...i,...e},numericAllowed:this.options.htmlEntities,limit:{maxTotalExpansions:this.options.processEntities.maxTotalExpansions,maxExpandedLength:this.options.processEntities.maxExpandedLength,applyLimitsTo:this.options.processEntities.appliesTo}})),this.matcher=new J,this.readonlyMatcher=this.matcher.readOnly(),this.isCurrentNodeStopNode=!1,this.stopNodeExpressionsSet=new Q;const s=this.options.stopNodes;if(s&&s.length>0){for(let t=0;t<s.length;t++){const e=s[t];"string"==typeof e?this.stopNodeExpressionsSet.add(new K(e)):e instanceof K&&this.stopNodeExpressionsSet.add(e)}this.stopNodeExpressionsSet.seal()}}}function ft(t,e,n,i,s,r,o){const a=this.options;if(void 0!==t&&(a.trimValues&&!i&&(t=t.trim()),t.length>0)){o||(t=this.replaceEntitiesValue(t,e,n));const i=a.jPath?n.toString():n,h=a.tagValueProcessor(e,t,i,s,r);return null==h?t:typeof h!=typeof t||h!==t?h:a.trimValues||t.trim()===t?Tt(t,a.parseTagValue,a.numberParseOptions):t}}function gt(t){if(this.options.removeNSPrefix){const e=t.split(":"),n="/"===t.charAt(0)?"/":"";if("xmlns"===e[0])return"";2===e.length&&(t=n+e[1])}return t}const mt=new RegExp("([^\\s=]+)\\s*(=\\s*(['\"])([\\s\\S]*?)\\3)?","gm");function xt(t,e,n,i=!1){const r=this.options;if(!0===i||!0!==r.ignoreAttributes&&"string"==typeof t){const i=s(t,mt),o=i.length,a={},h=new Array(o);let l=!1;const u={};for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]),s=i[t][4];if(e.length&&void 0!==s){let i=s;r.trimValues&&(i=i.trim()),i=this.replaceEntitiesValue(i,n,this.readonlyMatcher),h[t]=i,u[e]=i,l=!0}}l&&"object"==typeof e&&e.updateCurrent&&e.updateCurrent(u);const p=r.jPath?e.toString():this.readonlyMatcher;let c=!1;for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]);if(this.ignoreAttributesFn(e,p))continue;let n=r.attributeNamePrefix+e;if(e.length)if(r.transformAttributeName&&(n=r.transformAttributeName(n)),n=Pt(n,r),void 0!==i[t][4]){const i=h[t],s=r.attributeValueProcessor(e,i,p);a[n]=null==s?i:typeof s!=typeof i||s!==i?s:Tt(i,r.parseAttributeValue,r.numberParseOptions),c=!0}else r.allowBooleanAttributes&&(a[n]=!0,c=!0)}if(!c)return;if(r.attributesGroupName&&!r.preserveOrder){const t={};return t[r.attributesGroupName]=a,t}return a}}const Nt=function(t){t=t.replace(/\r\n?/g,"\n");const e=new $("!xml");let n=e,i="";this.matcher.reset(),this.entityDecoder.reset(),this.entityExpansionCount=0,this.currentExpandedLength=0;const s=this.options,r=new k(s.processEntities),o=t.length;for(let a=0;a<o;a++)if("<"===t[a]){const h=t.charCodeAt(a+1);if(47===h){const e=vt(t,">",a,"Closing Tag is not closed.");let r=t.substring(a+2,e).trim();if(s.removeNSPrefix){const t=r.indexOf(":");-1!==t&&(r=r.substr(t+1))}r=Ct(s.transformTagName,r,"",s).tagName,n&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher));const o=this.matcher.getCurrentTag();if(r&&s.unpairedTagsSet.has(r))throw new Error(`Unpaired tag can not be used as closing tag: </${r}>`);o&&s.unpairedTagsSet.has(o)&&(this.matcher.pop(),this.tagsNodeStack.pop()),this.matcher.pop(),this.isCurrentNodeStopNode=!1,n=this.tagsNodeStack.pop(),i="",a=e}else if(63===h){let e=_t(t,a,!1,"?>");if(!e)throw new Error("Pi Tag is not closed.");i=this.saveTextToParentTag(i,n,this.readonlyMatcher);const o=this.buildAttributesMap(e.tagExp,this.matcher,e.tagName,!0);if(o){const t=o[this.options.attributeNamePrefix+"version"];this.entityDecoder.setXmlVersion(Number(t)||1),r.setXmlVersion(Number(t)||1)}if(s.ignoreDeclaration&&"?xml"===e.tagName||s.ignorePiTags);else{const t=new $(e.tagName);t.add(s.textNodeName,""),e.tagName!==e.tagExp&&e.attrExpPresent&&!0!==s.ignoreAttributes&&(t[":@"]=o),this.addChild(n,t,this.readonlyMatcher,a)}a=e.closeIndex+1}else if(33===h&&45===t.charCodeAt(a+2)&&45===t.charCodeAt(a+3)){const e=vt(t,"--\x3e",a+4,"Comment is not closed.");if(s.commentPropName){const r=t.substring(a+4,e-2);i=this.saveTextToParentTag(i,n,this.readonlyMatcher),n.add(s.commentPropName,[{[s.textNodeName]:r}])}a=e}else if(33===h&&68===t.charCodeAt(a+2)){const e=r.readDocType(t,a);this.entityDecoder.addInputEntities(e.entities),a=e.i}else if(33===h&&91===t.charCodeAt(a+2)){const e=vt(t,"]]>",a,"CDATA is not closed.")-2,r=t.substring(a+9,e);i=this.saveTextToParentTag(i,n,this.readonlyMatcher);let o=this.parseTextData(r,n.tagname,this.readonlyMatcher,!0,!1,!0,!0);null==o&&(o=""),s.cdataPropName?n.add(s.cdataPropName,[{[s.textNodeName]:r}]):n.add(s.textNodeName,o),a=e+2}else{let r=_t(t,a,s.removeNSPrefix);if(!r){const e=t.substring(Math.max(0,a-50),Math.min(o,a+50));throw new Error(`readTagExp returned undefined at position ${a}. Context: "${e}"`)}let h=r.tagName;const l=r.rawTagName;let u=r.tagExp,p=r.attrExpPresent,c=r.closeIndex;if(({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s)),s.strictReservedNames&&(h===s.commentPropName||h===s.cdataPropName||h===s.textNodeName||h===s.attributesGroupName))throw new Error(`Invalid tag name: ${h}`);n&&i&&"!xml"!==n.tagname&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher,!1));const d=n;d&&s.unpairedTagsSet.has(d.tagname)&&(n=this.tagsNodeStack.pop(),this.matcher.pop());let f=!1;u.length>0&&u.lastIndexOf("/")===u.length-1&&(f=!0,"/"===h[h.length-1]?(h=h.substr(0,h.length-1),u=h):u=u.substr(0,u.length-1),p=h!==u);let g,m=null,x={};g=ct(l),h!==e.tagname&&this.matcher.push(h,{},g),h!==u&&p&&(m=this.buildAttributesMap(u,this.matcher,h),m&&(x=pt(m,s))),h!==e.tagname&&(this.isCurrentNodeStopNode=this.isItStopNode());const N=a;if(this.isCurrentNodeStopNode){let e="";if(f)a=r.closeIndex;else if(s.unpairedTagsSet.has(h))a=r.closeIndex;else{const n=this.readStopNodeData(t,l,c+1);if(!n)throw new Error(`Unexpected end of ${l}`);a=n.i,e=n.tagContent}const i=new $(h);m&&(i[":@"]=m),i.add(s.textNodeName,e),this.matcher.pop(),this.isCurrentNodeStopNode=!1,this.addChild(n,i,this.readonlyMatcher,N)}else{if(f){({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s));const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1}else{if(s.unpairedTagsSet.has(h)){const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1,a=r.closeIndex;continue}{const t=new $(h);if(this.tagsNodeStack.length>s.maxNestedTags)throw new Error("Maximum nested tags exceeded");this.tagsNodeStack.push(n),m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),n=t}}i="",a=c}}}else i+=t[a];return e.child};function bt(t,e,n,i){this.options.captureMetaData||(i=void 0);const s=this.options.jPath?n.toString():n,r=this.options.updateTag(e.tagname,s,e[":@"]);!1===r||("string"==typeof r?(e.tagname=r,t.addChild(e,i)):t.addChild(e,i))}function yt(t,e,n){const i=this.options.processEntities;if(!i||!i.enabled)return t;if(i.allowedTags){const s=this.options.jPath?n.toString():n;if(!(Array.isArray(i.allowedTags)?i.allowedTags.includes(e):i.allowedTags(e,s)))return t}if(i.tagFilter){const s=this.options.jPath?n.toString():n;if(!i.tagFilter(e,s))return t}return this.entityDecoder.decode(t)}function Et(t,e,n,i){return t&&(void 0===i&&(i=0===e.child.length),void 0!==(t=this.parseTextData(t,e.tagname,n,!1,!!e[":@"]&&0!==Object.keys(e[":@"]).length,i))&&""!==t&&e.add(this.options.textNodeName,t),t=""),t}function wt(){return 0!==this.stopNodeExpressionsSet.size&&this.matcher.matchesAny(this.stopNodeExpressionsSet)}function vt(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s+e.length-1}function St(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s}function _t(t,e,n,i=">"){const s=function(t,e,n=">"){let i=0;const s=t.length,r=n.charCodeAt(0),o=n.length>1?n.charCodeAt(1):-1;let a="",h=e;for(let n=e;n<s;n++){const e=t.charCodeAt(n);if(i)e===i&&(i=0);else if(34===e||39===e)i=e;else if(e===r){if(-1===o)return a+=t.substring(h,n),{data:a,index:n};if(t.charCodeAt(n+1)===o)return a+=t.substring(h,n),{data:a,index:n}}else 9!==e||i||(a+=t.substring(h,n)+" ",h=n+1)}}(t,e+1,i);if(!s)return;let r=s.data;const o=s.index,a=r.search(/\s/);let h=r,l=!0;-1!==a&&(h=r.substring(0,a),r=r.substring(a+1).trimStart());const u=h;if(n){const t=h.indexOf(":");-1!==t&&(h=h.substr(t+1),l=h!==s.data.substr(t+1))}return{tagName:h,tagExp:r,closeIndex:o,attrExpPresent:l,rawTagName:u}}function At(t,e,n){const i=n;let s=1;const r=t.length;for(;n<r;n++)if("<"===t[n]){const r=t.charCodeAt(n+1);if(47===r){const r=St(t,">",n,`${e} is not closed`);if(t.substring(n+2,r).trim()===e&&(s--,0===s))return{tagContent:t.substring(i,n),i:r};n=r}else if(63===r)n=vt(t,"?>",n+1,"StopNode is not closed.");else if(33===r&&45===t.charCodeAt(n+2)&&45===t.charCodeAt(n+3))n=vt(t,"--\x3e",n+3,"StopNode is not closed.");else if(33===r&&91===t.charCodeAt(n+2))n=vt(t,"]]>",n,"StopNode is not closed.")-2;else{const i=_t(t,n,!1);i&&((i&&i.tagName)===e&&"/"!==i.tagExp[i.tagExp.length-1]&&s++,n=i.closeIndex)}}}function Tt(t,e,n){if(e&&"string"==typeof t){const e=t.trim();return"true"===e||"false"!==e&&function(t,e={}){if(e=Object.assign({},X,e),!t||"string"!=typeof t)return t;let n=t.trim();if(0===n.length)return t;if(void 0!==e.skipLike&&e.skipLike.test(n))return t;if("0"===n)return 0;if(e.hex&&U.test(n))return q(n,16);if(e.binary&&B.test(n))return q(n,2);if(e.octal&&W.test(n))return q(n,8);if(isFinite(n)){if(n.includes("e")||n.includes("E"))return function(t,e,n){if(!n.eNotation)return t;const i=e.match(Y);if(i){let s=i[1]||"";const r=-1===i[3].indexOf("e")?"E":"e",o=i[2],a=s?t[o.length+1]===r:t[o.length]===r;return o.length>1&&a?t:(1!==o.length||!i[3].startsWith(`.${r}`)&&i[3][0]!==r)&&o.length>0?n.leadingZeros&&!a?(e=(i[1]||"")+i[3],Number(e)):t:Number(e)}return t}(t,n,e);{const s=z.exec(n);if(s){const r=s[1]||"",o=s[2];let a=(i=s[3])&&-1!==i.indexOf(".")?("."===(i=i.replace(/0+$/,""))?i="0":"."===i[0]?i="0"+i:"."===i[i.length-1]&&(i=i.substring(0,i.length-1)),i):i;const h=r?"."===t[o.length+1]:"."===t[o.length];if(!e.leadingZeros&&(o.length>1||1===o.length&&!h))return t;{const i=Number(n),s=String(i);if(0===i)return i;if(-1!==s.search(/[eE]/))return e.eNotation?i:t;if(-1!==n.indexOf("."))return"0"===s||s===a||s===`${r}${a}`?i:t;let h=o?a:n;return o?h===s||r+h===s?i:t:h===s||h===r+s?i:t}}return t}}var i;return function(t,e,n){const i=e===1/0;switch(n.infinity.toLowerCase()){case"null":return null;case"infinity":return e;case"string":return i?"Infinity":"-Infinity";default:return t}}(t,Number(n),e)}(t,n)}return void 0!==t?t:""}function Ct(t,e,n,i){if(t){const i=t(e);n===e&&(n=i),e=i}return{tagName:e=Pt(e,i),tagExp:n}}function Pt(t,e){if(a.includes(t))throw new Error(`[SECURITY] Invalid name: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);return o.includes(t)?e.onDangerousProperty(t):t}const $t=$.getMetaDataSymbol();function Ot(t,e){if(!t||"object"!=typeof t)return{};if(!e)return t;const n={};for(const i in t)i.startsWith(e)?n[i.substring(e.length)]=t[i]:n[i]=t[i];return n}function It(t,e,n,i){return Vt(t,e,n,i)}function Vt(t,e,n,i){let s;const r={};for(let o=0;o<t.length;o++){const a=t[o],h=Dt(a);if(void 0!==h&&h!==e.textNodeName){const t=Ot(a[":@"]||{},e.attributeNamePrefix);n.push(h,t)}if(h===e.textNodeName)void 0===s?s=a[h]:s+=""+a[h];else{if(void 0===h)continue;if(a[h]){let t=Vt(a[h],e,n,i);const s=jt(t,e);if(0===Object.keys(t).length&&e.alwaysCreateTextNode&&(t[e.textNodeName]=""),a[":@"]?Mt(t,a[":@"],i,e):1!==Object.keys(t).length||void 0===t[e.textNodeName]||e.alwaysCreateTextNode?0===Object.keys(t).length&&(e.alwaysCreateTextNode?t[e.textNodeName]="":t=""):t=t[e.textNodeName],void 0!==a[$t]&&"object"==typeof t&&null!==t&&(t[$t]=a[$t]),void 0!==r[h]&&Object.prototype.hasOwnProperty.call(r,h))Array.isArray(r[h])||(r[h]=[r[h]]),r[h].push(t);else{const n=e.jPath?i.toString():i;e.isArray(h,n,s)?r[h]=[t]:r[h]=t}void 0!==h&&h!==e.textNodeName&&n.pop()}}}return"string"==typeof s?s.length>0&&(r[e.textNodeName]=s):void 0!==s&&(r[e.textNodeName]=s),r}function Dt(t){const e=Object.keys(t);for(let t=0;t<e.length;t++){const n=e[t];if(":@"!==n)return n}}function Mt(t,e,n,i){if(e){const s=Object.keys(e),r=s.length;for(let o=0;o<r;o++){const r=s[o],a=r.startsWith(i.attributeNamePrefix)?r.substring(i.attributeNamePrefix.length):r,h=i.jPath?n.toString()+"."+a:n;i.isArray(r,h,!0,!0)?t[r]=[e[r]]:t[r]=e[r]}}}function jt(t,e){const{textNodeName:n}=e,i=Object.keys(t).length;return 0===i||!(1!==i||!t[n]&&"boolean"!=typeof t[n]&&0!==t[n])}class Lt{constructor(t){this.externalEntities={},this.options=C(t)}parse(t,e){if("string"!=typeof t&&t.toString)t=t.toString();else if("string"!=typeof t)throw new Error("XML data is accepted in String or Bytes[] form.");if(e){!0===e&&(e={});const n=l(t,e);if(!0!==n)throw Error(`${n.err.msg}:${n.err.line}:${n.err.col}`)}const n=new dt(this.options,this.externalEntities),i=n.parseXml(t);return this.options.preserveOrder||void 0===i?i:It(i,this.options,n.matcher,n.readonlyMatcher)}addEntity(t,e){if(-1!==e.indexOf("&"))throw new Error("Entity value can't have '&'");if(-1!==t.indexOf("&")||-1!==t.indexOf(";"))throw new Error("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");if("&"===e)throw new Error("An entity with value '&' is not permitted");this.externalEntities[t]=e}static getMetaDataSymbol(){return $.getMetaDataSymbol()}}function kt(t){return String(t).replace(/--/g,"- -").replace(/--/g,"- -").replace(/-$/,"- ")}function Rt(t){return String(t).replace(/\]\]>/g,"]]]]><![CDATA[>")}function Ft(t){return String(t).replace(/"/g,"&quot;").replace(/'/g,"&apos;")}function Gt(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function Ut(t,e){let n="";e.format&&(n="\n");const i=[];if(e.stopNodes&&Array.isArray(e.stopNodes))for(let t=0;t<e.stopNodes.length;t++){const n=e.stopNodes[t];"string"==typeof n?i.push(new K(n)):n instanceof K&&i.push(n)}const s=function(t,e){if(!Array.isArray(t)||0===t.length)return"1.0";const n=t[0];if("?xml"===Yt(n)){const t=n[":@"];if(t){const n=e.attributeNamePrefix+"version";if(t[n])return t[n]}}return"1.0"}(t,e);return Bt(t,e,n,new J,i,s)}function Bt(t,e,n,i,s,r){let o="",a=!1;if(e.maxNestedTags&&i.getDepth()>e.maxNestedTags)throw new Error("Maximum nested tags exceeded");if(!Array.isArray(t)){if(null!=t){let n=t.toString();return n=Jt(n,e),n}return""}for(let h=0;h<t.length;h++){const l=t[h],u=Yt(l);if(void 0===u)continue;const p=u===e.textNodeName||u===e.cdataPropName||u===e.commentPropName||"?"===u[0]?u:Gt(u,!1,e,i,r),c=Wt(l[":@"],e);i.push(p,c);const d=Zt(i,s);if(p===e.textNodeName){let t=l[u];d||(t=e.tagValueProcessor(p,t),t=Jt(t,e)),a&&(o+=n),o+=t,a=!1,i.pop();continue}if(p===e.cdataPropName){a&&(o+=n),o+=`<![CDATA[${Rt(l[u][0][e.textNodeName])}]]>`,a=!1,i.pop();continue}if(p===e.commentPropName){o+=n+`\x3c!--${kt(l[u][0][e.textNodeName])}--\x3e`,a=!0,i.pop();continue}if("?"===p[0]){o+=("?xml"===p?"":n)+`<${p}${qt(l[":@"],e,d,i,r)}?>`,a=!0,i.pop();continue}let f=n;""!==f&&(f+=e.indentBy);const g=n+`<${p}${qt(l[":@"],e,d,i,r)}`;let m;m=d?zt(l[u],e):Bt(l[u],e,f,i,s,r),-1!==e.unpairedTags.indexOf(p)?e.suppressUnpairedNode?o+=g+">":o+=g+"/>":m&&0!==m.length||!e.suppressEmptyNode?m&&m.endsWith(">")?o+=g+`>${m}${n}</${p}>`:(o+=g+">",m&&""!==n&&(m.includes("/>")||m.includes("</"))?o+=n+e.indentBy+m+n:o+=m,o+=`</${p}>`):o+=g+"/>",a=!0,i.pop()}return o}function Wt(t,e){if(!t||e.ignoreAttributes)return null;const n={};let i=!1;for(let s in t)Object.prototype.hasOwnProperty.call(t,s)&&(n[s.startsWith(e.attributeNamePrefix)?s.substr(e.attributeNamePrefix.length):s]=Ft(t[s]),i=!0);return i?n:null}function zt(t,e){if(!Array.isArray(t))return null!=t?t.toString():"";let n="";for(let i=0;i<t.length;i++){const s=t[i],r=Yt(s);if(r===e.textNodeName)n+=s[r];else if(r===e.cdataPropName)n+=s[r][0][e.textNodeName];else if(r===e.commentPropName)n+=s[r][0][e.textNodeName];else{if(r&&"?"===r[0])continue;if(r){const t=Xt(s[":@"],e),i=zt(s[r],e);i&&0!==i.length?n+=`<${r}${t}>${i}</${r}>`:n+=`<${r}${t}/>`}}}return n}function Xt(t,e){let n="";if(t&&!e.ignoreAttributes)for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;let s=t[i];!0===s&&e.suppressBooleanAttributes?n+=` ${i.substr(e.attributeNamePrefix.length)}`:n+=` ${i.substr(e.attributeNamePrefix.length)}="${Ft(s)}"`}return n}function Yt(t){const e=Object.keys(t);for(let n=0;n<e.length;n++){const i=e[n];if(Object.prototype.hasOwnProperty.call(t,i)&&":@"!==i)return i}}function qt(t,e,n,i,s){let r="";if(t&&!e.ignoreAttributes)for(let o in t){if(!Object.prototype.hasOwnProperty.call(t,o))continue;const a=o.substr(e.attributeNamePrefix.length),h=n?a:Gt(a,!0,e,i,s);let l;n?l=t[o]:(l=e.attributeValueProcessor(o,t[o]),l=Jt(l,e)),!0===l&&e.suppressBooleanAttributes?r+=` ${h}`:r+=` ${h}="${Ft(l)}"`}return r}function Zt(t,e){if(!e||0===e.length)return!1;for(let n=0;n<e.length;n++)if(t.matches(e[n]))return!0;return!1}function Jt(t,e){if(t&&t.length>0&&e.processEntities)for(let n=0;n<e.entities.length;n++){const i=e.entities[n];t=t.replace(i.regex,i.val)}return t}const Kt={attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,cdataPropName:!1,format:!1,indentBy:"  ",suppressEmptyNode:!1,suppressUnpairedNode:!0,suppressBooleanAttributes:!0,tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},preserveOrder:!1,commentPropName:!1,unpairedTags:[],entities:[{regex:new RegExp("&","g"),val:"&amp;"},{regex:new RegExp(">","g"),val:"&gt;"},{regex:new RegExp("<","g"),val:"&lt;"},{regex:new RegExp("'","g"),val:"&apos;"},{regex:new RegExp('"',"g"),val:"&quot;"}],processEntities:!0,stopNodes:[],oneListGroup:!1,maxNestedTags:100,jPath:!0,sanitizeName:!1};function Qt(t){if(this.options=Object.assign({},Kt,t),this.options.stopNodes&&Array.isArray(this.options.stopNodes)&&(this.options.stopNodes=this.options.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),this.stopNodeExpressions=[],this.options.stopNodes&&Array.isArray(this.options.stopNodes))for(let t=0;t<this.options.stopNodes.length;t++){const e=this.options.stopNodes[t];"string"==typeof e?this.stopNodeExpressions.push(new K(e)):e instanceof K&&this.stopNodeExpressions.push(e)}var e;!0===this.options.ignoreAttributes||this.options.attributesGroupName?this.isAttribute=function(){return!1}:(this.ignoreAttributesFn="function"==typeof(e=this.options.ignoreAttributes)?e:Array.isArray(e)?t=>{for(const n of e){if("string"==typeof n&&t===n)return!0;if(n instanceof RegExp&&n.test(t))return!0}}:()=>!1,this.attrPrefixLen=this.options.attributeNamePrefix.length,this.isAttribute=ne),this.processTextOrObjNode=te,this.options.format?(this.indentate=ee,this.tagEndChar=">\n",this.newLine="\n"):(this.indentate=function(){return""},this.tagEndChar=">",this.newLine="")}function Ht(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function te(t,e,n,i,s){const r=this.extractAttributes(t);if(i.push(e,r),this.checkStopNode(i)){const s=this.buildRawContent(t),r=this.buildAttributesForStopNode(t);return i.pop(),this.buildObjectNode(s,e,r,n)}const o=this.j2x(t,n+1,i,s);return i.pop(),"?"===e[0]?this.buildTextValNode("",e,o.attrStr,n,i):void 0!==t[this.options.textNodeName]&&1===Object.keys(t).length?this.buildTextValNode(t[this.options.textNodeName],e,o.attrStr,n,i):this.buildObjectNode(o.val,e,o.attrStr,n)}function ee(t){return this.options.indentBy.repeat(t)}function ne(t){return!(!t.startsWith(this.options.attributeNamePrefix)||t===this.options.textNodeName)&&t.substr(this.attrPrefixLen)}Qt.prototype.build=function(t){if(this.options.preserveOrder)return Ut(t,this.options);{Array.isArray(t)&&this.options.arrayNodeName&&this.options.arrayNodeName.length>1&&(t={[this.options.arrayNodeName]:t});const e=new J,n=function(t,e){const n=t["?xml"];if(n&&"object"==typeof n){if(e.attributesGroupName&&n[e.attributesGroupName]){const t=n[e.attributesGroupName][e.attributeNamePrefix+"version"];if(t)return t}const t=n[e.attributeNamePrefix+"version"];if(t)return t}return"1.0"}(t,this.options);return this.j2x(t,0,e,n).val}},Qt.prototype.j2x=function(t,e,n,i){let s="",r="";if(this.options.maxNestedTags&&n.getDepth()>=this.options.maxNestedTags)throw new Error("Maximum nested tags exceeded");const o=this.options.jPath?n.toString():n,a=this.checkStopNode(n);for(let h in t){if(!Object.prototype.hasOwnProperty.call(t,h))continue;const l=h===this.options.textNodeName||h===this.options.cdataPropName||h===this.options.commentPropName||this.options.attributesGroupName&&h===this.options.attributesGroupName||this.isAttribute(h)||"?"===h[0]?h:Ht(h,!1,this.options,n,i);if(void 0===t[h])this.isAttribute(h)&&(r+="");else if(null===t[h])this.isAttribute(h)||l===this.options.cdataPropName||l===this.options.commentPropName?r+="":"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if(t[h]instanceof Date)r+=this.buildTextValNode(t[h],l,"",e,n);else if("object"!=typeof t[h]){const u=this.isAttribute(h);if(u&&!this.ignoreAttributesFn(u,o)){const e=Ht(u,!0,this.options,n,i);s+=this.buildAttrPairStr(e,""+t[h],a)}else if(!u)if(h===this.options.textNodeName){let e=this.options.tagValueProcessor(h,""+t[h]);r+=this.replaceEntitiesValue(e)}else{n.push(l);const i=this.checkStopNode(n);if(n.pop(),i){const n=""+t[h];r+=""===n?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+n+"</"+l+this.tagEndChar}else r+=this.buildTextValNode(t[h],l,"",e,n)}}else if(Array.isArray(t[h])){const s=t[h].length;let o="",a="";for(let u=0;u<s;u++){const s=t[h][u];if(void 0===s);else if(null===s)"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if("object"==typeof s)if(this.options.oneListGroup){n.push(l);const t=this.j2x(s,e+1,n,i);n.pop(),o+=t.val,this.options.attributesGroupName&&s.hasOwnProperty(this.options.attributesGroupName)&&(a+=t.attrStr)}else o+=this.processTextOrObjNode(s,l,e,n,i);else if(this.options.oneListGroup){let t=this.options.tagValueProcessor(l,s);t=this.replaceEntitiesValue(t),o+=t}else{n.push(l);const t=this.checkStopNode(n);if(n.pop(),t){const t=""+s;o+=""===t?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+t+"</"+l+this.tagEndChar}else o+=this.buildTextValNode(s,l,"",e,n)}}this.options.oneListGroup&&(o=this.buildObjectNode(o,l,a,e)),r+=o}else if(this.options.attributesGroupName&&h===this.options.attributesGroupName){const e=Object.keys(t[h]),r=e.length;for(let o=0;o<r;o++){const r=Ht(e[o],!0,this.options,n,i);s+=this.buildAttrPairStr(r,""+t[h][e[o]],a)}}else r+=this.processTextOrObjNode(t[h],l,e,n,i)}return{attrStr:s,val:r}},Qt.prototype.buildAttrPairStr=function(t,e,n){return n||(e=this.options.attributeValueProcessor(t,""+e),e=this.replaceEntitiesValue(e)),this.options.suppressBooleanAttributes&&"true"===e?" "+t:" "+t+'="'+Ft(e)+'"'},Qt.prototype.extractAttributes=function(t){if(!t||"object"!=typeof t)return null;const e={};let n=!1;if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const i=t[this.options.attributesGroupName];for(let t in i)Object.prototype.hasOwnProperty.call(i,t)&&(e[t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t]=Ft(i[t]),n=!0)}else for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;const s=this.isAttribute(i);s&&(e[s]=Ft(t[i]),n=!0)}return n?e:null},Qt.prototype.buildRawContent=function(t){if("string"==typeof t)return t;if("object"!=typeof t||null===t)return String(t);if(void 0!==t[this.options.textNodeName])return t[this.options.textNodeName];let e="";for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;if(this.isAttribute(n))continue;if(this.options.attributesGroupName&&n===this.options.attributesGroupName)continue;const i=t[n];if(n===this.options.textNodeName)e+=i;else if(Array.isArray(i)){for(let t of i)if("string"==typeof t||"number"==typeof t)e+=`<${n}>${t}</${n}>`;else if("object"==typeof t&&null!==t){const i=this.buildRawContent(t),s=this.buildAttributesForStopNode(t);e+=""===i?`<${n}${s}/>`:`<${n}${s}>${i}</${n}>`}}else if("object"==typeof i&&null!==i){const t=this.buildRawContent(i),s=this.buildAttributesForStopNode(i);e+=""===t?`<${n}${s}/>`:`<${n}${s}>${t}</${n}>`}else e+=`<${n}>${i}</${n}>`}return e},Qt.prototype.buildAttributesForStopNode=function(t){if(!t||"object"!=typeof t)return"";let e="";if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const n=t[this.options.attributesGroupName];for(let t in n){if(!Object.prototype.hasOwnProperty.call(n,t))continue;const i=t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t,s=n[t];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}else for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;const i=this.isAttribute(n);if(i){const s=t[n];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}return e},Qt.prototype.buildObjectNode=function(t,e,n,i){if(""===t)return"?"===e[0]?this.indentate(i)+"<"+e+n+"?"+this.tagEndChar:this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar;if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s="</"+e+this.tagEndChar,r="";return"?"===e[0]&&(r="?",s=""),!n&&""!==n||-1!==t.indexOf("<")?!1!==this.options.commentPropName&&e===this.options.commentPropName&&0===r.length?this.indentate(i)+`\x3c!--${t}--\x3e`+this.newLine:this.indentate(i)+"<"+e+n+r+this.tagEndChar+t+this.indentate(i)+s:this.indentate(i)+"<"+e+n+r+">"+t+s}},Qt.prototype.closeTag=function(t){let e="";return-1!==this.options.unpairedTags.indexOf(t)?this.options.suppressUnpairedNode||(e="/"):e=this.options.suppressEmptyNode?"/":`></${t}`,e},Qt.prototype.checkStopNode=function(t){if(!this.stopNodeExpressions||0===this.stopNodeExpressions.length)return!1;for(let e=0;e<this.stopNodeExpressions.length;e++)if(t.matches(this.stopNodeExpressions[e]))return!0;return!1},Qt.prototype.buildTextValNode=function(t,e,n,i,s){if(!1!==this.options.cdataPropName&&e===this.options.cdataPropName){const e=Rt(t);return this.indentate(i)+`<![CDATA[${e}]]>`+this.newLine}if(!1!==this.options.commentPropName&&e===this.options.commentPropName){const e=kt(t);return this.indentate(i)+`\x3c!--${e}--\x3e`+this.newLine}if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s=this.options.tagValueProcessor(e,t);return s=this.replaceEntitiesValue(s),""===s?this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar:this.indentate(i)+"<"+e+n+">"+s+"</"+e+this.tagEndChar}},Qt.prototype.replaceEntitiesValue=function(t){if(t&&t.length>0&&this.options.processEntities)for(let e=0;e<this.options.entities.length;e++){const n=this.options.entities[e];t=t.replace(n.regex,n.val)}return t};const ie=Qt,se={validate:l};module.exports=e})();
 
 /***/ }),
 
-/***/ 322:
+/***/ 323:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -61162,7 +62012,7 @@ var KnownEncryptionAlgorithmType;
 
 /***/ }),
 
-/***/ 323:
+/***/ 324:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -61391,7 +62241,7 @@ function replaceAll(value, searchValue, replaceValue) {
 
 /***/ }),
 
-/***/ 324:
+/***/ 325:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61417,7 +62267,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(395);
+var import_exponentialRetryStrategy = __nccwpck_require__(396);
 var import_throttlingRetryStrategy = __nccwpck_require__(35);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_constants = __nccwpck_require__(48);
@@ -61437,7 +62287,7 @@ function defaultRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 325:
+/***/ 326:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61449,7 +62299,7 @@ exports.StorageRetryPolicyFactory = exports.NewRetryPolicyFactory = exports.Stor
 const StorageRetryPolicy_js_1 = __nccwpck_require__(81);
 Object.defineProperty(exports, "StorageRetryPolicy", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.StorageRetryPolicy; } }));
 Object.defineProperty(exports, "NewRetryPolicyFactory", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.NewRetryPolicyFactory; } }));
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(417);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(418);
 Object.defineProperty(exports, "StorageRetryPolicyType", ({ enumerable: true, get: function () { return StorageRetryPolicyType_js_1.StorageRetryPolicyType; } }));
 /**
  * StorageRetryPolicyFactory is a factory class helping generating {@link StorageRetryPolicy} objects.
@@ -61478,7 +62328,7 @@ exports.StorageRetryPolicyFactory = StorageRetryPolicyFactory;
 
 /***/ }),
 
-/***/ 326:
+/***/ 327:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61584,7 +62434,7 @@ function toArrayBuffer(source) {
 
 /***/ }),
 
-/***/ 327:
+/***/ 328:
 /***/ ((module) => {
 
 "use strict";
@@ -61689,7 +62539,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 328:
+/***/ 329:
 /***/ ((module) => {
 
 "use strict";
@@ -61697,7 +62547,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 329:
+/***/ 330:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -61716,7 +62566,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 330:
+/***/ 331:
 /***/ (function(module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61756,7 +62606,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._readLinuxVersionFile = exports._getOsVersion = exports._findMatch = void 0;
 const semver = __importStar(__nccwpck_require__(179));
-const core_1 = __nccwpck_require__(459);
+const core_1 = __nccwpck_require__(460);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
 const os = __nccwpck_require__(92);
@@ -61852,7 +62702,7 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
-/***/ 331:
+/***/ 332:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61921,7 +62771,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 332:
+/***/ 333:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -62029,7 +62879,7 @@ var WireType;
 
 /***/ }),
 
-/***/ 333:
+/***/ 334:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62050,7 +62900,7 @@ const utils_common_js_1 = __nccwpck_require__(154);
 const core_xml_1 = __nccwpck_require__(195);
 const constants_js_1 = __nccwpck_require__(148);
 const tracing_js_1 = __nccwpck_require__(31);
-const core_client_1 = __nccwpck_require__(439);
+const core_client_1 = __nccwpck_require__(440);
 /**
  * A BlobBatch represents an aggregated set of operations on blobs.
  * Currently, only `delete` and `setAccessTier` are supported.
@@ -62314,7 +63164,7 @@ function batchHeaderFilterPolicy() {
 
 /***/ }),
 
-/***/ 334:
+/***/ 335:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62323,9 +63173,9 @@ function batchHeaderFilterPolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = exports.AvroReadable = exports.AvroReader = void 0;
-var AvroReader_js_1 = __nccwpck_require__(421);
+var AvroReader_js_1 = __nccwpck_require__(422);
 Object.defineProperty(exports, "AvroReader", ({ enumerable: true, get: function () { return AvroReader_js_1.AvroReader; } }));
-var AvroReadable_js_1 = __nccwpck_require__(387);
+var AvroReadable_js_1 = __nccwpck_require__(388);
 Object.defineProperty(exports, "AvroReadable", ({ enumerable: true, get: function () { return AvroReadable_js_1.AvroReadable; } }));
 var AvroReadableFromStream_js_1 = __nccwpck_require__(252);
 Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, get: function () { return AvroReadableFromStream_js_1.AvroReadableFromStream; } }));
@@ -62333,7 +63183,7 @@ Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, ge
 
 /***/ }),
 
-/***/ 335:
+/***/ 336:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62364,7 +63214,7 @@ var import_constants = __nccwpck_require__(159);
 var import_userAgent = __nccwpck_require__(292);
 var import_log = __nccwpck_require__(184);
 var import_core_util = __nccwpck_require__(14);
-var import_restError = __nccwpck_require__(353);
+var import_restError = __nccwpck_require__(354);
 var import_util = __nccwpck_require__(146);
 const tracingPolicyName = "tracingPolicy";
 function tracingPolicy(options = {}) {
@@ -62479,7 +63329,7 @@ function tryProcessResponse(span, response) {
 
 /***/ }),
 
-/***/ 336:
+/***/ 337:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -62525,7 +63375,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.markPhase = markPhase;
 exports.finishPhase = finishPhase;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 function phaseEnvName(name) {
     const cleaned = name.replace(/[^A-Za-z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase() || "PHASE";
     return `SETUP_SOLDR_PHASE_${cleaned}_START_MS`;
@@ -62569,7 +63419,7 @@ async function finishPhase(phase) {
 
 /***/ }),
 
-/***/ 337:
+/***/ 338:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62581,7 +63431,7 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher
-} = __nccwpck_require__(369)
+} = __nccwpck_require__(370)
 const Client = __nccwpck_require__(88)
 const {
   InvalidArgumentError
@@ -62685,7 +63535,7 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 338:
+/***/ 339:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62711,7 +63561,7 @@ __export(oauth2AuthenticationPolicy_exports, {
   oauth2AuthenticationPolicyName: () => oauth2AuthenticationPolicyName
 });
 module.exports = __toCommonJS(oauth2AuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(435);
+var import_checkInsecureConnection = __nccwpck_require__(436);
 const oauth2AuthenticationPolicyName = "oauth2AuthenticationPolicy";
 function oauth2AuthenticationPolicy(options) {
   return {
@@ -62737,7 +63587,7 @@ function oauth2AuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 339:
+/***/ 340:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62764,7 +63614,7 @@ __export(formDataPolicy_exports, {
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
 var import_bytesEncoding = __nccwpck_require__(287);
-var import_checkEnvironment = __nccwpck_require__(438);
+var import_checkEnvironment = __nccwpck_require__(439);
 var import_httpHeaders = __nccwpck_require__(485);
 const formDataPolicyName = "formDataPolicy";
 function formDataToFormDataMap(formData) {
@@ -62853,7 +63703,7 @@ async function prepareFormData(formData, request) {
 
 /***/ }),
 
-/***/ 340:
+/***/ 341:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62890,7 +63740,7 @@ function redirectPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 341:
+/***/ 342:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62899,7 +63749,7 @@ function redirectPolicy(options = {}) {
 const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(196)
 const { URL } = __nccwpck_require__(85)
 const Agent = __nccwpck_require__(5)
-const Pool = __nccwpck_require__(337)
+const Pool = __nccwpck_require__(338)
 const DispatcherBase = __nccwpck_require__(62)
 const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(488)
 const buildConnector = __nccwpck_require__(266)
@@ -63087,7 +63937,7 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 342:
+/***/ 343:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -63156,16 +64006,16 @@ function readRawInputs(env) {
 
 /***/ }),
 
-/***/ 343:
+/***/ 344:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonReader = void 0;
-const json_typings_1 = __nccwpck_require__(394);
+const json_typings_1 = __nccwpck_require__(395);
 const base64_1 = __nccwpck_require__(303);
-const reflection_info_1 = __nccwpck_require__(452);
+const reflection_info_1 = __nccwpck_require__(453);
 const pb_long_1 = __nccwpck_require__(117);
 const assert_1 = __nccwpck_require__(484);
 const reflection_long_convert_1 = __nccwpck_require__(158);
@@ -63481,7 +64331,7 @@ exports.ReflectionJsonReader = ReflectionJsonReader;
 
 /***/ }),
 
-/***/ 344:
+/***/ 345:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -63771,7 +64621,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 345:
+/***/ 346:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -63854,13 +64704,13 @@ exports.utf8read = utf8read;
 
 /***/ }),
 
-/***/ 346:
+/***/ 347:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 /* eslint-disable no-new-wrappers, no-eval, camelcase, operator-linebreak */
-module.exports = makeParserClass(__nccwpck_require__(425))
+module.exports = makeParserClass(__nccwpck_require__(426))
 module.exports.makeParserClass = makeParserClass
 
 class TomlError extends Error {
@@ -63881,10 +64731,10 @@ TomlError.wrap = err => {
 }
 module.exports.TomlError = TomlError
 
-const createDateTime = __nccwpck_require__(384)
+const createDateTime = __nccwpck_require__(385)
 const createDateTimeFloat = __nccwpck_require__(172)
 const createDate = __nccwpck_require__(54)
-const createTime = __nccwpck_require__(348)
+const createTime = __nccwpck_require__(349)
 
 const CTRL_I = 0x09
 const CTRL_J = 0x0A
@@ -65241,7 +66091,7 @@ function makeParserClass (Parser) {
 
 /***/ }),
 
-/***/ 347:
+/***/ 348:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65250,8 +66100,8 @@ function makeParserClass (Parser) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = createTracingClient;
-const instrumenter_js_1 = __nccwpck_require__(406);
-const tracingContext_js_1 = __nccwpck_require__(370);
+const instrumenter_js_1 = __nccwpck_require__(407);
+const tracingContext_js_1 = __nccwpck_require__(371);
 /**
  * Creates a new tracing client.
  *
@@ -65329,12 +66179,12 @@ function createTracingClient(options) {
 
 /***/ }),
 
-/***/ 348:
+/***/ 349:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(403)
+const f = __nccwpck_require__(404)
 
 class Time extends Date {
   constructor (value) {
@@ -65359,14 +66209,14 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 349:
+/***/ 350:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { promisify } = __nccwpck_require__(123)
-const Pool = __nccwpck_require__(337)
+const Pool = __nccwpck_require__(338)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
   kDispatches,
@@ -65376,7 +66226,7 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(470)
+} = __nccwpck_require__(471)
 const { MockInterceptor } = __nccwpck_require__(135)
 const Symbols = __nccwpck_require__(196)
 const { InvalidArgumentError } = __nccwpck_require__(488)
@@ -65426,7 +66276,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 350:
+/***/ 351:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -65484,7 +66334,7 @@ exports.ClientStreamingCall = ClientStreamingCall;
 
 /***/ }),
 
-/***/ 351:
+/***/ 352:
 /***/ ((module) => {
 
 module.exports = function (xs, fn) {
@@ -65504,7 +66354,7 @@ var isArray = Array.isArray || function (xs) {
 
 /***/ }),
 
-/***/ 352:
+/***/ 353:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -65552,7 +66402,7 @@ exports.createLogger = createLogger;
 exports.colorForceEnvironment = colorForceEnvironment;
 exports.formatLogLine = formatLogLine;
 exports.isTimestampsEnabled = isTimestampsEnabled;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const fs = __importStar(__nccwpck_require__(249));
 function makeFileLogger(env) {
     const logPath = (env["SETUP_SOLDR_LOG"] ?? "").trim();
@@ -65675,7 +66525,7 @@ function isTimestampsEnabled(env) {
 
 /***/ }),
 
-/***/ 353:
+/***/ 354:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65712,7 +66562,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 354:
+/***/ 355:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65726,7 +66576,7 @@ const {
 } = __nccwpck_require__(488)
 const util = __nccwpck_require__(69)
 const { getResolveErrorBodyCallback } = __nccwpck_require__(190)
-const { AsyncResource } = __nccwpck_require__(429)
+const { AsyncResource } = __nccwpck_require__(430)
 const { addSignal, removeSignal } = __nccwpck_require__(103)
 
 class StreamHandler extends AsyncResource {
@@ -65940,7 +66790,7 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 355:
+/***/ 356:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65955,7 +66805,7 @@ module.exports = stream
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
 const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(439));
+const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
 const Mappers = tslib_1.__importStar(__nccwpck_require__(180));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing BlockBlob operations. */
@@ -66320,7 +67170,7 @@ const getBlockListOperationSpec = {
 
 /***/ }),
 
-/***/ 356:
+/***/ 357:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -66365,7 +67215,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 357:
+/***/ 358:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66460,7 +67310,7 @@ exports.GenericPollOperation = GenericPollOperation;
 
 /***/ }),
 
-/***/ 358:
+/***/ 359:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -66507,7 +67357,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.versionTuple = versionTuple;
 exports.verifySoldr = verifySoldr;
 const exec = __importStar(__nccwpck_require__(18));
-const log_utils_js_1 = __nccwpck_require__(352);
+const log_utils_js_1 = __nccwpck_require__(353);
 function versionTuple(value) {
     const cleaned = value.trim().replace(/^v/, "");
     const parts = cleaned.split(".");
@@ -66603,7 +67453,7 @@ async function verifySoldr(opts) {
 
 /***/ }),
 
-/***/ 359:
+/***/ 360:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -66626,7 +67476,7 @@ function ipRangeToString(ipRange) {
 
 /***/ }),
 
-/***/ 360:
+/***/ 361:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -66674,7 +67524,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 361:
+/***/ 362:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66682,7 +67532,7 @@ function userAgentPolicy(options = {}) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getUserAgentString = void 0;
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const packageJson = __nccwpck_require__(468);
+const packageJson = __nccwpck_require__(469);
 /**
  * Ensure that this User Agent String is used in all HTTP calls so that we can monitor telemetry between different versions of this package
  */
@@ -66694,7 +67544,7 @@ exports.getUserAgentString = getUserAgentString;
 
 /***/ }),
 
-/***/ 362:
+/***/ 363:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66703,8 +67553,8 @@ exports.getUserAgentString = getUserAgentString;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BufferScheduler = void 0;
-const events_1 = __nccwpck_require__(469);
-const PooledBuffer_js_1 = __nccwpck_require__(371);
+const events_1 = __nccwpck_require__(470);
+const PooledBuffer_js_1 = __nccwpck_require__(372);
 /**
  * This class accepts a Node.js Readable stream as input, and keeps reading data
  * from the stream into the internal buffer structure, until it reaches maxBuffers.
@@ -66983,7 +67833,7 @@ exports.BufferScheduler = BufferScheduler;
 
 /***/ }),
 
-/***/ 363:
+/***/ 364:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -67029,12 +67879,12 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureSoldr = ensureSoldr;
 const fs = __importStar(__nccwpck_require__(249));
-const os = __importStar(__nccwpck_require__(382));
+const os = __importStar(__nccwpck_require__(383));
 const path = __importStar(__nccwpck_require__(508));
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const exec = __importStar(__nccwpck_require__(18));
 const tc = __importStar(__nccwpck_require__(523));
-const log_utils_js_1 = __nccwpck_require__(352);
+const log_utils_js_1 = __nccwpck_require__(353);
 function detectTarget() {
     const machine = process.arch;
     let arch;
@@ -67375,7 +68225,7 @@ async function ensureSoldr(opts) {
 
 /***/ }),
 
-/***/ 364:
+/***/ 365:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67385,7 +68235,7 @@ const { Blob, File: NativeFile } = __nccwpck_require__(119)
 const { types } = __nccwpck_require__(123)
 const { kState } = __nccwpck_require__(15)
 const { isBlobLike } = __nccwpck_require__(518)
-const { webidl } = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(457)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(25)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 const encoder = new TextEncoder()
@@ -67727,14 +68577,14 @@ module.exports = { File, FileLike, isFileLike }
 
 /***/ }),
 
-/***/ 365:
+/***/ 366:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const diagnosticsChannel = __nccwpck_require__(141)
-const { uid, states } = __nccwpck_require__(465)
+const { uid, states } = __nccwpck_require__(466)
 const {
   kReadyState,
   kSentClose,
@@ -67744,9 +68594,9 @@ const {
 const { fireEvent, failWebsocketConnection } = __nccwpck_require__(57)
 const { CloseEvent } = __nccwpck_require__(250)
 const { makeRequest } = __nccwpck_require__(84)
-const { fetching } = __nccwpck_require__(450)
+const { fetching } = __nccwpck_require__(451)
 const { Headers } = __nccwpck_require__(517)
-const { getGlobalDispatcher } = __nccwpck_require__(376)
+const { getGlobalDispatcher } = __nccwpck_require__(377)
 const { kHeadersList } = __nccwpck_require__(196)
 
 const channels = {}
@@ -68026,7 +68876,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 366:
+/***/ 367:
 /***/ ((module) => {
 
 "use strict";
@@ -68042,7 +68892,7 @@ module.exports = (flag, argv = process.argv) => {
 
 /***/ }),
 
-/***/ 367:
+/***/ 368:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -68097,7 +68947,7 @@ exports.systemRustupSatisfiesRequest = systemRustupSatisfiesRequest;
 const node_crypto_1 = __nccwpck_require__(275);
 const fs = __importStar(__nccwpck_require__(249));
 const path = __importStar(__nccwpck_require__(508));
-const toml = __importStar(__nccwpck_require__(400));
+const toml = __importStar(__nccwpck_require__(401));
 const io = __importStar(__nccwpck_require__(295));
 const exec = __importStar(__nccwpck_require__(18));
 const ROLLING_TOOLCHAIN_ALIASES = ["stable", "beta", "nightly"];
@@ -68384,7 +69234,7 @@ async function defaultWhich(cmd) {
 
 /***/ }),
 
-/***/ 368:
+/***/ 369:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68409,7 +69259,7 @@ __export(restError_exports, {
   createRestError: () => createRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_restError = __nccwpck_require__(444);
+var import_restError = __nccwpck_require__(445);
 var import_httpHeaders = __nccwpck_require__(485);
 function createRestError(messageOrResponse, response) {
   const resp = typeof messageOrResponse === "string" ? response : messageOrResponse;
@@ -68440,7 +69290,7 @@ function statusCodeToNumber(statusCode) {
 
 /***/ }),
 
-/***/ 369:
+/***/ 370:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68642,7 +69492,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 370:
+/***/ 371:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -68702,7 +69552,7 @@ exports.TracingContextImpl = TracingContextImpl;
 
 /***/ }),
 
-/***/ 371:
+/***/ 372:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68712,7 +69562,7 @@ exports.TracingContextImpl = TracingContextImpl;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
 const tslib_1 = __nccwpck_require__(217);
-const BuffersStream_js_1 = __nccwpck_require__(385);
+const BuffersStream_js_1 = __nccwpck_require__(386);
 const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(264));
 /**
  * maxBufferLength is max size of each buffer in the pooled buffers.
@@ -68809,7 +69659,7 @@ exports.PooledBuffer = PooledBuffer;
 
 /***/ }),
 
-/***/ 372:
+/***/ 373:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68834,7 +69684,7 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_nodeHttpClient = __nccwpck_require__(441);
+var import_nodeHttpClient = __nccwpck_require__(442);
 function createDefaultHttpClient() {
   return (0, import_nodeHttpClient.createNodeHttpClient)();
 }
@@ -68845,13 +69695,13 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 373:
+/***/ 374:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { AsyncResource } = __nccwpck_require__(429)
+const { AsyncResource } = __nccwpck_require__(430)
 const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(488)
 const util = __nccwpck_require__(69)
 const { addSignal, removeSignal } = __nccwpck_require__(103)
@@ -68957,7 +69807,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 374:
+/***/ 375:
 /***/ ((module) => {
 
 /**
@@ -69126,7 +69976,7 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 375:
+/***/ 376:
 /***/ ((module) => {
 
 "use strict";
@@ -69134,7 +69984,7 @@ module.exports = require("node:util");
 
 /***/ }),
 
-/***/ 376:
+/***/ 377:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69174,7 +70024,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 377:
+/***/ 378:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69192,12 +70042,12 @@ const {
   kGetNetConnect,
   kOptions,
   kFactory
-} = __nccwpck_require__(470)
+} = __nccwpck_require__(471)
 const MockClient = __nccwpck_require__(200)
-const MockPool = __nccwpck_require__(349)
+const MockPool = __nccwpck_require__(350)
 const { matchValue, buildMockOptions } = __nccwpck_require__(7)
 const { InvalidArgumentError, UndiciError } = __nccwpck_require__(488)
-const Dispatcher = __nccwpck_require__(477)
+const Dispatcher = __nccwpck_require__(478)
 const Pluralizer = __nccwpck_require__(254)
 const PendingInterceptorsFormatter = __nccwpck_require__(234)
 
@@ -69353,7 +70203,7 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 378:
+/***/ 379:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69390,7 +70240,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 379:
+/***/ 380:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69479,7 +70329,7 @@ exports.AccountSASServices = AccountSASServices;
 
 /***/ }),
 
-/***/ 380:
+/***/ 381:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69505,7 +70355,7 @@ __export(bearerAuthenticationPolicy_exports, {
   bearerAuthenticationPolicyName: () => bearerAuthenticationPolicyName
 });
 module.exports = __toCommonJS(bearerAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(435);
+var import_checkInsecureConnection = __nccwpck_require__(436);
 const bearerAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function bearerAuthenticationPolicy(options) {
   return {
@@ -69533,7 +70383,7 @@ function bearerAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 381:
+/***/ 382:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69550,8 +70400,8 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(369)
-const Pool = __nccwpck_require__(337)
+} = __nccwpck_require__(370)
+const Pool = __nccwpck_require__(338)
 const { kUrl, kInterceptors } = __nccwpck_require__(196)
 const { parseOrigin } = __nccwpck_require__(69)
 const kFactory = Symbol('factory')
@@ -69731,7 +70581,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 382:
+/***/ 383:
 /***/ ((module) => {
 
 "use strict";
@@ -69739,7 +70589,7 @@ module.exports = require("node:os");
 
 /***/ }),
 
-/***/ 383:
+/***/ 384:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -69783,7 +70633,7 @@ function operationOptionsToRequestParameters(options) {
 
 /***/ }),
 
-/***/ 384:
+/***/ 385:
 /***/ ((module) => {
 
 "use strict";
@@ -69801,7 +70651,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 385:
+/***/ 386:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69810,7 +70660,7 @@ module.exports = value => {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BuffersStream = void 0;
-const node_stream_1 = __nccwpck_require__(430);
+const node_stream_1 = __nccwpck_require__(431);
 /**
  * This class generates a readable stream from the data in an array of buffers.
  */
@@ -69909,15 +70759,15 @@ exports.BuffersStream = BuffersStream;
 
 /***/ }),
 
-/***/ 386:
+/***/ 387:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { parseSetCookie } = __nccwpck_require__(423)
-const { stringify } = __nccwpck_require__(409)
-const { webidl } = __nccwpck_require__(456)
+const { parseSetCookie } = __nccwpck_require__(424)
+const { stringify } = __nccwpck_require__(410)
+const { webidl } = __nccwpck_require__(457)
 const { Headers } = __nccwpck_require__(517)
 
 /**
@@ -70100,7 +70950,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 387:
+/***/ 388:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -70116,7 +70966,7 @@ exports.AvroReadable = AvroReadable;
 
 /***/ }),
 
-/***/ 388:
+/***/ 389:
 /***/ ((module) => {
 
 "use strict";
@@ -70124,7 +70974,7 @@ module.exports = require("node:https");
 
 /***/ }),
 
-/***/ 389:
+/***/ 390:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -70171,7 +71021,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 390:
+/***/ 391:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70181,7 +71031,7 @@ const util = __nccwpck_require__(69)
 const { kBodyUsed } = __nccwpck_require__(196)
 const assert = __nccwpck_require__(527)
 const { InvalidArgumentError } = __nccwpck_require__(488)
-const EE = __nccwpck_require__(469)
+const EE = __nccwpck_require__(470)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
 
@@ -70400,7 +71250,7 @@ module.exports = RedirectHandler
 
 /***/ }),
 
-/***/ 391:
+/***/ 392:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -70426,7 +71276,7 @@ function arraysEqual(a, b) {
 
 /***/ }),
 
-/***/ 392:
+/***/ 393:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -70463,7 +71313,7 @@ function exponentialRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 393:
+/***/ 394:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -70498,7 +71348,7 @@ function randomUUID() {
 
 /***/ }),
 
-/***/ 394:
+/***/ 395:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -70531,7 +71381,7 @@ exports.isJsonObject = isJsonObject;
 
 /***/ }),
 
-/***/ 395:
+/***/ 396:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -70558,7 +71408,7 @@ __export(exponentialRetryStrategy_exports, {
   isSystemError: () => isSystemError
 });
 module.exports = __toCommonJS(exponentialRetryStrategy_exports);
-var import_delay = __nccwpck_require__(474);
+var import_delay = __nccwpck_require__(475);
 var import_throttlingRetryStrategy = __nccwpck_require__(35);
 const DEFAULT_CLIENT_RETRY_INTERVAL = 1e3;
 const DEFAULT_CLIENT_MAX_RETRY_INTERVAL = 1e3 * 64;
@@ -70604,7 +71454,7 @@ function isSystemError(err) {
 
 /***/ }),
 
-/***/ 396:
+/***/ 397:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70674,7 +71524,7 @@ exports.CacheScope = new CacheScope$Type();
 
 /***/ }),
 
-/***/ 397:
+/***/ 398:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70707,7 +71557,7 @@ exports.AnonymousCredential = AnonymousCredential;
 
 /***/ }),
 
-/***/ 398:
+/***/ 399:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70728,7 +71578,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 399:
+/***/ 400:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70738,7 +71588,7 @@ function getCachedDefaultHttpClient() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getStreamingResponseStatusCodes = getStreamingResponseStatusCodes;
 exports.getPathStringFromParameter = getPathStringFromParameter;
-const serializer_js_1 = __nccwpck_require__(479);
+const serializer_js_1 = __nccwpck_require__(480);
 /**
  * Gets the list of status codes for streaming responses.
  * @internal
@@ -70778,7 +71628,7 @@ function getPathStringFromParameter(parameter) {
 
 /***/ }),
 
-/***/ 400:
+/***/ 401:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70789,7 +71639,7 @@ exports.stringify = __nccwpck_require__(300)
 
 /***/ }),
 
-/***/ 401:
+/***/ 402:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70805,11 +71655,11 @@ const utils_common_js_1 = __nccwpck_require__(154);
 const storage_common_1 = __nccwpck_require__(277);
 const utils_common_js_2 = __nccwpck_require__(154);
 const tracing_js_1 = __nccwpck_require__(31);
-const BlobBatchClient_js_1 = __nccwpck_require__(402);
-const StorageClient_js_1 = __nccwpck_require__(454);
+const BlobBatchClient_js_1 = __nccwpck_require__(403);
+const StorageClient_js_1 = __nccwpck_require__(455);
 const AccountSASPermissions_js_1 = __nccwpck_require__(58);
 const AccountSASSignatureValues_js_1 = __nccwpck_require__(289);
-const AccountSASServices_js_1 = __nccwpck_require__(379);
+const AccountSASServices_js_1 = __nccwpck_require__(380);
 /**
  * A BlobServiceClient represents a Client to the Azure Storage Blob service allowing you
  * to manipulate blob containers.
@@ -71502,7 +72352,7 @@ exports.BlobServiceClient = BlobServiceClient;
 
 /***/ }),
 
-/***/ 402:
+/***/ 403:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71513,7 +72363,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatchClient = void 0;
 const BatchResponseParser_js_1 = __nccwpck_require__(310);
 const BatchUtils_js_1 = __nccwpck_require__(258);
-const BlobBatch_js_1 = __nccwpck_require__(333);
+const BlobBatch_js_1 = __nccwpck_require__(334);
 const tracing_js_1 = __nccwpck_require__(31);
 const storage_common_1 = __nccwpck_require__(277);
 const StorageContextClient_js_1 = __nccwpck_require__(267);
@@ -71685,7 +72535,7 @@ exports.BlobBatchClient = BlobBatchClient;
 
 /***/ }),
 
-/***/ 403:
+/***/ 404:
 /***/ ((module) => {
 
 "use strict";
@@ -71699,7 +72549,7 @@ module.exports = (d, num) => {
 
 /***/ }),
 
-/***/ 404:
+/***/ 405:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71897,7 +72747,7 @@ module.exports = UrlEncoded
 
 /***/ }),
 
-/***/ 405:
+/***/ 406:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -71915,7 +72765,7 @@ exports.MESSAGE_TYPE = Symbol.for("protobuf-ts/message-type");
 
 /***/ }),
 
-/***/ 406:
+/***/ 407:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71927,7 +72777,7 @@ exports.createDefaultTracingSpan = createDefaultTracingSpan;
 exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
-const tracingContext_js_1 = __nccwpck_require__(370);
+const tracingContext_js_1 = __nccwpck_require__(371);
 const state_js_1 = __nccwpck_require__(96);
 function createDefaultTracingSpan() {
     return {
@@ -71991,7 +72841,7 @@ function getInstrumenter() {
 
 /***/ }),
 
-/***/ 407:
+/***/ 408:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -72228,17 +73078,17 @@ function readSnapshotFile(filePath) {
 
 /***/ }),
 
-/***/ 408:
+/***/ 409:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
-const binary_format_contract_1 = __nccwpck_require__(332);
-const reflection_info_1 = __nccwpck_require__(452);
+const binary_format_contract_1 = __nccwpck_require__(333);
+const reflection_info_1 = __nccwpck_require__(453);
 const reflection_long_convert_1 = __nccwpck_require__(158);
-const reflection_scalar_default_1 = __nccwpck_require__(462);
+const reflection_scalar_default_1 = __nccwpck_require__(463);
 /**
  * Reads proto3 messages in binary format using reflection information.
  *
@@ -72419,7 +73269,7 @@ exports.ReflectionBinaryReader = ReflectionBinaryReader;
 
 /***/ }),
 
-/***/ 409:
+/***/ 410:
 /***/ ((module) => {
 
 "use strict";
@@ -72701,7 +73551,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 410:
+/***/ 411:
 /***/ ((module) => {
 
 "use strict";
@@ -72709,14 +73559,14 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 411:
+/***/ 412:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseAsync
 
-const TOMLParser = __nccwpck_require__(346)
+const TOMLParser = __nccwpck_require__(347)
 const prettyError = __nccwpck_require__(279)
 
 function parseAsync (str, opts) {
@@ -72747,7 +73597,7 @@ function parseAsync (str, opts) {
 
 /***/ }),
 
-/***/ 412:
+/***/ 413:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -72830,7 +73680,7 @@ function toPipelineResponse(compatResponse) {
 
 /***/ }),
 
-/***/ 413:
+/***/ 414:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -72856,7 +73706,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOptions = void 0;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 /**
  * Returns a copy with defaults filled in.
  */
@@ -72887,7 +73737,7 @@ exports.getOptions = getOptions;
 
 /***/ }),
 
-/***/ 414:
+/***/ 415:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72943,7 +73793,7 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 415:
+/***/ 416:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73071,18 +73921,18 @@ function getBlobServiceAccountAudience(storageAccountName) {
 
 /***/ }),
 
-/***/ 416:
+/***/ 417:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(430).Writable)
-const { inherits } = __nccwpck_require__(375)
+const WritableStream = (__nccwpck_require__(431).Writable)
+const { inherits } = __nccwpck_require__(376)
 const Dicer = __nccwpck_require__(13)
 
 const MultipartParser = __nccwpck_require__(0)
-const UrlencodedParser = __nccwpck_require__(404)
+const UrlencodedParser = __nccwpck_require__(405)
 const parseParams = __nccwpck_require__(193)
 
 function Busboy (opts) {
@@ -73164,7 +74014,7 @@ module.exports.Dicer = Dicer
 
 /***/ }),
 
-/***/ 417:
+/***/ 418:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -73191,7 +74041,7 @@ var StorageRetryPolicyType;
 
 /***/ }),
 
-/***/ 418:
+/***/ 419:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -73292,7 +74142,7 @@ exports.getDetails = getDetails;
 
 /***/ }),
 
-/***/ 419:
+/***/ 420:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -73400,7 +74250,7 @@ exports.parseProxyResponse = parseProxyResponse;
 
 /***/ }),
 
-/***/ 420:
+/***/ 421:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73408,7 +74258,7 @@ exports.parseProxyResponse = parseProxyResponse;
 module.exports = parseStream
 
 const stream = __nccwpck_require__(130)
-const TOMLParser = __nccwpck_require__(346)
+const TOMLParser = __nccwpck_require__(347)
 
 function parseStream (stm) {
   if (stm) {
@@ -73488,7 +74338,7 @@ function parseTransform () {
 
 /***/ }),
 
-/***/ 421:
+/***/ 422:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73501,7 +74351,7 @@ exports.AvroReader = void 0;
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
 const AvroConstants_js_1 = __nccwpck_require__(230);
 const AvroParser_js_1 = __nccwpck_require__(302);
-const utils_common_js_1 = __nccwpck_require__(391);
+const utils_common_js_1 = __nccwpck_require__(392);
 class AvroReader {
     _dataStream;
     _headerStream;
@@ -73615,7 +74465,7 @@ exports.AvroReader = AvroReader;
 
 /***/ }),
 
-/***/ 422:
+/***/ 423:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74024,14 +74874,14 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 
 /***/ }),
 
-/***/ 423:
+/***/ 424:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(127)
-const { isCTLExcludingHtab } = __nccwpck_require__(409)
+const { isCTLExcludingHtab } = __nccwpck_require__(410)
 const { collectASequenceOfCodePointsFast } = __nccwpck_require__(25)
 const assert = __nccwpck_require__(527)
 
@@ -74349,7 +75199,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 424:
+/***/ 425:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -74417,7 +75267,7 @@ exports.ServerCallContextController = ServerCallContextController;
 
 /***/ }),
 
-/***/ 425:
+/***/ 426:
 /***/ ((module) => {
 
 "use strict";
@@ -74552,7 +75402,7 @@ module.exports = Parser
 
 /***/ }),
 
-/***/ 426:
+/***/ 427:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75028,7 +75878,7 @@ exports.BlobDownloadResponse = BlobDownloadResponse;
 
 /***/ }),
 
-/***/ 427:
+/***/ 428:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -75073,7 +75923,7 @@ function storageRequestFailureDetailsParserPolicy() {
 
 /***/ }),
 
-/***/ 428:
+/***/ 429:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -75109,7 +75959,7 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(382));
+var import_node_os = __toESM(__nccwpck_require__(383));
 var import_node_process = __toESM(__nccwpck_require__(237));
 function getHeaderName() {
   return "User-Agent";
@@ -75133,7 +75983,7 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 429:
+/***/ 430:
 /***/ ((module) => {
 
 "use strict";
@@ -75141,7 +75991,7 @@ module.exports = require("async_hooks");
 
 /***/ }),
 
-/***/ 430:
+/***/ 431:
 /***/ ((module) => {
 
 "use strict";
@@ -75149,7 +75999,7 @@ module.exports = require("node:stream");
 
 /***/ }),
 
-/***/ 431:
+/***/ 432:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -75203,9 +76053,9 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DefaultGlobber = void 0;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const fs = __importStar(__nccwpck_require__(532));
-const globOptionsHelper = __importStar(__nccwpck_require__(413));
+const globOptionsHelper = __importStar(__nccwpck_require__(414));
 const path = __importStar(__nccwpck_require__(248));
 const patternHelper = __importStar(__nccwpck_require__(43));
 const internal_match_kind_1 = __nccwpck_require__(529);
@@ -75391,7 +76241,7 @@ exports.DefaultGlobber = DefaultGlobber;
 
 /***/ }),
 
-/***/ 432:
+/***/ 433:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75401,7 +76251,7 @@ exports.DefaultGlobber = DefaultGlobber;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOperationArgumentValueFromParameter = getOperationArgumentValueFromParameter;
 exports.getOperationRequestInfo = getOperationRequestInfo;
-const state_js_1 = __nccwpck_require__(329);
+const state_js_1 = __nccwpck_require__(330);
 /**
  * @internal
  * Retrieves the value to use for a given operation argument
@@ -75496,14 +76346,14 @@ function getOperationRequestInfo(request) {
 
 /***/ }),
 
-/***/ 433:
+/***/ 434:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(488)
-const { AsyncResource } = __nccwpck_require__(429)
+const { AsyncResource } = __nccwpck_require__(430)
 const util = __nccwpck_require__(69)
 const { addSignal, removeSignal } = __nccwpck_require__(103)
 const assert = __nccwpck_require__(527)
@@ -75609,14 +76459,14 @@ module.exports = upgrade
 
 /***/ }),
 
-/***/ 434:
+/***/ 435:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const os = __nccwpck_require__(92);
 const tty = __nccwpck_require__(182);
-const hasFlag = __nccwpck_require__(366);
+const hasFlag = __nccwpck_require__(367);
 
 const {env} = process;
 
@@ -75752,7 +76602,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 435:
+/***/ 436:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -75814,14 +76664,14 @@ function ensureSecureConnection(request, options) {
 
 /***/ }),
 
-/***/ 436:
+/***/ 437:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CacheServiceClientProtobuf = exports.CacheServiceClientJSON = void 0;
-const cache_1 = __nccwpck_require__(422);
+const cache_1 = __nccwpck_require__(423);
 class CacheServiceClientJSON {
     constructor(rpc) {
         this.rpc = rpc;
@@ -75889,7 +76739,7 @@ exports.CacheServiceClientProtobuf = CacheServiceClientProtobuf;
 
 /***/ }),
 
-/***/ 437:
+/***/ 438:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -75938,7 +76788,7 @@ function decodeStringToString(value) {
 
 /***/ }),
 
-/***/ 438:
+/***/ 439:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -75983,7 +76833,7 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 
 /***/ }),
 
-/***/ 439:
+/***/ 440:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75992,10 +76842,10 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.authorizeRequestOnTenantChallenge = exports.authorizeRequestOnClaimChallenge = exports.serializationPolicyName = exports.serializationPolicy = exports.deserializationPolicyName = exports.deserializationPolicy = exports.XML_CHARKEY = exports.XML_ATTRKEY = exports.createClientPipeline = exports.ServiceClient = exports.MapperTypeNames = exports.createSerializer = void 0;
-var serializer_js_1 = __nccwpck_require__(479);
+var serializer_js_1 = __nccwpck_require__(480);
 Object.defineProperty(exports, "createSerializer", ({ enumerable: true, get: function () { return serializer_js_1.createSerializer; } }));
 Object.defineProperty(exports, "MapperTypeNames", ({ enumerable: true, get: function () { return serializer_js_1.MapperTypeNames; } }));
-var serviceClient_js_1 = __nccwpck_require__(314);
+var serviceClient_js_1 = __nccwpck_require__(315);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
 var pipeline_js_1 = __nccwpck_require__(284);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
@@ -76016,7 +76866,7 @@ Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerabl
 
 /***/ }),
 
-/***/ 440:
+/***/ 441:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -76295,7 +77145,7 @@ exports.createTar = createTar;
 
 /***/ }),
 
-/***/ 441:
+/***/ 442:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -76332,12 +77182,12 @@ __export(nodeHttpClient_exports, {
 });
 module.exports = __toCommonJS(nodeHttpClient_exports);
 var import_node_http = __toESM(__nccwpck_require__(263));
-var import_node_https = __toESM(__nccwpck_require__(388));
+var import_node_https = __toESM(__nccwpck_require__(389));
 var import_node_zlib = __toESM(__nccwpck_require__(520));
-var import_node_stream = __nccwpck_require__(430);
+var import_node_stream = __nccwpck_require__(431);
 var import_AbortError = __nccwpck_require__(10);
 var import_httpHeaders = __nccwpck_require__(485);
-var import_restError = __nccwpck_require__(444);
+var import_restError = __nccwpck_require__(445);
 var import_log = __nccwpck_require__(151);
 var import_sanitizer = __nccwpck_require__(121);
 const DEFAULT_TLS_SETTINGS = {};
@@ -76644,13 +77494,13 @@ function createNodeHttpClient() {
 
 /***/ }),
 
-/***/ 442:
+/***/ 443:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(457)
 
 const kState = Symbol('ProgressEvent state')
 
@@ -76730,7 +77580,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 443:
+/***/ 444:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -76799,7 +77649,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 444:
+/***/ 445:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76901,7 +77751,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 445:
+/***/ 446:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -76954,7 +77804,7 @@ function wrapAbortSignalLike(abortSignalLike) {
 
 /***/ }),
 
-/***/ 446:
+/***/ 447:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77027,7 +77877,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 447:
+/***/ 448:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77039,23 +77889,23 @@ exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = expor
 const tslib_1 = __nccwpck_require__(217);
 const core_rest_pipeline_1 = __nccwpck_require__(101);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
-tslib_1.__exportStar(__nccwpck_require__(401), exports);
+tslib_1.__exportStar(__nccwpck_require__(402), exports);
 tslib_1.__exportStar(__nccwpck_require__(185), exports);
 tslib_1.__exportStar(__nccwpck_require__(64), exports);
 tslib_1.__exportStar(__nccwpck_require__(205), exports);
 tslib_1.__exportStar(__nccwpck_require__(58), exports);
 tslib_1.__exportStar(__nccwpck_require__(2), exports);
-tslib_1.__exportStar(__nccwpck_require__(379), exports);
+tslib_1.__exportStar(__nccwpck_require__(380), exports);
 var AccountSASSignatureValues_js_1 = __nccwpck_require__(289);
 Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(333), exports);
-tslib_1.__exportStar(__nccwpck_require__(402), exports);
+tslib_1.__exportStar(__nccwpck_require__(334), exports);
+tslib_1.__exportStar(__nccwpck_require__(403), exports);
 tslib_1.__exportStar(__nccwpck_require__(174), exports);
 tslib_1.__exportStar(__nccwpck_require__(503), exports);
 var BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
 tslib_1.__exportStar(__nccwpck_require__(280), exports);
-var models_js_1 = __nccwpck_require__(415);
+var models_js_1 = __nccwpck_require__(416);
 Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: function () { return models_js_1.BlockBlobTier; } }));
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
@@ -77079,14 +77929,14 @@ Object.defineProperty(exports, "StorageSharedKeyCredentialPolicy", ({ enumerable
 Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
 tslib_1.__exportStar(__nccwpck_require__(526), exports);
-tslib_1.__exportStar(__nccwpck_require__(322), exports);
+tslib_1.__exportStar(__nccwpck_require__(323), exports);
 var log_js_1 = __nccwpck_require__(106);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 448:
+/***/ 449:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77371,7 +78221,7 @@ exports.SPECIAL_HEADERS = {
 
 /***/ }),
 
-/***/ 449:
+/***/ 450:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -77397,7 +78247,7 @@ __export(sendRequest_exports, {
   sendRequest: () => sendRequest
 });
 module.exports = __toCommonJS(sendRequest_exports);
-var import_restError = __nccwpck_require__(444);
+var import_restError = __nccwpck_require__(445);
 var import_httpHeaders = __nccwpck_require__(485);
 var import_pipelineRequest = __nccwpck_require__(115);
 var import_clientHelpers = __nccwpck_require__(491);
@@ -77555,7 +78405,7 @@ function createParseError(response, err) {
 
 /***/ }),
 
-/***/ 450:
+/***/ 451:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77572,7 +78422,7 @@ const {
 } = __nccwpck_require__(41)
 const { Headers } = __nccwpck_require__(517)
 const { Request, makeRequest } = __nccwpck_require__(84)
-const zlib = __nccwpck_require__(410)
+const zlib = __nccwpck_require__(411)
 const {
   bytesMatch,
   makePolicyContainer,
@@ -77615,14 +78465,14 @@ const {
   DOMException
 } = __nccwpck_require__(30)
 const { kHeadersList } = __nccwpck_require__(196)
-const EE = __nccwpck_require__(469)
+const EE = __nccwpck_require__(470)
 const { Readable, pipeline } = __nccwpck_require__(130)
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(69)
 const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(25)
 const { TransformStream } = __nccwpck_require__(257)
-const { getGlobalDispatcher } = __nccwpck_require__(376)
-const { webidl } = __nccwpck_require__(456)
-const { STATUS_CODES } = __nccwpck_require__(328)
+const { getGlobalDispatcher } = __nccwpck_require__(377)
+const { webidl } = __nccwpck_require__(457)
+const { STATUS_CODES } = __nccwpck_require__(329)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
 /** @type {import('buffer').resolveObjectURL} */
@@ -79711,7 +80561,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 451:
+/***/ 452:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -79769,14 +80619,14 @@ exports.ServerStreamingCall = ServerStreamingCall;
 
 /***/ }),
 
-/***/ 452:
+/***/ 453:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.readMessageOption = exports.readFieldOption = exports.readFieldOptions = exports.normalizeFieldInfo = exports.RepeatType = exports.LongType = exports.ScalarType = void 0;
-const lower_camel_case_1 = __nccwpck_require__(453);
+const lower_camel_case_1 = __nccwpck_require__(454);
 /**
  * Scalar value types. This is a subset of field types declared by protobuf
  * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
@@ -79935,7 +80785,7 @@ exports.readMessageOption = readMessageOption;
 
 /***/ }),
 
-/***/ 453:
+/***/ 454:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -79978,7 +80828,7 @@ exports.lowerCamelCase = lowerCamelCase;
 
 /***/ }),
 
-/***/ 454:
+/***/ 455:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80041,7 +80891,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 455:
+/***/ 456:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -80116,7 +80966,7 @@ function parseHeaderValueAsNumber(response, headerName) {
 
 /***/ }),
 
-/***/ 456:
+/***/ 457:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80770,7 +81620,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 457:
+/***/ 458:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /**
@@ -80804,7 +81654,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = __nccwpck_require__(434);
+	const supportsColor = __nccwpck_require__(435);
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [
@@ -81040,7 +81890,7 @@ formatters.O = function (v) {
 
 /***/ }),
 
-/***/ 458:
+/***/ 459:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -81206,7 +82056,7 @@ function serializeManifest(diff, stats) {
 
 /***/ }),
 
-/***/ 459:
+/***/ 460:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -81246,7 +82096,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.platform = exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = exports.markdownSummary = exports.summary = exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(534);
-const file_command_1 = __nccwpck_require__(443);
+const file_command_1 = __nccwpck_require__(444);
 const utils_1 = __nccwpck_require__(505);
 const os = __importStar(__nccwpck_require__(92));
 const path = __importStar(__nccwpck_require__(248));
@@ -81535,29 +82385,29 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(344);
+var summary_1 = __nccwpck_require__(345);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(344);
+var summary_2 = __nccwpck_require__(345);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(331);
+var path_utils_1 = __nccwpck_require__(332);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
 /**
  * Platform utilities exports
  */
-exports.platform = __importStar(__nccwpck_require__(418));
+exports.platform = __importStar(__nccwpck_require__(419));
 //# sourceMappingURL=core.js.map
 
 /***/ }),
 
-/***/ 460:
+/***/ 461:
 /***/ ((module) => {
 
 "use strict";
@@ -81575,14 +82425,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 461:
+/***/ 462:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionEquals = void 0;
-const reflection_info_1 = __nccwpck_require__(452);
+const reflection_info_1 = __nccwpck_require__(453);
 /**
  * Determines whether two message of the same type have the same field values.
  * Checks for deep equality, traversing repeated fields, oneof groups, maps
@@ -81660,14 +82510,14 @@ function repeatedMsgEq(type, a, b) {
 
 /***/ }),
 
-/***/ 462:
+/***/ 463:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
-const reflection_info_1 = __nccwpck_require__(452);
+const reflection_info_1 = __nccwpck_require__(453);
 const reflection_long_convert_1 = __nccwpck_require__(158);
 const pb_long_1 = __nccwpck_require__(117);
 /**
@@ -81705,7 +82555,7 @@ exports.reflectionScalarDefault = reflectionScalarDefault;
 
 /***/ }),
 
-/***/ 463:
+/***/ 464:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -81743,7 +82593,7 @@ function storageCorrectContentLengthPolicy() {
 
 /***/ }),
 
-/***/ 464:
+/***/ 465:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -81788,7 +82638,7 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 465:
+/***/ 466:
 /***/ ((module) => {
 
 "use strict";
@@ -81847,7 +82697,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 466:
+/***/ 467:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -82037,7 +82887,7 @@ var debug_default = debugObj;
 
 /***/ }),
 
-/***/ 467:
+/***/ 468:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* eslint-env browser */
@@ -82316,7 +83166,7 @@ formatters.j = function (v) {
 
 /***/ }),
 
-/***/ 468:
+/***/ 469:
 /***/ ((module) => {
 
 "use strict";
@@ -82324,7 +83174,7 @@ module.exports = /*#__PURE__*/JSON.parse('{"name":"@actions/cache","version":"4.
 
 /***/ }),
 
-/***/ 469:
+/***/ 470:
 /***/ ((module) => {
 
 "use strict";
@@ -82332,7 +83182,7 @@ module.exports = require("events");
 
 /***/ }),
 
-/***/ 470:
+/***/ 471:
 /***/ ((module) => {
 
 "use strict";
@@ -82363,7 +83213,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 471:
+/***/ 472:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -82637,7 +83487,7 @@ var KnownStorageErrorCode;
 
 /***/ }),
 
-/***/ 472:
+/***/ 473:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -82678,7 +83528,7 @@ function proxyPolicy(proxySettings, options) {
 
 /***/ }),
 
-/***/ 473:
+/***/ 474:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -83258,7 +84108,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 474:
+/***/ 475:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -83297,7 +84147,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 475:
+/***/ 476:
 /***/ ((module) => {
 
 "use strict";
@@ -83340,7 +84190,7 @@ module.exports = class DecoratorHandler {
 
 /***/ }),
 
-/***/ 476:
+/***/ 477:
 /***/ ((module) => {
 
 "use strict";
@@ -83362,13 +84212,13 @@ module.exports = function basename (path) {
 
 /***/ }),
 
-/***/ 477:
+/***/ 478:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = __nccwpck_require__(469)
+const EventEmitter = __nccwpck_require__(470)
 
 class Dispatcher extends EventEmitter {
   dispatch () {
@@ -83389,7 +84239,7 @@ module.exports = Dispatcher
 
 /***/ }),
 
-/***/ 478:
+/***/ 479:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -83409,7 +84259,7 @@ exports.ServiceType = ServiceType;
 
 /***/ }),
 
-/***/ 479:
+/***/ 480:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -83420,9 +84270,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
 const tslib_1 = __nccwpck_require__(217);
-const base64 = tslib_1.__importStar(__nccwpck_require__(437));
+const base64 = tslib_1.__importStar(__nccwpck_require__(438));
 const interfaces_js_1 = __nccwpck_require__(99);
-const utils_js_1 = __nccwpck_require__(312);
+const utils_js_1 = __nccwpck_require__(313);
 class SerializerImpl {
     modelMappers;
     isXML;
@@ -84342,7 +85192,7 @@ exports.MapperTypeNames = {
 
 /***/ }),
 
-/***/ 480:
+/***/ 481:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84357,7 +85207,7 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 
 /***/ }),
 
-/***/ 481:
+/***/ 482:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84365,7 +85215,7 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 
 const { Writable } = __nccwpck_require__(130)
 const diagnosticsChannel = __nccwpck_require__(141)
-const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(465)
+const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(466)
 const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(98)
 const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(57)
 const { WebsocketFrameSend } = __nccwpck_require__(187)
@@ -84709,843 +85559,6 @@ module.exports = {
 
 /***/ }),
 
-/***/ 482:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// setup-soldr entry point. Owned by Agent 2.
-//
-// Replaces the composite action's main-phase steps with a single JS
-// orchestrator. Calls the helpers in src/lib/* in the same order the
-// composite's steps fire.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(249));
-const os = __importStar(__nccwpck_require__(382));
-const path = __importStar(__nccwpck_require__(508));
-const core = __importStar(__nccwpck_require__(459));
-const cache = __importStar(__nccwpck_require__(215));
-const log_utils_js_1 = __nccwpck_require__(352);
-const resolve_setup_js_1 = __nccwpck_require__(189);
-const phase_timing_js_1 = __nccwpck_require__(336);
-const ensure_rust_toolchain_js_1 = __nccwpck_require__(512);
-const ensure_soldr_js_1 = __nccwpck_require__(363);
-const verify_soldr_js_1 = __nccwpck_require__(358);
-const install_passthrough_js_1 = __nccwpck_require__(514);
-const normalize_source_mtime_js_1 = __nccwpck_require__(79);
-const detect_shared_target_warning_js_1 = __nccwpck_require__(219);
-const ensure_shims_js_1 = __nccwpck_require__(530);
-const cache_compress_js_1 = __nccwpck_require__(493);
-const stats_collector_js_1 = __nccwpck_require__(74);
-const toolchain_snapshot_js_1 = __nccwpck_require__(458);
-const solo_toolchain_cache_js_1 = __nccwpck_require__(294);
-const cook_cache_js_1 = __nccwpck_require__(170);
-const soldr_mini_cache_js_1 = __nccwpck_require__(157);
-const diagnostics_js_1 = __nccwpck_require__(111);
-const source_mtime_snapshot_js_1 = __nccwpck_require__(407);
-/**
- * Map (hit, matchedKey) → workflow-visible restore-status string.
- * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
- * for the `<layer>-cache-restore-status` outputs declared in action.yml.
- */
-function deriveRestoreStatus(hit, matchedKey) {
-    if (hit)
-        return "exact-hit";
-    if (matchedKey.trim())
-        return "restore-key-hit";
-    return "miss";
-}
-function writeCacheKeysManifest(result, runnerTemp, log) {
-    if (!runnerTemp)
-        return;
-    const keys = [
-        result.setupCache.key,
-        result.buildCache.key,
-        result.targetCache.key,
-        result.cargoRegistryCache.key,
-    ].filter((k) => Boolean(k));
-    if (keys.length === 0)
-        return;
-    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
-    try {
-        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
-        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
-    }
-    catch (err) {
-        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-const TRUTHY = new Set(["1", "true", "yes", "on"]);
-const FALSY = new Set(["0", "false", "no", "off"]);
-function isTruthy(value) {
-    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
-}
-function isFalsy(value) {
-    return FALSY.has(((value ?? "").trim().toLowerCase()));
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
-    }
-}
-function dirHasContent(p) {
-    try {
-        return fs.readdirSync(p).length > 0;
-    }
-    catch {
-        return false;
-    }
-}
-function buildActionContext() {
-    const env = process.env;
-    const logger = (0, log_utils_js_1.createLogger)(env);
-    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
-    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
-    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
-    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
-    const githubSha = env["GITHUB_SHA"]?.trim() || "";
-    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
-    const parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
-    return {
-        env: { ...env },
-        workspace,
-        runnerTemp,
-        runnerOs,
-        runnerArch,
-        githubSha,
-        githubToken,
-        parentSha,
-        logger,
-    };
-}
-async function restoreCacheSafe(paths, key, restoreKeys, logger) {
-    if (paths.length === 0 || !key) {
-        return { hit: false, matchedKey: "" };
-    }
-    try {
-        const matched = await cache.restoreCache(paths, key, restoreKeys);
-        return { hit: matched === key, matchedKey: matched ?? "" };
-    }
-    catch (err) {
-        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "" };
-    }
-}
-async function run() {
-    const ctx = buildActionContext();
-    const logger = ctx.logger;
-    await (0, phase_timing_js_1.markPhase)("action");
-    // ---- resolve ----
-    await (0, phase_timing_js_1.markPhase)("resolve");
-    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
-    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
-    await (0, resolve_setup_js_1.applyResolveResult)(result);
-    await (0, phase_timing_js_1.finishPhase)("resolve");
-    // Always emit the cache-keys manifest right after resolve so workflow
-    // steps that run between main and post (e.g. actions/upload-artifact)
-    // can read it. The four keys are fully determined by resolveSetup and
-    // never change later in the run.
-    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
-    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            logger,
-            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
-        });
-    }
-    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
-    if (dryRun) {
-        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
-        await (0, phase_timing_js_1.finishPhase)("action");
-        return;
-    }
-    // Persist resolve state for the post-job step.
-    core.saveState("resolveResult", JSON.stringify(result));
-    core.saveState("buildCacheMode", result.buildCache.mode);
-    core.saveState("logging", logging ? "true" : "false");
-    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
-    const statsMode = result.stats;
-    const debugMode = result.debugMode;
-    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
-    const statsCollector = new stats_collector_js_1.StatsCollector();
-    // ---- source-mtime-normalize ----
-    if (isTruthy(inputs.sourceMtimeNormalize)) {
-        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
-    }
-    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
-    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
-    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
-    core.saveState("setupCacheExactHit", "false");
-    core.saveState("setupCacheMatchedKey", "");
-    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
-    core.saveState("targetCacheExactHit", "false");
-    core.saveState("targetCacheMatchedKey", "");
-    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
-    core.saveState("buildCacheExactHit", "false");
-    core.saveState("buildCacheMatchedKey", "");
-    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
-    core.saveState("cargoRegistryCacheExactHit", "false");
-    core.saveState("cargoRegistryCacheMatchedKey", "");
-    // ---- parallel restores ----
-    // setup-cache, target-cache, build-cache, and cargo-registry write to
-    // disjoint paths and have no inter-dependencies, so they run concurrently.
-    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
-    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
-    //
-    // Layers that must stay sequential (wired below): solo-toolchain (writes
-    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
-    // install dir, must precede ensureSoldr), cook (writes target/ and needs
-    // the soldr binary). Cargo-registry was previously after-cook — it's been
-    // moved into this parallel block because nothing the soldr install path
-    // touches depends on its hydrated cargo registry state.
-    await (0, phase_timing_js_1.markPhase)("parallel-restore");
-    let setupCacheExactHit = false;
-    // Capture target-cache hit status so we can skip the redundant cook restore.
-    // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
-    // (~2.5 GB inflated) also contains compiled deps. When target-cache exact-hits
-    // we have a fully-warm target/ — cook restore would just overwrite identical
-    // content. Skipping saves ~5 s per warm run.
-    let targetCacheExactHit = false;
-    const setupRestorePromise = (async () => {
-        if (!(cacheEnabled && result.setupCache.paths.length > 0))
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
-        setupCacheExactHit = restore.hit;
-        core.setOutput("cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("setup_cache_matched_key", restore.matchedKey);
-        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("setupCacheMatchedKey", restore.matchedKey);
-        // Expose for ensure_rust_toolchain to read via env. Must be visible by
-        // the time toolchain phase runs — guaranteed by the Promise.all below.
-        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
-        statsCollector.record({
-            label: "setup-cache", operation: "restore", hit: restore.hit,
-            key: result.setupCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.setupCache.restorePrefix],
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const targetRestorePromise = (async () => {
-        if (!result.targetCache.enabled)
-            return;
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        if (targetPaths.length === 0)
-            return;
-        const restoreKeys = [];
-        if (result.targetCache.restoreKeyParent)
-            restoreKeys.push(result.targetCache.restoreKeyParent);
-        if (result.targetCache.restoreKeyLock)
-            restoreKeys.push(result.targetCache.restoreKeyLock);
-        if (result.targetCache.restoreKeyLockfile)
-            restoreKeys.push(result.targetCache.restoreKeyLockfile);
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
-        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("target_cache_matched_key", restore.matchedKey);
-        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("targetCacheMatchedKey", restore.matchedKey);
-        targetCacheExactHit = restore.hit;
-        statsCollector.record({
-            label: "target-cache", operation: "restore", hit: restore.hit,
-            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const buildRestorePromise = (async () => {
-        if (!buildCacheEnabled)
-            return;
-        const buildCachePath = result.buildCache.path;
-        const archivePath = `${buildCachePath}.tar.zst`;
-        const restoreKeys = [];
-        if (result.buildCache.restoreKeyParent)
-            restoreKeys.push(result.buildCache.restoreKeyParent);
-        if (result.buildCache.restoreKeyToolchain)
-            restoreKeys.push(result.buildCache.restoreKeyToolchain);
-        if (result.buildCache.restoreKeyOsArch)
-            restoreKeys.push(result.buildCache.restoreKeyOsArch);
-        const t0 = Date.now();
-        // @actions/cache hashes the `paths` array into a "version" key — save and
-        // restore MUST pass the same array or the lookup misses even when the
-        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
-        // restore must use the same single-path array. The decompression below
-        // unpacks archivePath → buildCachePath afterwards.
-        const restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
-        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("build_cache_matched_key", restore.matchedKey);
-        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("buildCacheMatchedKey", restore.matchedKey);
-        let buildArchiveBytes = null;
-        let buildInflatedBytes = null;
-        let buildFileCount = null;
-        if (fileExists(archivePath)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-            if (magic === "zstd" || magic === "gzip") {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath, debug: debugMode, log: debugLog });
-                    buildArchiveBytes = dr.archiveBytes;
-                    buildInflatedBytes = dr.inflatedBytes;
-                    buildFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
-        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
-        // dir on the cold side; if it's present after decompress, walk it and
-        // set each matching source file's mtime to what cold saw. The replay
-        // is gated by (size, content-hash) match so we never overwrite a
-        // genuinely modified file's mtime — that would underbuild.
-        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
-            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
-            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
-            if (snapshot) {
-                const rt0 = Date.now();
-                try {
-                    // Match the project-root selection that post.ts uses when
-                    // writing the snapshot — the parent of the resolved target-dir,
-                    // not the (outer) GITHUB_WORKSPACE.
-                    const projectRoot = path.dirname(result.targetCache.targetPath);
-                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
-                        workspace: projectRoot,
-                        snapshot,
-                        log: (msg) => logger.log(msg),
-                    });
-                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
-                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
-                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
-                }
-                catch (err) {
-                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-            else {
-                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
-            }
-        }
-        statsCollector.record({
-            label: "build-cache", operation: "restore", hit: restore.hit,
-            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    })();
-    // Cargo-registry restore moved here from after-cook. It writes only
-    // $CARGO_HOME/registry/ and has no dependency on soldr being installed;
-    // running it in parallel with target+build trims its ~5s off the critical
-    // path.
-    const cargoRegistryRestorePromise = (async () => {
-        if (!result.cargoRegistryCache.enabled)
-            return;
-        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe([registryArchive], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
-        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
-        let regArchiveBytes = null;
-        let regInflatedBytes = null;
-        let regFileCount = null;
-        if (fileExists(registryArchive)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
-            if (magic === "zstd" || magic === "gzip") {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({
-                        archivePath: registryArchive,
-                        targetDir: result.cargoRegistryCache.path,
-                        debug: debugMode, log: debugLog,
-                    });
-                    regArchiveBytes = dr.archiveBytes;
-                    regInflatedBytes = dr.inflatedBytes;
-                    regFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        statsCollector.record({
-            label: "cargo-registry", operation: "restore", hit: restore.hit,
-            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.cargoRegistryCache.restorePrefix],
-            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    })();
-    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
-    // try/catches, so this should only see rejections for genuine programming
-    // bugs.
-    await Promise.all([
-        setupRestorePromise,
-        targetRestorePromise,
-        buildRestorePromise,
-        cargoRegistryRestorePromise,
-    ]);
-    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
-    // ---- target-tree-cache (full mode) ----
-    // The bundle path is included in target-cache restore paths above when full
-    // mode is requested, so there's no separate restore here. We keep the phase
-    // marker for parity with the composite step ordering.
-    await (0, phase_timing_js_1.markPhase)("target-tree");
-    await (0, phase_timing_js_1.finishPhase)("target-tree");
-    // Kick off cook restore in the background. It overlaps with the
-    // sequential toolchain + soldr install + shims + verify steps that
-    // follow. By the time the cook phase runs, the restore is done — we
-    // just await the promise. Saves ~5–7 s of warm-build wall clock.
-    //
-    // Why this is safe (vs the disastrous PR #145 which added cook to the
-    // BIG parallel block): cook now races with SMALL ops (rust install
-    // ~1–2 s, soldr install ~2–3 s, shims/verify ~1–2 s). Those don't
-    // contend on disk write bandwidth the way target/build/cargo-registry
-    // restores did. Cook's 2.5 GB tar write becomes the long pole and
-    // hides behind the small ops.
-    //
-    // SAFETY: when target-cache writes to target/ (build-cache-mode: full),
-    // cook restore would race with target-cache restore on the same dir.
-    // The parallel-restore block above already finished target-cache, but
-    // we still want a runtime gate just in case the mode changes.
-    const cookGate = (0, cook_cache_js_1.decideCookGate)({
-        prebuildDeps: inputs.prebuildDeps,
-        cacheUmbrella: cacheEnabled,
-        lockfilePath: result.targetCache.lockfilePath,
-    });
-    const cookActive = cookGate.enabled && result.enabled;
-    let cookFlags = [];
-    let cookKey = "";
-    let cookProjectRoot = "";
-    let cookTargetDir = "";
-    let cookArchive = "";
-    let cookRestoreT0 = Date.now();
-    let cookRestorePromise = null;
-    // Skip cook restore when target-cache already exact-hit: target-cache
-    // contains the full prior compiled tree (including deps), so cook restore
-    // would just overwrite identical content. ~5 s saved per warm-exact-hit run.
-    // When target-cache miss/fallback, cook still acts as the dep-warming
-    // fallback (which is exactly what cook was designed for).
-    const cookSkippedDueToTargetHit = cookActive && targetCacheExactHit;
-    if (cookActive && !cookSkippedDueToTargetHit) {
-        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
-        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
-        const lockHash = result.targetCache.lockfileHash || "no-lock";
-        cookKey = (0, cook_cache_js_1.buildCookCacheKey)({
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            flagsHash,
-            lockHash,
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        });
-        cookProjectRoot = path.dirname(result.targetCache.targetPath);
-        cookTargetDir = result.targetCache.targetPath;
-        cookArchive = `${cookTargetDir}.tar.zst`;
-        logger.log(`cook: key=${cookKey} starting background restore concurrent with install`);
-        cookRestoreT0 = Date.now();
-        cookRestorePromise = (0, cook_cache_js_1.restoreCookCache)({
-            exactKey: cookKey,
-            archivePath: cookArchive,
-            targetDir: cookTargetDir,
-            longWindow: 27,
-            debug: debugMode,
-            log: (msg) => logger.log(msg),
-        });
-    }
-    // ---- toolchain ----
-    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
-    // toolchain install so we can see which inodes setup-soldr added on
-    // top of the runner image. When solo-toolchain-cache is opted in, a
-    // third snapshot is taken *before* the cache restore so the saved
-    // tarball captures the full above-runner state — not just the
-    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
-    // lifetime axis".
-    await (0, phase_timing_js_1.markPhase)("toolchain");
-    const snapshotRoots = [
-        path.join(result.rustupHome, "toolchains"),
-        path.join(result.cargoHome, "bin"),
-    ];
-    const soloRootMap = {
-        "rustup-toolchains": snapshotRoots[0],
-        "cargo-bin": snapshotRoots[1],
-    };
-    const soloEnabled = isTruthy(inputs.soloToolchainCache);
-    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "19");
-    let soloKeys = null;
-    let soloMatchedKey = "";
-    let soloExactHit = false;
-    // Pre-restore snapshot — only needed when solo cache is enabled, so
-    // we can compute the full save-diff (post-install vs runner-image,
-    // not vs post-restore baseline).
-    const preRestoreSnapshot = soloEnabled ? await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots) : null;
-    if (soloEnabled) {
-        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
-            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        });
-        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
-        const restoreT0 = Date.now();
-        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
-        const restored = await (0, solo_toolchain_cache_js_1.restoreSoloCache)({
-            keys: soloKeys,
-            rootMap: soloRootMap,
-            stagingDir,
-            log: (msg) => logger.log(msg),
-        });
-        soloMatchedKey = restored.matchedKey;
-        let verifiedMatch = true;
-        if (restored.verified && restored.matchedKey) {
-            const expected = result.toolchain.cacheChannel.trim();
-            // The rustup home is set up so `rustc` will resolve through the
-            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
-            // the cargo bin one.
-            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
-            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
-                expectedRelease: expected,
-                rustcCommand: rustcCmd,
-                log: (msg) => logger.log(msg),
-            });
-            verifiedMatch = verify.match;
-        }
-        soloExactHit = restored.hit && verifiedMatch;
-        core.saveState("soloToolchainEnabled", "true");
-        core.saveState("soloToolchainExactKey", soloKeys.exact);
-        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
-        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
-        core.saveState("soloToolchainLevel", soloLevel);
-        statsCollector.record({
-            label: "solo-toolchain-cache",
-            operation: "restore",
-            hit: soloExactHit,
-            key: soloKeys.exact,
-            matchedKey: soloMatchedKey,
-            restoreKeys: soloKeys.fallbacks,
-            archiveBytes: restored.restoredBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - restoreT0,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else {
-        core.saveState("soloToolchainEnabled", "false");
-    }
-    const baselineSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
-    await (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({ resolveResult: result, setupCacheExactHit });
-    const postInstallSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
-    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
-    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
-    // When solo cache is enabled, also compute the save-diff (post-install
-    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
-    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
-        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
-        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
-        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
-        try {
-            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
-            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
-            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
-            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
-                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
-                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
-                `incremental-empty=${toolchainDiff.added.length === 0}`);
-        }
-        catch (err) {
-            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
-    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
-        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
-    if (ctx.runnerTemp) {
-        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
-        try {
-            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
-            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
-        }
-        catch (err) {
-            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    await (0, phase_timing_js_1.finishPhase)("toolchain");
-    // ---- install soldr ----
-    // Try the soldr-mini-cache before ensureSoldr fires the GH Releases fetch.
-    // On hit, the install dir is pre-populated and ensureSoldr's existing
-    // installedVersion() check short-circuits. On miss, ensureSoldr does its
-    // normal fetch and post.ts saves to the mini-cache.
-    await (0, phase_timing_js_1.markPhase)("install");
-    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
-    const miniInstallDir = path.dirname(result.soldrPath);
-    const miniArchive = `${miniInstallDir}.tar.zst`;
-    let miniHit = false;
-    let miniKey = "";
-    if (miniEnabled) {
-        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
-            hasRef: Boolean(result.soldrRef.trim()),
-            enable: result.enabled,
-            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
-        });
-        if (eligibility.eligible) {
-            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
-            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
-                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-                soldrVersion: version,
-            });
-            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir}`);
-            const miniT0 = Date.now();
-            const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
-                exactKey: miniKey,
-                installDir: miniInstallDir,
-                archivePath: miniArchive,
-                longWindow: 27,
-                debug: debugMode,
-                log: (msg) => logger.log(msg),
-            });
-            miniHit = restore.hit;
-            statsCollector.record({
-                label: "soldr-mini-cache",
-                operation: "restore",
-                hit: restore.hit,
-                key: miniKey,
-                matchedKey: restore.matchedKey,
-                restoreKeys: [],
-                archiveBytes: restore.archiveBytes || null,
-                inflatedBytes: null,
-                fileCount: null,
-                durationMs: Date.now() - miniT0,
-                timestamp: new Date().toISOString(),
-            });
-        }
-        else {
-            logger.log(`soldr-mini-cache: skipped — ${eligibility.reason}`);
-        }
-    }
-    else {
-        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
-    }
-    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
-    core.saveState("soldrMiniExactKey", miniKey);
-    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
-    core.saveState("soldrMiniInstallDir", miniInstallDir);
-    core.saveState("soldrMiniArchive", miniArchive);
-    if (result.enabled) {
-        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
-        // restored binary at the expected path with the expected version and
-        // short-circuits — no GH fetch.
-        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
-    }
-    else {
-        (0, install_passthrough_js_1.installPassthrough)({
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
-            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
-            "verbatim, and soldr-aware caching/observability is disabled.");
-    }
-    await (0, phase_timing_js_1.finishPhase)("install");
-    // Export SOLDR_BINARY so shims can exec it directly
-    core.exportVariable("SOLDR_BINARY", result.soldrPath);
-    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
-    // ---- shims ----
-    if (result.shimsEnabled) {
-        await (0, ensure_shims_js_1.ensureShims)({
-            shimsDir: result.shimsDir,
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-    }
-    // ---- verify ----
-    await (0, phase_timing_js_1.markPhase)("verify");
-    if (result.enabled) {
-        const verify = await (0, verify_soldr_js_1.verifySoldr)({
-            soldrPath: result.soldrPath,
-            buildCacheMode: result.buildCache.mode,
-            requireRustPlan: result.targetCache.enabled,
-        });
-        core.setOutput("soldr-version", verify.soldrVersion);
-        core.setOutput("soldr_version", verify.soldrVersion);
-    }
-    else {
-        core.setOutput("soldr-version", "passthrough");
-        core.setOutput("soldr_version", "passthrough");
-    }
-    await (0, phase_timing_js_1.finishPhase)("verify");
-    // ---- cook (prebuild-deps via cargo-chef) ----
-    // The RESTORE was kicked off as a background promise right after the
-    // parallel-restore block above — we just await its result here. The
-    // RUN (actual cargo-chef invocation) still happens in this phase if
-    // the restore missed.
-    // Failures here are logged but never fail the action — the user's
-    // own cargo build will still work without the cooked deps.
-    await (0, phase_timing_js_1.markPhase)("cook");
-    if (cookActive && cookRestorePromise) {
-        const restore = await cookRestorePromise;
-        statsCollector.record({
-            label: "cook-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: cookKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        let cookRan = false;
-        if (!restore.hit) {
-            const runRes = await (0, cook_cache_js_1.runCook)({
-                soldrBinary: result.soldrPath,
-                projectRoot: cookProjectRoot,
-                flags: cookFlags,
-                log: (msg) => logger.log(msg),
-            });
-            cookRan = runRes.exitCode === 0;
-        }
-        else {
-            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
-        }
-        core.saveState("cookEnabled", "true");
-        core.saveState("cookExactKey", cookKey);
-        core.saveState("cookMatchedKey", restore.matchedKey);
-        core.saveState("cookHit", restore.hit ? "true" : "false");
-        core.saveState("cookRan", cookRan ? "true" : "false");
-        core.saveState("cookTargetDir", cookTargetDir);
-        core.saveState("cookLongWindow", "27");
-        core.saveState("cookCompressLevel", "19");
-    }
-    else if (cookSkippedDueToTargetHit) {
-        logger.log("cook: skipped - target-cache exact-hit already provides fully-warm target/ (no redundant restore needed)");
-        core.saveState("cookEnabled", "false");
-    }
-    else {
-        logger.log(`cook: skipped - ${cookGate.reason}`);
-        core.saveState("cookEnabled", "false");
-    }
-    await (0, phase_timing_js_1.finishPhase)("cook");
-    // ---- shared-target warning ----
-    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
-        buildCacheEnabled,
-        effectiveTargetCacheEnabled: result.targetCache.enabled,
-        buildCacheMode: result.buildCache.mode,
-        targetDir: result.targetCache.targetPath,
-    });
-    // ---- stats report ----
-    statsCollector.report(statsMode, (msg) => logger.log(msg));
-    if (statsMode === "detailed") {
-        try {
-            await statsCollector.writeFiles(ctx.runnerTemp);
-            statsCollector.setGithubOutputs();
-        }
-        catch (err) {
-            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    core.saveState("statsCollector", statsCollector.serialize());
-    core.saveState("statsMode", statsMode);
-    core.saveState("compileCacheStats", result.compileCacheStats);
-    core.saveState("runnerTemp", ctx.runnerTemp);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            cacheOutcomes: statsCollector.snapshot(),
-            logger,
-        });
-    }
-    await (0, phase_timing_js_1.finishPhase)("action");
-    // dirHasContent is exported for tests; suppress unused warning here.
-    void dirHasContent;
-}
-// Auto-invoke only when this module is run as the main entry point. This lets
-// tests import `run` (and helpers) without triggering the side-effectful
-// orchestration. The dist/main.js produced by ncc is invoked directly by the
-// Actions runtime so the check trips and the action executes normally.
-if (typeof process !== "undefined" &&
-    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
-    // import.meta.url is the file URL of this module; argv[1] is the runner
-    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
-    // the dev path — we rely on the env-var opt-out for tests instead.
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.setFailed(`setup-soldr failed: ${message}`);
-    });
-}
-
-
-/***/ }),
-
 /***/ 483:
 /***/ ((module) => {
 
@@ -85737,7 +85750,7 @@ function createHttpHeaders(rawHeaders) {
 /***/ 486:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __nccwpck_require__(351);
+var concatMap = __nccwpck_require__(352);
 var balanced = __nccwpck_require__(131);
 
 module.exports = expandTop;
@@ -85979,8 +85992,8 @@ __export(log_exports, {
   log: () => log
 });
 module.exports = __toCommonJS(log_exports);
-var import_node_os = __nccwpck_require__(382);
-var import_node_util = __toESM(__nccwpck_require__(375));
+var import_node_os = __nccwpck_require__(383);
+var import_node_util = __toESM(__nccwpck_require__(376));
 var import_node_process = __toESM(__nccwpck_require__(237));
 function log(message, ...args) {
   import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
@@ -86243,9 +86256,9 @@ exports.serializationPolicy = serializationPolicy;
 exports.serializeHeaders = serializeHeaders;
 exports.serializeRequestBody = serializeRequestBody;
 const interfaces_js_1 = __nccwpck_require__(99);
-const operationHelpers_js_1 = __nccwpck_require__(432);
-const serializer_js_1 = __nccwpck_require__(479);
-const interfaceHelpers_js_1 = __nccwpck_require__(399);
+const operationHelpers_js_1 = __nccwpck_require__(433);
+const serializer_js_1 = __nccwpck_require__(480);
+const interfaceHelpers_js_1 = __nccwpck_require__(400);
 /**
  * The programmatic identifier of the serializationPolicy.
  */
@@ -86402,9 +86415,9 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 var net = __nccwpck_require__(509);
 var tls = __nccwpck_require__(506);
-var http = __nccwpck_require__(328);
+var http = __nccwpck_require__(329);
 var https = __nccwpck_require__(70);
-var events = __nccwpck_require__(469);
+var events = __nccwpck_require__(470);
 var assert = __nccwpck_require__(527);
 var util = __nccwpck_require__(123);
 
@@ -86692,14 +86705,14 @@ __export(clientHelpers_exports, {
   getCachedDefaultHttpsClient: () => getCachedDefaultHttpsClient
 });
 module.exports = __toCommonJS(clientHelpers_exports);
-var import_defaultHttpClient = __nccwpck_require__(372);
-var import_createPipelineFromOptions = __nccwpck_require__(315);
+var import_defaultHttpClient = __nccwpck_require__(373);
+var import_createPipelineFromOptions = __nccwpck_require__(316);
 var import_apiVersionPolicy = __nccwpck_require__(228);
 var import_credentials = __nccwpck_require__(188);
 var import_apiKeyAuthenticationPolicy = __nccwpck_require__(87);
 var import_basicAuthenticationPolicy = __nccwpck_require__(152);
-var import_bearerAuthenticationPolicy = __nccwpck_require__(380);
-var import_oauth2AuthenticationPolicy = __nccwpck_require__(338);
+var import_bearerAuthenticationPolicy = __nccwpck_require__(381);
+var import_oauth2AuthenticationPolicy = __nccwpck_require__(339);
 let cachedHttpClient;
 function createDefaultPipeline(options = {}) {
   const pipeline = (0, import_createPipelineFromOptions.createPipelineFromOptions)(options);
@@ -86749,7 +86762,7 @@ function getCachedDefaultHttpsClient() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetriableReadableStream = void 0;
 const abort_controller_1 = __nccwpck_require__(496);
-const node_stream_1 = __nccwpck_require__(430);
+const node_stream_1 = __nccwpck_require__(431);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -86930,7 +86943,7 @@ exports.decompressCache = decompressCache;
 exports.compressCache = compressCache;
 const fs = __importStar(__nccwpck_require__(108));
 const path = __importStar(__nccwpck_require__(508));
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const exec = __importStar(__nccwpck_require__(18));
 const io = __importStar(__nccwpck_require__(295));
 /**
@@ -87409,8 +87422,8 @@ exports.AbortError = AbortError;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQuickQueryStream = void 0;
-const node_stream_1 = __nccwpck_require__(430);
-const index_js_1 = __nccwpck_require__(334);
+const node_stream_1 = __nccwpck_require__(431);
+const index_js_1 = __nccwpck_require__(335);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -88301,7 +88314,7 @@ const {
 } = __nccwpck_require__(488)
 const util = __nccwpck_require__(69)
 const { getResolveErrorBodyCallback } = __nccwpck_require__(190)
-const { AsyncResource } = __nccwpck_require__(429)
+const { AsyncResource } = __nccwpck_require__(430)
 const { addSignal, removeSignal } = __nccwpck_require__(103)
 
 class RequestHandler extends AsyncResource {
@@ -88524,13 +88537,13 @@ exports.shouldRefreshToolchain = shouldRefreshToolchain;
 exports.shouldSkipRefreshForExactHit = shouldSkipRefreshForExactHit;
 exports.ensureRustToolchain = ensureRustToolchain;
 const fs = __importStar(__nccwpck_require__(249));
-const os = __importStar(__nccwpck_require__(382));
+const os = __importStar(__nccwpck_require__(383));
 const path = __importStar(__nccwpck_require__(508));
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const exec = __importStar(__nccwpck_require__(18));
 const io = __importStar(__nccwpck_require__(295));
 const tc = __importStar(__nccwpck_require__(523));
-const log_utils_js_1 = __nccwpck_require__(352);
+const log_utils_js_1 = __nccwpck_require__(353);
 function rustupInitTargetTriple() {
     const system = process.platform;
     const arch = process.arch;
@@ -88834,8 +88847,8 @@ const runtime_1 = __nccwpck_require__(19);
 const rpc_output_stream_1 = __nccwpck_require__(307);
 const rpc_options_1 = __nccwpck_require__(293);
 const unary_call_1 = __nccwpck_require__(56);
-const server_streaming_call_1 = __nccwpck_require__(451);
-const client_streaming_call_1 = __nccwpck_require__(350);
+const server_streaming_call_1 = __nccwpck_require__(452);
+const client_streaming_call_1 = __nccwpck_require__(351);
 const duplex_streaming_call_1 = __nccwpck_require__(306);
 /**
  * Transport for testing.
@@ -89332,9 +89345,9 @@ Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: fu
  */
 
 if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
-	module.exports = __nccwpck_require__(467);
+	module.exports = __nccwpck_require__(468);
 } else {
-	module.exports = __nccwpck_require__(457);
+	module.exports = __nccwpck_require__(458);
 }
 
 
@@ -89357,7 +89370,7 @@ const {
   isValidHeaderValue
 } = __nccwpck_require__(518)
 const util = __nccwpck_require__(123)
-const { webidl } = __nccwpck_require__(456)
+const { webidl } = __nccwpck_require__(457)
 const assert = __nccwpck_require__(527)
 
 const kHeadersMap = Symbol('headers map')
@@ -89949,7 +89962,7 @@ module.exports = {
 
 const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(30)
 const { getGlobalOrigin } = __nccwpck_require__(139)
-const { performance } = __nccwpck_require__(320)
+const { performance } = __nccwpck_require__(321)
 const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(69)
 const assert = __nccwpck_require__(527)
 const { isUint8Array } = __nccwpck_require__(199)
@@ -91269,11 +91282,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.evaluateVersions = exports.isExplicitVersion = exports.findFromManifest = exports.getManifestFromRepo = exports.findAllVersions = exports.find = exports.cacheFile = exports.cacheDir = exports.extractZip = exports.extractXar = exports.extractTar = exports.extract7z = exports.downloadTool = exports.HTTPError = void 0;
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 const io = __importStar(__nccwpck_require__(295));
 const crypto = __importStar(__nccwpck_require__(291));
 const fs = __importStar(__nccwpck_require__(532));
-const mm = __importStar(__nccwpck_require__(330));
+const mm = __importStar(__nccwpck_require__(331));
 const os = __importStar(__nccwpck_require__(92));
 const path = __importStar(__nccwpck_require__(248));
 const httpm = __importStar(__nccwpck_require__(285));
@@ -91929,7 +91942,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(395);
+var import_exponentialRetryStrategy = __nccwpck_require__(396);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_constants = __nccwpck_require__(48);
 const exponentialRetryPolicyName = "exponentialRetryPolicy";
@@ -92176,7 +92189,7 @@ function createEmptyPipeline() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SASQueryParameters = exports.SASProtocol = void 0;
-const SasIPRange_js_1 = __nccwpck_require__(359);
+const SasIPRange_js_1 = __nccwpck_require__(360);
 const utils_common_js_1 = __nccwpck_require__(154);
 /**
  * Protocols for generated SAS.
@@ -92681,7 +92694,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureShims = ensureShims;
 const fs = __importStar(__nccwpck_require__(249));
 const path = __importStar(__nccwpck_require__(508));
-const core = __importStar(__nccwpck_require__(459));
+const core = __importStar(__nccwpck_require__(460));
 // Tools that route through `soldr <tool>`:
 const ROUTED_TOOLS = ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"];
 // Unix bash shim template (per tool):
@@ -92744,18 +92757,18 @@ async function ensureShims(opts) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(405);
-const reflection_info_1 = __nccwpck_require__(452);
+const message_type_contract_1 = __nccwpck_require__(406);
+const reflection_info_1 = __nccwpck_require__(453);
 const reflection_type_check_1 = __nccwpck_require__(290);
-const reflection_json_reader_1 = __nccwpck_require__(343);
+const reflection_json_reader_1 = __nccwpck_require__(344);
 const reflection_json_writer_1 = __nccwpck_require__(90);
-const reflection_binary_reader_1 = __nccwpck_require__(408);
+const reflection_binary_reader_1 = __nccwpck_require__(409);
 const reflection_binary_writer_1 = __nccwpck_require__(186);
 const reflection_create_1 = __nccwpck_require__(206);
 const reflection_merge_partial_1 = __nccwpck_require__(136);
-const json_typings_1 = __nccwpck_require__(394);
+const json_typings_1 = __nccwpck_require__(395);
 const json_format_contract_1 = __nccwpck_require__(242);
-const reflection_equals_1 = __nccwpck_require__(461);
+const reflection_equals_1 = __nccwpck_require__(462);
 const binary_writer_1 = __nccwpck_require__(251);
 const binary_reader_1 = __nccwpck_require__(134);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
@@ -93711,7 +93724,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(482);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(312);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/src/main.ts
+++ b/src/main.ts
@@ -240,12 +240,15 @@ export async function run(): Promise<void> {
   // touches depends on its hydrated cargo registry state.
   await markPhase("parallel-restore");
   let setupCacheExactHit = false;
-  // Capture target-cache hit status so we can skip the redundant cook restore.
+  // Capture target-cache match status so we can skip the redundant cook restore.
   // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
-  // (~2.5 GB inflated) also contains compiled deps. When target-cache exact-hits
-  // we have a fully-warm target/ — cook restore would just overwrite identical
-  // content. Skipping saves ~5 s per warm run.
-  let targetCacheExactHit = false;
+  // (~2.5 GB inflated) also contains compiled deps. When target-cache matched
+  // at the lockfile/shape/toolchain level (exact OR parent-SHA OR lock-prefix
+  // fallback), we have target/deps/ already populated with identical content —
+  // cook restore would just overwrite. Skipping saves ~5–10 s per warm run.
+  // A looser restoreKeyLockfile-only match (different shape) is NOT enough to
+  // skip cook, since cook output may differ across shapes.
+  let targetCacheMatchedKey = "";
 
   const setupRestorePromise = (async (): Promise<void> => {
     if (!(cacheEnabled && result.setupCache.paths.length > 0)) return;
@@ -295,7 +298,7 @@ export async function run(): Promise<void> {
     core.setOutput("target_cache_matched_key", restore.matchedKey);
     core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
     core.saveState("targetCacheMatchedKey", restore.matchedKey);
-    targetCacheExactHit = restore.hit;
+    targetCacheMatchedKey = restore.matchedKey;
     statsCollector.record({
       label: "target-cache", operation: "restore", hit: restore.hit,
       key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
@@ -488,12 +491,23 @@ export async function run(): Promise<void> {
   let cookArchive = "";
   let cookRestoreT0 = Date.now();
   let cookRestorePromise: Promise<{ hit: boolean; matchedKey: string; archiveBytes: number }> | null = null;
-  // Skip cook restore when target-cache already exact-hit: target-cache
-  // contains the full prior compiled tree (including deps), so cook restore
-  // would just overwrite identical content. ~5 s saved per warm-exact-hit run.
-  // When target-cache miss/fallback, cook still acts as the dep-warming
-  // fallback (which is exactly what cook was designed for).
-  const cookSkippedDueToTargetHit = cookActive && targetCacheExactHit;
+  // Skip cook restore when target-cache matched at the lockfile/shape level.
+  // restoreKeyLock = `${prefix}-${targetInputsHash}-${suffix}-` where
+  // targetInputsHash = sha256(toolchain, lockfile, manifest, shape). A
+  // matchedKey starting with restoreKeyLock means the cached entry was built
+  // with the same toolchain + lockfile + shape — its target/deps/ matches
+  // what cook would restore. Covers:
+  //   - exact hit  (matchedKey === current key, also startsWith restoreKeyLock)
+  //   - parent-SHA hit (matchedKey === restoreKeyParent, also startsWith)
+  //   - lock-prefix fallback (any saved entry with same lockfile+shape)
+  // Does NOT cover restoreKeyLockfile fallback (shorter prefix that drops
+  // shape) — different shape may mean different cook output, so cook still
+  // runs there as the safety net.
+  const targetCacheLockMatch =
+    !!targetCacheMatchedKey &&
+    !!result.targetCache.restoreKeyLock &&
+    targetCacheMatchedKey.startsWith(result.targetCache.restoreKeyLock);
+  const cookSkippedDueToTargetHit = cookActive && targetCacheLockMatch;
   if (cookActive && !cookSkippedDueToTargetHit) {
     cookFlags = canonicalizeCookFlags(parseCookFlags(inputs.prebuildDepsFlags));
     const flagsHash = hashCookFlags(cookFlags);
@@ -817,7 +831,7 @@ export async function run(): Promise<void> {
     core.saveState("cookCompressLevel", "19");
   } else if (cookSkippedDueToTargetHit) {
     logger.log(
-      "cook: skipped - target-cache exact-hit already provides fully-warm target/ (no redundant restore needed)",
+      `cook: skipped - target-cache matched at lockfile/shape level (matched=${targetCacheMatchedKey}); cook output would be redundant`,
     );
     core.saveState("cookEnabled", "false");
   } else {


### PR DESCRIPTION
## Summary

PR #150 only skipped cook on target-cache **exact-hit**. But target-cache also has restoreKey fallbacks (`restoreKeyParent`, `restoreKeyLock`) that match at the toolchain+lockfile+shape level — in those cases the restored `target/deps/` has the same compiled content cook would write, so cook restore is redundant.

This PR extends the skip condition to: `matchedKey.startsWith(restoreKeyLock)`. That prefix covers exact + restoreKeyParent (parent-SHA entry) + restoreKeyLock fallback. Conservative line: matches via the looser `restoreKeyLockfile` prefix (drops shape) do NOT skip cook — different shape may mean different cook output, cook still runs there as a safety net.

## Expected impact

Post-merge push-triggered demo currently lands on restoreKeyParent or restoreKeyLock fallback (different SHA, same lockfile). Pre this PR they paid ~10s for redundant cook restore. After this PR: skipped. ~7-10s saved on those runs; the warm-exact-hit case is unchanged (already covered by #150).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` 294/294 (Linux container node:22-bookworm)
- [x] `npm run build` regenerated dist
- [ ] After merge: dispatch warm demo from main, compare to baseline ~50s warm

🤖 Generated with [Claude Code](https://claude.com/claude-code)