### PR TITLE
chore(version): bump soldr 0.7.30 → 0.7.32 (closes external blockers from #158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.30`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.32`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -104,7 +104,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.30`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.32`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -168,7 +168,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.30`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.32`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action keeps using the runner's existing `CARGO_HOME` unless `CARGO_HOME` is already set by the workflow. When `RUSTUP_HOME` is not explicitly set, setup-soldr prefers the runner's existing rustup home if it already satisfies the requested toolchain/components/targets; otherwise it falls back to a managed `RUSTUP_HOME` under the action cache root and rehydrates that state on later warm runs.

--- a/__tests__/diagnostics.test.ts
+++ b/__tests__/diagnostics.test.ts
@@ -21,7 +21,7 @@ function captureLogger(): { logger: Logger; lines: string[] } {
 function fixtureRawInputs(): RawInputs {
   return {
     enable: "true",
-    version: "0.7.30",
+    version: "0.7.32",
     repo: "zackees/soldr",
     ref: "",
     cache: "true",
@@ -114,7 +114,7 @@ test("dumpDiagnostics includes parsed RawInputs", () => {
   const body = lines.join("\n");
   assert.match(body, /\[raw_inputs/);
   assert.match(body, /cacheKeySuffix="zccache-demo"/);
-  assert.match(body, /version="0\.7\.30"/);
+  assert.match(body, /version="0\.7\.32"/);
 });
 
 test("dumpDiagnostics redacts token-shaped env values", () => {

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.30.
+    description: Soldr version or tag to install. Defaults to 0.7.32.
     required: false
-    default: "0.7.30"
+    default: "0.7.32"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary

soldr **v0.7.31** closes the target-cache bundle audit (soldr#461) by flipping thin-v2 to the default + bumping managed zccache to 1.9.1.

soldr **v0.7.32** closes the cook trim work (soldr#459) by trimming cargo-recreatable noise from target/ post-build, plus a number of other perf + correctness changes (Phase 1 daemon, content-hash oracle for trampoline, target-registry memoization).

Both addressed external bottlenecks tracked in #158:
- target-cache restore (~30-80 s warm) was the load-bearing remaining cost — thin-v2 should shrink the bundle materially
- cook output trim shrinks the 214 MB compressed / 2.5 GB inflated tarball

## Touched

- \`action.yml\`: default version + description (\`0.7.30\` → \`0.7.32\`)
- \`README.md\`: 3 prose references
- \`__tests__/diagnostics.test.ts\`: fixture + assertion
- \`dist/\`: unchanged (action.yml is metadata, not bundled)

No other code change — the new soldr release works with the existing setup-soldr install path (already supports \`.tar.zst\` assets since #147). The new soldr native-cache input (soldr 0.7.32 PR #311) is **not** wired up here; can be added in a follow-up if demand materializes.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 300/300 (Linux container node:22-bookworm)
- [ ] After merge: dispatch warm demo, measure target-cache bundle size + restore time (expected: bundle materially smaller after thin-v2 default)
- [ ] After merge: cut v0.9.4 tag, move v0 floating tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)