### PR TITLE
chore(version): bump soldr 0.7.32 -> 0.7.33

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.32`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.33`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -104,7 +104,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.32`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.33`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -168,7 +168,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.32`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.33`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action keeps using the runner's existing `CARGO_HOME` unless `CARGO_HOME` is already set by the workflow. When `RUSTUP_HOME` is not explicitly set, setup-soldr prefers the runner's existing rustup home if it already satisfies the requested toolchain/components/targets; otherwise it falls back to a managed `RUSTUP_HOME` under the action cache root and rehydrates that state on later warm runs.

--- a/__tests__/diagnostics.test.ts
+++ b/__tests__/diagnostics.test.ts
@@ -21,7 +21,7 @@ function captureLogger(): { logger: Logger; lines: string[] } {
 function fixtureRawInputs(): RawInputs {
   return {
     enable: "true",
-    version: "0.7.32",
+    version: "0.7.33",
     repo: "zackees/soldr",
     ref: "",
     cache: "true",
@@ -114,7 +114,7 @@ test("dumpDiagnostics includes parsed RawInputs", () => {
   const body = lines.join("\n");
   assert.match(body, /\[raw_inputs/);
   assert.match(body, /cacheKeySuffix="zccache-demo"/);
-  assert.match(body, /version="0\.7\.32"/);
+  assert.match(body, /version="0\.7\.33"/);
 });
 
 test("dumpDiagnostics redacts token-shaped env values", () => {

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.32.
+    description: Soldr version or tag to install. Defaults to 0.7.33.
     required: false
-    default: "0.7.32"
+    default: "0.7.33"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary

Bumps the default soldr version from 0.7.32 -> 0.7.33.

soldr 0.7.33 (zackees/soldr#510, released 2026-05-24) bumps the bundled zccache pin from 1.10.0 -> 1.11.0. zccache 1.11.0 (zackees/zccache#392) adds the \`zccache cc\` subcommand: the \`CC=\"zccache cc\"\` injection landed in soldr 0.7.32 (#310) now hits zccache's first-class \`cc\` codepath instead of the wrap-mode fallback. No setup-soldr behavior change; this is just a default-pin bump.

soldr 0.7.33 also includes the wave-4 follow-ups (#503): cook restore now skips on prepopulated target/ (soldr#480 / setup-soldr#159), child-process shims for tools spawning cargo (soldr#493), Windows Defender exclusions subcommand (soldr#355), gc cargo_git_checkouts walker (soldr#323), and rustup passthrough drop-in coverage (soldr#331). The setup-soldr-side workaround for cook prepopulated target/ (detect-shared-target-warning.ts) becomes redundant but is left in place as a defense-in-depth diagnostic.

## Test plan
- [x] \`action.yml\`: \`default: \"0.7.33\"\`
- [x] \`README.md\`: docs updated to 0.7.33
- [x] \`__tests__/diagnostics.test.ts\`: version regex fixture updated
- [x] diagnostics test passes locally
- [x] No dist rebuild needed (action.yml defaults are read at runtime, not bundled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)