### PR TITLE
feat(cache): close cache-retention gaps for .global-cache, git deps, update-hashes (#102)

### DIFF
--- a/__tests__/cache-keys.test.ts
+++ b/__tests__/cache-keys.test.ts
@@ -288,16 +288,30 @@ test("setupCachePaths includes rustup files when rustupHome inside setupCachePat
   assert.ok(lines.some((l) => l.endsWith("update-hashes")));
 });
 
-test("setupCachePaths omits rustup files when rustupHome outside setupCachePath", () => {
-  const out = setupCachePaths(
-    "/tmp/setup-soldr",
-    "/tmp/setup-soldr/bin",
-    "/tmp/setup-soldr-soldr/bin",
-    "/home/runner/.rustup",
-  );
-  const lines = out.split("\n");
-  assert.equal(lines.length, 2);
-});
+test(
+  "setupCachePaths still caches update-hashes when rustupHome is the system layout (setup-soldr#102)",
+  () => {
+    // System rustup case: toolchains/ + settings.toml stay excluded (the
+    // runner image already owns those), but update-hashes/ is tiny and the
+    // latency win is large, so it must always be in the cached path list.
+    const out = setupCachePaths(
+      "/tmp/setup-soldr",
+      "/tmp/setup-soldr/bin",
+      "/tmp/setup-soldr-soldr/bin",
+      "/home/runner/.rustup",
+    );
+    const lines = out.split("\n");
+    assert.equal(lines.length, 3);
+    assert.ok(
+      lines.some((l) => l.endsWith("update-hashes")),
+      `expected update-hashes in ${lines.join(", ")}`,
+    );
+    // The toolchains/ + settings.toml entries are the gated ones — they
+    // must NOT leak into the system-rustup layout.
+    assert.ok(!lines.some((l) => l.endsWith("toolchains")));
+    assert.ok(!lines.some((l) => l.endsWith("settings.toml")));
+  },
+);
 
 test("setupCacheLayout reports bin+soldr-bin when rustup outside", () => {
   assert.equal(setupCacheLayout("/tmp/sc", "/home/r/.rustup"), "bin+soldr-bin");

--- a/__tests__/resolve-setup.test.ts
+++ b/__tests__/resolve-setup.test.ts
@@ -956,3 +956,127 @@ test("cache-shutdown-on-idle rejects malformed values", async () => {
     /invalid 'cache-shutdown-on-idle' input/,
   );
 });
+
+// --- cache retention gaps (setup-soldr#102) ---
+//
+// PRs 1+2 of the rollout: `.global-cache` (cargo's RFC-3413 GC db) and
+// `git/` (db/ + checkouts/ for git-source crate deps) ride inside the
+// existing cargo-registry cache archive. PR 3: `~/.rustup/update-hashes/`
+// is always part of setup-cache so `rustup update` short-circuits.
+//
+// Cache *key* shape must not move — these are pure path-list additions
+// living under the same actions/cache key.
+
+test(
+  "cargo-registry-cache extraBasenames bundles .global-cache + git (#102 PR 1-2)",
+  async () => {
+    const { result } = await run();
+    const extras = result.cargoRegistryCache.extraBasenames;
+    assert.ok(
+      extras.includes(".global-cache"),
+      `expected .global-cache in extraBasenames, got ${JSON.stringify(extras)}`,
+    );
+    assert.ok(
+      extras.includes("git"),
+      `expected git in extraBasenames, got ${JSON.stringify(extras)}`,
+    );
+  },
+);
+
+test(
+  "cargo-registry-cache extras are siblings of path (under $CARGO_HOME)",
+  async () => {
+    // The extras are basenames, not full paths — compressCache joins them
+    // against dirname(path). Verify the parent is $CARGO_HOME so the saved
+    // archive lays out as <cargoHome>/{registry,.global-cache,git}/.
+    const { result } = await run();
+    const parent = path.dirname(result.cargoRegistryCache.path);
+    assert.equal(
+      parent,
+      result.cargoHome,
+      `expected dirname(cargoRegistryCache.path) to equal cargoHome`,
+    );
+  },
+);
+
+test(
+  "cargo-registry-cache key is unchanged by extraBasenames (#102: no key shape change)",
+  async () => {
+    // PR 1-2 must only add paths inside the archive — the cache KEY itself
+    // (prefix + lock hash + toolchain digest + sha + suffix) cannot
+    // incorporate the new path names or warm caches on existing consumers
+    // would invalidate.
+    const { result } = await run();
+    // 1) Key shape: prefix `setup-soldr-cargoregistry-v1-<os>-<arch>-<lock>-<digest>-<sha>`.
+    const key = result.cargoRegistryCache.key;
+    assert.match(
+      key,
+      /^setup-soldr-cargoregistry-v1-linux-x64-[0-9a-f]{16}-[0-9a-f]{16}-0123456789abcdef$/,
+      `cache key shape regressed: ${key}`,
+    );
+    // 2) The .global-cache / git names must NOT appear in the key.
+    assert.ok(!key.includes(".global-cache"), `key leaked extra name: ${key}`);
+    assert.ok(!key.includes("/git"), `key leaked extra name: ${key}`);
+  },
+);
+
+test(
+  "setup-cache always includes rustup update-hashes path (#102 PR 3)",
+  async () => {
+    // System rustup layout (no explicit RUSTUP_HOME, system rustup satisfies):
+    // toolchains/ + settings.toml are owned by the runner image and stay
+    // out of the cache, but update-hashes/ is tiny and a huge latency win
+    // so it must always be in the path list.
+    const { root, workspace, runnerTemp } = makeWorkspace({});
+    const ctx = makeContext(root, workspace, runnerTemp);
+    delete ctx.env["RUSTUP_HOME"];
+    const inputs = readRawInputs(ctx.env);
+    const sys = await resolveSetup(ctx, inputs, {
+      fetchReleaseTag: async () => "v0.7.11",
+      systemRustupOverride: async () => true,
+    });
+    const sysPaths = sys.setupCache.paths;
+    assert.ok(
+      sysPaths.some((p) => p.endsWith(path.join("update-hashes")) || p.endsWith("update-hashes")),
+      `expected update-hashes in system-layout setup-cache paths: ${sysPaths.join(", ")}`,
+    );
+    // Managed layout still includes everything.
+    const { root: root2, workspace: ws2, runnerTemp: rt2 } = makeWorkspace({});
+    const ctx2 = makeContext(root2, ws2, rt2);
+    delete ctx2.env["RUSTUP_HOME"];
+    const inputs2 = readRawInputs(ctx2.env);
+    const mgd = await resolveSetup(ctx2, inputs2, {
+      fetchReleaseTag: async () => "v0.7.11",
+      systemRustupOverride: async () => false,
+    });
+    const mgdPaths = mgd.setupCache.paths;
+    assert.ok(
+      mgdPaths.some((p) => p.endsWith("update-hashes")),
+      `expected update-hashes in managed-layout setup-cache paths: ${mgdPaths.join(", ")}`,
+    );
+  },
+);
+
+test(
+  "setup-cache layout key is unchanged by always-on update-hashes (#102: no key shape change)",
+  async () => {
+    // The layout label drives the cache-key digest. Adding update-hashes to
+    // the path list of the *system* layout must not flip the layout label
+    // — that would invalidate every warm cache. We assert the label and
+    // the cache key prefix shape directly.
+    const { root, workspace, runnerTemp } = makeWorkspace({});
+    const ctx = makeContext(root, workspace, runnerTemp);
+    delete ctx.env["RUSTUP_HOME"];
+    const inputs = readRawInputs(ctx.env);
+    const result = await resolveSetup(ctx, inputs, {
+      fetchReleaseTag: async () => "v0.7.11",
+      systemRustupOverride: async () => true,
+    });
+    assert.equal(result.setupCache.layout, "bin+soldr-bin");
+    assert.match(
+      result.setupCache.key,
+      /^setup-soldr-v4-linux-x64-[0-9a-f]{16}$/,
+      `setup-cache key shape regressed: ${result.setupCache.key}`,
+    );
+  },
+);

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,9 @@ inputs:
     description: >
       Umbrella switch for all caching layers. Default "true" (caches
       managed normally). Set to "false" to disable every layer in one
-      go: setup-cache, build-cache (zccache compilation cache),
+      go: setup-cache (soldr binary + rustup state including
+      `~/.rustup/update-hashes/` for fast `rustup update` no-ops, see
+      setup-soldr#102), build-cache (zccache compilation cache),
       target-cache (Rust target/ artifacts), and cargo-registry-cache.
       Also exports `SOLDR_BUILD_CACHE_MODE=off` / `SOLDR_TARGET_CACHE_MODE=off`
       so soldr skips its zccache wrapping entirely — the daemon won't be
@@ -206,11 +208,25 @@ inputs:
     description: >
       When "true" (default), setup-soldr manages a separate actions/cache step
       for ~/.cargo/registry that pre-compresses the directory into a single
-      .tar.zst via the embedded setup-soldr-cache-compress sub-action. Also
-      exports SOLDR_SKIP_CARGO_REGISTRY_SAVE=1 so the zccache CLI's built-in
+      .tar.zst via the embedded setup-soldr-cache-compress sub-action. The
+      same archive also bundles ~/.cargo/.global-cache (cargo's RFC-3413 GC
+      database — without it every job's cargo-gc sees fresh access times and
+      conservatively keeps everything) and ~/.cargo/git/ (bare mirrors and
+      checkouts for git-source crate deps; missing on cold checkouts and
+      silently skipped in that case). See setup-soldr#102. Also exports
+      SOLDR_SKIP_CARGO_REGISTRY_SAVE=1 so the zccache CLI's built-in
       cargo-registry save (honored in zccache >=1.4.4) no-ops and the
       payload is not double-saved. Set to "false" to opt out and let
       zccache own the registry cache via its legacy gzip path.
+
+      Deliberately NOT cached on this layer: ~/.cargo/.package-cache and
+      ~/.cargo/.package-cache-mutate are cargo's "another build is running"
+      mutex files — caching them causes false "another cargo is running"
+      errors on the next job. ~/.cargo/credentials.toml is a secret and
+      must not be persisted. The list is enforced by exclusion: we cache
+      explicit basenames (registry, .global-cache, git) rather than the
+      full $CARGO_HOME so accidentally-staged secrets never enter the
+      archive.
     required: false
     default: "true"
   shims:

--- a/dist/main.js
+++ b/dist/main.js
@@ -14,15 +14,15 @@
 //  * support limits.fieldNameSize
 //     -- this will require modifications to utils.parseParams
 
-const { Readable } = __nccwpck_require__(431)
-const { inherits } = __nccwpck_require__(376)
+const { Readable } = __nccwpck_require__(432)
+const { inherits } = __nccwpck_require__(377)
 
 const Dicer = __nccwpck_require__(13)
 
-const parseParams = __nccwpck_require__(193)
+const parseParams = __nccwpck_require__(191)
 const decodeText = __nccwpck_require__(276)
 const basename = __nccwpck_require__(478)
-const getLimit = __nccwpck_require__(484)
+const getLimit = __nccwpck_require__(485)
 
 const RE_BOUNDARY = /^boundary$/i
 const RE_FIELD = /^form-data$/i
@@ -340,7 +340,7 @@ __export(inspect_exports, {
   custom: () => custom
 });
 module.exports = __toCommonJS(inspect_exports);
-var import_node_util = __nccwpck_require__(376);
+var import_node_util = __nccwpck_require__(377);
 const custom = import_node_util.inspect.custom;
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -469,17 +469,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = exports.downloadCacheHttpClient = exports.DownloadProgress = void 0;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 const http_client_1 = __nccwpck_require__(285);
-const storage_blob_1 = __nccwpck_require__(448);
+const storage_blob_1 = __nccwpck_require__(449);
 const buffer = __importStar(__nccwpck_require__(120));
-const fs = __importStar(__nccwpck_require__(533));
+const fs = __importStar(__nccwpck_require__(534));
 const stream = __importStar(__nccwpck_require__(131));
 const util = __importStar(__nccwpck_require__(124));
 const utils = __importStar(__nccwpck_require__(76));
 const constants_1 = __nccwpck_require__(45);
 const requestUtils_1 = __nccwpck_require__(261);
-const abort_controller_1 = __nccwpck_require__(229);
+const abort_controller_1 = __nccwpck_require__(228);
 /**
  * Pipes the body of a HTTP response to a stream
  *
@@ -839,14 +839,14 @@ exports.SearchState = SearchState;
 "use strict";
 
 
-const { InvalidArgumentError } = __nccwpck_require__(489)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(196)
+const { InvalidArgumentError } = __nccwpck_require__(490)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(194)
 const DispatcherBase = __nccwpck_require__(62)
 const Pool = __nccwpck_require__(338)
-const Client = __nccwpck_require__(89)
+const Client = __nccwpck_require__(90)
 const util = __nccwpck_require__(69)
 const createRedirectInterceptor = __nccwpck_require__(255)
-const { WeakRef, FinalizationRegistry } = __nccwpck_require__(415)()
+const { WeakRef, FinalizationRegistry } = __nccwpck_require__(416)()
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -1071,7 +1071,7 @@ function isNamedKeyCredential(credential) {
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(233)
+const { MockNotMatchedError } = __nccwpck_require__(232)
 const {
   kDispatches,
   kMockAgent,
@@ -1510,7 +1510,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetryHelper = void 0;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 /**
  * Internal class for retries
  */
@@ -1656,17 +1656,17 @@ function formatDefaultJson(value) {
 
 
 const { kConstruct } = __nccwpck_require__(157)
-const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(80)
+const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(81)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(69)
-const { kHeadersList } = __nccwpck_require__(196)
-const { webidl } = __nccwpck_require__(457)
+const { kHeadersList } = __nccwpck_require__(194)
+const { webidl } = __nccwpck_require__(458)
 const { Response, cloneResponse } = __nccwpck_require__(41)
-const { Request } = __nccwpck_require__(84)
+const { Request } = __nccwpck_require__(86)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(15)
-const { fetching } = __nccwpck_require__(451)
+const { fetching } = __nccwpck_require__(452)
 const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(519)
 const assert = __nccwpck_require__(528)
-const { getGlobalDispatcher } = __nccwpck_require__(377)
+const { getGlobalDispatcher } = __nccwpck_require__(378)
 
 /**
  * @see https://w3c.github.io/ServiceWorker/#dfn-cache-batch-operation
@@ -2501,13 +2501,13 @@ module.exports = {
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(431).Writable)
-const inherits = (__nccwpck_require__(376).inherits)
+const WritableStream = (__nccwpck_require__(432).Writable)
+const inherits = (__nccwpck_require__(377).inherits)
 
 const StreamSearch = __nccwpck_require__(115)
 
 const PartStream = __nccwpck_require__(66)
-const HeaderParser = __nccwpck_require__(108)
+const HeaderParser = __nccwpck_require__(109)
 
 const DASH = 45
 const B_ONEDASH = Buffer.from('-')
@@ -2734,17 +2734,17 @@ exports.isObject = isObject;
 exports.randomUUID = randomUUID;
 exports.uint8ArrayToString = uint8ArrayToString;
 exports.stringToUint8Array = stringToUint8Array;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(216);
 const tspRuntime = tslib_1.__importStar(__nccwpck_require__(147));
-var aborterUtils_js_1 = __nccwpck_require__(101);
+var aborterUtils_js_1 = __nccwpck_require__(102);
 Object.defineProperty(exports, "cancelablePromiseRace", ({ enumerable: true, get: function () { return aborterUtils_js_1.cancelablePromiseRace; } }));
 var createAbortablePromise_js_1 = __nccwpck_require__(260);
 Object.defineProperty(exports, "createAbortablePromise", ({ enumerable: true, get: function () { return createAbortablePromise_js_1.createAbortablePromise; } }));
 var delay_js_1 = __nccwpck_require__(114);
 Object.defineProperty(exports, "delay", ({ enumerable: true, get: function () { return delay_js_1.delay; } }));
-var error_js_1 = __nccwpck_require__(213);
+var error_js_1 = __nccwpck_require__(212);
 Object.defineProperty(exports, "getErrorMessage", ({ enumerable: true, get: function () { return error_js_1.getErrorMessage; } }));
-var typeGuards_js_1 = __nccwpck_require__(111);
+var typeGuards_js_1 = __nccwpck_require__(112);
 Object.defineProperty(exports, "isDefined", ({ enumerable: true, get: function () { return typeGuards_js_1.isDefined; } }));
 Object.defineProperty(exports, "isObjectWithProperties", ({ enumerable: true, get: function () { return typeGuards_js_1.isObjectWithProperties; } }));
 Object.defineProperty(exports, "objectHasProperty", ({ enumerable: true, get: function () { return typeGuards_js_1.objectHasProperty; } }));
@@ -2917,8 +2917,8 @@ __export(retryPolicy_exports, {
   retryPolicy: () => retryPolicy
 });
 module.exports = __toCommonJS(retryPolicy_exports);
-var import_helpers = __nccwpck_require__(456);
-var import_restError = __nccwpck_require__(445);
+var import_helpers = __nccwpck_require__(457);
+var import_restError = __nccwpck_require__(446);
 var import_AbortError = __nccwpck_require__(10);
 var import_logger = __nccwpck_require__(246);
 var import_constants = __nccwpck_require__(48);
@@ -3162,7 +3162,7 @@ exports.getExecOutput = getExecOutput;
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Convenience JSON typings and corresponding type guards
-var json_typings_1 = __nccwpck_require__(395);
+var json_typings_1 = __nccwpck_require__(396);
 Object.defineProperty(exports, "typeofJsonValue", ({ enumerable: true, get: function () { return json_typings_1.typeofJsonValue; } }));
 Object.defineProperty(exports, "isJsonObject", ({ enumerable: true, get: function () { return json_typings_1.isJsonObject; } }));
 // Base 64 encoding
@@ -3195,13 +3195,13 @@ Object.defineProperty(exports, "jsonReadOptions", ({ enumerable: true, get: func
 Object.defineProperty(exports, "jsonWriteOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonWriteOptions; } }));
 Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: function () { return json_format_contract_1.mergeJsonOptions; } }));
 // Message type contract
-var message_type_contract_1 = __nccwpck_require__(406);
+var message_type_contract_1 = __nccwpck_require__(407);
 Object.defineProperty(exports, "MESSAGE_TYPE", ({ enumerable: true, get: function () { return message_type_contract_1.MESSAGE_TYPE; } }));
 // Message type implementation via reflection
-var message_type_1 = __nccwpck_require__(532);
+var message_type_1 = __nccwpck_require__(533);
 Object.defineProperty(exports, "MessageType", ({ enumerable: true, get: function () { return message_type_1.MessageType; } }));
 // Reflection info, generated by the plugin, exposed to the user, used by reflection ops
-var reflection_info_1 = __nccwpck_require__(453);
+var reflection_info_1 = __nccwpck_require__(454);
 Object.defineProperty(exports, "ScalarType", ({ enumerable: true, get: function () { return reflection_info_1.ScalarType; } }));
 Object.defineProperty(exports, "LongType", ({ enumerable: true, get: function () { return reflection_info_1.LongType; } }));
 Object.defineProperty(exports, "RepeatType", ({ enumerable: true, get: function () { return reflection_info_1.RepeatType; } }));
@@ -3212,26 +3212,26 @@ Object.defineProperty(exports, "readMessageOption", ({ enumerable: true, get: fu
 // Message operations via reflection
 var reflection_type_check_1 = __nccwpck_require__(290);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
-var reflection_create_1 = __nccwpck_require__(206);
+var reflection_create_1 = __nccwpck_require__(205);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
-var reflection_scalar_default_1 = __nccwpck_require__(463);
+var reflection_scalar_default_1 = __nccwpck_require__(464);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
 var reflection_merge_partial_1 = __nccwpck_require__(137);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
-var reflection_equals_1 = __nccwpck_require__(462);
+var reflection_equals_1 = __nccwpck_require__(463);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
-var reflection_binary_reader_1 = __nccwpck_require__(409);
+var reflection_binary_reader_1 = __nccwpck_require__(410);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
-var reflection_binary_writer_1 = __nccwpck_require__(187);
+var reflection_binary_writer_1 = __nccwpck_require__(185);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
 var reflection_json_reader_1 = __nccwpck_require__(343);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
-var reflection_json_writer_1 = __nccwpck_require__(91);
+var reflection_json_writer_1 = __nccwpck_require__(92);
 Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get: function () { return reflection_json_writer_1.ReflectionJsonWriter; } }));
 var reflection_contains_message_type_1 = __nccwpck_require__(50);
 Object.defineProperty(exports, "containsMessageType", ({ enumerable: true, get: function () { return reflection_contains_message_type_1.containsMessageType; } }));
 // Oneof helpers
-var oneof_1 = __nccwpck_require__(191);
+var oneof_1 = __nccwpck_require__(189);
 Object.defineProperty(exports, "isOneofGroup", ({ enumerable: true, get: function () { return oneof_1.isOneofGroup; } }));
 Object.defineProperty(exports, "setOneofValue", ({ enumerable: true, get: function () { return oneof_1.setOneofValue; } }));
 Object.defineProperty(exports, "getOneofValue", ({ enumerable: true, get: function () { return oneof_1.getOneofValue; } }));
@@ -3244,10 +3244,10 @@ Object.defineProperty(exports, "listEnumNames", ({ enumerable: true, get: functi
 Object.defineProperty(exports, "listEnumNumbers", ({ enumerable: true, get: function () { return enum_object_1.listEnumNumbers; } }));
 Object.defineProperty(exports, "isEnumObject", ({ enumerable: true, get: function () { return enum_object_1.isEnumObject; } }));
 // lowerCamelCase() is exported for plugin, rpc-runtime and other rpc packages
-var lower_camel_case_1 = __nccwpck_require__(454);
+var lower_camel_case_1 = __nccwpck_require__(455);
 Object.defineProperty(exports, "lowerCamelCase", ({ enumerable: true, get: function () { return lower_camel_case_1.lowerCamelCase; } }));
 // assertion functions are exported for plugin, may also be useful to user
-var assert_1 = __nccwpck_require__(485);
+var assert_1 = __nccwpck_require__(486);
 Object.defineProperty(exports, "assert", ({ enumerable: true, get: function () { return assert_1.assert; } }));
 Object.defineProperty(exports, "assertNever", ({ enumerable: true, get: function () { return assert_1.assertNever; } }));
 Object.defineProperty(exports, "assertInt32", ({ enumerable: true, get: function () { return assert_1.assertInt32; } }));
@@ -3282,7 +3282,7 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_ts_http_runtime = __nccwpck_require__(90);
+var import_ts_http_runtime = __nccwpck_require__(91);
 function createPipelineRequest(options) {
   return (0, import_ts_http_runtime.createPipelineRequest)(options);
 }
@@ -3330,7 +3330,7 @@ const XML_CHARKEY = "_";
 /***/ 22:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(196)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(194)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -3411,7 +3411,7 @@ function throttlingRetryPolicy(options = {}) {
 "use strict";
 
 
-const Busboy = __nccwpck_require__(417)
+const Busboy = __nccwpck_require__(418)
 const util = __nccwpck_require__(69)
 const {
   ReadableStreamFrom,
@@ -3421,16 +3421,16 @@ const {
   createDeferredPromise,
   fullyReadBody
 } = __nccwpck_require__(519)
-const { FormData } = __nccwpck_require__(208)
+const { FormData } = __nccwpck_require__(207)
 const { kState } = __nccwpck_require__(15)
-const { webidl } = __nccwpck_require__(457)
+const { webidl } = __nccwpck_require__(458)
 const { DOMException, structuredClone } = __nccwpck_require__(30)
 const { Blob, File: NativeFile } = __nccwpck_require__(120)
-const { kBodyUsed } = __nccwpck_require__(196)
+const { kBodyUsed } = __nccwpck_require__(194)
 const assert = __nccwpck_require__(528)
 const { isErrored } = __nccwpck_require__(69)
-const { isUint8Array, isArrayBuffer } = __nccwpck_require__(199)
-const { File: UndiciFile } = __nccwpck_require__(365)
+const { isUint8Array, isArrayBuffer } = __nccwpck_require__(198)
+const { File: UndiciFile } = __nccwpck_require__(366)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(25)
 
 let random
@@ -4674,9 +4674,9 @@ module.exports = {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const tslib_1 = __nccwpck_require__(216);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(441));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(179));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing AppendBlob operations. */
 class AppendBlobImpl {
@@ -5009,7 +5009,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(396);
+var import_exponentialRetryStrategy = __nccwpck_require__(397);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_constants = __nccwpck_require__(48);
 const systemErrorRetryPolicyName = "systemErrorRetryPolicy";
@@ -5245,7 +5245,7 @@ module.exports = {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tracingClient = void 0;
-const core_tracing_1 = __nccwpck_require__(82);
+const core_tracing_1 = __nccwpck_require__(84);
 const constants_js_1 = __nccwpck_require__(149);
 /**
  * Creates a span using the global tracer.
@@ -5370,18 +5370,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.reserveCache = exports.downloadCache = exports.getCacheEntry = void 0;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 const http_client_1 = __nccwpck_require__(285);
 const auth_1 = __nccwpck_require__(27);
-const fs = __importStar(__nccwpck_require__(533));
-const url_1 = __nccwpck_require__(86);
+const fs = __importStar(__nccwpck_require__(534));
+const url_1 = __nccwpck_require__(87);
 const utils = __importStar(__nccwpck_require__(76));
-const uploadUtils_1 = __nccwpck_require__(161);
+const uploadUtils_1 = __nccwpck_require__(160);
 const downloadUtils_1 = __nccwpck_require__(3);
 const options_1 = __nccwpck_require__(265);
 const requestUtils_1 = __nccwpck_require__(261);
 const config_1 = __nccwpck_require__(37);
-const user_agent_1 = __nccwpck_require__(361);
+const user_agent_1 = __nccwpck_require__(362);
 function getCacheApiUrl(resource) {
     const baseUrl = (0, config_1.getCacheServiceURL)();
     if (!baseUrl) {
@@ -5620,7 +5620,7 @@ __export(throttlingRetryStrategy_exports, {
   throttlingRetryStrategy: () => throttlingRetryStrategy
 });
 module.exports = __toCommonJS(throttlingRetryStrategy_exports);
-var import_helpers = __nccwpck_require__(456);
+var import_helpers = __nccwpck_require__(457);
 const RetryAfterHeader = "Retry-After";
 const AllRetryAfterHeaders = ["retry-after-ms", "x-ms-retry-after-ms", RetryAfterHeader];
 function getRetryAfterInMs(response) {
@@ -5836,7 +5836,7 @@ __export(proxyPolicy_exports, {
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
 var import_https_proxy_agent = __nccwpck_require__(133);
-var import_http_proxy_agent = __nccwpck_require__(225);
+var import_http_proxy_agent = __nccwpck_require__(224);
 var import_log = __nccwpck_require__(152);
 const HTTPS_PROXY = "HTTPS_PROXY";
 const HTTP_PROXY = "HTTP_PROXY";
@@ -6029,11 +6029,11 @@ const {
   DOMException
 } = __nccwpck_require__(30)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(15)
-const { webidl } = __nccwpck_require__(457)
-const { FormData } = __nccwpck_require__(208)
+const { webidl } = __nccwpck_require__(458)
+const { FormData } = __nccwpck_require__(207)
 const { getGlobalOrigin } = __nccwpck_require__(140)
 const { URLSerializer } = __nccwpck_require__(25)
-const { kHeadersList, kConstruct } = __nccwpck_require__(196)
+const { kHeadersList, kConstruct } = __nccwpck_require__(194)
 const assert = __nccwpck_require__(528)
 const { types } = __nccwpck_require__(124)
 
@@ -6671,8 +6671,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
-const pathHelper = __importStar(__nccwpck_require__(223));
-const internal_match_kind_1 = __nccwpck_require__(530);
+const pathHelper = __importStar(__nccwpck_require__(222));
+const internal_match_kind_1 = __nccwpck_require__(531);
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Given an array of patterns, returns an array of paths to search.
@@ -6910,9 +6910,9 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const tslib_1 = __nccwpck_require__(216);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(441));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(179));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Blob operations. */
 class BlobImpl {
@@ -8038,7 +8038,7 @@ exports.StorageBrowserPolicy = StorageBrowserPolicy;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.containsMessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(406);
+const message_type_contract_1 = __nccwpck_require__(407);
 /**
  * Check if the provided object is a proto message.
  *
@@ -8063,7 +8063,7 @@ exports.containsMessageType = containsMessageType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollHttpOperation = exports.isOperationError = exports.getResourceLocation = exports.getOperationStatus = exports.getOperationLocation = exports.initHttpOperation = exports.getStatusFromInitialResponse = exports.getErrorFromResponse = exports.parseRetryAfter = exports.inferLroMode = void 0;
 const operation_js_1 = __nccwpck_require__(141);
-const logger_js_1 = __nccwpck_require__(192);
+const logger_js_1 = __nccwpck_require__(190);
 function getOperationLocationPollingUrl(inputs) {
     const { azureAsyncOperation, operationLocation } = inputs;
     return operationLocation !== null && operationLocation !== void 0 ? operationLocation : azureAsyncOperation;
@@ -8461,9 +8461,9 @@ const {
   kResult,
   kAborted,
   kLastProgressEventFired
-} = __nccwpck_require__(461)
-const { ProgressEvent } = __nccwpck_require__(443)
-const { getEncoding } = __nccwpck_require__(98)
+} = __nccwpck_require__(462)
+const { ProgressEvent } = __nccwpck_require__(444)
+const { getEncoding } = __nccwpck_require__(99)
 const { DOMException } = __nccwpck_require__(30)
 const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(25)
 const { types } = __nccwpck_require__(124)
@@ -8854,7 +8854,7 @@ module.exports = {
 
 "use strict";
 
-const f = __nccwpck_require__(404)
+const f = __nccwpck_require__(405)
 const DateTime = global.Date
 
 class Date extends DateTime {
@@ -8980,8 +8980,8 @@ exports.UnaryCall = UnaryCall;
 "use strict";
 
 
-const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(99)
-const { states, opcodes } = __nccwpck_require__(466)
+const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(100)
+const { states, opcodes } = __nccwpck_require__(467)
 const { MessageEvent, ErrorEvent } = __nccwpck_require__(250)
 
 /* globals Blob */
@@ -9463,14 +9463,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.internalCacheTwirpClient = void 0;
-const core_1 = __nccwpck_require__(460);
-const user_agent_1 = __nccwpck_require__(361);
+const core_1 = __nccwpck_require__(461);
+const user_agent_1 = __nccwpck_require__(362);
 const errors_1 = __nccwpck_require__(305);
 const config_1 = __nccwpck_require__(37);
 const cacheUtils_1 = __nccwpck_require__(76);
 const auth_1 = __nccwpck_require__(27);
 const http_client_1 = __nccwpck_require__(285);
-const cache_twirp_client_1 = __nccwpck_require__(437);
+const cache_twirp_client_1 = __nccwpck_require__(438);
 const util_1 = __nccwpck_require__(296);
 /**
  * This class is a wrapper around the CacheServiceClientJSON class generated by Twirp.
@@ -9627,8 +9627,8 @@ const {
   ClientDestroyedError,
   ClientClosedError,
   InvalidArgumentError
-} = __nccwpck_require__(489)
-const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(196)
+} = __nccwpck_require__(490)
+const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(194)
 
 const kDestroyed = Symbol('destroyed')
 const kClosed = Symbol('closed')
@@ -9843,8 +9843,8 @@ __export(requestPolicyFactoryPolicy_exports, {
   requestPolicyFactoryPolicyName: () => requestPolicyFactoryPolicyName
 });
 module.exports = __toCommonJS(requestPolicyFactoryPolicy_exports);
-var import_util = __nccwpck_require__(110);
-var import_response = __nccwpck_require__(413);
+var import_util = __nccwpck_require__(111);
+var import_response = __nccwpck_require__(414);
 var HttpPipelineLogLevel = /* @__PURE__ */ ((HttpPipelineLogLevel2) => {
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["ERROR"] = 1] = "ERROR";
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["INFO"] = 3] = "INFO";
@@ -9894,18 +9894,18 @@ function createRequestPolicyFactoryPolicy(factories) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 const core_util_1 = __nccwpck_require__(14);
 const core_auth_1 = __nccwpck_require__(516);
 const storage_common_1 = __nccwpck_require__(277);
-const Pipeline_js_1 = __nccwpck_require__(184);
-const StorageClient_js_1 = __nccwpck_require__(455);
+const Pipeline_js_1 = __nccwpck_require__(182);
+const StorageClient_js_1 = __nccwpck_require__(456);
 const tracing_js_1 = __nccwpck_require__(31);
 const utils_common_js_1 = __nccwpck_require__(155);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
-const BlobLeaseClient_js_1 = __nccwpck_require__(205);
-const Clients_js_1 = __nccwpck_require__(186);
-const BlobBatchClient_js_1 = __nccwpck_require__(403);
+const BlobLeaseClient_js_1 = __nccwpck_require__(204);
+const Clients_js_1 = __nccwpck_require__(184);
+const BlobBatchClient_js_1 = __nccwpck_require__(404);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
  */
@@ -11207,7 +11207,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.action3 = exports.action2 = exports.leaseId1 = exports.action1 = exports.proposedLeaseId = exports.duration = exports.action = exports.comp10 = exports.sourceLeaseId = exports.sourceContainerName = exports.comp9 = exports.deletedContainerVersion = exports.deletedContainerName = exports.comp8 = exports.containerAcl = exports.comp7 = exports.comp6 = exports.ifUnmodifiedSince = exports.ifModifiedSince = exports.leaseId = exports.preventEncryptionScopeOverride = exports.defaultEncryptionScope = exports.access = exports.metadata = exports.restype2 = exports.where = exports.comp5 = exports.multipartContentType = exports.contentLength = exports.comp4 = exports.body = exports.restype1 = exports.comp3 = exports.keyInfo = exports.include = exports.maxPageSize = exports.marker = exports.prefix = exports.comp2 = exports.comp1 = exports.accept1 = exports.requestId = exports.version = exports.timeoutInSeconds = exports.comp = exports.restype = exports.url = exports.accept = exports.blobServiceProperties = exports.contentType = void 0;
 exports.copySourceTags = exports.copySourceAuthorization = exports.sourceContentMD5 = exports.xMsRequiresSync = exports.legalHold1 = exports.sealBlob = exports.blobTagsString = exports.copySource = exports.sourceIfTags = exports.sourceIfNoneMatch = exports.sourceIfMatch = exports.sourceIfUnmodifiedSince = exports.sourceIfModifiedSince = exports.rehydratePriority = exports.tier = exports.comp14 = exports.encryptionScope = exports.legalHold = exports.comp13 = exports.immutabilityPolicyMode = exports.immutabilityPolicyExpiry = exports.comp12 = exports.blobContentDisposition = exports.blobContentLanguage = exports.blobContentEncoding = exports.blobContentMD5 = exports.blobContentType = exports.blobCacheControl = exports.expiresOn = exports.expiryOptions = exports.comp11 = exports.blobDeleteType = exports.deleteSnapshots = exports.ifTags = exports.ifNoneMatch = exports.ifMatch = exports.encryptionAlgorithm = exports.encryptionKeySha256 = exports.encryptionKey = exports.rangeGetContentCRC64 = exports.rangeGetContentMD5 = exports.range = exports.versionId = exports.snapshot = exports.delimiter = exports.startFrom = exports.include1 = exports.proposedLeaseId1 = exports.action4 = exports.breakPeriod = void 0;
 exports.listType = exports.comp25 = exports.blocks = exports.blockId = exports.comp24 = exports.copySourceBlobProperties = exports.blobType2 = exports.comp23 = exports.sourceRange1 = exports.appendPosition = exports.maxSize = exports.comp22 = exports.blobType1 = exports.comp21 = exports.sequenceNumberAction = exports.prevSnapshotUrl = exports.prevsnapshot = exports.comp20 = exports.range1 = exports.sourceContentCrc64 = exports.sourceRange = exports.sourceUrl = exports.pageWrite1 = exports.ifSequenceNumberEqualTo = exports.ifSequenceNumberLessThan = exports.ifSequenceNumberLessThanOrEqualTo = exports.pageWrite = exports.comp19 = exports.accept2 = exports.body1 = exports.contentType1 = exports.blobSequenceNumber = exports.blobContentLength = exports.blobType = exports.transactionalContentCrc64 = exports.transactionalContentMD5 = exports.tags = exports.ifNoneMatch1 = exports.ifMatch1 = exports.ifUnmodifiedSince1 = exports.ifModifiedSince1 = exports.comp18 = exports.comp17 = exports.queryRequest = exports.tier1 = exports.comp16 = exports.copyId = exports.copyActionAbortConstant = exports.comp15 = exports.fileRequestIntent = void 0;
-const mappers_js_1 = __nccwpck_require__(181);
+const mappers_js_1 = __nccwpck_require__(179);
 exports.contentType = {
     parameterPath: ["options", "contentType"],
     mapper: {
@@ -12883,8 +12883,8 @@ exports.listType = {
 "use strict";
 
 
-const inherits = (__nccwpck_require__(376).inherits)
-const ReadableStream = (__nccwpck_require__(431).Readable)
+const inherits = (__nccwpck_require__(377).inherits)
+const ReadableStream = (__nccwpck_require__(432).Readable)
 
 function PartStream (opts) {
   ReadableStream.call(this, opts)
@@ -12919,7 +12919,7 @@ exports.generateBlobSASQueryParametersInternal = generateBlobSASQueryParametersI
 const BlobSASPermissions_js_1 = __nccwpck_require__(504);
 const ContainerSASPermissions_js_1 = __nccwpck_require__(280);
 const storage_common_1 = __nccwpck_require__(277);
-const SasIPRange_js_1 = __nccwpck_require__(359);
+const SasIPRange_js_1 = __nccwpck_require__(360);
 const SASQueryParameters_js_1 = __nccwpck_require__(527);
 const constants_js_1 = __nccwpck_require__(149);
 const utils_common_js_1 = __nccwpck_require__(155);
@@ -13590,11 +13590,11 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 
 
 const assert = __nccwpck_require__(528)
-const { kDestroyed, kBodyUsed } = __nccwpck_require__(196)
+const { kDestroyed, kBodyUsed } = __nccwpck_require__(194)
 const { IncomingMessage } = __nccwpck_require__(329)
 const stream = __nccwpck_require__(131)
 const net = __nccwpck_require__(510)
-const { InvalidArgumentError } = __nccwpck_require__(489)
+const { InvalidArgumentError } = __nccwpck_require__(490)
 const { Blob } = __nccwpck_require__(120)
 const nodeUtil = __nccwpck_require__(124)
 const { stringify } = __nccwpck_require__(130)
@@ -14147,7 +14147,7 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(185);
+var import_log = __nccwpck_require__(183);
 var import_policies = __nccwpck_require__(286);
 const logPolicyName = import_policies.logPolicyName;
 function logPolicy(options = {}) {
@@ -14194,12 +14194,12 @@ __export(src_exports, {
   toHttpHeadersLike: () => import_util.toHttpHeadersLike
 });
 module.exports = __toCommonJS(src_exports);
-var import_extendedClient = __nccwpck_require__(216);
-var import_response = __nccwpck_require__(413);
+var import_extendedClient = __nccwpck_require__(215);
+var import_response = __nccwpck_require__(414);
 var import_requestPolicyFactoryPolicy = __nccwpck_require__(63);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_httpClientAdapter = __nccwpck_require__(211);
-var import_util = __nccwpck_require__(110);
+var import_httpClientAdapter = __nccwpck_require__(210);
+var import_util = __nccwpck_require__(111);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -14373,9 +14373,9 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StatsCollector = void 0;
-const fs = __importStar(__nccwpck_require__(109));
+const fs = __importStar(__nccwpck_require__(110));
 const path = __importStar(__nccwpck_require__(509));
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 function fmtBytes(n) {
     if (n === null)
         return "-";
@@ -14989,14 +14989,14 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 const exec = __importStar(__nccwpck_require__(18));
-const glob = __importStar(__nccwpck_require__(169));
+const glob = __importStar(__nccwpck_require__(168));
 const io = __importStar(__nccwpck_require__(295));
-const crypto = __importStar(__nccwpck_require__(291));
-const fs = __importStar(__nccwpck_require__(533));
+const crypto = __importStar(__nccwpck_require__(292));
+const fs = __importStar(__nccwpck_require__(534));
 const path = __importStar(__nccwpck_require__(248));
-const semver = __importStar(__nccwpck_require__(180));
+const semver = __importStar(__nccwpck_require__(178));
 const util = __importStar(__nccwpck_require__(124));
 const constants_1 = __nccwpck_require__(45);
 const versionSalt = '1.0';
@@ -15187,7 +15187,7 @@ exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
 const node_crypto_1 = __nccwpck_require__(275);
 const constants_js_1 = __nccwpck_require__(36);
 const utils_common_js_1 = __nccwpck_require__(475);
-const SharedKeyComparator_js_1 = __nccwpck_require__(178);
+const SharedKeyComparator_js_1 = __nccwpck_require__(176);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
  */
@@ -15322,6 +15322,248 @@ function storageSharedKeyCredentialPolicy(options) {
 
 "use strict";
 
+// Soldr-mini-cache — the narrowest cache layer: just the soldr binary,
+// keyed only on (version, platform, arch, libc).
+//
+// Per CLAUDE.md "Layer per change cadence" + "Coarse keys, shared across
+// workflows": the soldr binary's invalidation rhythm is per-soldr-release
+// (~1×/week). Mixing it into the existing setup-cache (which is keyed on
+// toolchain hash + cache-key-suffix) means it re-downloads whenever those
+// move — even though the binary content didn't change.
+//
+// This layer caches *only* the install dir contents (binary + optional
+// source-metadata sidecar), keyed coarsely so every workflow in the repo
+// pinned to the same soldr version hits the same entry.
+//
+// Position in the lifecycle:
+//   main.ts: try restore → if hit, soldrPath is pre-populated and
+//   ensureSoldr's installedVersion check short-circuits the GH fetch.
+//   post.ts: if restore missed AND ensureSoldr fetched, save the binary
+//   for next time.
+//
+// Refs (rebuild-from-source) are skipped: the binary content depends on
+// the commit, not the version tag, so the cache key would be wrong.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.buildMiniCacheKey = buildMiniCacheKey;
+exports.restoreMiniCache = restoreMiniCache;
+exports.saveMiniCache = saveMiniCache;
+exports.isEligibleForMiniCache = isEligibleForMiniCache;
+const fs = __importStar(__nccwpck_require__(249));
+const fsp = __importStar(__nccwpck_require__(110));
+const path = __importStar(__nccwpck_require__(509));
+const cache = __importStar(__nccwpck_require__(214));
+const cache_compress_js_1 = __nccwpck_require__(529);
+const MINI_KEY_PREFIX = "soldr-mini";
+/**
+ * Build the mini-cache key. Deliberately coarse — only the dimensions
+ * that change soldr's binary content. No toolchain hash, no Cargo.lock,
+ * no cache-key-suffix, no SHA. Cross-workflow sharing within a repo.
+ */
+function buildMiniCacheKey(parts) {
+    const v = parts.soldrVersion.trim().replace(/^v/, "") || "unresolved";
+    return [
+        MINI_KEY_PREFIX,
+        parts.runnerOs,
+        parts.runnerArch,
+        parts.libc,
+        `v${v}`,
+    ].join("-");
+}
+/**
+ * Try to restore the soldr install dir from the mini-cache. Single exact
+ * key — content-addressable so a fallback would be wrong. On hit, the
+ * caller's normal ensureSoldr() will see the binary already present at
+ * the expected path and skip the GH Releases fetch.
+ */
+async function restoreMiniCache(opts) {
+    const { exactKey, installDir, archivePath, longWindow, log } = opts;
+    await fsp.mkdir(installDir, { recursive: true });
+    await fsp.mkdir(path.dirname(archivePath), { recursive: true });
+    await fsp.rm(archivePath, { force: true });
+    let matched;
+    try {
+        matched = await cache.restoreCache([archivePath], exactKey);
+    }
+    catch (err) {
+        log(`soldr-mini-cache: restore threw: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "", archiveBytes: 0 };
+    }
+    if (!matched) {
+        log(`soldr-mini-cache: no entry for key ${exactKey}`);
+        return { hit: false, matchedKey: "", archiveBytes: 0 };
+    }
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fsp.stat(archivePath)).size;
+    }
+    catch {
+        return { hit: false, matchedKey: matched, archiveBytes: 0 };
+    }
+    const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+    if (magic !== "zstd" && magic !== "gzip") {
+        log(`soldr-mini-cache: archive has unknown codec, treating as miss`);
+        return { hit: false, matchedKey: matched, archiveBytes };
+    }
+    try {
+        await (0, cache_compress_js_1.decompressCache)({
+            archivePath,
+            targetDir: installDir,
+            longWindow,
+            log,
+            debug: opts.debug,
+        });
+    }
+    catch (err) {
+        log(`soldr-mini-cache: decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: matched, archiveBytes };
+    }
+    log(`soldr-mini-cache: restored matched=${matched} archive=${archiveBytes}B target=${installDir}`);
+    return { hit: true, matchedKey: matched, archiveBytes };
+}
+/**
+ * Tar+zstd the soldr install dir and upload to cache. Caller should only
+ * call this when restore missed AND ensureSoldr actually fetched (otherwise
+ * we'd be re-saving the same content).
+ */
+async function saveMiniCache(opts) {
+    const { installDir, archivePath, exactKey, level, longWindow, debug, log } = opts;
+    if (!fs.existsSync(installDir)) {
+        return { status: "skipped-missing-dir" };
+    }
+    let entryCount = 0;
+    try {
+        entryCount = (await fsp.readdir(installDir)).length;
+    }
+    catch { /* */ }
+    if (entryCount === 0) {
+        return { status: "skipped-empty" };
+    }
+    // compressCache writes to `${cacheDir}.tar.zst` by default. We pass
+    // installDir as cacheDir, so the archive ends up at
+    // `${installDir}.tar.zst`. The caller's main.ts side uses the same
+    // path so @actions/cache hashes the paths array identically on save
+    // and restore (mirrors the cook-cache lesson from #141).
+    let outputArchivePath = null;
+    let archiveBytes;
+    let inflatedBytes;
+    let fileCount;
+    try {
+        const compress = await (0, cache_compress_js_1.compressCache)({
+            cacheDir: installDir,
+            codec: "zstd",
+            level,
+            longWindow,
+            debug,
+            log,
+        });
+        outputArchivePath = compress.archivePath;
+        archiveBytes = compress.archiveBytes;
+        if (compress.inflatedBytes !== null)
+            inflatedBytes = compress.inflatedBytes;
+        if (compress.fileCount !== null)
+            fileCount = compress.fileCount;
+    }
+    catch (err) {
+        return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+    }
+    if (!outputArchivePath) {
+        return { status: "failed", error: "compressCache returned null archive (zstd unavailable?)" };
+    }
+    if (path.resolve(outputArchivePath) !== path.resolve(archivePath)) {
+        log(`soldr-mini-cache: WARNING archive path mismatch — compress wrote ${outputArchivePath}, ` +
+            `expected ${archivePath}. Future restore may miss due to paths-version hash.`);
+    }
+    try {
+        const id = await cache.saveCache([outputArchivePath], exactKey);
+        if (id <= 0) {
+            log(`soldr-mini-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
+                `job already saved key=${exactKey}`);
+            return {
+                status: "skipped-race",
+                cacheId: id,
+                archiveBytes,
+                inflatedBytes,
+                fileCount,
+            };
+        }
+        log(`soldr-mini-cache: saved id=${id} key=${exactKey} archive=${outputArchivePath}`);
+        return {
+            status: "saved",
+            cacheId: id,
+            archiveBytes,
+            inflatedBytes,
+            fileCount,
+        };
+    }
+    catch (err) {
+        return {
+            status: "failed",
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+}
+/**
+ * Should we use the mini-cache for this run? Independent of the
+ * `soldr-mini-cache` input flag (that gate is checked in main.ts).
+ * Returns false when building from source — binary content depends on
+ * the commit SHA, not the version tag.
+ */
+function isEligibleForMiniCache(opts) {
+    if (!opts.enable)
+        return { eligible: false, reason: "enable=false (passthrough stub mode)" };
+    if (opts.hasRef) {
+        return {
+            eligible: false,
+            reason: "ref is set — building from source, binary depends on commit not version",
+        };
+    }
+    if (!opts.resolvedVersion.trim()) {
+        return { eligible: false, reason: "no resolved version available" };
+    }
+    return { eligible: true, reason: "eligible" };
+}
+
+
+/***/ }),
+
+/***/ 80:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
 // Source mtime normalizer. Owned by Agent 2.
 //
 // Port of .github/actions/setup-soldr/normalize_source_mtime.py.
@@ -15371,7 +15613,7 @@ exports.normalizeSourceMtime = normalizeSourceMtime;
 const fs = __importStar(__nccwpck_require__(249));
 const path = __importStar(__nccwpck_require__(509));
 const exec = __importStar(__nccwpck_require__(18));
-const log_utils_js_1 = __nccwpck_require__(352);
+const log_utils_js_1 = __nccwpck_require__(353);
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 // Globs evaluated against the repo-relative POSIX path of each tracked file.
 const INCLUDE_GLOBS = [
@@ -15603,7 +15845,7 @@ exports._internal = {
 
 /***/ }),
 
-/***/ 80:
+/***/ 81:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15660,7 +15902,358 @@ module.exports = {
 
 /***/ }),
 
-/***/ 81:
+/***/ 82:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Read + summarize zccache's per-rustc-invocation JSONL journal so
+// `dumpDiagnostics` can emit a `[compile_journal]` section telling
+// the reader (or future-me) *what* was cached and *why* every miss
+// missed. Without this, "warm reports hits=0 misses=206" is true but
+// useless — we can't tell whether the cache lookups all returned
+// "no cache file with this key" (genuinely-new fingerprint) or "the
+// cached entry's recorded inputs don't match my current inputs"
+// (content/path/env drift between cold and warm). The journal records
+// the per-invocation `outcome` and `miss_reason`; soldr's
+// `cache report --json` already returns `zccache analyze --json`'s
+// rollups under `report.rollups`. We just have to parse them.
+//
+// Pure-functional: no `core.*` here, no side effects beyond reading
+// the journal file. Easier to unit-test that way.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.readJournal = readJournal;
+exports.summarize = summarize;
+exports.formatJournalSection = formatJournalSection;
+exports.formatRollupsSection = formatRollupsSection;
+const fs = __importStar(__nccwpck_require__(249));
+const diagnostics_js_1 = __nccwpck_require__(233);
+const SLOWEST_TOP_N = 20;
+/**
+ * Read a `last-session.jsonl` file. Returns `null` if it doesn't exist
+ * (the common "no build happened" case); throws nothing for malformed
+ * lines — they're silently skipped so a single garbled record doesn't
+ * blank the whole dump.
+ */
+function readJournal(path) {
+    let raw;
+    try {
+        raw = fs.readFileSync(path, "utf8");
+    }
+    catch (err) {
+        if (err.code === "ENOENT")
+            return null;
+        throw err;
+    }
+    const out = [];
+    for (const line of raw.split(/\r?\n/)) {
+        if (line.trim() === "")
+            continue;
+        try {
+            const obj = JSON.parse(line);
+            if (obj && typeof obj === "object")
+                out.push(obj);
+        }
+        catch {
+            // Skip malformed lines.
+        }
+    }
+    return out;
+}
+/**
+ * Pure summary. Stable across runs given the same input order so the
+ * dump diffs cleanly across CI runs.
+ */
+function summarize(records) {
+    const outcomes = {};
+    const miss_reasons = {};
+    const per_extension = {};
+    const misses = [];
+    for (const r of records) {
+        const outcome = r.outcome ?? "unknown";
+        outcomes[outcome] = (outcomes[outcome] ?? 0) + 1;
+        if (outcome === "miss") {
+            const reason = r.miss_reason ?? "unknown";
+            miss_reasons[reason] = (miss_reasons[reason] ?? 0) + 1;
+            misses.push(r);
+        }
+        const ext = r.output_ext ?? "?";
+        if (!per_extension[ext])
+            per_extension[ext] = { hit: 0, miss: 0 };
+        if (outcome === "hit" || outcome === "link_hit")
+            per_extension[ext].hit += 1;
+        else if (outcome === "miss" || outcome === "link_miss")
+            per_extension[ext].miss += 1;
+    }
+    // Sort misses by latency descending and take top N.
+    const slowest_misses = [...misses]
+        .sort((a, b) => (b.latency_ns ?? 0) - (a.latency_ns ?? 0))
+        .slice(0, SLOWEST_TOP_N)
+        .map((r) => ({
+        crate: r.crate_name ?? "?",
+        reason: r.miss_reason ?? "?",
+        ext: r.output_ext ?? "?",
+        latency_ms: Math.round((r.latency_ns ?? 0) / 1_000_000),
+        diff: r.miss_diff ?? null,
+    }));
+    // One sample per distinct miss_reason (covers the long-tail rarer
+    // reasons even when ContentChanged dominates the histogram).
+    const seenReasons = new Set();
+    const sample_records = [];
+    for (const r of misses) {
+        const reason = r.miss_reason ?? "unknown";
+        if (seenReasons.has(reason))
+            continue;
+        seenReasons.add(reason);
+        sample_records.push(r);
+        if (sample_records.length >= 5)
+            break;
+    }
+    // Also include one hit sample if we have any, so cold/warm diffs are
+    // diffable in both directions.
+    const firstHit = records.find((r) => r.outcome === "hit" || r.outcome === "link_hit");
+    if (firstHit && sample_records.length < 6)
+        sample_records.push(firstHit);
+    return {
+        total: records.length,
+        outcomes,
+        miss_reasons,
+        per_extension,
+        slowest_misses,
+        sample_records,
+    };
+}
+// ---------- formatters ----------
+function pad(left, right, label, value) {
+    return `${label.padEnd(left)}${String(value).padStart(right)}`;
+}
+/**
+ * Normalise zccache's `env` field into a plain `{key: value}` map.
+ * The wire format is array-of-pairs (`Array<[string, string]>`) in
+ * current zccache builds; older / future builds may use a plain
+ * object. We tolerate both — and crucially, when given the array
+ * form we DO NOT use array indices as keys (the previous bug:
+ * indices like "0", "1" don't match the redaction regex so secrets
+ * leaked verbatim).
+ */
+function normaliseEnv(env) {
+    if (!env)
+        return {};
+    if (Array.isArray(env)) {
+        const out = {};
+        for (const pair of env) {
+            if (Array.isArray(pair) && pair.length >= 2 && typeof pair[0] === "string") {
+                out[pair[0]] = String(pair[1] ?? "");
+            }
+        }
+        return out;
+    }
+    // Plain object form. Defend against the legacy index-keyed shape that
+    // sneaks in if some intermediate code stringifies an array via
+    // `Object.fromEntries(arr.entries())` — detect that and recover.
+    const entries = Object.entries(env);
+    const looksLikeIndexedArray = entries.length > 0 &&
+        entries.every(([k, v]) => /^\d+$/.test(k) &&
+            Array.isArray(v) &&
+            v.length >= 2 &&
+            typeof v[0] === "string");
+    if (looksLikeIndexedArray) {
+        const out = {};
+        for (const [, v] of entries) {
+            const pair = v;
+            out[pair[0]] = String(pair[1] ?? "");
+        }
+        return out;
+    }
+    return env;
+}
+function redactEnv(env) {
+    const norm = normaliseEnv(env);
+    const out = {};
+    for (const [k, v] of Object.entries(norm))
+        out[k] = (0, diagnostics_js_1.redactValue)(k, v);
+    return out;
+}
+function envIsNonEmpty(env) {
+    if (!env)
+        return false;
+    if (Array.isArray(env))
+        return env.length > 0;
+    return Object.keys(env).length > 0;
+}
+function formatRecord(r) {
+    // Hand-shape JSON to keep one record-per-line readable: top-level keys
+    // on one line, then args/env/miss_diff (if present) on their own.
+    const summary = {
+        outcome: r.outcome,
+        miss_reason: r.miss_reason,
+        crate_name: r.crate_name,
+        crate_type: r.crate_type,
+        output_ext: r.output_ext,
+        latency_ms: r.latency_ns !== undefined ? Math.round(r.latency_ns / 1_000_000) : undefined,
+        cwd: r.cwd,
+    };
+    const parts = [];
+    parts.push(`    summary: ${JSON.stringify(summary)}`);
+    if (r.args && r.args.length > 0) {
+        parts.push(`    args: ${JSON.stringify(r.args)}`);
+    }
+    if (envIsNonEmpty(r.env)) {
+        parts.push(`    env (redacted): ${JSON.stringify(redactEnv(r.env))}`);
+    }
+    if (r.miss_diff && Object.keys(r.miss_diff).length > 0) {
+        parts.push(`    miss_diff: ${JSON.stringify(r.miss_diff)}`);
+    }
+    if (r.self_profile_ns) {
+        parts.push(`    self_profile_ns: ${JSON.stringify(r.self_profile_ns)}`);
+    }
+    return parts.join("\n");
+}
+/**
+ * Format a `[compile_journal]` section's body lines (without the
+ * surrounding header/footer — those are added by `dumpDiagnostics`).
+ */
+function formatJournalSection(summary) {
+    const lines = [];
+    lines.push(`[compile_journal]`);
+    lines.push(`  total_records=${summary.total}`);
+    lines.push(`  outcomes:`);
+    const outcomeEntries = Object.entries(summary.outcomes).sort((a, b) => b[1] - a[1]);
+    if (outcomeEntries.length === 0)
+        lines.push(`    (none)`);
+    for (const [k, v] of outcomeEntries)
+        lines.push(`    ${pad(16, 8, k, v)}`);
+    lines.push(`  miss_reasons (zccache fingerprint divergence; the answer to "why warm missed"):`);
+    const missEntries = Object.entries(summary.miss_reasons).sort((a, b) => b[1] - a[1]);
+    if (missEntries.length === 0)
+        lines.push(`    (none)`);
+    for (const [k, v] of missEntries)
+        lines.push(`    ${pad(28, 8, k, v)}`);
+    lines.push(`  per_output_ext (hit/miss split per artifact kind):`);
+    const extEntries = Object.entries(summary.per_extension).sort((a, b) => a[0] < b[0] ? -1 : 1);
+    if (extEntries.length === 0)
+        lines.push(`    (none)`);
+    for (const [ext, c] of extEntries) {
+        lines.push(`    ${ext.padEnd(10)}hit=${String(c.hit).padStart(5)}  miss=${String(c.miss).padStart(5)}`);
+    }
+    lines.push(`  slowest_misses (top ${summary.slowest_misses.length} by wall-clock):`);
+    if (summary.slowest_misses.length === 0)
+        lines.push(`    (none)`);
+    for (const m of summary.slowest_misses) {
+        lines.push(`    ${String(m.latency_ms + "ms").padStart(7)}  ${m.reason.padEnd(20)}  ${m.ext.padEnd(8)}  ${m.crate}`);
+        if (m.diff && typeof m.diff === "object" && Object.keys(m.diff).length > 0) {
+            lines.push(`        diff: ${JSON.stringify(m.diff)}`);
+        }
+    }
+    lines.push(`  sample_records (one verbatim per distinct outcome, env redacted):`);
+    if (summary.sample_records.length === 0)
+        lines.push(`    (none)`);
+    for (let i = 0; i < summary.sample_records.length; i += 1) {
+        lines.push(`  --- record ${i + 1} ---`);
+        lines.push(formatRecord(summary.sample_records[i]));
+    }
+    return lines;
+}
+/**
+ * Format the `rollups` field returned by `soldr cache report --json`
+ * (i.e. `zccache analyze --json` output). Tolerates missing /
+ * malformed fields — older soldr versions or error paths just yield
+ * an empty section.
+ */
+function formatRollupsSection(report) {
+    const lines = [];
+    lines.push(`[compile_rollups (zccache analyze --json)]`);
+    if (!report || typeof report !== "object") {
+        lines.push(`  (no report payload)`);
+        return lines;
+    }
+    const rollups = report.rollups;
+    if (!rollups || typeof rollups !== "object") {
+        lines.push(`  (no rollups field)`);
+        return lines;
+    }
+    const r = rollups;
+    // by_extension: { ext: { hits, misses, total_ns } }
+    const byExt = r.by_extension;
+    lines.push(`  by_extension:`);
+    if (!byExt || Object.keys(byExt).length === 0)
+        lines.push(`    (none)`);
+    else {
+        for (const [ext, v] of Object.entries(byExt)) {
+            const hits = v?.hits ?? 0;
+            const misses = v?.misses ?? 0;
+            const totalMs = Math.round((v?.total_ns ?? 0) / 1_000_000);
+            const denom = hits + misses;
+            const rate = denom > 0 ? ((hits / denom) * 100).toFixed(1) : "n/a";
+            lines.push(`    ${ext.padEnd(10)}hits=${String(hits).padStart(5)}  misses=${String(misses).padStart(5)}  rate=${rate.padStart(5)}%  total=${totalMs}ms`);
+        }
+    }
+    // slowest_entries: [{outcome, crate_name, latency_ns}, ...]
+    const slowest = r.slowest_entries;
+    lines.push(`  slowest_entries (analyze top-N):`);
+    if (!slowest || slowest.length === 0)
+        lines.push(`    (none)`);
+    else {
+        for (const e of slowest.slice(0, 20)) {
+            const latencyMs = Math.round(Number(e.latency_ns ?? 0) / 1_000_000);
+            const outcome = String(e.outcome ?? "?");
+            const crate = String(e.crate_name ?? "?");
+            lines.push(`    ${String(latencyMs + "ms").padStart(7)}  ${outcome.padEnd(10)}  ${crate}`);
+        }
+    }
+    // miss_crate_counts: { crate: N }
+    const missByCrate = r.miss_crate_counts;
+    lines.push(`  miss_crate_counts (top 20):`);
+    if (!missByCrate || Object.keys(missByCrate).length === 0)
+        lines.push(`    (none)`);
+    else {
+        const sorted = Object.entries(missByCrate)
+            .sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))
+            .slice(0, 20);
+        for (const [crate, count] of sorted) {
+            lines.push(`    ${String(count).padStart(5)}  ${crate}`);
+        }
+    }
+    return lines;
+}
+
+
+/***/ }),
+
+/***/ 83:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15675,7 +16268,7 @@ const RequestPolicy_js_1 = __nccwpck_require__(46);
 const constants_js_1 = __nccwpck_require__(36);
 const utils_common_js_1 = __nccwpck_require__(475);
 const log_js_1 = __nccwpck_require__(17);
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(418);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(419);
 /**
  * A factory method used to generated a RetryPolicy factory.
  *
@@ -15891,7 +16484,7 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 
 /***/ }),
 
-/***/ 82:
+/***/ 84:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15900,15 +16493,15 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = exports.useInstrumenter = void 0;
-var instrumenter_js_1 = __nccwpck_require__(407);
+var instrumenter_js_1 = __nccwpck_require__(408);
 Object.defineProperty(exports, "useInstrumenter", ({ enumerable: true, get: function () { return instrumenter_js_1.useInstrumenter; } }));
-var tracingClient_js_1 = __nccwpck_require__(347);
+var tracingClient_js_1 = __nccwpck_require__(348);
 Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: function () { return tracingClient_js_1.createTracingClient; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 83:
+/***/ 85:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -15920,7 +16513,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 84:
+/***/ 86:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15930,7 +16523,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 const { extractBody, mixinBody, cloneBody } = __nccwpck_require__(24)
 const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(518)
-const { FinalizationRegistry } = __nccwpck_require__(415)()
+const { FinalizationRegistry } = __nccwpck_require__(416)()
 const util = __nccwpck_require__(69)
 const {
   isValidHTTPToken,
@@ -15951,10 +16544,10 @@ const {
 } = __nccwpck_require__(30)
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(15)
-const { webidl } = __nccwpck_require__(457)
+const { webidl } = __nccwpck_require__(458)
 const { getGlobalOrigin } = __nccwpck_require__(140)
 const { URLSerializer } = __nccwpck_require__(25)
-const { kHeadersList, kConstruct } = __nccwpck_require__(196)
+const { kHeadersList, kConstruct } = __nccwpck_require__(194)
 const assert = __nccwpck_require__(528)
 const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(471)
 
@@ -16874,899 +17467,7 @@ module.exports = { Request, makeRequest }
 
 /***/ }),
 
-/***/ 85:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// setup-soldr entry point. Owned by Agent 2.
-//
-// Replaces the composite action's main-phase steps with a single JS
-// orchestrator. Calls the helpers in src/lib/* in the same order the
-// composite's steps fire.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(249));
-const os = __importStar(__nccwpck_require__(383));
-const path = __importStar(__nccwpck_require__(509));
-const core = __importStar(__nccwpck_require__(460));
-const cache = __importStar(__nccwpck_require__(215));
-const log_utils_js_1 = __nccwpck_require__(352);
-const resolve_setup_js_1 = __nccwpck_require__(467);
-const phase_timing_js_1 = __nccwpck_require__(337);
-const ensure_rust_toolchain_js_1 = __nccwpck_require__(513);
-const ensure_soldr_js_1 = __nccwpck_require__(364);
-const verify_soldr_js_1 = __nccwpck_require__(358);
-const install_passthrough_js_1 = __nccwpck_require__(515);
-const normalize_source_mtime_js_1 = __nccwpck_require__(79);
-const detect_shared_target_warning_js_1 = __nccwpck_require__(219);
-const ensure_shims_js_1 = __nccwpck_require__(531);
-const cache_compress_js_1 = __nccwpck_require__(494);
-const stats_collector_js_1 = __nccwpck_require__(74);
-const toolchain_snapshot_js_1 = __nccwpck_require__(459);
-const solo_toolchain_cache_js_1 = __nccwpck_require__(294);
-const cook_cache_js_1 = __nccwpck_require__(171);
-const soldr_mini_cache_js_1 = __nccwpck_require__(158);
-const diagnostics_js_1 = __nccwpck_require__(112);
-const shim_bypass_check_js_1 = __nccwpck_require__(312);
-const source_mtime_snapshot_js_1 = __nccwpck_require__(408);
-/**
- * Map (hit, matchedKey) → workflow-visible restore-status string.
- * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
- * for the `<layer>-cache-restore-status` outputs declared in action.yml.
- */
-function deriveRestoreStatus(hit, matchedKey) {
-    if (hit)
-        return "exact-hit";
-    if (matchedKey.trim())
-        return "restore-key-hit";
-    return "miss";
-}
-function writeCacheKeysManifest(result, runnerTemp, log) {
-    if (!runnerTemp)
-        return;
-    const keys = [
-        result.setupCache.key,
-        result.buildCache.key,
-        result.targetCache.key,
-        result.cargoRegistryCache.key,
-    ].filter((k) => Boolean(k));
-    if (keys.length === 0)
-        return;
-    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
-    try {
-        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
-        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
-    }
-    catch (err) {
-        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-const TRUTHY = new Set(["1", "true", "yes", "on"]);
-const FALSY = new Set(["0", "false", "no", "off"]);
-function isTruthy(value) {
-    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
-}
-function isFalsy(value) {
-    return FALSY.has(((value ?? "").trim().toLowerCase()));
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
-    }
-}
-function dirHasContent(p) {
-    try {
-        return fs.readdirSync(p).length > 0;
-    }
-    catch {
-        return false;
-    }
-}
-function buildActionContext() {
-    const env = process.env;
-    const logger = (0, log_utils_js_1.createLogger)(env);
-    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
-    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
-    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
-    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
-    const githubSha = env["GITHUB_SHA"]?.trim() || "";
-    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
-    const parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
-    return {
-        env: { ...env },
-        workspace,
-        runnerTemp,
-        runnerOs,
-        runnerArch,
-        githubSha,
-        githubToken,
-        parentSha,
-        logger,
-    };
-}
-async function restoreCacheSafe(paths, key, restoreKeys, logger) {
-    if (paths.length === 0 || !key) {
-        return { hit: false, matchedKey: "" };
-    }
-    try {
-        const matched = await cache.restoreCache(paths, key, restoreKeys);
-        return { hit: matched === key, matchedKey: matched ?? "" };
-    }
-    catch (err) {
-        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "" };
-    }
-}
-async function run() {
-    const ctx = buildActionContext();
-    const logger = ctx.logger;
-    await (0, phase_timing_js_1.markPhase)("action");
-    // ---- resolve ----
-    await (0, phase_timing_js_1.markPhase)("resolve");
-    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
-    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
-    await (0, resolve_setup_js_1.applyResolveResult)(result);
-    await (0, phase_timing_js_1.finishPhase)("resolve");
-    // Always emit the cache-keys manifest right after resolve so workflow
-    // steps that run between main and post (e.g. actions/upload-artifact)
-    // can read it. The four keys are fully determined by resolveSetup and
-    // never change later in the run.
-    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
-    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            logger,
-            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
-        });
-    }
-    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
-    if (dryRun) {
-        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
-        await (0, phase_timing_js_1.finishPhase)("action");
-        return;
-    }
-    // Persist resolve state for the post-job step.
-    core.saveState("resolveResult", JSON.stringify(result));
-    core.saveState("buildCacheMode", result.buildCache.mode);
-    core.saveState("logging", logging ? "true" : "false");
-    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
-    const statsMode = result.stats;
-    const debugMode = result.debugMode;
-    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
-    const statsCollector = new stats_collector_js_1.StatsCollector();
-    // ---- source-mtime-normalize ----
-    if (isTruthy(inputs.sourceMtimeNormalize)) {
-        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
-    }
-    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
-    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
-    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
-    core.saveState("setupCacheExactHit", "false");
-    core.saveState("setupCacheMatchedKey", "");
-    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
-    core.saveState("targetCacheExactHit", "false");
-    core.saveState("targetCacheMatchedKey", "");
-    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
-    core.saveState("buildCacheExactHit", "false");
-    core.saveState("buildCacheMatchedKey", "");
-    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
-    core.saveState("cargoRegistryCacheExactHit", "false");
-    core.saveState("cargoRegistryCacheMatchedKey", "");
-    // ---- parallel restores ----
-    // setup-cache, target-cache, build-cache, and cargo-registry write to
-    // disjoint paths and have no inter-dependencies, so they run concurrently.
-    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
-    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
-    //
-    // Layers that must stay sequential (wired below): solo-toolchain (writes
-    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
-    // install dir, must precede ensureSoldr), cook (writes target/ and needs
-    // the soldr binary). Cargo-registry was previously after-cook — it's been
-    // moved into this parallel block because nothing the soldr install path
-    // touches depends on its hydrated cargo registry state.
-    await (0, phase_timing_js_1.markPhase)("parallel-restore");
-    let setupCacheExactHit = false;
-    // Capture target-cache match status so we can skip the redundant cook restore.
-    // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
-    // (~2.5 GB inflated) also contains compiled deps. When target-cache matched
-    // at the lockfile/shape/toolchain level (exact OR parent-SHA OR lock-prefix
-    // fallback), we have target/deps/ already populated with identical content —
-    // cook restore would just overwrite. Skipping saves ~5–10 s per warm run.
-    // A looser restoreKeyLockfile-only match (different shape) is NOT enough to
-    // skip cook, since cook output may differ across shapes.
-    let targetCacheMatchedKey = "";
-    const setupRestorePromise = (async () => {
-        if (!(cacheEnabled && result.setupCache.paths.length > 0))
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
-        setupCacheExactHit = restore.hit;
-        core.setOutput("cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("setup_cache_matched_key", restore.matchedKey);
-        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("setupCacheMatchedKey", restore.matchedKey);
-        // Expose for ensure_rust_toolchain to read via env. Must be visible by
-        // the time toolchain phase runs — guaranteed by the Promise.all below.
-        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
-        statsCollector.record({
-            label: "setup-cache", operation: "restore", hit: restore.hit,
-            key: result.setupCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.setupCache.restorePrefix],
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const targetRestorePromise = (async () => {
-        if (!result.targetCache.enabled)
-            return;
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        if (targetPaths.length === 0)
-            return;
-        const restoreKeys = [];
-        if (result.targetCache.restoreKeyParent)
-            restoreKeys.push(result.targetCache.restoreKeyParent);
-        if (result.targetCache.restoreKeyLock)
-            restoreKeys.push(result.targetCache.restoreKeyLock);
-        if (result.targetCache.restoreKeyLockfile)
-            restoreKeys.push(result.targetCache.restoreKeyLockfile);
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
-        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("target_cache_matched_key", restore.matchedKey);
-        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("targetCacheMatchedKey", restore.matchedKey);
-        targetCacheMatchedKey = restore.matchedKey;
-        statsCollector.record({
-            label: "target-cache", operation: "restore", hit: restore.hit,
-            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const buildRestorePromise = (async () => {
-        if (!buildCacheEnabled)
-            return;
-        const buildCachePath = result.buildCache.path;
-        const archivePath = `${buildCachePath}.tar.zst`;
-        const restoreKeys = [];
-        if (result.buildCache.restoreKeyParent)
-            restoreKeys.push(result.buildCache.restoreKeyParent);
-        if (result.buildCache.restoreKeyToolchain)
-            restoreKeys.push(result.buildCache.restoreKeyToolchain);
-        if (result.buildCache.restoreKeyOsArch)
-            restoreKeys.push(result.buildCache.restoreKeyOsArch);
-        const t0 = Date.now();
-        // @actions/cache hashes the `paths` array into a "version" key — save and
-        // restore MUST pass the same array or the lookup misses even when the
-        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
-        // restore must use the same single-path array. The decompression below
-        // unpacks archivePath → buildCachePath afterwards.
-        const restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
-        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("build_cache_matched_key", restore.matchedKey);
-        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("buildCacheMatchedKey", restore.matchedKey);
-        let buildArchiveBytes = null;
-        let buildInflatedBytes = null;
-        let buildFileCount = null;
-        if (fileExists(archivePath)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-            if (magic === "zstd" || magic === "gzip") {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath, debug: debugMode, log: debugLog });
-                    buildArchiveBytes = dr.archiveBytes;
-                    buildInflatedBytes = dr.inflatedBytes;
-                    buildFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
-        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
-        // dir on the cold side; if it's present after decompress, walk it and
-        // set each matching source file's mtime to what cold saw. The replay
-        // is gated by (size, content-hash) match so we never overwrite a
-        // genuinely modified file's mtime — that would underbuild.
-        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
-            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
-            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
-            if (snapshot) {
-                const rt0 = Date.now();
-                try {
-                    // Match the project-root selection that post.ts uses when
-                    // writing the snapshot — the parent of the resolved target-dir,
-                    // not the (outer) GITHUB_WORKSPACE.
-                    const projectRoot = path.dirname(result.targetCache.targetPath);
-                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
-                        workspace: projectRoot,
-                        snapshot,
-                        log: (msg) => logger.log(msg),
-                    });
-                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
-                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
-                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
-                }
-                catch (err) {
-                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-            else {
-                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
-            }
-        }
-        statsCollector.record({
-            label: "build-cache", operation: "restore", hit: restore.hit,
-            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    })();
-    // Cargo-registry restore moved here from after-cook. It writes only
-    // $CARGO_HOME/registry/ and has no dependency on soldr being installed;
-    // running it in parallel with target+build trims its ~5s off the critical
-    // path.
-    const cargoRegistryRestorePromise = (async () => {
-        if (!result.cargoRegistryCache.enabled)
-            return;
-        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe([registryArchive], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
-        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
-        let regArchiveBytes = null;
-        let regInflatedBytes = null;
-        let regFileCount = null;
-        if (fileExists(registryArchive)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
-            if (magic === "zstd" || magic === "gzip") {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({
-                        archivePath: registryArchive,
-                        targetDir: result.cargoRegistryCache.path,
-                        debug: debugMode, log: debugLog,
-                    });
-                    regArchiveBytes = dr.archiveBytes;
-                    regInflatedBytes = dr.inflatedBytes;
-                    regFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        statsCollector.record({
-            label: "cargo-registry", operation: "restore", hit: restore.hit,
-            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.cargoRegistryCache.restorePrefix],
-            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    })();
-    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
-    // try/catches, so this should only see rejections for genuine programming
-    // bugs.
-    await Promise.all([
-        setupRestorePromise,
-        targetRestorePromise,
-        buildRestorePromise,
-        cargoRegistryRestorePromise,
-    ]);
-    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
-    // ---- target-tree-cache (full mode) ----
-    // The bundle path is included in target-cache restore paths above when full
-    // mode is requested, so there's no separate restore here. We keep the phase
-    // marker for parity with the composite step ordering.
-    await (0, phase_timing_js_1.markPhase)("target-tree");
-    await (0, phase_timing_js_1.finishPhase)("target-tree");
-    // Kick off soldr-mini-cache restore in the background. Same pattern as
-    // cook below: small, no inter-dependencies (writes to a fresh install
-    // dir, no toolchain or workspace state), so it overlaps with the
-    // toolchain phase that follows. Saves ~600 ms per warm run. Kept out
-    // of the BIG parallel-restore block above because the install phase
-    // needs to commit state-save side effects in a fixed order (state
-    // entries persist across pre/post and downstream readers expect them
-    // by the time `ensureSoldr` runs).
-    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
-    const miniInstallDir = path.dirname(result.soldrPath);
-    const miniArchive = `${miniInstallDir}.tar.zst`;
-    let miniHit = false;
-    let miniKey = "";
-    let miniSkipReason = "";
-    let miniRestorePromise = null;
-    if (miniEnabled) {
-        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
-            hasRef: Boolean(result.soldrRef.trim()),
-            enable: result.enabled,
-            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
-        });
-        if (eligibility.eligible) {
-            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
-            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
-                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-                soldrVersion: version,
-            });
-            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir} (background)`);
-            const miniT0 = Date.now();
-            miniRestorePromise = (async () => {
-                const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
-                    exactKey: miniKey,
-                    installDir: miniInstallDir,
-                    archivePath: miniArchive,
-                    longWindow: 27,
-                    debug: debugMode,
-                    log: (msg) => logger.log(msg),
-                });
-                return { ...restore, durationMs: Date.now() - miniT0 };
-            })();
-        }
-        else {
-            miniSkipReason = eligibility.reason;
-        }
-    }
-    // Kick off cook restore in the background. It overlaps with the
-    // sequential toolchain + soldr install + shims + verify steps that
-    // follow. By the time the cook phase runs, the restore is done — we
-    // just await the promise. Saves ~5–7 s of warm-build wall clock.
-    //
-    // Why this is safe (vs the disastrous PR #145 which added cook to the
-    // BIG parallel block): cook now races with SMALL ops (rust install
-    // ~1–2 s, soldr install ~2–3 s, shims/verify ~1–2 s). Those don't
-    // contend on disk write bandwidth the way target/build/cargo-registry
-    // restores did. Cook's 2.5 GB tar write becomes the long pole and
-    // hides behind the small ops.
-    //
-    // SAFETY: when target-cache writes to target/ (build-cache-mode: full),
-    // cook restore would race with target-cache restore on the same dir.
-    // The parallel-restore block above already finished target-cache, but
-    // we still want a runtime gate just in case the mode changes.
-    const cookGate = (0, cook_cache_js_1.decideCookGate)({
-        prebuildDeps: inputs.prebuildDeps,
-        cacheUmbrella: cacheEnabled,
-        lockfilePath: result.targetCache.lockfilePath,
-    });
-    const cookActive = cookGate.enabled && result.enabled;
-    let cookFlags = [];
-    let cookKey = "";
-    let cookProjectRoot = "";
-    let cookTargetDir = "";
-    let cookArchive = "";
-    let cookRestoreT0 = Date.now();
-    let cookRestorePromise = null;
-    // Skip cook restore when target-cache matched at the lockfile/shape level.
-    // restoreKeyLock = `${prefix}-${targetInputsHash}-${suffix}-` where
-    // targetInputsHash = sha256(toolchain, lockfile, manifest, shape). A
-    // matchedKey starting with restoreKeyLock means the cached entry was built
-    // with the same toolchain + lockfile + shape — its target/deps/ matches
-    // what cook would restore. Covers:
-    //   - exact hit  (matchedKey === current key, also startsWith restoreKeyLock)
-    //   - parent-SHA hit (matchedKey === restoreKeyParent, also startsWith)
-    //   - lock-prefix fallback (any saved entry with same lockfile+shape)
-    // Does NOT cover restoreKeyLockfile fallback (shorter prefix that drops
-    // shape) — different shape may mean different cook output, so cook still
-    // runs there as the safety net.
-    const targetCacheLockMatch = !!targetCacheMatchedKey &&
-        !!result.targetCache.restoreKeyLock &&
-        targetCacheMatchedKey.startsWith(result.targetCache.restoreKeyLock);
-    const cookSkippedDueToTargetHit = cookActive && targetCacheLockMatch;
-    if (cookActive && !cookSkippedDueToTargetHit) {
-        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
-        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
-        const lockHash = result.targetCache.lockfileHash || "no-lock";
-        cookKey = (0, cook_cache_js_1.buildCookCacheKey)({
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            flagsHash,
-            lockHash,
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        });
-        cookProjectRoot = path.dirname(result.targetCache.targetPath);
-        cookTargetDir = result.targetCache.targetPath;
-        cookArchive = `${cookTargetDir}.tar.zst`;
-        logger.log(`cook: key=${cookKey} starting background restore concurrent with install`);
-        cookRestoreT0 = Date.now();
-        cookRestorePromise = (0, cook_cache_js_1.restoreCookCache)({
-            exactKey: cookKey,
-            archivePath: cookArchive,
-            targetDir: cookTargetDir,
-            longWindow: 27,
-            debug: debugMode,
-            log: (msg) => logger.log(msg),
-        });
-    }
-    // ---- toolchain ----
-    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
-    // toolchain install so we can see which inodes setup-soldr added on
-    // top of the runner image. When solo-toolchain-cache is opted in, a
-    // third snapshot is taken *before* the cache restore so the saved
-    // tarball captures the full above-runner state — not just the
-    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
-    // lifetime axis".
-    await (0, phase_timing_js_1.markPhase)("toolchain");
-    const snapshotRoots = [
-        path.join(result.rustupHome, "toolchains"),
-        path.join(result.cargoHome, "bin"),
-    ];
-    const soloRootMap = {
-        "rustup-toolchains": snapshotRoots[0],
-        "cargo-bin": snapshotRoots[1],
-    };
-    const soloEnabled = isTruthy(inputs.soloToolchainCache);
-    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "19");
-    let soloKeys = null;
-    let soloMatchedKey = "";
-    let soloExactHit = false;
-    // Pre-restore snapshot — only needed when solo cache is enabled, so
-    // we can compute the full save-diff (post-install vs runner-image,
-    // not vs post-restore baseline).
-    const preRestoreSnapshot = soloEnabled ? await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots) : null;
-    if (soloEnabled) {
-        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
-            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        });
-        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
-        const restoreT0 = Date.now();
-        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
-        const restored = await (0, solo_toolchain_cache_js_1.restoreSoloCache)({
-            keys: soloKeys,
-            rootMap: soloRootMap,
-            stagingDir,
-            log: (msg) => logger.log(msg),
-        });
-        soloMatchedKey = restored.matchedKey;
-        let verifiedMatch = true;
-        if (restored.verified && restored.matchedKey) {
-            const expected = result.toolchain.cacheChannel.trim();
-            // The rustup home is set up so `rustc` will resolve through the
-            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
-            // the cargo bin one.
-            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
-            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
-                expectedRelease: expected,
-                rustcCommand: rustcCmd,
-                log: (msg) => logger.log(msg),
-            });
-            verifiedMatch = verify.match;
-        }
-        soloExactHit = restored.hit && verifiedMatch;
-        core.saveState("soloToolchainEnabled", "true");
-        core.saveState("soloToolchainExactKey", soloKeys.exact);
-        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
-        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
-        core.saveState("soloToolchainLevel", soloLevel);
-        statsCollector.record({
-            label: "solo-toolchain-cache",
-            operation: "restore",
-            hit: soloExactHit,
-            key: soloKeys.exact,
-            matchedKey: soloMatchedKey,
-            restoreKeys: soloKeys.fallbacks,
-            archiveBytes: restored.restoredBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - restoreT0,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else {
-        core.saveState("soloToolchainEnabled", "false");
-    }
-    const baselineSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
-    await (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({ resolveResult: result, setupCacheExactHit });
-    const postInstallSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
-    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
-    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
-    // When solo cache is enabled, also compute the save-diff (post-install
-    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
-    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
-        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
-        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
-        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
-        try {
-            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
-            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
-            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
-            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
-                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
-                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
-                `incremental-empty=${toolchainDiff.added.length === 0}`);
-        }
-        catch (err) {
-            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
-    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
-        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
-    if (ctx.runnerTemp) {
-        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
-        try {
-            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
-            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
-        }
-        catch (err) {
-            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    await (0, phase_timing_js_1.finishPhase)("toolchain");
-    // ---- install soldr ----
-    // soldr-mini-cache was kicked off as a background promise after the
-    // parallel-restore block; await it here so the restored binary is on
-    // disk by the time ensureSoldr's installedVersion() check runs.
-    await (0, phase_timing_js_1.markPhase)("install");
-    if (miniRestorePromise) {
-        const restore = await miniRestorePromise;
-        miniHit = restore.hit;
-        statsCollector.record({
-            label: "soldr-mini-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: miniKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: restore.durationMs,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else if (miniSkipReason) {
-        logger.log(`soldr-mini-cache: skipped — ${miniSkipReason}`);
-    }
-    else if (!miniEnabled) {
-        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
-    }
-    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
-    core.saveState("soldrMiniExactKey", miniKey);
-    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
-    core.saveState("soldrMiniInstallDir", miniInstallDir);
-    core.saveState("soldrMiniArchive", miniArchive);
-    if (result.enabled) {
-        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
-        // restored binary at the expected path with the expected version and
-        // short-circuits — no GH fetch.
-        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
-    }
-    else {
-        (0, install_passthrough_js_1.installPassthrough)({
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
-            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
-            "verbatim, and soldr-aware caching/observability is disabled.");
-    }
-    await (0, phase_timing_js_1.finishPhase)("install");
-    // Export SOLDR_BINARY so shims can exec it directly
-    core.exportVariable("SOLDR_BINARY", result.soldrPath);
-    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
-    // ---- shims ----
-    if (result.shimsEnabled) {
-        await (0, ensure_shims_js_1.ensureShims)({
-            shimsDir: result.shimsDir,
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-    }
-    // ---- verify ----
-    await (0, phase_timing_js_1.markPhase)("verify");
-    if (result.enabled) {
-        const verify = await (0, verify_soldr_js_1.verifySoldr)({
-            soldrPath: result.soldrPath,
-            buildCacheMode: result.buildCache.mode,
-            requireRustPlan: result.targetCache.enabled,
-        });
-        core.setOutput("soldr-version", verify.soldrVersion);
-        core.setOutput("soldr_version", verify.soldrVersion);
-    }
-    else {
-        core.setOutput("soldr-version", "passthrough");
-        core.setOutput("soldr_version", "passthrough");
-    }
-    await (0, phase_timing_js_1.finishPhase)("verify");
-    // ---- cook (prebuild-deps via cargo-chef) ----
-    // The RESTORE was kicked off as a background promise right after the
-    // parallel-restore block above — we just await its result here. The
-    // RUN (actual cargo-chef invocation) still happens in this phase if
-    // the restore missed.
-    // Failures here are logged but never fail the action — the user's
-    // own cargo build will still work without the cooked deps.
-    await (0, phase_timing_js_1.markPhase)("cook");
-    if (cookActive && cookRestorePromise) {
-        const restore = await cookRestorePromise;
-        statsCollector.record({
-            label: "cook-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: cookKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        let cookRan = false;
-        if (!restore.hit) {
-            const runRes = await (0, cook_cache_js_1.runCook)({
-                soldrBinary: result.soldrPath,
-                projectRoot: cookProjectRoot,
-                flags: cookFlags,
-                log: (msg) => logger.log(msg),
-            });
-            cookRan = runRes.exitCode === 0;
-        }
-        else {
-            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
-        }
-        core.saveState("cookEnabled", "true");
-        core.saveState("cookExactKey", cookKey);
-        core.saveState("cookMatchedKey", restore.matchedKey);
-        core.saveState("cookHit", restore.hit ? "true" : "false");
-        core.saveState("cookRan", cookRan ? "true" : "false");
-        core.saveState("cookTargetDir", cookTargetDir);
-        core.saveState("cookLongWindow", "27");
-        core.saveState("cookCompressLevel", "19");
-    }
-    else if (cookSkippedDueToTargetHit) {
-        logger.log(`cook: skipped - target-cache matched at lockfile/shape level (matched=${targetCacheMatchedKey}); cook output would be redundant`);
-        core.saveState("cookEnabled", "false");
-    }
-    else {
-        logger.log(`cook: skipped - ${cookGate.reason}`);
-        core.saveState("cookEnabled", "false");
-    }
-    await (0, phase_timing_js_1.finishPhase)("cook");
-    // ---- shared-target warning ----
-    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
-        buildCacheEnabled,
-        effectiveTargetCacheEnabled: result.targetCache.enabled,
-        buildCacheMode: result.buildCache.mode,
-        targetDir: result.targetCache.targetPath,
-    });
-    // ---- shim-bypass diagnostic ----
-    // Issue #160: when shims: true is requested but the effective environment
-    // (PATH ordering, CARGO/RUSTC/RUSTC_WRAPPER overrides) would bypass them,
-    // caching looks configured but compile work runs through plain cargo.
-    // Emit advisory warnings naming each offender. Runs at the very end so it
-    // sees the final state of process.env after every prior phase.
-    if (result.shimsEnabled) {
-        const bypassWarnings = (0, shim_bypass_check_js_1.diagnoseShimBypass)({
-            shimsEnabled: true,
-            shimDir: result.shimsDir,
-            path: process.env["PATH"] ?? "",
-            cargoEnv: process.env["CARGO"],
-            rustcEnv: process.env["RUSTC"],
-            rustcWrapperEnv: process.env["RUSTC_WRAPPER"],
-            soldrBinary: result.soldrPath,
-        });
-        for (const msg of bypassWarnings) {
-            core.warning(msg);
-        }
-        if (bypassWarnings.length === 0) {
-            logger.log(`shim-bypass check clean: shim dir ${result.shimsDir} at PATH front, no competing CARGO/RUSTC/RUSTC_WRAPPER overrides`);
-        }
-    }
-    // ---- stats report ----
-    statsCollector.report(statsMode, (msg) => logger.log(msg));
-    if (statsMode === "detailed") {
-        try {
-            await statsCollector.writeFiles(ctx.runnerTemp);
-            statsCollector.setGithubOutputs();
-        }
-        catch (err) {
-            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    core.saveState("statsCollector", statsCollector.serialize());
-    core.saveState("statsMode", statsMode);
-    core.saveState("compileCacheStats", result.compileCacheStats);
-    core.saveState("runnerTemp", ctx.runnerTemp);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            cacheOutcomes: statsCollector.snapshot(),
-            logger,
-        });
-    }
-    await (0, phase_timing_js_1.finishPhase)("action");
-    // dirHasContent is exported for tests; suppress unused warning here.
-    void dirHasContent;
-}
-// Auto-invoke only when this module is run as the main entry point. This lets
-// tests import `run` (and helpers) without triggering the side-effectful
-// orchestration. The dist/main.js produced by ncc is invoked directly by the
-// Actions runtime so the check trips and the action executes normally.
-if (typeof process !== "undefined" &&
-    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
-    // import.meta.url is the file URL of this module; argv[1] is the runner
-    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
-    // the dev path — we rely on the env-var opt-out for tests instead.
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.setFailed(`setup-soldr failed: ${message}`);
-    });
-}
-
-
-/***/ }),
-
-/***/ 86:
+/***/ 87:
 /***/ ((module) => {
 
 "use strict";
@@ -17774,7 +17475,7 @@ module.exports = require("url");
 
 /***/ }),
 
-/***/ 87:
+/***/ 88:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -17784,10 +17485,10 @@ module.exports = require("url");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.deserializationPolicyName = void 0;
 exports.deserializationPolicy = deserializationPolicy;
-const interfaces_js_1 = __nccwpck_require__(100);
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const interfaces_js_1 = __nccwpck_require__(101);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 const serializer_js_1 = __nccwpck_require__(481);
-const operationHelpers_js_1 = __nccwpck_require__(433);
+const operationHelpers_js_1 = __nccwpck_require__(434);
 const defaultJsonContentTypes = ["application/json", "text/json"];
 const defaultXmlContentTypes = ["application/xml", "application/atom+xml"];
 /**
@@ -18015,7 +17716,7 @@ async function parse(jsonContentTypes, xmlContentTypes, operationResponse, opts,
 
 /***/ }),
 
-/***/ 88:
+/***/ 89:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -18041,7 +17742,7 @@ __export(apiKeyAuthenticationPolicy_exports, {
   apiKeyAuthenticationPolicyName: () => apiKeyAuthenticationPolicyName
 });
 module.exports = __toCommonJS(apiKeyAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(436);
+var import_checkInsecureConnection = __nccwpck_require__(437);
 const apiKeyAuthenticationPolicyName = "apiKeyAuthenticationPolicy";
 function apiKeyAuthenticationPolicy(options) {
   return {
@@ -18067,7 +17768,7 @@ function apiKeyAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 89:
+/***/ 90:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18098,7 +17799,7 @@ const {
   HTTPParserError,
   ResponseExceededMaxSizeError,
   ClientDestroyedError
-} = __nccwpck_require__(489)
+} = __nccwpck_require__(490)
 const buildConnector = __nccwpck_require__(266)
 const {
   kUrl,
@@ -18151,7 +17852,7 @@ const {
   kHTTP2BuildRequest,
   kHTTP2CopyHeaders,
   kHTTP1BuildRequest
-} = __nccwpck_require__(196)
+} = __nccwpck_require__(194)
 
 /** @type {import('http2')} */
 let http2
@@ -18557,7 +18258,7 @@ function onHTTP2GoAway (code) {
   resume(client)
 }
 
-const constants = __nccwpck_require__(449)
+const constants = __nccwpck_require__(450)
 const createRedirectInterceptor = __nccwpck_require__(255)
 const EMPTY_BUF = Buffer.alloc(0)
 
@@ -20358,7 +20059,7 @@ module.exports = Client
 
 /***/ }),
 
-/***/ 90:
+/***/ 91:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -20400,15 +20101,15 @@ __export(src_exports, {
 module.exports = __toCommonJS(src_exports);
 var import_AbortError = __nccwpck_require__(10);
 var import_logger = __nccwpck_require__(246);
-var import_httpHeaders = __nccwpck_require__(486);
+var import_httpHeaders = __nccwpck_require__(487);
 var import_pipelineRequest = __nccwpck_require__(116);
 var import_pipeline = __nccwpck_require__(526);
-var import_restError = __nccwpck_require__(445);
+var import_restError = __nccwpck_require__(446);
 var import_bytesEncoding = __nccwpck_require__(287);
-var import_defaultHttpClient = __nccwpck_require__(373);
-var import_getClient = __nccwpck_require__(210);
-var import_operationOptionHelpers = __nccwpck_require__(384);
-var import_restError2 = __nccwpck_require__(369);
+var import_defaultHttpClient = __nccwpck_require__(374);
+var import_getClient = __nccwpck_require__(209);
+var import_operationOptionHelpers = __nccwpck_require__(385);
+var import_restError2 = __nccwpck_require__(370);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -20416,7 +20117,7 @@ var import_restError2 = __nccwpck_require__(369);
 
 /***/ }),
 
-/***/ 91:
+/***/ 92:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20425,8 +20126,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
 const base64_1 = __nccwpck_require__(303);
 const pb_long_1 = __nccwpck_require__(118);
-const reflection_info_1 = __nccwpck_require__(453);
-const assert_1 = __nccwpck_require__(485);
+const reflection_info_1 = __nccwpck_require__(454);
+const assert_1 = __nccwpck_require__(486);
 /**
  * Writes proto3 messages in canonical JSON format using reflection
  * information.
@@ -20654,7 +20355,7 @@ exports.ReflectionJsonWriter = ReflectionJsonWriter;
 
 /***/ }),
 
-/***/ 92:
+/***/ 93:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20795,7 +20496,7 @@ exports.Batch = Batch;
 
 /***/ }),
 
-/***/ 93:
+/***/ 94:
 /***/ ((module) => {
 
 "use strict";
@@ -20803,7 +20504,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 94:
+/***/ 95:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20834,7 +20535,7 @@ exports.AnonymousCredentialPolicy = AnonymousCredentialPolicy;
 
 /***/ }),
 
-/***/ 95:
+/***/ 96:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20851,8 +20552,8 @@ const {
   kResult,
   kEvents,
   kAborted
-} = __nccwpck_require__(461)
-const { webidl } = __nccwpck_require__(457)
+} = __nccwpck_require__(462)
+const { webidl } = __nccwpck_require__(458)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 
 class FileReader extends EventTarget {
@@ -21186,7 +20887,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 96:
+/***/ 97:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21215,7 +20916,7 @@ exports.Credential = Credential;
 
 /***/ }),
 
-/***/ 97:
+/***/ 98:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21236,7 +20937,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 98:
+/***/ 99:
 /***/ ((module) => {
 
 "use strict";
@@ -21534,7 +21235,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 99:
+/***/ 100:
 /***/ ((module) => {
 
 "use strict";
@@ -21554,7 +21255,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 100:
+/***/ 101:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21575,7 +21276,7 @@ exports.XML_CHARKEY = "_";
 
 /***/ }),
 
-/***/ 101:
+/***/ 102:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21605,7 +21306,7 @@ async function cancelablePromiseRace(abortablePromiseBuilders, options) {
 
 /***/ }),
 
-/***/ 102:
+/***/ 103:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -21680,26 +21381,26 @@ var import_createPipelineFromOptions = __nccwpck_require__(281);
 var import_defaultHttpClient = __nccwpck_require__(236);
 var import_httpHeaders = __nccwpck_require__(243);
 var import_pipelineRequest = __nccwpck_require__(20);
-var import_restError = __nccwpck_require__(353);
+var import_restError = __nccwpck_require__(354);
 var import_decompressResponsePolicy = __nccwpck_require__(239);
-var import_exponentialRetryPolicy = __nccwpck_require__(393);
+var import_exponentialRetryPolicy = __nccwpck_require__(394);
 var import_setClientRequestIdPolicy = __nccwpck_require__(151);
 var import_logPolicy = __nccwpck_require__(71);
 var import_multipartPolicy = __nccwpck_require__(272);
 var import_proxyPolicy = __nccwpck_require__(474);
 var import_redirectPolicy = __nccwpck_require__(341);
-var import_systemErrorRetryPolicy = __nccwpck_require__(220);
+var import_systemErrorRetryPolicy = __nccwpck_require__(219);
 var import_throttlingRetryPolicy = __nccwpck_require__(23);
-var import_retryPolicy = __nccwpck_require__(212);
+var import_retryPolicy = __nccwpck_require__(211);
 var import_tracingPolicy = __nccwpck_require__(336);
 var import_defaultRetryPolicy = __nccwpck_require__(55);
-var import_userAgentPolicy = __nccwpck_require__(390);
-var import_tlsPolicy = __nccwpck_require__(379);
+var import_userAgentPolicy = __nccwpck_require__(391);
+var import_tlsPolicy = __nccwpck_require__(380);
 var import_formDataPolicy = __nccwpck_require__(269);
-var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(218);
+var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(217);
 var import_ndJsonPolicy = __nccwpck_require__(240);
-var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(194);
-var import_agentPolicy = __nccwpck_require__(232);
+var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(192);
+var import_agentPolicy = __nccwpck_require__(231);
 var import_file = __nccwpck_require__(327);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -21707,7 +21408,7 @@ var import_file = __nccwpck_require__(327);
 
 /***/ }),
 
-/***/ 103:
+/***/ 104:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -21763,11 +21464,11 @@ function logPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 104:
+/***/ 105:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const { addAbortListener } = __nccwpck_require__(69)
-const { RequestAbortedError } = __nccwpck_require__(489)
+const { RequestAbortedError } = __nccwpck_require__(490)
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')
@@ -21824,7 +21525,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 105:
+/***/ 106:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21855,7 +21556,7 @@ function rangeToString(iRange) {
 
 /***/ }),
 
-/***/ 106:
+/***/ 107:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21870,10 +21571,10 @@ const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(489)
+} = __nccwpck_require__(490)
 const util = __nccwpck_require__(69)
-const { AsyncResource } = __nccwpck_require__(430)
-const { addSignal, removeSignal } = __nccwpck_require__(104)
+const { AsyncResource } = __nccwpck_require__(431)
+const { addSignal, removeSignal } = __nccwpck_require__(105)
 const assert = __nccwpck_require__(528)
 
 const kResume = Symbol('resume')
@@ -22112,7 +21813,7 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 107:
+/***/ 108:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22130,15 +21831,15 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 
 /***/ }),
 
-/***/ 108:
+/***/ 109:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const EventEmitter = (__nccwpck_require__(144).EventEmitter)
-const inherits = (__nccwpck_require__(376).inherits)
-const getLimit = __nccwpck_require__(484)
+const inherits = (__nccwpck_require__(377).inherits)
+const getLimit = __nccwpck_require__(485)
 
 const StreamSearch = __nccwpck_require__(115)
 
@@ -22238,7 +21939,7 @@ module.exports = HeaderParser
 
 /***/ }),
 
-/***/ 109:
+/***/ 110:
 /***/ ((module) => {
 
 "use strict";
@@ -22246,7 +21947,7 @@ module.exports = require("node:fs/promises");
 
 /***/ }),
 
-/***/ 110:
+/***/ 111:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -22274,7 +21975,7 @@ __export(util_exports, {
   toWebResourceLike: () => toWebResourceLike
 });
 module.exports = __toCommonJS(util_exports);
-var import_core_rest_pipeline = __nccwpck_require__(102);
+var import_core_rest_pipeline = __nccwpck_require__(103);
 const originalRequestSymbol = /* @__PURE__ */ Symbol("Original PipelineRequest");
 const originalClientRequestSymbol = /* @__PURE__ */ Symbol.for("@azure/core-client original request");
 function toPipelineRequest(webResource, options = {}) {
@@ -22516,7 +22217,7 @@ class HttpHeaders {
 
 /***/ }),
 
-/***/ 111:
+/***/ 112:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22562,374 +22263,6 @@ function objectHasProperty(thing, property) {
 
 /***/ }),
 
-/***/ 112:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Verbose diagnostic dump emitted when the action receives `logging: true`.
-//
-// The goal is to make cache-behavior surprises trivially debuggable from a
-// single CI run. The dump bundles:
-//   - every observed INPUT_* env var (so the kebab-vs-underscore plumbing
-//     bug that motivated this module is visible without re-running)
-//   - the parsed RawInputs struct
-//   - every constructed cache key with restore-key fallbacks
-//   - resolved env exports (SOLDR_*, ZCCACHE_*, SETUP_SOLDR_*)
-//   - cache restore/save outcomes recorded so far
-//   - the final cache summary + compile-cache report in post phase
-//
-// Token-shaped values are redacted before printing.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.redactValue = redactValue;
-exports.captureProcessSnapshot = captureProcessSnapshot;
-exports.dumpDiagnostics = dumpDiagnostics;
-exports.loggingEnabled = loggingEnabled;
-const fs = __importStar(__nccwpck_require__(249));
-const node_child_process_1 = __nccwpck_require__(198);
-const compile_journal_js_1 = __nccwpck_require__(536);
-const ENV_KEY_PREFIXES = [
-    "INPUT_",
-    "SOLDR_",
-    "ZCCACHE_",
-    "SCCACHE_",
-    "SETUP_SOLDR_",
-    "GITHUB_",
-    "RUNNER_",
-    "ACTION_",
-    "CARGO_",
-    "RUSTUP_",
-    "RUSTC_",
-];
-const SECRET_KEY_PATTERN = /(token|secret|password|^.*_pass$|api[_-]?key|client[_-]?secret|webhook)/i;
-// Cache-key fields look secret-y but never are; never redact them.
-const NEVER_REDACT_PATTERN = /(_key$|cache[-_]key|cache[-_]keys$|key[-_]suffix$|public[-_]key)/i;
-function redactValue(key, value) {
-    if (NEVER_REDACT_PATTERN.test(key))
-        return value;
-    if (SECRET_KEY_PATTERN.test(key))
-        return value ? "<redacted>" : "";
-    return value;
-}
-function pickEnv(env) {
-    const pairs = [];
-    for (const [k, v] of Object.entries(env)) {
-        if (v === undefined)
-            continue;
-        if (!ENV_KEY_PREFIXES.some((p) => k.startsWith(p)))
-            continue;
-        pairs.push([k, redactValue(k, v)]);
-    }
-    pairs.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
-    return pairs;
-}
-function rawInputsLines(inputs) {
-    const lines = [];
-    const entries = Object.entries(inputs).sort((a, b) => (a[0] < b[0] ? -1 : 1));
-    for (const [k, v] of entries) {
-        lines.push(`  ${k}=${JSON.stringify(v)}`);
-    }
-    return lines;
-}
-function cachePlanLines(result) {
-    const lines = [];
-    lines.push("  setup_cache:");
-    lines.push(`    key=${result.setupCache.key}`);
-    lines.push(`    restore_prefix=${result.setupCache.restorePrefix}`);
-    lines.push(`    paths=${JSON.stringify(result.setupCache.paths)}`);
-    lines.push(`    layout=${result.setupCache.layout}`);
-    lines.push("  build_cache:");
-    lines.push(`    key=${result.buildCache.key}`);
-    lines.push(`    restore_key_parent=${result.buildCache.restoreKeyParent || "(none)"}`);
-    lines.push(`    restore_key_toolchain=${result.buildCache.restoreKeyToolchain}`);
-    lines.push(`    restore_key_os_arch=${result.buildCache.restoreKeyOsArch}`);
-    lines.push(`    path=${result.buildCache.path}`);
-    lines.push(`    mode=${result.buildCache.mode}`);
-    lines.push("  target_cache:");
-    lines.push(`    enabled=${result.targetCache.enabled}`);
-    lines.push(`    key=${result.targetCache.key}`);
-    lines.push(`    restore_key_parent=${result.targetCache.restoreKeyParent || "(none)"}`);
-    lines.push(`    restore_key_lock=${result.targetCache.restoreKeyLock || "(none)"}`);
-    lines.push(`    restore_key_lockfile=${result.targetCache.restoreKeyLockfile || "(none)"}`);
-    lines.push(`    paths=${result.targetCache.paths}`);
-    lines.push(`    bundle_path=${result.targetCache.bundlePath}`);
-    lines.push(`    target_path=${result.targetCache.targetPath}`);
-    lines.push(`    effective_mode=${result.targetCache.effectiveMode}`);
-    lines.push(`    profile=${result.targetCache.profile}`);
-    lines.push("  cargo_registry_cache:");
-    lines.push(`    enabled=${result.cargoRegistryCache.enabled}`);
-    lines.push(`    key=${result.cargoRegistryCache.key}`);
-    lines.push(`    restore_prefix=${result.cargoRegistryCache.restorePrefix}`);
-    lines.push(`    path=${result.cargoRegistryCache.path}`);
-    return lines;
-}
-function envExportLines(result) {
-    const entries = Object.entries(result.envExports).sort((a, b) => (a[0] < b[0] ? -1 : 1));
-    return entries.map(([k, v]) => `  ${k}=${redactValue(k, v)}`);
-}
-function cacheOutcomeLines(outcomes) {
-    if (outcomes.length === 0)
-        return ["  (no outcomes recorded yet)"];
-    const lines = [];
-    for (const o of outcomes) {
-        lines.push(`  [${o.operation}] ${o.label}: hit=${o.hit} matched=${o.matchedKey || "(none)"} ` +
-            `key=${o.key} duration_ms=${o.durationMs}`);
-        if (o.archiveBytes !== null) {
-            lines.push(`    archive_bytes=${o.archiveBytes} inflated_bytes=${o.inflatedBytes ?? "?"} files=${o.fileCount ?? "?"}`);
-        }
-    }
-    return lines;
-}
-/**
- * Capture a runtime process snapshot via `ps` (Unix) or `tasklist`
- * (Windows). Returns null only on an actual exec failure (binary
- * missing, etc.); a non-zero exit is reported in the result so the
- * stderr can be inspected.
- *
- * Why this lives here: the post step uses it to expose orphan daemons
- * (e.g. zccache-daemon processes that survive `soldr cache shutdown`
- * and get SIGKILL'd by the runner) so root-cause analysis doesn't
- * require another build.
- */
-function captureProcessSnapshot() {
-    const isWindows = process.platform === "win32";
-    const cmd = isWindows ? "tasklist" : "ps";
-    // Unix: print pid, ppid, user, state, command-name, full-args.
-    // BSD ps (macOS) supports the same -o keys but uses `command` instead
-    // of `args` — accept both via the column listing.
-    const args = isWindows
-        ? ["/V", "/FO", "CSV", "/NH"]
-        : ["-eo", "pid,ppid,user,stat,comm,args"];
-    try {
-        const result = (0, node_child_process_1.spawnSync)(cmd, args, {
-            encoding: "utf8",
-            maxBuffer: 8 * 1024 * 1024,
-            timeout: 15_000,
-        });
-        return {
-            cmd: `${cmd} ${args.join(" ")}`,
-            stdout: result.stdout ?? "",
-            stderr: result.stderr ?? "",
-            exitCode: result.status,
-        };
-    }
-    catch {
-        return null;
-    }
-}
-/**
- * Emit the full diagnostic dump to the logger and (optionally) the step summary.
- * Safe to call when `result`, `cacheOutcomes`, or `finalSummary` are missing —
- * each section is independent.
- */
-function dumpDiagnostics(opts) {
-    const lines = [];
-    const header = `=== DIAGNOSTIC DUMP (phase=${opts.phase}) ===`;
-    const footer = "=== END DIAGNOSTIC DUMP ===";
-    lines.push(header);
-    lines.push("[env: observed INPUT_/SOLDR_/ZCCACHE_/SETUP_SOLDR_/GITHUB_/RUNNER_/ACTION_/CARGO_/RUSTUP_/RUSTC_]");
-    const envPairs = pickEnv(opts.env);
-    if (envPairs.length === 0) {
-        lines.push("  (none observed)");
-    }
-    else {
-        for (const [k, v] of envPairs) {
-            lines.push(`  ${k}=${v}`);
-        }
-    }
-    if (opts.rawInputs) {
-        lines.push("[raw_inputs: parsed RawInputs after kebab-case lookup]");
-        lines.push(...rawInputsLines(opts.rawInputs));
-    }
-    if (opts.result) {
-        lines.push("[cache_plans: every constructed cache key + restore-key fallbacks]");
-        lines.push(...cachePlanLines(opts.result));
-        lines.push("[env_exports: resolved SOLDR_/ZCCACHE_/etc env exports]");
-        if (Object.keys(opts.result.envExports).length === 0) {
-            lines.push("  (none)");
-        }
-        else {
-            lines.push(...envExportLines(opts.result));
-        }
-        lines.push("[resolved_state]");
-        lines.push(`  enabled=${opts.result.enabled}`);
-        lines.push(`  workspace=${opts.result.workspace}`);
-        lines.push(`  cache_root=${opts.result.cacheRoot}`);
-        lines.push(`  soldr_root=${opts.result.soldrRoot}`);
-        lines.push(`  cargo_home=${opts.result.cargoHome}`);
-        lines.push(`  rustup_home=${opts.result.rustupHome}`);
-        lines.push(`  soldr_path=${opts.result.soldrPath}`);
-        lines.push(`  soldr_repo=${opts.result.soldrRepo}`);
-        lines.push(`  soldr_ref=${opts.result.soldrRef || "(release)"}`);
-        lines.push(`  soldr_version_requested=${opts.result.soldrVersionRequested}`);
-        lines.push(`  soldr_version_resolved=${opts.result.soldrVersionResolved}`);
-        lines.push(`  toolchain_channel=${opts.result.toolchain.channel}`);
-        lines.push(`  toolchain_cache_channel=${opts.result.toolchain.cacheChannel}`);
-        lines.push(`  rustup_strategy=${opts.result.rustupStrategy}`);
-        lines.push(`  shims_enabled=${opts.result.shimsEnabled}`);
-        lines.push(`  shims_dir=${opts.result.shimsDir}`);
-        lines.push(`  stats=${opts.result.stats}`);
-        lines.push(`  compile_cache_stats=${opts.result.compileCacheStats}`);
-        lines.push(`  debug_mode=${opts.result.debugMode}`);
-        lines.push(`  cache_shutdown_on_idle_seconds=${opts.result.cacheShutdownOnIdleSeconds ?? "(unset)"}`);
-    }
-    if (opts.cacheOutcomes !== undefined) {
-        lines.push("[cache_outcomes: per-layer restore/save results]");
-        lines.push(...cacheOutcomeLines(opts.cacheOutcomes));
-    }
-    if (opts.finalSummary) {
-        lines.push("[final_cache_summary]");
-        const json = JSON.stringify(opts.finalSummary, null, 2);
-        for (const line of json.split("\n")) {
-            lines.push(`  ${line}`);
-        }
-    }
-    // Per-compilation zccache journal — the answer to "warm reports
-    // hits=0; WHY did each lookup miss?". Reads the JSONL emitted by
-    // zccache for the just-finished session, summarizes it (outcome +
-    // miss_reason histograms, slowest misses with their miss_diff, a
-    // handful of verbatim records), and prints. Silently no-ops when
-    // the journal file isn't present.
-    if (opts.journalPath) {
-        try {
-            const records = (0, compile_journal_js_1.readJournal)(opts.journalPath);
-            if (records === null) {
-                lines.push(`[compile_journal]`);
-                lines.push(`  (journal file not found at ${opts.journalPath})`);
-            }
-            else if (records.length === 0) {
-                lines.push(`[compile_journal]`);
-                lines.push(`  (journal file empty at ${opts.journalPath})`);
-            }
-            else {
-                lines.push(...(0, compile_journal_js_1.formatJournalSection)((0, compile_journal_js_1.summarize)(records)));
-            }
-        }
-        catch (err) {
-            lines.push(`[compile_journal]`);
-            lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
-        }
-        // Raw JSONL dump — verbatim file contents under the summary. Only
-        // emitted when the caller opts in (debug=true) because it's huge
-        // (one record per rustc invocation, frequently MBs of output).
-        if (opts.journalPrintRaw) {
-            try {
-                const raw = fs.readFileSync(opts.journalPath, "utf8");
-                const rawLines = raw.split(/\r?\n/).filter((l) => l.length > 0);
-                lines.push(`[compile_journal_raw: verbatim JSONL from ${opts.journalPath} — ${rawLines.length} records]`);
-                for (const rawLine of rawLines) {
-                    lines.push(`  ${rawLine}`);
-                }
-            }
-            catch (err) {
-                const code = err.code;
-                if (code === "ENOENT") {
-                    // Already noted by the summary section above; no need to repeat.
-                }
-                else {
-                    lines.push(`[compile_journal_raw]`);
-                    lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
-                }
-            }
-        }
-    }
-    // Rollups (per-extension / per-crate) from `soldr cache report --json`.
-    // The raw report is already parsed into finalSummary's
-    // compile_cache_report.report; we accept it as a separate
-    // `cacheReport` so callers can pass it without rebuilding the
-    // FinalCacheSummary shape.
-    if (opts.cacheReport) {
-        lines.push(...(0, compile_journal_js_1.formatRollupsSection)(opts.cacheReport));
-    }
-    // Process snapshot — captured by the caller via captureProcessSnapshot()
-    // when debug mode is on. Useful for spotting orphan daemons (e.g.
-    // zccache-daemon survivors after `soldr cache shutdown`) that the runner
-    // SIGKILLs at job cleanup.
-    if (opts.processSnapshot) {
-        const snap = opts.processSnapshot;
-        lines.push(`[processes: snapshot via \`${snap.cmd}\` exit=${snap.exitCode ?? "null"}]`);
-        if (snap.stderr.trim().length > 0) {
-            lines.push(`  stderr: ${snap.stderr.trim().replace(/\n+/g, " | ")}`);
-        }
-        const trimmed = snap.stdout.replace(/\r\n/g, "\n").trimEnd();
-        if (trimmed.length === 0) {
-            lines.push("  (no stdout)");
-        }
-        else {
-            for (const line of trimmed.split("\n")) {
-                lines.push(`  ${line}`);
-            }
-        }
-    }
-    lines.push(footer);
-    for (const line of lines) {
-        opts.logger.log(line);
-    }
-    if (opts.stepSummaryPath) {
-        appendToStepSummary(opts.stepSummaryPath, opts.phase, lines, opts.logger);
-    }
-}
-function appendToStepSummary(summaryPath, phase, lines, logger) {
-    const block = [
-        `### setup-soldr diagnostic dump (phase=${phase})`,
-        "",
-        "```",
-        ...lines,
-        "```",
-        "",
-    ];
-    try {
-        fs.appendFileSync(summaryPath, block.join("\n") + "\n", "utf8");
-    }
-    catch (err) {
-        logger.log(`diagnostics: failed to append to step summary: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-/**
- * Truthy check matching the rest of the action: "1", "true", "yes", "on".
- * Empty / unset / anything else is false.
- */
-function loggingEnabled(value) {
-    const v = (value ?? "").trim().toLowerCase();
-    return v === "1" || v === "true" || v === "yes" || v === "on";
-}
-
-
-/***/ }),
-
 /***/ 113:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -22941,7 +22274,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseCAEChallenge = parseCAEChallenge;
 exports.authorizeRequestOnClaimChallenge = authorizeRequestOnClaimChallenge;
 const log_js_1 = __nccwpck_require__(482);
-const base64_js_1 = __nccwpck_require__(438);
+const base64_js_1 = __nccwpck_require__(439);
 /**
  * Converts: `Bearer a="b", c="d", Bearer d="e", f="g"`.
  * Into: `[ { a: 'b', c: 'd' }, { d: 'e', f: 'g' } ]`.
@@ -23096,7 +22429,7 @@ function calculateRetryDelay(retryAttempt, config) {
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
 const EventEmitter = (__nccwpck_require__(144).EventEmitter)
-const inherits = (__nccwpck_require__(376).inherits)
+const inherits = (__nccwpck_require__(377).inherits)
 
 function SBMH (needle) {
   if (typeof needle === 'string') {
@@ -23324,8 +22657,8 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_httpHeaders = __nccwpck_require__(486);
-var import_uuidUtils = __nccwpck_require__(394);
+var import_httpHeaders = __nccwpck_require__(487);
+var import_uuidUtils = __nccwpck_require__(395);
 class PipelineRequestImpl {
   url;
   method;
@@ -23414,7 +22747,7 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(383));
+var import_node_os = __toESM(__nccwpck_require__(384));
 var import_node_process = __toESM(__nccwpck_require__(237));
 function getHeaderName() {
   return "User-Agent";
@@ -23445,7 +22778,7 @@ async function setPlatformSpecificData(map) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PbLong = exports.PbULong = exports.detectBi = void 0;
-const goog_varint_1 = __nccwpck_require__(204);
+const goog_varint_1 = __nccwpck_require__(203);
 let BI;
 function detectBi() {
     const dv = new DataView(new ArrayBuffer(8));
@@ -23739,7 +23072,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
 const path = __importStar(__nccwpck_require__(248));
-const pathHelper = __importStar(__nccwpck_require__(223));
+const pathHelper = __importStar(__nccwpck_require__(222));
 const assert_1 = __importDefault(__nccwpck_require__(528));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -24040,7 +23373,7 @@ var path = (function () { try { return __nccwpck_require__(248) } catch (e) {}}(
 minimatch.sep = path.sep
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __nccwpck_require__(487)
+var expand = __nccwpck_require__(488)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -25075,12 +24408,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
-const os = __importStar(__nccwpck_require__(93));
+const os = __importStar(__nccwpck_require__(94));
 const events = __importStar(__nccwpck_require__(471));
 const child = __importStar(__nccwpck_require__(165));
 const path = __importStar(__nccwpck_require__(248));
 const io = __importStar(__nccwpck_require__(295));
-const ioUtil = __importStar(__nccwpck_require__(226));
+const ioUtil = __importStar(__nccwpck_require__(225));
 const timers_1 = __nccwpck_require__(511);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
@@ -25677,7 +25010,7 @@ exports.StorageSharedKeyCredentialPolicy = void 0;
 const constants_js_1 = __nccwpck_require__(36);
 const utils_common_js_1 = __nccwpck_require__(475);
 const CredentialPolicy_js_1 = __nccwpck_require__(309);
-const SharedKeyComparator_js_1 = __nccwpck_require__(178);
+const SharedKeyComparator_js_1 = __nccwpck_require__(176);
 /**
  * StorageSharedKeyCredentialPolicy is a policy used to sign HTTP request with a shared key.
  */
@@ -25851,7 +25184,7 @@ module.exports = {
 
 const assert = __nccwpck_require__(528)
 const { Readable } = __nccwpck_require__(131)
-const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(489)
+const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(490)
 const util = __nccwpck_require__(69)
 const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(69)
 
@@ -26295,8 +25628,8 @@ const tls = __importStar(__nccwpck_require__(507));
 const assert_1 = __importDefault(__nccwpck_require__(528));
 const debug_1 = __importDefault(__nccwpck_require__(517));
 const agent_base_1 = __nccwpck_require__(241);
-const url_1 = __nccwpck_require__(86);
-const parse_proxy_response_1 = __nccwpck_require__(420);
+const url_1 = __nccwpck_require__(87);
+const parse_proxy_response_1 = __nccwpck_require__(421);
 const debug = (0, debug_1.default)('https-proxy-agent');
 const setServernameFromNonIpHost = (options) => {
     if (options.servername === undefined &&
@@ -26462,7 +25795,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
 const http_client_1 = __nccwpck_require__(285);
 const auth_1 = __nccwpck_require__(27);
-const core_1 = __nccwpck_require__(460);
+const core_1 = __nccwpck_require__(461);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -26537,7 +25870,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
 const binary_format_contract_1 = __nccwpck_require__(333);
 const pb_long_1 = __nccwpck_require__(118);
-const goog_varint_1 = __nccwpck_require__(204);
+const goog_varint_1 = __nccwpck_require__(203);
 const defaultsRead = {
     readUnknownField: true,
     readerFactory: bytes => new BinaryReader(bytes),
@@ -26734,7 +26067,7 @@ const {
   kContentLength,
   kMockDispatch
 } = __nccwpck_require__(472)
-const { InvalidArgumentError } = __nccwpck_require__(489)
+const { InvalidArgumentError } = __nccwpck_require__(490)
 const { buildURL } = __nccwpck_require__(69)
 
 /**
@@ -27131,10 +26464,10 @@ async function parseXML(str, opts = {}) {
 
 
 module.exports.request = __nccwpck_require__(512)
-module.exports.stream = __nccwpck_require__(354)
-module.exports.pipeline = __nccwpck_require__(106)
-module.exports.upgrade = __nccwpck_require__(434)
-module.exports.connect = __nccwpck_require__(374)
+module.exports.stream = __nccwpck_require__(355)
+module.exports.pipeline = __nccwpck_require__(107)
+module.exports.upgrade = __nccwpck_require__(435)
+module.exports.connect = __nccwpck_require__(375)
 
 
 /***/ }),
@@ -27196,7 +26529,7 @@ module.exports = {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollOperation = exports.initOperation = exports.deserializeState = void 0;
-const logger_js_1 = __nccwpck_require__(192);
+const logger_js_1 = __nccwpck_require__(190);
 const constants_js_1 = __nccwpck_require__(60);
 /**
  * Deserializes the state
@@ -27390,7 +26723,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(375);
+	createDebug.humanize = __nccwpck_require__(376);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -27829,9 +27162,9 @@ var import_delay = __nccwpck_require__(476);
 var import_random = __nccwpck_require__(508);
 var import_object = __nccwpck_require__(145);
 var import_error = __nccwpck_require__(154);
-var import_sha256 = __nccwpck_require__(201);
-var import_uuidUtils = __nccwpck_require__(394);
-var import_checkEnvironment = __nccwpck_require__(439);
+var import_sha256 = __nccwpck_require__(200);
+var import_uuidUtils = __nccwpck_require__(395);
+var import_checkEnvironment = __nccwpck_require__(440);
 var import_bytesEncoding = __nccwpck_require__(287);
 var import_sanitizer = __nccwpck_require__(122);
 // Annotate the CommonJS export names for ESM import in node:
@@ -28223,7 +27556,7 @@ __export(basicAuthenticationPolicy_exports, {
 });
 module.exports = __toCommonJS(basicAuthenticationPolicy_exports);
 var import_bytesEncoding = __nccwpck_require__(287);
-var import_checkInsecureConnection = __nccwpck_require__(436);
+var import_checkInsecureConnection = __nccwpck_require__(437);
 const basicAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function basicAuthenticationPolicy(options) {
   return {
@@ -28338,7 +27671,7 @@ exports.ConvertInternalResponseOfListBlobHierarchy = ConvertInternalResponseOfLi
 exports.ExtractPageRangeInfoItems = ExtractPageRangeInfoItems;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 const core_util_1 = __nccwpck_require__(14);
 const constants_js_1 = __nccwpck_require__(149);
 /**
@@ -29145,262 +28478,20 @@ exports.StorageBrowserPolicyFactory = StorageBrowserPolicyFactory;
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(196).kConstruct)
+  kConstruct: (__nccwpck_require__(194).kConstruct)
 }
 
 
 /***/ }),
 
 /***/ 158:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Soldr-mini-cache — the narrowest cache layer: just the soldr binary,
-// keyed only on (version, platform, arch, libc).
-//
-// Per CLAUDE.md "Layer per change cadence" + "Coarse keys, shared across
-// workflows": the soldr binary's invalidation rhythm is per-soldr-release
-// (~1×/week). Mixing it into the existing setup-cache (which is keyed on
-// toolchain hash + cache-key-suffix) means it re-downloads whenever those
-// move — even though the binary content didn't change.
-//
-// This layer caches *only* the install dir contents (binary + optional
-// source-metadata sidecar), keyed coarsely so every workflow in the repo
-// pinned to the same soldr version hits the same entry.
-//
-// Position in the lifecycle:
-//   main.ts: try restore → if hit, soldrPath is pre-populated and
-//   ensureSoldr's installedVersion check short-circuits the GH fetch.
-//   post.ts: if restore missed AND ensureSoldr fetched, save the binary
-//   for next time.
-//
-// Refs (rebuild-from-source) are skipped: the binary content depends on
-// the commit, not the version tag, so the cache key would be wrong.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.buildMiniCacheKey = buildMiniCacheKey;
-exports.restoreMiniCache = restoreMiniCache;
-exports.saveMiniCache = saveMiniCache;
-exports.isEligibleForMiniCache = isEligibleForMiniCache;
-const fs = __importStar(__nccwpck_require__(249));
-const fsp = __importStar(__nccwpck_require__(109));
-const path = __importStar(__nccwpck_require__(509));
-const cache = __importStar(__nccwpck_require__(215));
-const cache_compress_js_1 = __nccwpck_require__(494);
-const MINI_KEY_PREFIX = "soldr-mini";
-/**
- * Build the mini-cache key. Deliberately coarse — only the dimensions
- * that change soldr's binary content. No toolchain hash, no Cargo.lock,
- * no cache-key-suffix, no SHA. Cross-workflow sharing within a repo.
- */
-function buildMiniCacheKey(parts) {
-    const v = parts.soldrVersion.trim().replace(/^v/, "") || "unresolved";
-    return [
-        MINI_KEY_PREFIX,
-        parts.runnerOs,
-        parts.runnerArch,
-        parts.libc,
-        `v${v}`,
-    ].join("-");
-}
-/**
- * Try to restore the soldr install dir from the mini-cache. Single exact
- * key — content-addressable so a fallback would be wrong. On hit, the
- * caller's normal ensureSoldr() will see the binary already present at
- * the expected path and skip the GH Releases fetch.
- */
-async function restoreMiniCache(opts) {
-    const { exactKey, installDir, archivePath, longWindow, log } = opts;
-    await fsp.mkdir(installDir, { recursive: true });
-    await fsp.mkdir(path.dirname(archivePath), { recursive: true });
-    await fsp.rm(archivePath, { force: true });
-    let matched;
-    try {
-        matched = await cache.restoreCache([archivePath], exactKey);
-    }
-    catch (err) {
-        log(`soldr-mini-cache: restore threw: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "", archiveBytes: 0 };
-    }
-    if (!matched) {
-        log(`soldr-mini-cache: no entry for key ${exactKey}`);
-        return { hit: false, matchedKey: "", archiveBytes: 0 };
-    }
-    let archiveBytes = 0;
-    try {
-        archiveBytes = (await fsp.stat(archivePath)).size;
-    }
-    catch {
-        return { hit: false, matchedKey: matched, archiveBytes: 0 };
-    }
-    const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-    if (magic !== "zstd" && magic !== "gzip") {
-        log(`soldr-mini-cache: archive has unknown codec, treating as miss`);
-        return { hit: false, matchedKey: matched, archiveBytes };
-    }
-    try {
-        await (0, cache_compress_js_1.decompressCache)({
-            archivePath,
-            targetDir: installDir,
-            longWindow,
-            log,
-            debug: opts.debug,
-        });
-    }
-    catch (err) {
-        log(`soldr-mini-cache: decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: matched, archiveBytes };
-    }
-    log(`soldr-mini-cache: restored matched=${matched} archive=${archiveBytes}B target=${installDir}`);
-    return { hit: true, matchedKey: matched, archiveBytes };
-}
-/**
- * Tar+zstd the soldr install dir and upload to cache. Caller should only
- * call this when restore missed AND ensureSoldr actually fetched (otherwise
- * we'd be re-saving the same content).
- */
-async function saveMiniCache(opts) {
-    const { installDir, archivePath, exactKey, level, longWindow, debug, log } = opts;
-    if (!fs.existsSync(installDir)) {
-        return { status: "skipped-missing-dir" };
-    }
-    let entryCount = 0;
-    try {
-        entryCount = (await fsp.readdir(installDir)).length;
-    }
-    catch { /* */ }
-    if (entryCount === 0) {
-        return { status: "skipped-empty" };
-    }
-    // compressCache writes to `${cacheDir}.tar.zst` by default. We pass
-    // installDir as cacheDir, so the archive ends up at
-    // `${installDir}.tar.zst`. The caller's main.ts side uses the same
-    // path so @actions/cache hashes the paths array identically on save
-    // and restore (mirrors the cook-cache lesson from #141).
-    let outputArchivePath = null;
-    let archiveBytes;
-    let inflatedBytes;
-    let fileCount;
-    try {
-        const compress = await (0, cache_compress_js_1.compressCache)({
-            cacheDir: installDir,
-            codec: "zstd",
-            level,
-            longWindow,
-            debug,
-            log,
-        });
-        outputArchivePath = compress.archivePath;
-        archiveBytes = compress.archiveBytes;
-        if (compress.inflatedBytes !== null)
-            inflatedBytes = compress.inflatedBytes;
-        if (compress.fileCount !== null)
-            fileCount = compress.fileCount;
-    }
-    catch (err) {
-        return { status: "failed", error: err instanceof Error ? err.message : String(err) };
-    }
-    if (!outputArchivePath) {
-        return { status: "failed", error: "compressCache returned null archive (zstd unavailable?)" };
-    }
-    if (path.resolve(outputArchivePath) !== path.resolve(archivePath)) {
-        log(`soldr-mini-cache: WARNING archive path mismatch — compress wrote ${outputArchivePath}, ` +
-            `expected ${archivePath}. Future restore may miss due to paths-version hash.`);
-    }
-    try {
-        const id = await cache.saveCache([outputArchivePath], exactKey);
-        if (id <= 0) {
-            log(`soldr-mini-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
-                `job already saved key=${exactKey}`);
-            return {
-                status: "skipped-race",
-                cacheId: id,
-                archiveBytes,
-                inflatedBytes,
-                fileCount,
-            };
-        }
-        log(`soldr-mini-cache: saved id=${id} key=${exactKey} archive=${outputArchivePath}`);
-        return {
-            status: "saved",
-            cacheId: id,
-            archiveBytes,
-            inflatedBytes,
-            fileCount,
-        };
-    }
-    catch (err) {
-        return {
-            status: "failed",
-            error: err instanceof Error ? err.message : String(err),
-        };
-    }
-}
-/**
- * Should we use the mini-cache for this run? Independent of the
- * `soldr-mini-cache` input flag (that gate is checked in main.ts).
- * Returns false when building from source — binary content depends on
- * the commit SHA, not the version tag.
- */
-function isEligibleForMiniCache(opts) {
-    if (!opts.enable)
-        return { eligible: false, reason: "enable=false (passthrough stub mode)" };
-    if (opts.hasRef) {
-        return {
-            eligible: false,
-            reason: "ref is set — building from source, binary depends on commit not version",
-        };
-    }
-    if (!opts.resolvedVersion.trim()) {
-        return { eligible: false, reason: "no resolved version available" };
-    }
-    return { eligible: true, reason: "eligible" };
-}
-
-
-/***/ }),
-
-/***/ 159:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionLongConvert = void 0;
-const reflection_info_1 = __nccwpck_require__(453);
+const reflection_info_1 = __nccwpck_require__(454);
 /**
  * Utility method to convert a PbLong or PbUlong to a JavaScript
  * representation during runtime.
@@ -29425,7 +28516,7 @@ exports.reflectionLongConvert = reflectionLongConvert;
 
 /***/ }),
 
-/***/ 160:
+/***/ 159:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -29459,7 +28550,7 @@ const DEFAULT_RETRY_POLICY_COUNT = 3;
 
 /***/ }),
 
-/***/ 161:
+/***/ 160:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29498,8 +28589,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.uploadCacheArchiveSDK = exports.UploadProgress = void 0;
-const core = __importStar(__nccwpck_require__(460));
-const storage_blob_1 = __nccwpck_require__(448);
+const core = __importStar(__nccwpck_require__(461));
+const storage_blob_1 = __nccwpck_require__(449);
 const errors_1 = __nccwpck_require__(305);
 /**
  * Class for tracking the upload state and displaying stats.
@@ -29633,7 +28724,7 @@ exports.uploadCacheArchiveSDK = uploadCacheArchiveSDK;
 
 /***/ }),
 
-/***/ 162:
+/***/ 161:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29706,7 +28797,7 @@ exports.req = req;
 
 /***/ }),
 
-/***/ 163:
+/***/ 162:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -29844,36 +28935,36 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 
 /***/ }),
 
-/***/ 164:
+/***/ 163:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Client = __nccwpck_require__(89)
+const Client = __nccwpck_require__(90)
 const Dispatcher = __nccwpck_require__(479)
-const errors = __nccwpck_require__(489)
+const errors = __nccwpck_require__(490)
 const Pool = __nccwpck_require__(338)
-const BalancedPool = __nccwpck_require__(382)
+const BalancedPool = __nccwpck_require__(383)
 const Agent = __nccwpck_require__(5)
 const util = __nccwpck_require__(69)
 const { InvalidArgumentError } = errors
 const api = __nccwpck_require__(139)
 const buildConnector = __nccwpck_require__(266)
-const MockClient = __nccwpck_require__(200)
-const MockAgent = __nccwpck_require__(378)
-const MockPool = __nccwpck_require__(349)
-const mockErrors = __nccwpck_require__(233)
+const MockClient = __nccwpck_require__(199)
+const MockAgent = __nccwpck_require__(379)
+const MockPool = __nccwpck_require__(350)
+const mockErrors = __nccwpck_require__(232)
 const ProxyAgent = __nccwpck_require__(342)
 const RetryHandler = __nccwpck_require__(274)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(377)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(378)
 const DecoratorHandler = __nccwpck_require__(477)
-const RedirectHandler = __nccwpck_require__(391)
+const RedirectHandler = __nccwpck_require__(392)
 const createRedirectInterceptor = __nccwpck_require__(255)
 
 let hasCrypto
 try {
-  __nccwpck_require__(291)
+  __nccwpck_require__(292)
   hasCrypto = true
 } catch {
   hasCrypto = false
@@ -29952,7 +29043,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   let fetchImpl = null
   module.exports.fetch = async function fetch (resource) {
     if (!fetchImpl) {
-      fetchImpl = (__nccwpck_require__(451).fetch)
+      fetchImpl = (__nccwpck_require__(452).fetch)
     }
 
     try {
@@ -29967,10 +29058,10 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   }
   module.exports.Headers = __nccwpck_require__(518).Headers
   module.exports.Response = __nccwpck_require__(41).Response
-  module.exports.Request = __nccwpck_require__(84).Request
-  module.exports.FormData = __nccwpck_require__(208).FormData
-  module.exports.File = __nccwpck_require__(365).File
-  module.exports.FileReader = __nccwpck_require__(95).FileReader
+  module.exports.Request = __nccwpck_require__(86).Request
+  module.exports.FormData = __nccwpck_require__(207).FormData
+  module.exports.File = __nccwpck_require__(366).File
+  module.exports.FileReader = __nccwpck_require__(96).FileReader
 
   const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(140)
 
@@ -29986,7 +29077,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
 }
 
 if (util.nodeMajor >= 16) {
-  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(387)
+  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(388)
 
   module.exports.deleteCookie = deleteCookie
   module.exports.getCookies = getCookies
@@ -30019,15 +29110,7 @@ module.exports.mockErrors = mockErrors
 
 /***/ }),
 
-/***/ 165:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("child_process");
-
-/***/ }),
-
-/***/ 166:
+/***/ 164:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -30456,12 +29539,20 @@ function isPathInside(parent, child) {
 }
 function setupCachePaths(setupCachePath, binDir, soldrBinCachePath, rustupHome) {
     const paths = [binDir, soldrBinCachePath];
+    // setup-soldr#102: always cache `~/.rustup/update-hashes/<channel>-<host>`.
+    // These are ~64-byte manifest hashes that let `rustup update` short-circuit
+    // without a dist-server roundtrip. The dir is tiny (KB range) and the
+    // latency win is large, so we include it even on the `system` rustup layout
+    // where the toolchains/ tree itself is shared with the runner image and
+    // deliberately excluded. (Toolchains/settings.toml stay gated on
+    // rustupHome being inside setupCachePath — those payloads are large and
+    // only owned by the managed rustup layout.)
+    paths.push(path.join(rustupHome, "update-hashes"));
     if (!isPathInside(setupCachePath, rustupHome)) {
         return paths.join("\n");
     }
     paths.push(path.join(rustupHome, "settings.toml"));
     paths.push(path.join(rustupHome, "toolchains"));
-    paths.push(path.join(rustupHome, "update-hashes"));
     return paths.join("\n");
 }
 function setupCacheLayout(setupCachePath, rustupHome) {
@@ -30483,7 +29574,15 @@ function pathForOutput(workspace, p) {
 
 /***/ }),
 
-/***/ 167:
+/***/ 165:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("child_process");
+
+/***/ }),
+
+/***/ 166:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30496,18 +29595,18 @@ function pathForOutput(workspace, p) {
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(216);
 tslib_1.__exportStar(__nccwpck_require__(119), exports);
-tslib_1.__exportStar(__nccwpck_require__(182), exports);
+tslib_1.__exportStar(__nccwpck_require__(180), exports);
 tslib_1.__exportStar(__nccwpck_require__(123), exports);
 tslib_1.__exportStar(__nccwpck_require__(317), exports);
-tslib_1.__exportStar(__nccwpck_require__(209), exports);
+tslib_1.__exportStar(__nccwpck_require__(208), exports);
 tslib_1.__exportStar(__nccwpck_require__(271), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 168:
+/***/ 167:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30518,7 +29617,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageRetryPolicyName = void 0;
 exports.storageRetryPolicy = storageRetryPolicy;
 const abort_controller_1 = __nccwpck_require__(496);
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 const core_util_1 = __nccwpck_require__(14);
 const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(326);
 const constants_js_1 = __nccwpck_require__(36);
@@ -30682,7 +29781,7 @@ function storageRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 169:
+/***/ 168:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -30698,7 +29797,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.create = void 0;
-const internal_globber_1 = __nccwpck_require__(432);
+const internal_globber_1 = __nccwpck_require__(433);
 /**
  * Constructs a globber
  *
@@ -30715,7 +29814,7 @@ exports.create = create;
 
 /***/ }),
 
-/***/ 170:
+/***/ 169:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30769,335 +29868,7 @@ exports.UserDelegationKeyCredential = UserDelegationKeyCredential;
 
 /***/ }),
 
-/***/ 171:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Cook cache layer — long-lived deps tarball keyed by Cargo.lock content.
-//
-// Per CLAUDE.md "Cache-lifetime axis" + the cook simulation findings:
-// the cook cache is short-lived/large (churns on every Cargo.lock change,
-// 100s of MB to multi-GB). It must NOT include SHA in the key (causes
-// catastrophic eviction churn). Content-addressable keying gives parent-
-// to-branch sharing automatically: same Cargo.lock = same key, regardless
-// of branch or commit.
-//
-// Save path: snapshot `target/` immediately after cook completes, before
-// the user's `cargo build` adds project artifacts. We tar+zstd-19 with
-// `--long=27` because compiled rust deps have heavy cross-crate
-// redundancy that benefits from the 128 MB zstd window.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.hashCookFlags = hashCookFlags;
-exports.buildCookCacheKey = buildCookCacheKey;
-exports.decideCookGate = decideCookGate;
-exports.runCook = runCook;
-exports.restoreCookCache = restoreCookCache;
-exports.saveCookCache = saveCookCache;
-exports.parseCookFlags = parseCookFlags;
-exports.canonicalizeCookFlags = canonicalizeCookFlags;
-const node_crypto_1 = __nccwpck_require__(275);
-const fs = __importStar(__nccwpck_require__(249));
-const fsp = __importStar(__nccwpck_require__(109));
-const path = __importStar(__nccwpck_require__(509));
-const exec = __importStar(__nccwpck_require__(18));
-const cache = __importStar(__nccwpck_require__(215));
-const cache_compress_js_1 = __nccwpck_require__(494);
-const COOK_KEY_PREFIX = "cook";
-/**
- * Compute the canonical flag fingerprint. Sorts and lowercases so flag
- * order doesn't perturb the key, and so `--release` vs `--RELEASE`
- * collapse. Only flags that affect cook output structure should be
- * here; cosmetic flags must be filtered upstream.
- */
-function hashCookFlags(flags) {
-    const sorted = [...flags.map((s) => s.trim()).filter((s) => s.length > 0)].sort();
-    if (sorted.length === 0)
-        return "none";
-    const h = (0, node_crypto_1.createHash)("sha256");
-    for (const s of sorted) {
-        h.update(s);
-        h.update("\0");
-    }
-    return h.digest("hex").slice(0, 8);
-}
-function buildCookCacheKey(parts) {
-    const release = parts.rustcRelease.trim() || "unresolved";
-    return [
-        COOK_KEY_PREFIX,
-        parts.runnerOs,
-        parts.runnerArch,
-        parts.libc,
-        `rustc${release}`,
-        `f${parts.flagsHash}`,
-        `l${parts.lockHash}`,
-        `soldr${parts.soldrVersion}`,
-    ].join("-");
-}
-/**
- * Decide whether to run cook based on the runtime environment. Returns a
- * reason string for diagnostic logging in both branches.
- */
-function decideCookGate(opts) {
-    const mode = opts.prebuildDeps.trim().toLowerCase();
-    if (mode === "" || mode === "none" || mode === "off" || mode === "false") {
-        return { enabled: false, reason: `prebuild-deps=${opts.prebuildDeps || "(empty)"} - cook disabled` };
-    }
-    if (mode !== "cargo-chef") {
-        return {
-            enabled: false,
-            reason: `prebuild-deps=${opts.prebuildDeps} - unknown strategy, only "cargo-chef" supported`,
-        };
-    }
-    if (!opts.cacheUmbrella) {
-        return { enabled: false, reason: "cache: false - cook produces no value without caching" };
-    }
-    if (!opts.lockfilePath) {
-        return { enabled: false, reason: "no Cargo.lock found - cook needs a lockfile to derive recipe" };
-    }
-    if (!fs.existsSync(opts.lockfilePath)) {
-        return { enabled: false, reason: `Cargo.lock path ${opts.lockfilePath} does not exist` };
-    }
-    return { enabled: true, reason: "cook enabled" };
-}
-/**
- * Run `soldr cook` in the project directory. Cargo-chef itself emits
- * the recipe and runs the cook compile. We tolerate failure: cook is
- * an optimization, not a correctness primitive, so any non-zero exit
- * is logged and the action proceeds. The user's normal `cargo build`
- * step will work fine without a cooked target.
- */
-async function runCook(opts) {
-    const { soldrBinary, projectRoot, flags, log } = opts;
-    log(`cook: running '${soldrBinary} cook ${flags.join(" ")}' in ${projectRoot}`);
-    const t0 = Date.now();
-    let exitCode = 0;
-    try {
-        exitCode = await exec.exec(soldrBinary, ["cook", ...flags], {
-            cwd: projectRoot,
-            ignoreReturnCode: true,
-        });
-    }
-    catch (err) {
-        log(`cook: exec threw: ${err instanceof Error ? err.message : String(err)}`);
-        exitCode = 1;
-    }
-    const ranSeconds = (Date.now() - t0) / 1000;
-    if (exitCode !== 0) {
-        log(`cook: failed with exit ${exitCode} after ${ranSeconds.toFixed(1)}s; continuing without cooked deps`);
-    }
-    else {
-        log(`cook: completed in ${ranSeconds.toFixed(1)}s`);
-    }
-    return { exitCode, ranSeconds };
-}
-/**
- * Attempt to restore a cooked target directory from the actions cache.
- * Single exact key — no fallback ladder; cook is content-addressable so
- * a fallback would either be redundant or wrong.
- */
-async function restoreCookCache(opts) {
-    const { exactKey, archivePath, targetDir, longWindow, log } = opts;
-    await fsp.mkdir(path.dirname(archivePath), { recursive: true });
-    await fsp.rm(archivePath, { force: true });
-    let matched;
-    try {
-        matched = await cache.restoreCache([archivePath], exactKey);
-    }
-    catch (err) {
-        log(`cook-cache: restore failed: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "", archiveBytes: 0 };
-    }
-    if (!matched) {
-        log(`cook-cache: no entry for key ${exactKey}`);
-        return { hit: false, matchedKey: "", archiveBytes: 0 };
-    }
-    let archiveBytes = 0;
-    try {
-        archiveBytes = (await fsp.stat(archivePath)).size;
-    }
-    catch {
-        return { hit: false, matchedKey: matched, archiveBytes: 0 };
-    }
-    const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-    if (magic !== "zstd" && magic !== "gzip") {
-        log(`cook-cache: restored archive has unknown codec, treating as miss`);
-        return { hit: false, matchedKey: matched, archiveBytes };
-    }
-    await fsp.mkdir(targetDir, { recursive: true });
-    try {
-        await (0, cache_compress_js_1.decompressCache)({
-            archivePath,
-            targetDir,
-            longWindow,
-            log,
-            debug: opts.debug,
-        });
-    }
-    catch (err) {
-        log(`cook-cache: decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: matched, archiveBytes };
-    }
-    log(`cook-cache: restored matched=${matched} archive=${archiveBytes}B target=${targetDir}`);
-    return { hit: true, matchedKey: matched, archiveBytes };
-}
-/**
- * Tar+zstd the post-cook target directory and upload via actions cache.
- * Caller passes the same `longWindow` as the restore side so the archive
- * is readable on subsequent runs.
- */
-async function saveCookCache(opts) {
-    const { targetDir, exactKey, level, longWindow, debug, log } = opts;
-    if (!fs.existsSync(targetDir)) {
-        return { status: "skipped-missing-target" };
-    }
-    // Bail if the directory is effectively empty — cook should have produced
-    // *something*; an empty target dir indicates cook failed silently or the
-    // gate let us through when it shouldn't have.
-    let entryCount = 0;
-    try {
-        entryCount = (await fsp.readdir(targetDir)).length;
-    }
-    catch { /* */ }
-    if (entryCount === 0) {
-        return { status: "skipped-empty" };
-    }
-    let archivePath = null;
-    let archiveBytes;
-    let inflatedBytes;
-    let fileCount;
-    try {
-        const compress = await (0, cache_compress_js_1.compressCache)({
-            cacheDir: targetDir,
-            codec: "zstd",
-            level,
-            longWindow,
-            debug,
-            log,
-        });
-        archivePath = compress.archivePath;
-        archiveBytes = compress.archiveBytes;
-        if (compress.inflatedBytes !== null)
-            inflatedBytes = compress.inflatedBytes;
-        if (compress.fileCount !== null)
-            fileCount = compress.fileCount;
-    }
-    catch (err) {
-        return { status: "failed", error: err instanceof Error ? err.message : String(err) };
-    }
-    if (!archivePath) {
-        return { status: "failed", error: "compressCache returned null archive (zstd unavailable?)" };
-    }
-    try {
-        const id = await cache.saveCache([archivePath], exactKey);
-        if (id <= 0) {
-            // @actions/cache returns -1 when reserveCache fails — typically
-            // because the key already exists (parallel job got there first)
-            // or the cache budget is exhausted. Not an error: future runs
-            // will hit the entry the other job saved.
-            log(`cook-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
-                `job already saved key=${exactKey} or repo cache budget is exhausted`);
-            return {
-                status: "skipped-race",
-                cacheId: id,
-                archiveBytes,
-                inflatedBytes,
-                fileCount,
-                archivePath,
-            };
-        }
-        log(`cook-cache: saved id=${id} key=${exactKey} archive=${archivePath}`);
-        return {
-            status: "saved",
-            cacheId: id,
-            archiveBytes,
-            inflatedBytes,
-            fileCount,
-            archivePath,
-        };
-    }
-    catch (err) {
-        return {
-            status: "failed",
-            error: err instanceof Error ? err.message : String(err),
-            archivePath,
-        };
-    }
-}
-/** Tokenize a free-form flags string into a flags array. Whitespace-split. */
-function parseCookFlags(raw) {
-    return raw
-        .trim()
-        .split(/\s+/)
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
-}
-/**
- * From a flags array, extract only the tokens that materially affect cook
- * output structure for hashing. Excludes verbosity / colour flags.
- *
- * Conservative: keep anything that isn't on a known-cosmetic list. This
- * over-keys (extra misses on cosmetic-only changes) rather than under-keys
- * (serving stale cooked artifacts under a key that doesn't reflect them).
- */
-function canonicalizeCookFlags(flags) {
-    const COSMETIC = new Set([
-        "--verbose", "-v", "-vv", "--quiet", "-q",
-        "--color=auto", "--color=always", "--color=never",
-        "--no-default-features", // affects output; KEEP — moved out below
-    ]);
-    COSMETIC.delete("--no-default-features"); // safety net for the comment above
-    const out = [];
-    for (let i = 0; i < flags.length; i++) {
-        const f = flags[i];
-        if (COSMETIC.has(f))
-            continue;
-        if (f === "--color" || f === "--message-format") {
-            i += 1; // skip the value
-            continue;
-        }
-        out.push(f);
-    }
-    return out;
-}
-
-
-/***/ }),
-
-/***/ 172:
+/***/ 170:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -31125,7 +29896,7 @@ __export(multipartPolicy_exports, {
 module.exports = __toCommonJS(multipartPolicy_exports);
 var import_bytesEncoding = __nccwpck_require__(287);
 var import_typeGuards = __nccwpck_require__(498);
-var import_uuidUtils = __nccwpck_require__(394);
+var import_uuidUtils = __nccwpck_require__(395);
 var import_concat = __nccwpck_require__(304);
 function generateBoundary() {
   return `----AzSDKFormBoundary${(0, import_uuidUtils.randomUUID)()}`;
@@ -31235,12 +30006,12 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 173:
+/***/ 171:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(404)
+const f = __nccwpck_require__(405)
 
 class FloatingDateTime extends Date {
   constructor (value) {
@@ -31267,7 +30038,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 174:
+/***/ 172:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -31394,7 +30165,7 @@ function requestToOptions(request) {
 
 /***/ }),
 
-/***/ 175:
+/***/ 173:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -31406,7 +30177,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 176:
+/***/ 174:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31417,13 +30188,13 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 var service_type_1 = __nccwpck_require__(480);
 Object.defineProperty(exports, "ServiceType", ({ enumerable: true, get: function () { return service_type_1.ServiceType; } }));
-var reflection_info_1 = __nccwpck_require__(529);
+var reflection_info_1 = __nccwpck_require__(530);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
 Object.defineProperty(exports, "readMethodOption", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOption; } }));
 Object.defineProperty(exports, "readServiceOption", ({ enumerable: true, get: function () { return reflection_info_1.readServiceOption; } }));
-var rpc_error_1 = __nccwpck_require__(177);
+var rpc_error_1 = __nccwpck_require__(175);
 Object.defineProperty(exports, "RpcError", ({ enumerable: true, get: function () { return rpc_error_1.RpcError; } }));
-var rpc_options_1 = __nccwpck_require__(293);
+var rpc_options_1 = __nccwpck_require__(294);
 Object.defineProperty(exports, "mergeRpcOptions", ({ enumerable: true, get: function () { return rpc_options_1.mergeRpcOptions; } }));
 var rpc_output_stream_1 = __nccwpck_require__(307);
 Object.defineProperty(exports, "RpcOutputStreamController", ({ enumerable: true, get: function () { return rpc_output_stream_1.RpcOutputStreamController; } }));
@@ -31434,25 +30205,25 @@ Object.defineProperty(exports, "Deferred", ({ enumerable: true, get: function ()
 Object.defineProperty(exports, "DeferredState", ({ enumerable: true, get: function () { return deferred_1.DeferredState; } }));
 var duplex_streaming_call_1 = __nccwpck_require__(306);
 Object.defineProperty(exports, "DuplexStreamingCall", ({ enumerable: true, get: function () { return duplex_streaming_call_1.DuplexStreamingCall; } }));
-var client_streaming_call_1 = __nccwpck_require__(350);
+var client_streaming_call_1 = __nccwpck_require__(351);
 Object.defineProperty(exports, "ClientStreamingCall", ({ enumerable: true, get: function () { return client_streaming_call_1.ClientStreamingCall; } }));
-var server_streaming_call_1 = __nccwpck_require__(452);
+var server_streaming_call_1 = __nccwpck_require__(453);
 Object.defineProperty(exports, "ServerStreamingCall", ({ enumerable: true, get: function () { return server_streaming_call_1.ServerStreamingCall; } }));
 var unary_call_1 = __nccwpck_require__(56);
 Object.defineProperty(exports, "UnaryCall", ({ enumerable: true, get: function () { return unary_call_1.UnaryCall; } }));
-var rpc_interceptor_1 = __nccwpck_require__(534);
+var rpc_interceptor_1 = __nccwpck_require__(535);
 Object.defineProperty(exports, "stackIntercept", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackIntercept; } }));
 Object.defineProperty(exports, "stackDuplexStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackDuplexStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackClientStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackClientStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackServerStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackServerStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackUnaryInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackUnaryInterceptors; } }));
-var server_call_context_1 = __nccwpck_require__(425);
+var server_call_context_1 = __nccwpck_require__(426);
 Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: true, get: function () { return server_call_context_1.ServerCallContextController; } }));
 
 
 /***/ }),
 
-/***/ 177:
+/***/ 175:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -31496,7 +30267,7 @@ exports.RpcError = RpcError;
 
 /***/ }),
 
-/***/ 178:
+/***/ 176:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -31579,7 +30350,7 @@ function isLessThan(lhs, rhs) {
 
 /***/ }),
 
-/***/ 179:
+/***/ 177:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31588,7 +30359,7 @@ function isLessThan(lhs, rhs) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-const operation_js_1 = __nccwpck_require__(357);
+const operation_js_1 = __nccwpck_require__(358);
 const constants_js_1 = __nccwpck_require__(60);
 const poller_js_1 = __nccwpck_require__(75);
 const operation_js_2 = __nccwpck_require__(141);
@@ -31619,7 +30390,7 @@ exports.LroEngine = LroEngine;
 
 /***/ }),
 
-/***/ 180:
+/***/ 178:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -33269,7 +32040,7 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 181:
+/***/ 179:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -41612,7 +40383,7 @@ exports.BlockBlobGetBlockListExceptionHeaders = {
 
 /***/ }),
 
-/***/ 182:
+/***/ 180:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -41629,7 +40400,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 183:
+/***/ 181:
 /***/ ((module) => {
 
 "use strict";
@@ -41637,7 +40408,7 @@ module.exports = require("tty");
 
 /***/ }),
 
-/***/ 184:
+/***/ 182:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -41651,11 +40422,11 @@ exports.newPipeline = newPipeline;
 exports.getCoreClientOptions = getCoreClientOptions;
 exports.getCredentialFromPipeline = getCredentialFromPipeline;
 const core_http_compat_1 = __nccwpck_require__(72);
-const core_rest_pipeline_1 = __nccwpck_require__(102);
-const core_client_1 = __nccwpck_require__(440);
-const core_xml_1 = __nccwpck_require__(195);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
+const core_client_1 = __nccwpck_require__(441);
+const core_xml_1 = __nccwpck_require__(193);
 const core_auth_1 = __nccwpck_require__(516);
-const log_js_1 = __nccwpck_require__(107);
+const log_js_1 = __nccwpck_require__(108);
 const storage_common_1 = __nccwpck_require__(277);
 const constants_js_1 = __nccwpck_require__(149);
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return constants_js_1.StorageOAuthScopes; } }));
@@ -41921,7 +40692,7 @@ function isCoreHttpPolicyFactory(factory) {
 
 /***/ }),
 
-/***/ 185:
+/***/ 183:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -41954,7 +40725,7 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 
 /***/ }),
 
-/***/ 186:
+/***/ 184:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -41963,27 +40734,27 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobClient = exports.BlockBlobClient = exports.AppendBlobClient = exports.BlobClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 const core_auth_1 = __nccwpck_require__(516);
 const core_util_1 = __nccwpck_require__(14);
 const core_util_2 = __nccwpck_require__(14);
-const BlobDownloadResponse_js_1 = __nccwpck_require__(427);
-const BlobQueryResponse_js_1 = __nccwpck_require__(202);
+const BlobDownloadResponse_js_1 = __nccwpck_require__(428);
+const BlobQueryResponse_js_1 = __nccwpck_require__(201);
 const storage_common_1 = __nccwpck_require__(277);
-const models_js_1 = __nccwpck_require__(416);
+const models_js_1 = __nccwpck_require__(417);
 const PageBlobRangeResponse_js_1 = __nccwpck_require__(29);
-const Pipeline_js_1 = __nccwpck_require__(184);
+const Pipeline_js_1 = __nccwpck_require__(182);
 const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(537);
-const Range_js_1 = __nccwpck_require__(105);
-const StorageClient_js_1 = __nccwpck_require__(455);
-const Batch_js_1 = __nccwpck_require__(92);
+const Range_js_1 = __nccwpck_require__(106);
+const StorageClient_js_1 = __nccwpck_require__(456);
+const Batch_js_1 = __nccwpck_require__(93);
 const storage_common_2 = __nccwpck_require__(277);
 const constants_js_1 = __nccwpck_require__(149);
 const tracing_js_1 = __nccwpck_require__(31);
 const utils_common_js_1 = __nccwpck_require__(155);
-const utils_js_1 = __nccwpck_require__(203);
+const utils_js_1 = __nccwpck_require__(202);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
-const BlobLeaseClient_js_1 = __nccwpck_require__(205);
+const BlobLeaseClient_js_1 = __nccwpck_require__(204);
 /**
  * A BlobClient represents a URL to an Azure Storage blob; the blob may be a block blob,
  * append blob, or page blob.
@@ -44813,7 +43584,7 @@ exports.PageBlobClient = PageBlobClient;
 
 /***/ }),
 
-/***/ 187:
+/***/ 185:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44821,8 +43592,8 @@ exports.PageBlobClient = PageBlobClient;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryWriter = void 0;
 const binary_format_contract_1 = __nccwpck_require__(333);
-const reflection_info_1 = __nccwpck_require__(453);
-const assert_1 = __nccwpck_require__(485);
+const reflection_info_1 = __nccwpck_require__(454);
+const assert_1 = __nccwpck_require__(486);
 const pb_long_1 = __nccwpck_require__(118);
 /**
  * Writes proto3 messages in binary format using reflection information.
@@ -45054,18 +43825,18 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 
 /***/ }),
 
-/***/ 188:
+/***/ 186:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxUnsigned16Bit } = __nccwpck_require__(466)
+const { maxUnsigned16Bit } = __nccwpck_require__(467)
 
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(291)
+  crypto = __nccwpck_require__(292)
 } catch {
 
 }
@@ -45135,7 +43906,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 189:
+/***/ 187:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -45182,13 +43953,13 @@ function isApiKeyCredential(credential) {
 
 /***/ }),
 
-/***/ 190:
+/***/ 188:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(528)
 const {
   ResponseStatusCodeError
-} = __nccwpck_require__(489)
+} = __nccwpck_require__(490)
 const { toUSVString } = __nccwpck_require__(69)
 
 async function getResolveErrorBodyCallback ({ callback, body, contentType, statusCode, statusMessage, headers }) {
@@ -45235,7 +44006,7 @@ module.exports = { getResolveErrorBodyCallback }
 
 /***/ }),
 
-/***/ 191:
+/***/ 189:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -45357,7 +44128,7 @@ exports.getSelectedOneofValue = getSelectedOneofValue;
 
 /***/ }),
 
-/***/ 192:
+/***/ 190:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45376,7 +44147,7 @@ exports.logger = (0, logger_1.createClientLogger)("core-lro");
 
 /***/ }),
 
-/***/ 193:
+/***/ 191:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45580,7 +44351,7 @@ module.exports = parseParams
 
 /***/ }),
 
-/***/ 194:
+/***/ 192:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45606,8 +44377,8 @@ __export(auxiliaryAuthenticationHeaderPolicy_exports, {
   auxiliaryAuthenticationHeaderPolicyName: () => auxiliaryAuthenticationHeaderPolicyName
 });
 module.exports = __toCommonJS(auxiliaryAuthenticationHeaderPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(163);
-var import_log = __nccwpck_require__(185);
+var import_tokenCycler = __nccwpck_require__(162);
+var import_log = __nccwpck_require__(183);
 const auxiliaryAuthenticationHeaderPolicyName = "auxiliaryAuthenticationHeaderPolicy";
 const AUTHORIZATION_AUXILIARY_HEADER = "x-ms-authorization-auxiliary";
 async function sendAuthorizeRequest(options) {
@@ -45673,7 +44444,7 @@ function auxiliaryAuthenticationHeaderPolicy(options) {
 
 /***/ }),
 
-/***/ 195:
+/***/ 193:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45710,7 +44481,7 @@ var import_xml_common = __nccwpck_require__(21);
 
 /***/ }),
 
-/***/ 196:
+/***/ 194:
 /***/ ((module) => {
 
 module.exports = {
@@ -45780,7 +44551,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 197:
+/***/ 195:
 /***/ ((module) => {
 
 "use strict";
@@ -45905,7 +44676,7 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 198:
+/***/ 196:
 /***/ ((module) => {
 
 "use strict";
@@ -45913,7 +44684,699 @@ module.exports = require("node:child_process");
 
 /***/ }),
 
-/***/ 199:
+/***/ 197:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Top-level resolve-setup entry point. Owned by Agent 1.
+//
+// Full port of resolve_setup.py::main(). Reads INPUT_* / GITHUB_* env vars,
+// resolves the toolchain spec, derives all cache keys, computes the env
+// exports + outputs the orchestrator needs.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.pythonDefaultJson = exports.buildOutputs = exports.detectMuslCcEnv = exports.detectUserLinkerEnv = exports.parseRustBacktrace = exports.parseCacheShutdownOnIdleSeconds = exports.readRawInputs = void 0;
+exports.resolveRustupStrategy = resolveRustupStrategy;
+exports.resolveSetup = resolveSetup;
+exports.applyResolveResult = applyResolveResult;
+const os = __importStar(__nccwpck_require__(384));
+const path = __importStar(__nccwpck_require__(509));
+const fs = __importStar(__nccwpck_require__(249));
+const core = __importStar(__nccwpck_require__(461));
+const cache_keys_js_1 = __nccwpck_require__(164);
+const log_utils_js_1 = __nccwpck_require__(353);
+const detect_musl_cc_js_1 = __nccwpck_require__(505);
+Object.defineProperty(exports, "detectMuslCcEnv", ({ enumerable: true, get: function () { return detect_musl_cc_js_1.detectMuslCcEnv; } }));
+const build_outputs_js_1 = __nccwpck_require__(268);
+Object.defineProperty(exports, "buildOutputs", ({ enumerable: true, get: function () { return build_outputs_js_1.buildOutputs; } }));
+const raw_inputs_js_1 = __nccwpck_require__(363);
+Object.defineProperty(exports, "readRawInputs", ({ enumerable: true, get: function () { return raw_inputs_js_1.readRawInputs; } }));
+const input_parsers_js_1 = __nccwpck_require__(213);
+Object.defineProperty(exports, "detectUserLinkerEnv", ({ enumerable: true, get: function () { return input_parsers_js_1.detectUserLinkerEnv; } }));
+Object.defineProperty(exports, "parseCacheShutdownOnIdleSeconds", ({ enumerable: true, get: function () { return input_parsers_js_1.parseCacheShutdownOnIdleSeconds; } }));
+Object.defineProperty(exports, "parseRustBacktrace", ({ enumerable: true, get: function () { return input_parsers_js_1.parseRustBacktrace; } }));
+const fetch_release_js_1 = __nccwpck_require__(146);
+const python_json_js_1 = __nccwpck_require__(11);
+Object.defineProperty(exports, "pythonDefaultJson", ({ enumerable: true, get: function () { return python_json_js_1.pythonDefaultJson; } }));
+const toolchain_js_1 = __nccwpck_require__(369);
+const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
+const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
+const ALLOWED_LINKER_VALUES = [
+    "default",
+    "platform-default",
+    "ld",
+    "mold",
+    "rust-lld",
+    "fast",
+];
+// CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
+// FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
+// causes "failed to connect to jobserver" warnings in every downstream step.
+// See setup-soldr#71.
+const GITHUB_ENV_DENY_LIST = new Set(["CARGO_MAKEFLAGS", "MAKEFLAGS"]);
+function expanduser(p, env) {
+    if (!p)
+        return p;
+    if (p.startsWith("~")) {
+        const home = env["HOME"] || env["USERPROFILE"] || "";
+        if (p === "~")
+            return home;
+        if (p.startsWith("~/") || p.startsWith("~\\")) {
+            return path.join(home, p.slice(2));
+        }
+    }
+    return p;
+}
+function resolveAbsolute(p, env) {
+    return path.resolve(expanduser(p, env));
+}
+function isFalsy(value) {
+    return FALSY_VALUES.has(value.trim().toLowerCase());
+}
+function isTruthy(value) {
+    return TRUTHY_VALUES.has(value.trim().toLowerCase());
+}
+function defaultHomeDir(env, name) {
+    const home = env["HOME"] || env["USERPROFILE"] || os.homedir();
+    return path.resolve(path.join(home, name));
+}
+function makeDirs(...paths) {
+    for (const p of paths) {
+        fs.mkdirSync(p, { recursive: true });
+    }
+}
+/**
+ * Pure helper: decide the final rustup strategy from the requested one and
+ * the host platform. On macOS we always override `system` to `managed` to
+ * avoid the pre-installed rustup toolchain conflicts (see setup-soldr#105).
+ *
+ * GitHub-hosted `macos-15` (ARM) runners ship with a stable rustup toolchain
+ * that already includes `clippy`. Downstream actions that try to install a
+ * different toolchain with clippy hit
+ *   detected conflict: 'bin/cargo-clippy'
+ * because rustup component add refuses to overwrite the existing binary in
+ * the shared rustup home. Forcing the managed strategy gives setup-soldr its
+ * own private rustup home so the pre-installed components cannot collide.
+ *
+ * `explicit` (user-provided RUSTUP_HOME) is left untouched on every platform
+ * — opting in to a specific home means accepting any conflicts that come
+ * with it.
+ */
+function resolveRustupStrategy(opts) {
+    const { requested, platform, warn } = opts;
+    if (platform === "darwin" && requested === "system") {
+        warn?.("setup-soldr: forcing rustup strategy to 'managed' on macOS to avoid " +
+            "pre-installed rustup toolchain component conflicts (e.g. " +
+            "\"detected conflict: 'bin/cargo-clippy'\" on macos-15 runners). " +
+            "See https://github.com/zackees/setup-soldr/issues/105 for context. " +
+            "This may change which setup-cache key is used compared to other " +
+            "platforms.");
+        return "managed";
+    }
+    return requested;
+}
+// `fetchReleaseTagDefault` and `resolveSoldrReleaseVersion` live in
+// ./fetch-release.js — used directly from resolveSetup() below.
+/**
+ * Resolve setup state. The orchestrator calls this once at the start of the
+ * action and uses the returned ResolveResult to drive every subsequent step.
+ */
+async function resolveSetup(ctx, inputs, deps) {
+    const env = { ...ctx.env };
+    // ---- timing seed ----
+    const logStart = String(Math.floor(Date.now() / 1000));
+    const timestamps = (inputs.timestamps && inputs.timestamps.trim()) || "true";
+    env["SETUP_SOLDR_LOG_START_EPOCH"] = logStart;
+    env["SETUP_SOLDR_TIMESTAMPS"] = timestamps;
+    const logger = ctx.logger ?? (0, log_utils_js_1.createLogger)(env);
+    const log = (msg) => logger.log(msg);
+    if (!ctx.workspace) {
+        throw new Error("ACTION_WORKSPACE / ctx.workspace must be set");
+    }
+    const workspace = path.resolve(ctx.workspace);
+    const runnerTemp = ctx.runnerTemp
+        ? path.resolve(ctx.runnerTemp)
+        : path.resolve(path.join(workspace, ".tmp"));
+    // ---- cache roots ----
+    const requestedCacheDir = inputs.cacheDir.trim();
+    const cacheRoot = requestedCacheDir
+        ? resolveAbsolute(requestedCacheDir, env)
+        : path.resolve(path.join(runnerTemp, "setup-soldr"));
+    const soldrRoot = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-soldr`);
+    const cargoHomeInput = (env["CARGO_HOME"] ?? "").trim();
+    const cargoHome = cargoHomeInput
+        ? resolveAbsolute(cargoHomeInput, env)
+        : defaultHomeDir(env, ".cargo");
+    const binDir = path.join(cacheRoot, "bin");
+    const setupCachePath = cacheRoot;
+    const soldrBinCachePath = path.join(soldrRoot, "bin");
+    const zccacheCacheDir = path.join(soldrRoot, "cache", "zccache");
+    const thinTargetCacheBundlePath = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-target-thin`);
+    // When the action is disabled (`enable: false`), we write a script-based
+    // passthrough stub at soldrPath instead of installing the real binary.
+    // The stub is a bash script on Unix and a .cmd shim on Windows — Windows
+    // cannot spawn a script via the .exe extension without a real PE, so
+    // soldrPath must end in .cmd in passthrough mode.
+    const enableRaw = inputs.enable.trim() || "true";
+    if (!TRUTHY_VALUES.has(enableRaw.toLowerCase()) && !FALSY_VALUES.has(enableRaw.toLowerCase())) {
+        throw new Error(`invalid 'enable' input: '${enableRaw}'. Allowed: true | false`);
+    }
+    const enabled = !FALSY_VALUES.has(enableRaw.toLowerCase());
+    const soldrBinary = enabled
+        ? process.platform === "win32"
+            ? "soldr.exe"
+            : "soldr"
+        : process.platform === "win32"
+            ? "soldr.cmd"
+            : "soldr";
+    const soldrPath = path.join(binDir, soldrBinary);
+    // ---- toolchain ----
+    const toolchain = await (0, toolchain_js_1.loadToolchainSpec)({
+        workspace,
+        toolchainFile: inputs.toolchainFile || "rust-toolchain.toml",
+        toolchainOverride: inputs.toolchain,
+        log,
+    });
+    // ---- rustup home selection ----
+    const explicitRustupHome = (env["RUSTUP_HOME"] ?? "").trim();
+    let rustupHome;
+    let rustupStrategy;
+    if (explicitRustupHome) {
+        rustupHome = resolveAbsolute(explicitRustupHome, env);
+        rustupStrategy = "explicit";
+    }
+    else {
+        const runnerRustupHome = defaultHomeDir(env, ".rustup");
+        let satisfied = false;
+        if (deps?.systemRustupOverride) {
+            satisfied = await deps.systemRustupOverride(cargoHome, runnerRustupHome, toolchain);
+        }
+        else {
+            satisfied = await (0, toolchain_js_1.systemRustupSatisfiesRequest)({
+                cargoHome,
+                rustupHome: runnerRustupHome,
+                toolchain,
+                env,
+                logger,
+                deps: deps?.systemRustup,
+            });
+        }
+        if (satisfied) {
+            rustupHome = runnerRustupHome;
+            rustupStrategy = "system";
+        }
+        else {
+            rustupHome = path.join(cacheRoot, "rustup-home");
+            rustupStrategy = "managed";
+        }
+        // Platform override: macOS pre-installed rustup toolchains conflict with
+        // downstream component adds (setup-soldr#105). Force `managed` when the
+        // initial selection landed on `system` so we get a private rustup home.
+        const overridden = resolveRustupStrategy({
+            requested: rustupStrategy,
+            platform: process.platform,
+            warn: (msg) => logger.warning(msg),
+        });
+        if (overridden !== rustupStrategy) {
+            rustupStrategy = overridden;
+            if (rustupStrategy === "managed") {
+                rustupHome = path.join(cacheRoot, "rustup-home");
+            }
+        }
+    }
+    const setupCachePathsList = (0, cache_keys_js_1.setupCachePaths)(setupCachePath, binDir, soldrBinCachePath, rustupHome);
+    const setupCacheLayoutValue = (0, cache_keys_js_1.setupCacheLayout)(setupCachePath, rustupHome);
+    for (const dir of [
+        cacheRoot,
+        soldrRoot,
+        path.join(soldrRoot, "cache"),
+        soldrBinCachePath,
+        cargoHome,
+        path.join(cargoHome, "bin"),
+        rustupHome,
+        binDir,
+        zccacheCacheDir,
+        thinTargetCacheBundlePath,
+    ]) {
+        makeDirs(dir);
+    }
+    const soldrRepo = inputs.repo.trim() || "zackees/soldr";
+    const soldrRef = inputs.ref.trim();
+    const soldrVersionRequested = inputs.version.trim();
+    const soldrVersionResolved = await (0, fetch_release_js_1.resolveSoldrReleaseVersion)(soldrRepo, soldrVersionRequested, soldrRef, env, deps);
+    const toolchainSignature = {
+        channel: toolchain.cacheChannel,
+        profile: toolchain.profile,
+        components: toolchain.components,
+        targets: toolchain.targets,
+        source: toolchain.source,
+        file_hash: toolchain.fileHash,
+        setup_cache_layout: setupCacheLayoutValue,
+        soldr_repo: soldrRepo,
+        soldr_ref: soldrRef || "release",
+        soldr_version: soldrVersionResolved || soldrRef || "source-ref",
+    };
+    // Python uses json.dumps(sort_keys=True) without compact separators here,
+    // so canonical_json_stringify is wrong; mirror Python's default separators
+    // (", " and ": ") to match byte-for-byte.
+    const signatureString = (0, python_json_js_1.pythonDefaultJson)(toolchainSignature);
+    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 275, 23));
+    const digest = createHash("sha256").update(signatureString, "utf8").digest("hex").slice(0, 16);
+    const runnerOs = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_OS"] ?? process.platform).toLowerCase());
+    const runnerArch = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_ARCH"] ?? "unknown").toLowerCase());
+    const cachePrefix = `setup-soldr-v4-${runnerOs}-${runnerArch}`;
+    let cacheKey = `${cachePrefix}-${digest}`;
+    const wsManifestHash = await (0, cache_keys_js_1.workspaceManifestHash)(workspace);
+    const cargoConfigHashValue = await (0, cache_keys_js_1.cargoConfigHash)(workspace);
+    const suffix = inputs.cacheKeySuffix.trim();
+    const sanitizedSuffix = suffix ? (0, cache_keys_js_1.sanitizeFragment)(suffix) : "";
+    if (suffix) {
+        cacheKey = `${cacheKey}-${sanitizedSuffix}`;
+    }
+    // ---- build cache ----
+    const githubSha = (env["GITHUB_SHA"] ?? "").trim() || "nosha";
+    let parentSha = (env["ACTION_PARENT_SHA"] ?? "").trim();
+    if (parentSha === githubSha) {
+        parentSha = "";
+    }
+    const buildCachePrefix = `setup-soldr-buildcache-v2-${runnerOs}-${runnerArch}`;
+    const buildCacheToolchainPrefix = `${buildCachePrefix}-${digest}-`;
+    let buildCacheKey = `${buildCacheToolchainPrefix}${githubSha}`;
+    let buildCacheParentKey = parentSha ? `${buildCacheToolchainPrefix}${parentSha}` : "";
+    // ---- target cache ----
+    const targetDirInput = inputs.targetDir.trim() || "target";
+    let targetCachePath = expanduser(targetDirInput, env);
+    if (!path.isAbsolute(targetCachePath)) {
+        targetCachePath = path.join(workspace, targetCachePath);
+    }
+    targetCachePath = path.resolve(targetCachePath);
+    makeDirs(targetCachePath);
+    const lockfilePath = (0, cache_keys_js_1.resolveLockfilePath)(workspace, targetCachePath, inputs.lockfile);
+    const cargoLockHash = lockfilePath ? await (0, cache_keys_js_1.shortFileHash)(lockfilePath, "no-lock") : "no-lock";
+    const legacyTargetCacheModeInput = inputs.targetCacheMode;
+    const legacyTargetCacheMode = (0, cache_keys_js_1.normalizeLegacyTargetCacheMode)(legacyTargetCacheModeInput, log);
+    const targetCacheProfile = (0, cache_keys_js_1.normalizeTargetCacheProfile)(inputs.targetCacheProfile);
+    // `cache: "false"` is the umbrella switch. It originally only gated the
+    // action-managed setup-cache (soldr binary + rustup state), but consumers
+    // reasonably expect it to mean "no caching at all" — so when the umbrella
+    // is off we force every per-layer flag off too AND tell soldr to skip its
+    // zccache build-cache wrapper. See zccache#307 / zackees/setup-soldr#118
+    // follow-up.
+    const cacheUmbrellaEnabled = !isFalsy(inputs.cache.trim() || "true");
+    const targetCacheInputRaw = inputs.targetCache.trim() || "true";
+    const targetCacheRequested = cacheUmbrellaEnabled &&
+        !isFalsy(targetCacheInputRaw) &&
+        legacyTargetCacheMode !== "off";
+    const explicitBuildCacheMode = inputs.buildCacheMode.trim();
+    const buildCacheMode = (0, cache_keys_js_1.normalizeBuildCacheMode)(inputs.buildCacheMode, legacyTargetCacheModeInput, !explicitBuildCacheMode && targetCacheRequested, log);
+    const buildCacheInputRaw = inputs.buildCache.trim() || "true";
+    const buildCacheEnabled = cacheUmbrellaEnabled && !isFalsy(buildCacheInputRaw);
+    const buildCacheRuntimeMode = buildCacheMode === "once" ? "full" : buildCacheMode;
+    let targetCacheEnabled = buildCacheEnabled && targetCacheRequested;
+    if (buildCacheMode === "thin" && cargoLockHash === "no-lock") {
+        log("build-cache-mode 'thin' requires Cargo.lock; target artifact cache disabled.");
+        targetCacheEnabled = false;
+    }
+    const [targetCacheBudgetBytes, targetCacheBudgetFiles] = (0, cache_keys_js_1.targetCacheSoftBudget)(targetCacheEnabled, buildCacheMode);
+    const targetShapeHash = (0, cache_keys_js_1.shortJsonHash)({
+        target_dir: targetCachePath,
+        target_dir_input: targetDirInput,
+        target_env: (0, cache_keys_js_1.targetEnvHash)(env),
+    });
+    const targetInputsHash = (0, cache_keys_js_1.shortJsonHash)({
+        cargo_config: cargoConfigHashValue,
+        cargo_lock: cargoLockHash,
+        manifest: wsManifestHash,
+        target_shape: targetShapeHash,
+        toolchain: digest,
+    });
+    const lockfileOnlyHash = (0, cache_keys_js_1.shortJsonHash)({
+        cargo_lock: cargoLockHash,
+        toolchain: digest,
+    });
+    const targetCacheBundlePath = thinTargetCacheBundlePath;
+    const targetTreeCacheEnabled = targetCacheEnabled && buildCacheMode === "full";
+    let targetCachePaths;
+    let targetCacheEffectiveMode;
+    let targetCachePrefix;
+    let targetCacheLockPrefix;
+    let targetCacheLockfilePrefix;
+    let targetCacheKey;
+    let targetCacheParentKey;
+    if (!targetCacheEnabled) {
+        targetCachePaths = "";
+        targetCacheEffectiveMode = "off";
+        targetCachePrefix = `setup-soldr-targetcache-off-v1-${runnerOs}-${runnerArch}`;
+        targetCacheLockPrefix = "";
+        targetCacheLockfilePrefix = "";
+        targetCacheKey = `${targetCachePrefix}-${targetInputsHash}`;
+        targetCacheParentKey = "";
+    }
+    else if (targetTreeCacheEnabled) {
+        targetCachePaths = [targetCachePath, targetCacheBundlePath].join("\n");
+        targetCacheEffectiveMode = buildCacheMode;
+        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v1-${runnerOs}-${runnerArch}`;
+        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
+        targetCacheLockPrefix = `${targetCachePrefix}-${digest}-${cargoLockHash}-${targetShapeHash}-${sf}`;
+        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
+        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
+        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
+    }
+    else {
+        targetCachePaths = targetCacheBundlePath;
+        targetCacheEffectiveMode = buildCacheMode;
+        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v1-${runnerOs}-${runnerArch}`;
+        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
+        targetCacheLockPrefix = `${targetCachePrefix}-${targetInputsHash}-${sf}`;
+        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
+        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
+        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
+    }
+    if (suffix) {
+        buildCacheKey = `${buildCacheKey}-${sanitizedSuffix}`;
+        if (buildCacheParentKey) {
+            buildCacheParentKey = `${buildCacheParentKey}-${sanitizedSuffix}`;
+        }
+    }
+    // ---- cargo registry cache ----
+    const cargoRegistryCacheRequested = isTruthy(inputs.cargoRegistryCache.trim() || "true");
+    const cargoRegistryCachePath = path.join(cargoHome, "registry");
+    // setup-soldr#102: bundle additional `$CARGO_HOME` siblings into the same
+    // cargo-registry archive so we close the cache-retention gaps without
+    // introducing a new top-level cache layer or changing the cache key shape.
+    //   - `.global-cache` — cargo's RFC-3413 GC sqlite database. Without it the
+    //     per-job `cargo gc` sees fresh access times and conservatively keeps
+    //     everything. Shared read-only dep between setup-soldr (persists) and
+    //     soldr (reads via zackees/soldr#323). One-line leverage win.
+    //   - `git`           — `$CARGO_HOME/git/{db,checkouts}/`. `db/` holds the
+    //     bare mirrors of git-source crate deps and `checkouts/` holds the
+    //     per-commit working trees derived from `db/`; both are required for
+    //     cargo to build from a restored `db/`. Caching the parent `git/` dir
+    //     covers both subtrees and any future siblings cargo introduces.
+    // Siblings that don't exist on disk at save time (e.g. workspaces with no
+    // git-source deps) are silently skipped by compressCache — see #102.
+    const cargoRegistryCacheExtras = [".global-cache", "git"];
+    const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-v1-${runnerOs}-${runnerArch}`;
+    const cargoRegistryCacheRestorePrefix = `${cargoRegistryCachePrefix}-${cargoLockHash}-`;
+    let cargoRegistryCacheKey = `${cargoRegistryCacheRestorePrefix}${digest}-${githubSha}`;
+    if (suffix) {
+        cargoRegistryCacheKey = `${cargoRegistryCacheKey}-${sanitizedSuffix}`;
+    }
+    const cargoRegistryCacheEnabled = cacheUmbrellaEnabled && cargoRegistryCacheRequested;
+    if (cargoRegistryCacheEnabled) {
+        makeDirs(cargoRegistryCachePath);
+    }
+    // ---- env exports ----
+    const cacheShutdownOnIdleSeconds = (0, input_parsers_js_1.parseCacheShutdownOnIdleSeconds)(inputs.cacheShutdownOnIdle);
+    const rustBacktraceValue = (0, input_parsers_js_1.parseRustBacktrace)(inputs.rustBacktrace);
+    const envExports = {};
+    const setEnv = (name, value) => {
+        if (GITHUB_ENV_DENY_LIST.has(name))
+            return;
+        envExports[name] = value;
+    };
+    setEnv("SOLDR_CACHE_DIR", soldrRoot);
+    setEnv("CARGO_HOME", cargoHome);
+    setEnv("RUSTUP_HOME", rustupHome);
+    setEnv("ZCCACHE_CACHE_DIR", zccacheCacheDir);
+    setEnv("SETUP_SOLDR_BUILD_CACHE_MODE", cacheUmbrellaEnabled ? buildCacheMode : "off");
+    setEnv("SOLDR_BUILD_CACHE_MODE", cacheUmbrellaEnabled ? buildCacheRuntimeMode : "off");
+    setEnv("SOLDR_TARGET_CACHE_MODE", targetCacheEnabled ? buildCacheRuntimeMode : "off");
+    setEnv("SOLDR_TARGET_CACHE_DIR", targetCachePath);
+    setEnv("SOLDR_TARGET_CACHE_BUNDLE_DIR", targetCacheBundlePath);
+    setEnv("SOLDR_TARGET_CACHE_PROFILE", targetCacheProfile);
+    const stripDebug = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-strip-debuginfo", inputs.targetCacheStripDebuginfo);
+    if (stripDebug !== null) {
+        setEnv("SOLDR_TARGET_CACHE_STRIP_DEBUGINFO", stripDebug);
+    }
+    const includeIncremental = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-incremental", inputs.targetCacheIncludeIncremental);
+    if (includeIncremental !== null) {
+        setEnv("SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL", includeIncremental);
+    }
+    const includeBuildScripts = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-build-script-binaries", inputs.targetCacheIncludeBuildScriptBinaries);
+    if (includeBuildScripts !== null) {
+        setEnv("SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES", includeBuildScripts);
+    }
+    const targetCacheCompress = (0, cache_keys_js_1.normalizeTargetCacheCompress)(inputs.targetCacheCompress);
+    const targetCacheCompressLevel = (0, cache_keys_js_1.normalizeTargetCacheCompressLevel)(inputs.targetCacheCompressLevel);
+    setEnv("SOLDR_TARGET_CACHE_COMPRESS", targetCacheCompress);
+    setEnv("SOLDR_TARGET_CACHE_COMPRESS_LEVEL", targetCacheCompressLevel);
+    if (cargoRegistryCacheEnabled) {
+        setEnv("SOLDR_SKIP_CARGO_REGISTRY_SAVE", "1");
+    }
+    setEnv("SOLDR_TARGET_CACHE_BACKEND", "local");
+    setEnv("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain.channel);
+    setEnv("SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL", toolchain.cacheChannel);
+    setEnv("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain.profile);
+    setEnv("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", JSON.stringify(toolchain.components));
+    setEnv("SETUP_SOLDR_TOOLCHAIN_TARGETS", JSON.stringify(toolchain.targets));
+    setEnv("SETUP_SOLDR_LOG_START_EPOCH", logStart);
+    setEnv("SETUP_SOLDR_TIMESTAMPS", timestamps);
+    if (!FALSY_VALUES.has(timestamps.toLowerCase()) && env["NO_COLOR"] === undefined) {
+        if (!env["CARGO_TERM_COLOR"])
+            setEnv("CARGO_TERM_COLOR", "always");
+        if (!env["CLICOLOR_FORCE"])
+            setEnv("CLICOLOR_FORCE", "1");
+        if (!env["FORCE_COLOR"])
+            setEnv("FORCE_COLOR", "1");
+    }
+    if (inputs.trustMode.trim()) {
+        setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
+    }
+    const linkerRaw = inputs.linker.trim();
+    if (linkerRaw === "") {
+        const preset = (0, input_parsers_js_1.detectUserLinkerEnv)(env);
+        if (preset.length > 0) {
+            logger.info(`setup-soldr: deferring to user-set ${preset.join(", ")}; skipping default SOLDR_LINKER=fast injection. See https://github.com/zackees/setup-soldr/issues/108`);
+        }
+        else {
+            setEnv("SOLDR_LINKER", "fast");
+            logger.warning("setup-soldr: defaulting SOLDR_LINKER=fast (mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows) for faster CI links. Soldr's native default is no injection, which produces a smaller build-cache and a slower link. Set `linker: platform-default` to opt out and keep cargo/rust-toolchain.toml in charge, or set `linker: <value>` to silence this warning.");
+        }
+    }
+    else if (!ALLOWED_LINKER_VALUES.includes(linkerRaw)) {
+        throw new Error(`invalid 'linker' input: '${linkerRaw}'. Allowed: default | platform-default | ld | mold | rust-lld | fast`);
+    }
+    else if (linkerRaw !== "default" && linkerRaw !== "platform-default") {
+        setEnv("SOLDR_LINKER", linkerRaw);
+    }
+    const compilePriorityRaw = inputs.compilePriority.trim();
+    if (compilePriorityRaw !== "") {
+        setEnv("ZCCACHE_COMPILE_PRIORITY", compilePriorityRaw);
+    }
+    if (cacheShutdownOnIdleSeconds !== null) {
+        // Set both env vars. zccache reads its own, sccache reads the
+        // SCCACHE_-prefixed one; exporting both means a zccache fork that
+        // still honors only the sccache name keeps working, and a vanilla
+        // sccache invoked via this action would too.
+        const seconds = String(cacheShutdownOnIdleSeconds);
+        setEnv("ZCCACHE_IDLE_TIMEOUT", seconds);
+        setEnv("SCCACHE_IDLE_TIMEOUT", seconds);
+    }
+    if (rustBacktraceValue !== null) {
+        setEnv("RUST_BACKTRACE", rustBacktraceValue);
+    }
+    // Auto-export cc-rs cross-compile env for *-unknown-linux-musl triples
+    // when the matching `<triple>-gcc/g++/ar` binaries are on PATH. cc-rs
+    // strips the "-unknown-" segment when looking up cross compilers, so
+    // archives that ship binaries with the full triple are missed without
+    // these per-target overrides. See setup-soldr#... and the cc-rs docs.
+    const muslCcHits = (0, detect_musl_cc_js_1.detectMuslCcEnv)(env);
+    for (const hit of muslCcHits) {
+        const suffix = (0, detect_musl_cc_js_1.tripleToCcRsSuffix)(hit.triple);
+        for (const [name, value] of Object.entries(hit.exports)) {
+            setEnv(name, value);
+        }
+        logger.warning(`setup-soldr: auto-exporting cc-rs cross-compile env for ${hit.triple} ` +
+            `(CC_${suffix}=${hit.exports[`CC_${suffix}`]}, ` +
+            `CXX_${suffix}=${hit.exports[`CXX_${suffix}`]}, ` +
+            `AR_${suffix}=${hit.exports[`AR_${suffix}`]}) ` +
+            "because cc-rs strips \"-unknown-\" from the triple when probing for a " +
+            "cross compiler and would otherwise fall back to the host gcc. " +
+            `Resolved: cc=${hit.resolvedPaths.cc}, cxx=${hit.resolvedPaths.cxx}, ar=${hit.resolvedPaths.ar}. ` +
+            `Pre-set CC_${suffix} yourself to opt out.`);
+    }
+    // ---- path additions ----
+    const pathAdditions = [binDir, path.join(cargoHome, "bin")];
+    // ---- logging summary ----
+    log("setup-soldr cache plan");
+    log(`cache key=${cacheKey}`);
+    log(`cache restore-key=${cachePrefix}-`);
+    log(`build-cache key=${buildCacheKey}`);
+    log(`build-cache mode=${buildCacheMode}`);
+    log(`build-cache soldr-mode=${buildCacheRuntimeMode}`);
+    if (buildCacheParentKey) {
+        log(`build-cache restore-key-parent=${buildCacheParentKey}`);
+    }
+    log(`build-cache restore-key-toolchain=${buildCacheToolchainPrefix}`);
+    log(`build-cache restore-key-os-arch=${buildCachePrefix}-`);
+    log(`target-cache key=${targetCacheKey}`);
+    log(`target-cache enabled=${targetCacheEnabled ? "true" : "false"}`);
+    log(`target-cache mode=${targetCacheEffectiveMode}`);
+    log("target-cache backend=local");
+    if (targetCacheEnabled) {
+        log(`target-cache soft-budget-bytes=${targetCacheBudgetBytes}`);
+        log(`target-cache soft-budget-files=${targetCacheBudgetFiles}`);
+    }
+    log(`soldr repo=${soldrRepo}`);
+    log(`soldr ref=${soldrRef || "release"}`);
+    if (soldrVersionResolved) {
+        log(`soldr version=${soldrVersionResolved}`);
+    }
+    log(`toolchain channel=${toolchain.channel}`);
+    log(`toolchain cache-channel=${toolchain.cacheChannel}`);
+    log(`rustup strategy=${rustupStrategy}`);
+    log(`setup-cache layout=${setupCacheLayoutValue}`);
+    if (targetCacheParentKey) {
+        log(`target-cache restore-key-parent=${targetCacheParentKey}`);
+    }
+    log(`target-cache restore-key-lock=${targetCacheLockPrefix}`);
+    log(`target-cache restore-key-lockfile=${targetCacheLockfilePrefix}`);
+    log(`target-cache paths=${targetCachePaths}`);
+    log(`target-cache bundle-dir=${targetCacheBundlePath}`);
+    log(`target-cache lockfile=${(0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath)}`);
+    log(`target-cache lockfile-hash=${cargoLockHash}`);
+    // ---- assemble plans ----
+    const setupCache = {
+        key: cacheKey,
+        restorePrefix: `${cachePrefix}-`,
+        paths: setupCachePathsList ? setupCachePathsList.split("\n") : [],
+        setupCachePath,
+        layout: setupCacheLayoutValue,
+    };
+    const buildCache = {
+        key: buildCacheKey,
+        restoreKeyParent: buildCacheParentKey,
+        restoreKeyToolchain: buildCacheToolchainPrefix,
+        restoreKeyOsArch: `${buildCachePrefix}-`,
+        path: zccacheCacheDir,
+        mode: buildCacheMode,
+    };
+    const targetCache = {
+        enabled: targetCacheEnabled,
+        key: targetCacheKey,
+        restoreKeyParent: targetCacheParentKey,
+        restoreKeyLock: targetCacheLockPrefix,
+        restoreKeyLockfile: targetCacheLockfilePrefix,
+        paths: targetCachePaths,
+        bundlePath: targetCacheBundlePath,
+        targetPath: targetCachePath,
+        effectiveMode: targetCacheEffectiveMode,
+        profile: targetCacheProfile,
+        budgetBytes: targetCacheBudgetBytes,
+        budgetFiles: targetCacheBudgetFiles,
+        lockfilePath: (0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath),
+        lockfileHash: cargoLockHash,
+    };
+    const cargoRegistryCachePlan = {
+        enabled: cargoRegistryCacheEnabled,
+        key: cargoRegistryCacheKey,
+        restorePrefix: cargoRegistryCacheRestorePrefix,
+        path: cargoRegistryCachePath,
+        extraBasenames: cargoRegistryCacheExtras,
+    };
+    // Avoid unused warnings on alias helper.
+    void toolchain_js_1.rollingToolchainAlias;
+    void cache_keys_js_1.canonicalJsonStringify;
+    const compileCacheStats = (0, input_parsers_js_1.normalizeCompileCacheStats)(inputs.compileCacheStats);
+    const stats = (0, input_parsers_js_1.normalizeStatsMode)(inputs.stats);
+    const debugMode = isTruthy(inputs.debugMode.trim() || "false");
+    // ---- shims ----
+    const shimsRaw = inputs.shims.trim() || "false";
+    const shimsEnabled = !isFalsy(shimsRaw);
+    const shimsDir = path.join(cacheRoot, "shims");
+    return {
+        enabled,
+        workspace,
+        cacheRoot,
+        soldrRoot,
+        binDir,
+        cargoHome,
+        rustupHome,
+        soldrPath,
+        soldrBinCachePath,
+        toolchain,
+        rustupStrategy,
+        soldrRepo,
+        soldrRef,
+        soldrVersionRequested,
+        soldrVersionResolved,
+        setupCache,
+        buildCache,
+        targetCache,
+        cargoRegistryCache: cargoRegistryCachePlan,
+        targetCacheCompress,
+        targetCacheCompressLevel,
+        envExports,
+        pathAdditions,
+        logStartEpoch: logStart,
+        timestamps,
+        shimsEnabled,
+        shimsDir,
+        compileCacheStats,
+        stats,
+        debugMode,
+        cacheShutdownOnIdleSeconds,
+    };
+}
+/**
+ * Apply ResolveResult to the runner: write $GITHUB_ENV, $GITHUB_PATH, and
+ * $GITHUB_OUTPUT keys.
+ */
+async function applyResolveResult(result) {
+    for (const [name, value] of Object.entries(result.envExports)) {
+        if (GITHUB_ENV_DENY_LIST.has(name))
+            continue;
+        core.exportVariable(name, value);
+    }
+    for (const p of result.pathAdditions) {
+        core.addPath(p);
+    }
+    const outputs = (0, build_outputs_js_1.buildOutputs)(result);
+    for (const [key, value] of Object.entries(outputs)) {
+        core.setOutput(key, value);
+    }
+}
+// `buildOutputs` and `pythonDefaultJson` are re-exported at the top of
+// this file from their dedicated submodules.
+
+
+/***/ }),
+
+/***/ 198:
 /***/ ((module) => {
 
 "use strict";
@@ -45921,14 +45384,14 @@ module.exports = require("util/types");
 
 /***/ }),
 
-/***/ 200:
+/***/ 199:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { promisify } = __nccwpck_require__(124)
-const Client = __nccwpck_require__(89)
+const Client = __nccwpck_require__(90)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
   kDispatches,
@@ -45940,8 +45403,8 @@ const {
   kConnected
 } = __nccwpck_require__(472)
 const { MockInterceptor } = __nccwpck_require__(136)
-const Symbols = __nccwpck_require__(196)
-const { InvalidArgumentError } = __nccwpck_require__(489)
+const Symbols = __nccwpck_require__(194)
+const { InvalidArgumentError } = __nccwpck_require__(490)
 
 /**
  * MockClient provides an API that extends the Client to influence the mockDispatches.
@@ -45988,7 +45451,7 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 201:
+/***/ 200:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -46029,7 +45492,7 @@ async function computeSha256Hash(content, encoding) {
 
 /***/ }),
 
-/***/ 202:
+/***/ 201:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46409,7 +45872,7 @@ exports.BlobQueryResponse = BlobQueryResponse;
 
 /***/ }),
 
-/***/ 203:
+/***/ 202:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46422,9 +45885,9 @@ exports.streamToBuffer = streamToBuffer;
 exports.streamToBuffer2 = streamToBuffer2;
 exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(216);
 const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(249));
-const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(376));
+const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(377));
 const constants_js_1 = __nccwpck_require__(149);
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
@@ -46556,7 +46019,7 @@ exports.fsCreateReadStream = node_fs_1.default.createReadStream;
 
 /***/ }),
 
-/***/ 204:
+/***/ 203:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -46838,7 +46301,7 @@ exports.varint32read = varint32read;
 
 /***/ }),
 
-/***/ 205:
+/***/ 204:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47050,15 +46513,15 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 /***/ }),
 
-/***/ 206:
+/***/ 205:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionCreate = void 0;
-const reflection_scalar_default_1 = __nccwpck_require__(463);
-const message_type_contract_1 = __nccwpck_require__(406);
+const reflection_scalar_default_1 = __nccwpck_require__(464);
+const message_type_contract_1 = __nccwpck_require__(407);
 /**
  * Creates an instance of the generic message, using the field
  * information.
@@ -47106,7 +46569,7 @@ exports.reflectionCreate = reflectionCreate;
 
 /***/ }),
 
-/***/ 207:
+/***/ 206:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47148,7 +46611,7 @@ function storageBrowserPolicy() {
 
 /***/ }),
 
-/***/ 208:
+/***/ 207:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47156,8 +46619,8 @@ function storageBrowserPolicy() {
 
 const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(519)
 const { kState } = __nccwpck_require__(15)
-const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(365)
-const { webidl } = __nccwpck_require__(457)
+const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(366)
+const { webidl } = __nccwpck_require__(458)
 const { Blob, File: NativeFile } = __nccwpck_require__(120)
 
 /** @type {globalThis['File']} */
@@ -47421,7 +46884,7 @@ module.exports = { FormData }
 
 /***/ }),
 
-/***/ 209:
+/***/ 208:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -47438,7 +46901,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 210:
+/***/ 209:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47463,10 +46926,10 @@ __export(getClient_exports, {
   getClient: () => getClient
 });
 module.exports = __toCommonJS(getClient_exports);
-var import_clientHelpers = __nccwpck_require__(492);
-var import_sendRequest = __nccwpck_require__(450);
+var import_clientHelpers = __nccwpck_require__(493);
+var import_sendRequest = __nccwpck_require__(451);
 var import_urlHelpers = __nccwpck_require__(324);
-var import_checkEnvironment = __nccwpck_require__(439);
+var import_checkEnvironment = __nccwpck_require__(440);
 function getClient(endpoint, clientOptions = {}) {
   const pipeline = clientOptions.pipeline ?? (0, import_clientHelpers.createDefaultPipeline)(clientOptions);
   if (clientOptions.additionalPolicies?.length) {
@@ -47621,7 +47084,7 @@ function buildOperation(method, url, pipeline, options, allowInsecureConnection,
 
 /***/ }),
 
-/***/ 211:
+/***/ 210:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47646,8 +47109,8 @@ __export(httpClientAdapter_exports, {
   convertHttpClient: () => convertHttpClient
 });
 module.exports = __toCommonJS(httpClientAdapter_exports);
-var import_response = __nccwpck_require__(413);
-var import_util = __nccwpck_require__(110);
+var import_response = __nccwpck_require__(414);
+var import_util = __nccwpck_require__(111);
 function convertHttpClient(requestPolicyClient) {
   return {
     sendRequest: async (request) => {
@@ -47665,7 +47128,7 @@ function convertHttpClient(requestPolicyClient) {
 
 /***/ }),
 
-/***/ 212:
+/***/ 211:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47691,7 +47154,7 @@ __export(retryPolicy_exports, {
 });
 module.exports = __toCommonJS(retryPolicy_exports);
 var import_logger = __nccwpck_require__(44);
-var import_constants = __nccwpck_require__(160);
+var import_constants = __nccwpck_require__(159);
 var import_policies = __nccwpck_require__(286);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("core-rest-pipeline retryPolicy");
 function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAULT_RETRY_POLICY_COUNT }) {
@@ -47706,7 +47169,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 
 /***/ }),
 
-/***/ 213:
+/***/ 212:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47746,7 +47209,7 @@ function getErrorMessage(e) {
 
 /***/ }),
 
-/***/ 214:
+/***/ 213:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -47856,7 +47319,7 @@ function normalizeCompileCacheStats(raw) {
 
 /***/ }),
 
-/***/ 215:
+/***/ 214:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -47895,13 +47358,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.restoreCache = exports.isFeatureAvailable = exports.FinalizeCacheError = exports.ReserveCacheError = exports.ValidationError = void 0;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 const path = __importStar(__nccwpck_require__(248));
 const utils = __importStar(__nccwpck_require__(76));
 const cacheHttpClient = __importStar(__nccwpck_require__(34));
 const cacheTwirpClient = __importStar(__nccwpck_require__(61));
 const config_1 = __nccwpck_require__(37);
-const tar_1 = __nccwpck_require__(441);
+const tar_1 = __nccwpck_require__(442);
 const http_client_1 = __nccwpck_require__(285);
 class ValidationError extends Error {
     constructor(message) {
@@ -48382,7 +47845,7 @@ function saveCacheV2(paths, key, options, enableCrossOsArchive = false) {
 
 /***/ }),
 
-/***/ 216:
+/***/ 215:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48408,9 +47871,9 @@ __export(extendedClient_exports, {
 });
 module.exports = __toCommonJS(extendedClient_exports);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_core_rest_pipeline = __nccwpck_require__(102);
-var import_core_client = __nccwpck_require__(440);
-var import_response = __nccwpck_require__(413);
+var import_core_rest_pipeline = __nccwpck_require__(103);
+var import_core_client = __nccwpck_require__(441);
+var import_response = __nccwpck_require__(414);
 class ExtendedServiceClient extends import_core_client.ServiceClient {
   constructor(options) {
     super(options);
@@ -48459,7 +47922,7 @@ class ExtendedServiceClient extends import_core_client.ServiceClient {
 
 /***/ }),
 
-/***/ 217:
+/***/ 216:
 /***/ ((module) => {
 
 /******************************************************************************
@@ -48917,7 +48380,7 @@ var __rewriteRelativeImportExtension;
 
 /***/ }),
 
-/***/ 218:
+/***/ 217:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48944,9 +48407,9 @@ __export(bearerTokenAuthenticationPolicy_exports, {
   parseChallenges: () => parseChallenges
 });
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(163);
-var import_log = __nccwpck_require__(185);
-var import_restError = __nccwpck_require__(353);
+var import_tokenCycler = __nccwpck_require__(162);
+var import_log = __nccwpck_require__(183);
+var import_restError = __nccwpck_require__(354);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
   try {
@@ -49136,7 +48599,7 @@ function getCaeChallengeClaims(challenges) {
 
 /***/ }),
 
-/***/ 219:
+/***/ 218:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49187,8 +48650,8 @@ exports.shouldEmitSharedTargetWarning = shouldEmitSharedTargetWarning;
 exports.detectSharedTargetWarning = detectSharedTargetWarning;
 const fs = __importStar(__nccwpck_require__(249));
 const path = __importStar(__nccwpck_require__(509));
-const core = __importStar(__nccwpck_require__(460));
-const log_utils_js_1 = __nccwpck_require__(352);
+const core = __importStar(__nccwpck_require__(461));
+const log_utils_js_1 = __nccwpck_require__(353);
 const WARNING_MESSAGE = "setup-soldr detected a pre-populated shared target directory; a " +
     "subsequent `soldr cargo build` using the same `--target-dir` may fail " +
     "with a missing .rmeta error - see README 'Known limitations'.";
@@ -49282,7 +48745,7 @@ async function detectSharedTargetWarning(opts) {
 
 /***/ }),
 
-/***/ 220:
+/***/ 219:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49319,7 +48782,7 @@ function systemErrorRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 221:
+/***/ 220:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49333,9 +48796,9 @@ function systemErrorRetryPolicy(options = {}) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const tslib_1 = __nccwpck_require__(216);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(441));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(179));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Container operations. */
 class ContainerImpl {
@@ -50047,7 +49510,7 @@ const getAccountInfoOperationSpec = {
 
 /***/ }),
 
-/***/ 222:
+/***/ 221:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -50092,7 +49555,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 223:
+/***/ 222:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -50297,20 +49760,20 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 
 /***/ }),
 
-/***/ 224:
+/***/ 223:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = __nccwpck_require__(288)
-module.exports.async = __nccwpck_require__(412)
-module.exports.stream = __nccwpck_require__(421)
+module.exports.async = __nccwpck_require__(413)
+module.exports.stream = __nccwpck_require__(422)
 module.exports.prettyError = __nccwpck_require__(279)
 
 
 /***/ }),
 
-/***/ 225:
+/***/ 224:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -50348,7 +49811,7 @@ const tls = __importStar(__nccwpck_require__(507));
 const debug_1 = __importDefault(__nccwpck_require__(517));
 const events_1 = __nccwpck_require__(471);
 const agent_base_1 = __nccwpck_require__(241);
-const url_1 = __nccwpck_require__(86);
+const url_1 = __nccwpck_require__(87);
 const debug = (0, debug_1.default)('http-proxy-agent');
 /**
  * The `HttpProxyAgent` implements an HTTP Agent subclass that connects
@@ -50465,7 +49928,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 226:
+/***/ 225:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -50501,7 +49964,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
-const fs = __importStar(__nccwpck_require__(533));
+const fs = __importStar(__nccwpck_require__(534));
 const path = __importStar(__nccwpck_require__(248));
 _a = fs.promises
 // export const {open} = 'fs'
@@ -50655,7 +50118,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 227:
+/***/ 226:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50664,7 +50127,7 @@ exports.getCmdPath = getCmdPath;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(216);
 var poller_js_1 = __nccwpck_require__(320);
 Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: function () { return poller_js_1.createHttpPoller; } }));
 /**
@@ -50686,7 +50149,7 @@ tslib_1.__exportStar(__nccwpck_require__(40), exports);
 
 /***/ }),
 
-/***/ 228:
+/***/ 227:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -50732,7 +50195,7 @@ function apiVersionPolicy(options) {
 
 /***/ }),
 
-/***/ 229:
+/***/ 228:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50979,7 +50442,7 @@ exports.AbortSignal = AbortSignal;
 
 /***/ }),
 
-/***/ 230:
+/***/ 229:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50996,7 +50459,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 
 /***/ }),
 
-/***/ 231:
+/***/ 230:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51010,9 +50473,9 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const tslib_1 = __nccwpck_require__(216);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(441));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(179));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing Service operations. */
 class ServiceImpl {
@@ -51332,7 +50795,7 @@ const filterBlobsOperationSpec = {
 
 /***/ }),
 
-/***/ 232:
+/***/ 231:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51369,13 +50832,13 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 233:
+/***/ 232:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { UndiciError } = __nccwpck_require__(489)
+const { UndiciError } = __nccwpck_require__(490)
 
 class MockNotMatchedError extends UndiciError {
   constructor (message) {
@@ -51389,6 +50852,377 @@ class MockNotMatchedError extends UndiciError {
 
 module.exports = {
   MockNotMatchedError
+}
+
+
+/***/ }),
+
+/***/ 233:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Verbose diagnostic dump emitted when the action receives `logging: true`.
+//
+// The goal is to make cache-behavior surprises trivially debuggable from a
+// single CI run. The dump bundles:
+//   - every observed INPUT_* env var (so the kebab-vs-underscore plumbing
+//     bug that motivated this module is visible without re-running)
+//   - the parsed RawInputs struct
+//   - every constructed cache key with restore-key fallbacks
+//   - resolved env exports (SOLDR_*, ZCCACHE_*, SETUP_SOLDR_*)
+//   - cache restore/save outcomes recorded so far
+//   - the final cache summary + compile-cache report in post phase
+//
+// Token-shaped values are redacted before printing.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.redactValue = redactValue;
+exports.captureProcessSnapshot = captureProcessSnapshot;
+exports.dumpDiagnostics = dumpDiagnostics;
+exports.loggingEnabled = loggingEnabled;
+const fs = __importStar(__nccwpck_require__(249));
+const node_child_process_1 = __nccwpck_require__(196);
+const compile_journal_js_1 = __nccwpck_require__(82);
+const ENV_KEY_PREFIXES = [
+    "INPUT_",
+    "SOLDR_",
+    "ZCCACHE_",
+    "SCCACHE_",
+    "SETUP_SOLDR_",
+    "GITHUB_",
+    "RUNNER_",
+    "ACTION_",
+    "CARGO_",
+    "RUSTUP_",
+    "RUSTC_",
+];
+const SECRET_KEY_PATTERN = /(token|secret|password|^.*_pass$|api[_-]?key|client[_-]?secret|webhook)/i;
+// Cache-key fields look secret-y but never are; never redact them.
+const NEVER_REDACT_PATTERN = /(_key$|cache[-_]key|cache[-_]keys$|key[-_]suffix$|public[-_]key)/i;
+function redactValue(key, value) {
+    if (NEVER_REDACT_PATTERN.test(key))
+        return value;
+    if (SECRET_KEY_PATTERN.test(key))
+        return value ? "<redacted>" : "";
+    return value;
+}
+function pickEnv(env) {
+    const pairs = [];
+    for (const [k, v] of Object.entries(env)) {
+        if (v === undefined)
+            continue;
+        if (!ENV_KEY_PREFIXES.some((p) => k.startsWith(p)))
+            continue;
+        pairs.push([k, redactValue(k, v)]);
+    }
+    pairs.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+    return pairs;
+}
+function rawInputsLines(inputs) {
+    const lines = [];
+    const entries = Object.entries(inputs).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+    for (const [k, v] of entries) {
+        lines.push(`  ${k}=${JSON.stringify(v)}`);
+    }
+    return lines;
+}
+function cachePlanLines(result) {
+    const lines = [];
+    lines.push("  setup_cache:");
+    lines.push(`    key=${result.setupCache.key}`);
+    lines.push(`    restore_prefix=${result.setupCache.restorePrefix}`);
+    lines.push(`    paths=${JSON.stringify(result.setupCache.paths)}`);
+    lines.push(`    layout=${result.setupCache.layout}`);
+    lines.push("  build_cache:");
+    lines.push(`    key=${result.buildCache.key}`);
+    lines.push(`    restore_key_parent=${result.buildCache.restoreKeyParent || "(none)"}`);
+    lines.push(`    restore_key_toolchain=${result.buildCache.restoreKeyToolchain}`);
+    lines.push(`    restore_key_os_arch=${result.buildCache.restoreKeyOsArch}`);
+    lines.push(`    path=${result.buildCache.path}`);
+    lines.push(`    mode=${result.buildCache.mode}`);
+    lines.push("  target_cache:");
+    lines.push(`    enabled=${result.targetCache.enabled}`);
+    lines.push(`    key=${result.targetCache.key}`);
+    lines.push(`    restore_key_parent=${result.targetCache.restoreKeyParent || "(none)"}`);
+    lines.push(`    restore_key_lock=${result.targetCache.restoreKeyLock || "(none)"}`);
+    lines.push(`    restore_key_lockfile=${result.targetCache.restoreKeyLockfile || "(none)"}`);
+    lines.push(`    paths=${result.targetCache.paths}`);
+    lines.push(`    bundle_path=${result.targetCache.bundlePath}`);
+    lines.push(`    target_path=${result.targetCache.targetPath}`);
+    lines.push(`    effective_mode=${result.targetCache.effectiveMode}`);
+    lines.push(`    profile=${result.targetCache.profile}`);
+    lines.push("  cargo_registry_cache:");
+    lines.push(`    enabled=${result.cargoRegistryCache.enabled}`);
+    lines.push(`    key=${result.cargoRegistryCache.key}`);
+    lines.push(`    restore_prefix=${result.cargoRegistryCache.restorePrefix}`);
+    lines.push(`    path=${result.cargoRegistryCache.path}`);
+    // setup-soldr#102: sibling basenames bundled into the same archive.
+    const extras = result.cargoRegistryCache.extraBasenames;
+    lines.push(`    extra_basenames=${extras.length > 0 ? extras.join(",") : "(none)"}`);
+    return lines;
+}
+function envExportLines(result) {
+    const entries = Object.entries(result.envExports).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+    return entries.map(([k, v]) => `  ${k}=${redactValue(k, v)}`);
+}
+function cacheOutcomeLines(outcomes) {
+    if (outcomes.length === 0)
+        return ["  (no outcomes recorded yet)"];
+    const lines = [];
+    for (const o of outcomes) {
+        lines.push(`  [${o.operation}] ${o.label}: hit=${o.hit} matched=${o.matchedKey || "(none)"} ` +
+            `key=${o.key} duration_ms=${o.durationMs}`);
+        if (o.archiveBytes !== null) {
+            lines.push(`    archive_bytes=${o.archiveBytes} inflated_bytes=${o.inflatedBytes ?? "?"} files=${o.fileCount ?? "?"}`);
+        }
+    }
+    return lines;
+}
+/**
+ * Capture a runtime process snapshot via `ps` (Unix) or `tasklist`
+ * (Windows). Returns null only on an actual exec failure (binary
+ * missing, etc.); a non-zero exit is reported in the result so the
+ * stderr can be inspected.
+ *
+ * Why this lives here: the post step uses it to expose orphan daemons
+ * (e.g. zccache-daemon processes that survive `soldr cache shutdown`
+ * and get SIGKILL'd by the runner) so root-cause analysis doesn't
+ * require another build.
+ */
+function captureProcessSnapshot() {
+    const isWindows = process.platform === "win32";
+    const cmd = isWindows ? "tasklist" : "ps";
+    // Unix: print pid, ppid, user, state, command-name, full-args.
+    // BSD ps (macOS) supports the same -o keys but uses `command` instead
+    // of `args` — accept both via the column listing.
+    const args = isWindows
+        ? ["/V", "/FO", "CSV", "/NH"]
+        : ["-eo", "pid,ppid,user,stat,comm,args"];
+    try {
+        const result = (0, node_child_process_1.spawnSync)(cmd, args, {
+            encoding: "utf8",
+            maxBuffer: 8 * 1024 * 1024,
+            timeout: 15_000,
+        });
+        return {
+            cmd: `${cmd} ${args.join(" ")}`,
+            stdout: result.stdout ?? "",
+            stderr: result.stderr ?? "",
+            exitCode: result.status,
+        };
+    }
+    catch {
+        return null;
+    }
+}
+/**
+ * Emit the full diagnostic dump to the logger and (optionally) the step summary.
+ * Safe to call when `result`, `cacheOutcomes`, or `finalSummary` are missing —
+ * each section is independent.
+ */
+function dumpDiagnostics(opts) {
+    const lines = [];
+    const header = `=== DIAGNOSTIC DUMP (phase=${opts.phase}) ===`;
+    const footer = "=== END DIAGNOSTIC DUMP ===";
+    lines.push(header);
+    lines.push("[env: observed INPUT_/SOLDR_/ZCCACHE_/SETUP_SOLDR_/GITHUB_/RUNNER_/ACTION_/CARGO_/RUSTUP_/RUSTC_]");
+    const envPairs = pickEnv(opts.env);
+    if (envPairs.length === 0) {
+        lines.push("  (none observed)");
+    }
+    else {
+        for (const [k, v] of envPairs) {
+            lines.push(`  ${k}=${v}`);
+        }
+    }
+    if (opts.rawInputs) {
+        lines.push("[raw_inputs: parsed RawInputs after kebab-case lookup]");
+        lines.push(...rawInputsLines(opts.rawInputs));
+    }
+    if (opts.result) {
+        lines.push("[cache_plans: every constructed cache key + restore-key fallbacks]");
+        lines.push(...cachePlanLines(opts.result));
+        lines.push("[env_exports: resolved SOLDR_/ZCCACHE_/etc env exports]");
+        if (Object.keys(opts.result.envExports).length === 0) {
+            lines.push("  (none)");
+        }
+        else {
+            lines.push(...envExportLines(opts.result));
+        }
+        lines.push("[resolved_state]");
+        lines.push(`  enabled=${opts.result.enabled}`);
+        lines.push(`  workspace=${opts.result.workspace}`);
+        lines.push(`  cache_root=${opts.result.cacheRoot}`);
+        lines.push(`  soldr_root=${opts.result.soldrRoot}`);
+        lines.push(`  cargo_home=${opts.result.cargoHome}`);
+        lines.push(`  rustup_home=${opts.result.rustupHome}`);
+        lines.push(`  soldr_path=${opts.result.soldrPath}`);
+        lines.push(`  soldr_repo=${opts.result.soldrRepo}`);
+        lines.push(`  soldr_ref=${opts.result.soldrRef || "(release)"}`);
+        lines.push(`  soldr_version_requested=${opts.result.soldrVersionRequested}`);
+        lines.push(`  soldr_version_resolved=${opts.result.soldrVersionResolved}`);
+        lines.push(`  toolchain_channel=${opts.result.toolchain.channel}`);
+        lines.push(`  toolchain_cache_channel=${opts.result.toolchain.cacheChannel}`);
+        lines.push(`  rustup_strategy=${opts.result.rustupStrategy}`);
+        lines.push(`  shims_enabled=${opts.result.shimsEnabled}`);
+        lines.push(`  shims_dir=${opts.result.shimsDir}`);
+        lines.push(`  stats=${opts.result.stats}`);
+        lines.push(`  compile_cache_stats=${opts.result.compileCacheStats}`);
+        lines.push(`  debug_mode=${opts.result.debugMode}`);
+        lines.push(`  cache_shutdown_on_idle_seconds=${opts.result.cacheShutdownOnIdleSeconds ?? "(unset)"}`);
+    }
+    if (opts.cacheOutcomes !== undefined) {
+        lines.push("[cache_outcomes: per-layer restore/save results]");
+        lines.push(...cacheOutcomeLines(opts.cacheOutcomes));
+    }
+    if (opts.finalSummary) {
+        lines.push("[final_cache_summary]");
+        const json = JSON.stringify(opts.finalSummary, null, 2);
+        for (const line of json.split("\n")) {
+            lines.push(`  ${line}`);
+        }
+    }
+    // Per-compilation zccache journal — the answer to "warm reports
+    // hits=0; WHY did each lookup miss?". Reads the JSONL emitted by
+    // zccache for the just-finished session, summarizes it (outcome +
+    // miss_reason histograms, slowest misses with their miss_diff, a
+    // handful of verbatim records), and prints. Silently no-ops when
+    // the journal file isn't present.
+    if (opts.journalPath) {
+        try {
+            const records = (0, compile_journal_js_1.readJournal)(opts.journalPath);
+            if (records === null) {
+                lines.push(`[compile_journal]`);
+                lines.push(`  (journal file not found at ${opts.journalPath})`);
+            }
+            else if (records.length === 0) {
+                lines.push(`[compile_journal]`);
+                lines.push(`  (journal file empty at ${opts.journalPath})`);
+            }
+            else {
+                lines.push(...(0, compile_journal_js_1.formatJournalSection)((0, compile_journal_js_1.summarize)(records)));
+            }
+        }
+        catch (err) {
+            lines.push(`[compile_journal]`);
+            lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
+        }
+        // Raw JSONL dump — verbatim file contents under the summary. Only
+        // emitted when the caller opts in (debug=true) because it's huge
+        // (one record per rustc invocation, frequently MBs of output).
+        if (opts.journalPrintRaw) {
+            try {
+                const raw = fs.readFileSync(opts.journalPath, "utf8");
+                const rawLines = raw.split(/\r?\n/).filter((l) => l.length > 0);
+                lines.push(`[compile_journal_raw: verbatim JSONL from ${opts.journalPath} — ${rawLines.length} records]`);
+                for (const rawLine of rawLines) {
+                    lines.push(`  ${rawLine}`);
+                }
+            }
+            catch (err) {
+                const code = err.code;
+                if (code === "ENOENT") {
+                    // Already noted by the summary section above; no need to repeat.
+                }
+                else {
+                    lines.push(`[compile_journal_raw]`);
+                    lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
+                }
+            }
+        }
+    }
+    // Rollups (per-extension / per-crate) from `soldr cache report --json`.
+    // The raw report is already parsed into finalSummary's
+    // compile_cache_report.report; we accept it as a separate
+    // `cacheReport` so callers can pass it without rebuilding the
+    // FinalCacheSummary shape.
+    if (opts.cacheReport) {
+        lines.push(...(0, compile_journal_js_1.formatRollupsSection)(opts.cacheReport));
+    }
+    // Process snapshot — captured by the caller via captureProcessSnapshot()
+    // when debug mode is on. Useful for spotting orphan daemons (e.g.
+    // zccache-daemon survivors after `soldr cache shutdown`) that the runner
+    // SIGKILLs at job cleanup.
+    if (opts.processSnapshot) {
+        const snap = opts.processSnapshot;
+        lines.push(`[processes: snapshot via \`${snap.cmd}\` exit=${snap.exitCode ?? "null"}]`);
+        if (snap.stderr.trim().length > 0) {
+            lines.push(`  stderr: ${snap.stderr.trim().replace(/\n+/g, " | ")}`);
+        }
+        const trimmed = snap.stdout.replace(/\r\n/g, "\n").trimEnd();
+        if (trimmed.length === 0) {
+            lines.push("  (no stdout)");
+        }
+        else {
+            for (const line of trimmed.split("\n")) {
+                lines.push(`  ${line}`);
+            }
+        }
+    }
+    lines.push(footer);
+    for (const line of lines) {
+        opts.logger.log(line);
+    }
+    if (opts.stepSummaryPath) {
+        appendToStepSummary(opts.stepSummaryPath, opts.phase, lines, opts.logger);
+    }
+}
+function appendToStepSummary(summaryPath, phase, lines, logger) {
+    const block = [
+        `### setup-soldr diagnostic dump (phase=${phase})`,
+        "",
+        "```",
+        ...lines,
+        "```",
+        "",
+    ];
+    try {
+        fs.appendFileSync(summaryPath, block.join("\n") + "\n", "utf8");
+    }
+    catch (err) {
+        logger.log(`diagnostics: failed to append to step summary: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+/**
+ * Truthy check matching the rest of the action: "1", "true", "yes", "on".
+ * Empty / unset / anything else is false.
+ */
+function loggingEnabled(value) {
+    const v = (value ?? "").trim().toLowerCase();
+    return v === "1" || v === "true" || v === "yes" || v === "on";
 }
 
 
@@ -51454,7 +51288,7 @@ const runtime_2 = __nccwpck_require__(19);
 const runtime_3 = __nccwpck_require__(19);
 const runtime_4 = __nccwpck_require__(19);
 const runtime_5 = __nccwpck_require__(19);
-const cachescope_1 = __nccwpck_require__(397);
+const cachescope_1 = __nccwpck_require__(398);
 // @generated message type with reflection information, may provide speed optimized methods
 class CacheMetadata$Type extends runtime_5.MessageType {
     constructor() {
@@ -51538,8 +51372,8 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_ts_http_runtime = __nccwpck_require__(90);
-var import_wrapAbortSignal = __nccwpck_require__(446);
+var import_ts_http_runtime = __nccwpck_require__(91);
+var import_wrapAbortSignal = __nccwpck_require__(447);
 function createDefaultHttpClient() {
   const client = (0, import_ts_http_runtime.createDefaultHttpClient)();
   return {
@@ -51578,8 +51412,8 @@ module.exports = require("node:process");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRequestUrl = getRequestUrl;
 exports.appendQueryParams = appendQueryParams;
-const operationHelpers_js_1 = __nccwpck_require__(433);
-const interfaceHelpers_js_1 = __nccwpck_require__(400);
+const operationHelpers_js_1 = __nccwpck_require__(434);
+const interfaceHelpers_js_1 = __nccwpck_require__(401);
 const CollectionFormatToDelimiterMap = {
     CSV: ",",
     SSV: " ",
@@ -51932,7 +51766,7 @@ exports.Agent = void 0;
 const net = __importStar(__nccwpck_require__(510));
 const http = __importStar(__nccwpck_require__(329));
 const https_1 = __nccwpck_require__(70);
-__exportStar(__nccwpck_require__(162), exports);
+__exportStar(__nccwpck_require__(161), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
 class Agent extends http.Agent {
     constructor(opts) {
@@ -52149,7 +51983,7 @@ __export(httpHeaders_exports, {
   createHttpHeaders: () => createHttpHeaders
 });
 module.exports = __toCommonJS(httpHeaders_exports);
-var import_ts_http_runtime = __nccwpck_require__(90);
+var import_ts_http_runtime = __nccwpck_require__(91);
 function createHttpHeaders(rawHeaders) {
   return (0, import_ts_http_runtime.createHttpHeaders)(rawHeaders);
 }
@@ -52168,7 +52002,7 @@ function createHttpHeaders(rawHeaders) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-var lroEngine_js_1 = __nccwpck_require__(179);
+var lroEngine_js_1 = __nccwpck_require__(177);
 Object.defineProperty(exports, "LroEngine", ({ enumerable: true, get: function () { return lroEngine_js_1.LroEngine; } }));
 //# sourceMappingURL=index.js.map
 
@@ -52199,7 +52033,7 @@ __export(pipeline_exports, {
   createEmptyPipeline: () => createEmptyPipeline
 });
 module.exports = __toCommonJS(pipeline_exports);
-var import_ts_http_runtime = __nccwpck_require__(90);
+var import_ts_http_runtime = __nccwpck_require__(91);
 function createEmptyPipeline() {
   return (0, import_ts_http_runtime.createEmptyPipeline)();
 }
@@ -52423,7 +52257,7 @@ module.exports = require("node:fs");
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(457)
+const { webidl } = __nccwpck_require__(458)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 const { MessagePort } = __nccwpck_require__(319)
 
@@ -52736,8 +52570,8 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryWriter = exports.binaryWriteOptions = void 0;
 const pb_long_1 = __nccwpck_require__(118);
-const goog_varint_1 = __nccwpck_require__(204);
-const assert_1 = __nccwpck_require__(485);
+const goog_varint_1 = __nccwpck_require__(203);
+const assert_1 = __nccwpck_require__(486);
 const defaultsWrite = {
     writeUnknownFields: true,
     writerFactory: () => new BinaryWriter(),
@@ -52977,7 +52811,7 @@ exports.BinaryWriter = BinaryWriter;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
-const AvroReadable_js_1 = __nccwpck_require__(388);
+const AvroReadable_js_1 = __nccwpck_require__(389);
 const abort_controller_1 = __nccwpck_require__(497);
 const buffer_1 = __nccwpck_require__(120);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
@@ -53074,7 +52908,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 let _defaultHttpClient;
 function getCachedDefaultHttpClient() {
     if (!_defaultHttpClient) {
@@ -53129,7 +52963,7 @@ module.exports = class Pluralizer {
 "use strict";
 
 
-const RedirectHandler = __nccwpck_require__(391)
+const RedirectHandler = __nccwpck_require__(392)
 
 function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections }) {
   return (dispatch) => {
@@ -53178,7 +53012,7 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(429);
+var import_userAgentPlatform = __nccwpck_require__(430);
 var import_constants = __nccwpck_require__(48);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
@@ -53224,7 +53058,7 @@ module.exports = require("stream/web");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getBodyAsText = getBodyAsText;
 exports.utf8ByteLength = utf8ByteLength;
-const utils_js_1 = __nccwpck_require__(203);
+const utils_js_1 = __nccwpck_require__(202);
 const constants_js_1 = __nccwpck_require__(149);
 async function getBodyAsText(batchResponse) {
     let buffer = Buffer.alloc(constants_js_1.BATCH_MAX_PAYLOAD_IN_BYTES);
@@ -53266,7 +53100,7 @@ __export(wrapAbortSignalLikePolicy_exports, {
   wrapAbortSignalLikePolicyName: () => wrapAbortSignalLikePolicyName
 });
 module.exports = __toCommonJS(wrapAbortSignalLikePolicy_exports);
-var import_wrapAbortSignal = __nccwpck_require__(446);
+var import_wrapAbortSignal = __nccwpck_require__(447);
 const wrapAbortSignalLikePolicyName = "wrapAbortSignalLikePolicy";
 function wrapAbortSignalLikePolicy() {
   return {
@@ -53382,7 +53216,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.retryHttpClientResponse = exports.retryTypedResponse = exports.retry = exports.isRetryableStatusCode = exports.isServerErrorStatusCode = exports.isSuccessStatusCode = void 0;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 const http_client_1 = __nccwpck_require__(285);
 const constants_1 = __nccwpck_require__(45);
 function isSuccessStatusCode(statusCode) {
@@ -53498,7 +53332,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredential = void 0;
 const node_crypto_1 = __nccwpck_require__(275);
 const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(127);
-const Credential_js_1 = __nccwpck_require__(96);
+const Credential_js_1 = __nccwpck_require__(97);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -53592,7 +53426,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDownloadOptions = exports.getUploadOptions = void 0;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 /**
  * Returns a copy of the upload options with defaults filled in.
  *
@@ -53695,7 +53529,7 @@ exports.getDownloadOptions = getDownloadOptions;
 const net = __nccwpck_require__(510)
 const assert = __nccwpck_require__(528)
 const util = __nccwpck_require__(69)
-const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(489)
+const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(490)
 
 let tls // include tls conditionally since it is not always available
 
@@ -54089,8 +53923,8 @@ __export(multipart_exports, {
   buildMultipartBody: () => buildMultipartBody
 });
 module.exports = __toCommonJS(multipart_exports);
-var import_restError = __nccwpck_require__(445);
-var import_httpHeaders = __nccwpck_require__(486);
+var import_restError = __nccwpck_require__(446);
+var import_httpHeaders = __nccwpck_require__(487);
 var import_bytesEncoding = __nccwpck_require__(287);
 var import_typeGuards = __nccwpck_require__(498);
 function getHeaderValue(descriptor, headerName) {
@@ -54369,8 +54203,8 @@ exports.listEnumNumbers = listEnumNumbers;
 
 const assert = __nccwpck_require__(528)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(196)
-const { RequestRetryError } = __nccwpck_require__(489)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(194)
+const { RequestRetryError } = __nccwpck_require__(490)
 const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(69)
 
 function calculateRetryAfterHeader (retryAfter) {
@@ -54846,27 +54680,27 @@ module.exports = decodeText
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
-const tslib_1 = __nccwpck_require__(217);
-tslib_1.__exportStar(__nccwpck_require__(363), exports);
+const tslib_1 = __nccwpck_require__(216);
+tslib_1.__exportStar(__nccwpck_require__(364), exports);
 var cache_js_1 = __nccwpck_require__(253);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(83), exports);
+tslib_1.__exportStar(__nccwpck_require__(85), exports);
 tslib_1.__exportStar(__nccwpck_require__(156), exports);
-tslib_1.__exportStar(__nccwpck_require__(398), exports);
-tslib_1.__exportStar(__nccwpck_require__(96), exports);
+tslib_1.__exportStar(__nccwpck_require__(399), exports);
+tslib_1.__exportStar(__nccwpck_require__(97), exports);
 tslib_1.__exportStar(__nccwpck_require__(262), exports);
 tslib_1.__exportStar(__nccwpck_require__(326), exports);
 var RequestPolicy_js_1 = __nccwpck_require__(46);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
-tslib_1.__exportStar(__nccwpck_require__(94), exports);
+tslib_1.__exportStar(__nccwpck_require__(95), exports);
 tslib_1.__exportStar(__nccwpck_require__(309), exports);
-tslib_1.__exportStar(__nccwpck_require__(207), exports);
-tslib_1.__exportStar(__nccwpck_require__(464), exports);
-tslib_1.__exportStar(__nccwpck_require__(168), exports);
+tslib_1.__exportStar(__nccwpck_require__(206), exports);
+tslib_1.__exportStar(__nccwpck_require__(465), exports);
+tslib_1.__exportStar(__nccwpck_require__(167), exports);
 tslib_1.__exportStar(__nccwpck_require__(127), exports);
 tslib_1.__exportStar(__nccwpck_require__(78), exports);
-tslib_1.__exportStar(__nccwpck_require__(428), exports);
-tslib_1.__exportStar(__nccwpck_require__(170), exports);
+tslib_1.__exportStar(__nccwpck_require__(429), exports);
+tslib_1.__exportStar(__nccwpck_require__(169), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -54884,13 +54718,13 @@ tslib_1.__exportStar(__nccwpck_require__(170), exports);
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(217);
-tslib_1.__exportStar(__nccwpck_require__(231), exports);
-tslib_1.__exportStar(__nccwpck_require__(221), exports);
+const tslib_1 = __nccwpck_require__(216);
+tslib_1.__exportStar(__nccwpck_require__(230), exports);
+tslib_1.__exportStar(__nccwpck_require__(220), exports);
 tslib_1.__exportStar(__nccwpck_require__(47), exports);
 tslib_1.__exportStar(__nccwpck_require__(282), exports);
 tslib_1.__exportStar(__nccwpck_require__(26), exports);
-tslib_1.__exportStar(__nccwpck_require__(355), exports);
+tslib_1.__exportStar(__nccwpck_require__(356), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -55194,7 +55028,7 @@ module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(71);
 var import_pipeline = __nccwpck_require__(245);
 var import_redirectPolicy = __nccwpck_require__(341);
-var import_userAgentPolicy = __nccwpck_require__(390);
+var import_userAgentPolicy = __nccwpck_require__(391);
 var import_multipartPolicy = __nccwpck_require__(272);
 var import_decompressResponsePolicy = __nccwpck_require__(239);
 var import_defaultRetryPolicy = __nccwpck_require__(55);
@@ -55202,8 +55036,8 @@ var import_formDataPolicy = __nccwpck_require__(269);
 var import_core_util = __nccwpck_require__(14);
 var import_proxyPolicy = __nccwpck_require__(474);
 var import_setClientRequestIdPolicy = __nccwpck_require__(151);
-var import_agentPolicy = __nccwpck_require__(232);
-var import_tlsPolicy = __nccwpck_require__(379);
+var import_agentPolicy = __nccwpck_require__(231);
+var import_tlsPolicy = __nccwpck_require__(380);
 var import_tracingPolicy = __nccwpck_require__(336);
 var import_wrapAbortSignalLikePolicy = __nccwpck_require__(259);
 function createPipelineFromOptions(options) {
@@ -55253,9 +55087,9 @@ function createPipelineFromOptions(options) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const tslib_1 = __nccwpck_require__(216);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(441));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(179));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing PageBlob operations. */
 class PageBlobImpl {
@@ -55717,7 +55551,7 @@ const copyIncrementalOperationSpec = {
 
 const { kConstruct } = __nccwpck_require__(157)
 const { Cache } = __nccwpck_require__(12)
-const { webidl } = __nccwpck_require__(457)
+const { webidl } = __nccwpck_require__(458)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 
 class CacheStorage {
@@ -55870,9 +55704,9 @@ module.exports = {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createClientPipeline = createClientPipeline;
-const deserializationPolicy_js_1 = __nccwpck_require__(87);
-const core_rest_pipeline_1 = __nccwpck_require__(102);
-const serializationPolicy_js_1 = __nccwpck_require__(490);
+const deserializationPolicy_js_1 = __nccwpck_require__(88);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
+const serializationPolicy_js_1 = __nccwpck_require__(491);
 /**
  * Creates a new Pipeline for use with a Service Client.
  * Adds in deserializationPolicy by default.
@@ -55941,7 +55775,7 @@ const http = __importStar(__nccwpck_require__(329));
 const https = __importStar(__nccwpck_require__(70));
 const pm = __importStar(__nccwpck_require__(311));
 const tunnel = __importStar(__nccwpck_require__(522));
-const undici_1 = __nccwpck_require__(164);
+const undici_1 = __nccwpck_require__(163);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -56608,20 +56442,20 @@ __export(internal_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(internal_exports);
-var import_agentPolicy = __nccwpck_require__(465);
-var import_decompressResponsePolicy = __nccwpck_require__(356);
+var import_agentPolicy = __nccwpck_require__(466);
+var import_decompressResponsePolicy = __nccwpck_require__(357);
 var import_defaultRetryPolicy = __nccwpck_require__(325);
 var import_exponentialRetryPolicy = __nccwpck_require__(525);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_systemErrorRetryPolicy = __nccwpck_require__(28);
 var import_throttlingRetryPolicy = __nccwpck_require__(523);
 var import_formDataPolicy = __nccwpck_require__(340);
-var import_logPolicy = __nccwpck_require__(103);
-var import_multipartPolicy = __nccwpck_require__(172);
+var import_logPolicy = __nccwpck_require__(104);
+var import_multipartPolicy = __nccwpck_require__(170);
 var import_proxyPolicy = __nccwpck_require__(39);
 var import_redirectPolicy = __nccwpck_require__(318);
-var import_tlsPolicy = __nccwpck_require__(222);
-var import_userAgentPolicy = __nccwpck_require__(360);
+var import_tlsPolicy = __nccwpck_require__(221);
+var import_userAgentPolicy = __nccwpck_require__(361);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -56675,7 +56509,7 @@ function stringToUint8Array(value, format) {
 
 module.exports = parseString
 
-const TOMLParser = __nccwpck_require__(346)
+const TOMLParser = __nccwpck_require__(347)
 const prettyError = __nccwpck_require__(279)
 
 function parseString (str) {
@@ -56706,8 +56540,8 @@ exports.generateAccountSASQueryParameters = generateAccountSASQueryParameters;
 exports.generateAccountSASQueryParametersInternal = generateAccountSASQueryParametersInternal;
 const AccountSASPermissions_js_1 = __nccwpck_require__(58);
 const AccountSASResourceTypes_js_1 = __nccwpck_require__(2);
-const AccountSASServices_js_1 = __nccwpck_require__(380);
-const SasIPRange_js_1 = __nccwpck_require__(359);
+const AccountSASServices_js_1 = __nccwpck_require__(381);
+const SasIPRange_js_1 = __nccwpck_require__(360);
 const SASQueryParameters_js_1 = __nccwpck_require__(527);
 const constants_js_1 = __nccwpck_require__(149);
 const utils_common_js_1 = __nccwpck_require__(155);
@@ -56812,8 +56646,8 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
-const reflection_info_1 = __nccwpck_require__(453);
-const oneof_1 = __nccwpck_require__(191);
+const reflection_info_1 = __nccwpck_require__(454);
+const oneof_1 = __nccwpck_require__(189);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
     constructor(info) {
@@ -57044,141 +56878,6 @@ exports.ReflectionTypeCheck = ReflectionTypeCheck;
 /***/ }),
 
 /***/ 291:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("crypto");
-
-/***/ }),
-
-/***/ 292:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-var __defProp = Object.defineProperty;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __export = (target, all) => {
-  for (var name in all)
-    __defProp(target, name, { get: all[name], enumerable: true });
-};
-var __copyProps = (to, from, except, desc) => {
-  if (from && typeof from === "object" || typeof from === "function") {
-    for (let key of __getOwnPropNames(from))
-      if (!__hasOwnProp.call(to, key) && key !== except)
-        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
-  }
-  return to;
-};
-var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
-var userAgent_exports = {};
-__export(userAgent_exports, {
-  getUserAgentHeaderName: () => getUserAgentHeaderName,
-  getUserAgentValue: () => getUserAgentValue
-});
-module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(117);
-var import_constants = __nccwpck_require__(160);
-function getUserAgentString(telemetryInfo) {
-  const parts = [];
-  for (const [key, value] of telemetryInfo) {
-    const token = value ? `${key}/${value}` : key;
-    parts.push(token);
-  }
-  return parts.join(" ");
-}
-function getUserAgentHeaderName() {
-  return (0, import_userAgentPlatform.getHeaderName)();
-}
-async function getUserAgentValue(prefix) {
-  const runtimeInfo = /* @__PURE__ */ new Map();
-  runtimeInfo.set("core-rest-pipeline", import_constants.SDK_VERSION);
-  await (0, import_userAgentPlatform.setPlatformSpecificData)(runtimeInfo);
-  const defaultAgent = getUserAgentString(runtimeInfo);
-  const userAgentValue = prefix ? `${prefix} ${defaultAgent}` : defaultAgent;
-  return userAgentValue;
-}
-// Annotate the CommonJS export names for ESM import in node:
-0 && (0);
-
-
-/***/ }),
-
-/***/ 293:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.mergeRpcOptions = void 0;
-const runtime_1 = __nccwpck_require__(19);
-/**
- * Merges custom RPC options with defaults. Returns a new instance and keeps
- * the "defaults" and the "options" unmodified.
- *
- * Merges `RpcMetadata` "meta", overwriting values from "defaults" with
- * values from "options". Does not append values to existing entries.
- *
- * Merges "jsonOptions", including "jsonOptions.typeRegistry", by creating
- * a new array that contains types from "options.jsonOptions.typeRegistry"
- * first, then types from "defaults.jsonOptions.typeRegistry".
- *
- * Merges "binaryOptions".
- *
- * Merges "interceptors" by creating a new array that contains interceptors
- * from "defaults" first, then interceptors from "options".
- *
- * Works with objects that extend `RpcOptions`, but only if the added
- * properties are of type Date, primitive like string, boolean, or Array
- * of primitives. If you have other property types, you have to merge them
- * yourself.
- */
-function mergeRpcOptions(defaults, options) {
-    if (!options)
-        return defaults;
-    let o = {};
-    copy(defaults, o);
-    copy(options, o);
-    for (let key of Object.keys(options)) {
-        let val = options[key];
-        switch (key) {
-            case "jsonOptions":
-                o.jsonOptions = runtime_1.mergeJsonOptions(defaults.jsonOptions, o.jsonOptions);
-                break;
-            case "binaryOptions":
-                o.binaryOptions = runtime_1.mergeBinaryOptions(defaults.binaryOptions, o.binaryOptions);
-                break;
-            case "meta":
-                o.meta = {};
-                copy(defaults.meta, o.meta);
-                copy(options.meta, o.meta);
-                break;
-            case "interceptors":
-                o.interceptors = defaults.interceptors ? defaults.interceptors.concat(val) : val.concat();
-                break;
-        }
-    }
-    return o;
-}
-exports.mergeRpcOptions = mergeRpcOptions;
-function copy(a, into) {
-    if (!a)
-        return;
-    let c = into;
-    for (let [k, v] of Object.entries(a)) {
-        if (v instanceof Date)
-            c[k] = new Date(v.getTime());
-        else if (Array.isArray(v))
-            c[k] = v.concat();
-        else
-            c[k] = v;
-    }
-}
-
-
-/***/ }),
-
-/***/ 294:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -57240,11 +56939,11 @@ exports.restoreSoloCache = restoreSoloCache;
 exports.verifyRestoredToolchain = verifyRestoredToolchain;
 const node_crypto_1 = __nccwpck_require__(275);
 const fs = __importStar(__nccwpck_require__(249));
-const fsp = __importStar(__nccwpck_require__(109));
+const fsp = __importStar(__nccwpck_require__(110));
 const path = __importStar(__nccwpck_require__(509));
-const cache = __importStar(__nccwpck_require__(215));
+const cache = __importStar(__nccwpck_require__(214));
 const exec = __importStar(__nccwpck_require__(18));
-const cache_compress_js_1 = __nccwpck_require__(494);
+const cache_compress_js_1 = __nccwpck_require__(529);
 /**
  * The two live roots whose deltas this cache layer tracks. The string keys
  * are also the directory names used inside the tarball staging layout.
@@ -57570,6 +57269,141 @@ async function verifyRestoredToolchain(opts) {
 
 /***/ }),
 
+/***/ 292:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("crypto");
+
+/***/ }),
+
+/***/ 293:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var userAgent_exports = {};
+__export(userAgent_exports, {
+  getUserAgentHeaderName: () => getUserAgentHeaderName,
+  getUserAgentValue: () => getUserAgentValue
+});
+module.exports = __toCommonJS(userAgent_exports);
+var import_userAgentPlatform = __nccwpck_require__(117);
+var import_constants = __nccwpck_require__(159);
+function getUserAgentString(telemetryInfo) {
+  const parts = [];
+  for (const [key, value] of telemetryInfo) {
+    const token = value ? `${key}/${value}` : key;
+    parts.push(token);
+  }
+  return parts.join(" ");
+}
+function getUserAgentHeaderName() {
+  return (0, import_userAgentPlatform.getHeaderName)();
+}
+async function getUserAgentValue(prefix) {
+  const runtimeInfo = /* @__PURE__ */ new Map();
+  runtimeInfo.set("core-rest-pipeline", import_constants.SDK_VERSION);
+  await (0, import_userAgentPlatform.setPlatformSpecificData)(runtimeInfo);
+  const defaultAgent = getUserAgentString(runtimeInfo);
+  const userAgentValue = prefix ? `${prefix} ${defaultAgent}` : defaultAgent;
+  return userAgentValue;
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (0);
+
+
+/***/ }),
+
+/***/ 294:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.mergeRpcOptions = void 0;
+const runtime_1 = __nccwpck_require__(19);
+/**
+ * Merges custom RPC options with defaults. Returns a new instance and keeps
+ * the "defaults" and the "options" unmodified.
+ *
+ * Merges `RpcMetadata` "meta", overwriting values from "defaults" with
+ * values from "options". Does not append values to existing entries.
+ *
+ * Merges "jsonOptions", including "jsonOptions.typeRegistry", by creating
+ * a new array that contains types from "options.jsonOptions.typeRegistry"
+ * first, then types from "defaults.jsonOptions.typeRegistry".
+ *
+ * Merges "binaryOptions".
+ *
+ * Merges "interceptors" by creating a new array that contains interceptors
+ * from "defaults" first, then interceptors from "options".
+ *
+ * Works with objects that extend `RpcOptions`, but only if the added
+ * properties are of type Date, primitive like string, boolean, or Array
+ * of primitives. If you have other property types, you have to merge them
+ * yourself.
+ */
+function mergeRpcOptions(defaults, options) {
+    if (!options)
+        return defaults;
+    let o = {};
+    copy(defaults, o);
+    copy(options, o);
+    for (let key of Object.keys(options)) {
+        let val = options[key];
+        switch (key) {
+            case "jsonOptions":
+                o.jsonOptions = runtime_1.mergeJsonOptions(defaults.jsonOptions, o.jsonOptions);
+                break;
+            case "binaryOptions":
+                o.binaryOptions = runtime_1.mergeBinaryOptions(defaults.binaryOptions, o.binaryOptions);
+                break;
+            case "meta":
+                o.meta = {};
+                copy(defaults.meta, o.meta);
+                copy(options.meta, o.meta);
+                break;
+            case "interceptors":
+                o.interceptors = defaults.interceptors ? defaults.interceptors.concat(val) : val.concat();
+                break;
+        }
+    }
+    return o;
+}
+exports.mergeRpcOptions = mergeRpcOptions;
+function copy(a, into) {
+    if (!a)
+        return;
+    let c = into;
+    for (let [k, v] of Object.entries(a)) {
+        if (v instanceof Date)
+            c[k] = new Date(v.getTime());
+        else if (Array.isArray(v))
+            c[k] = v.concat();
+        else
+            c[k] = v;
+    }
+}
+
+
+/***/ }),
+
 /***/ 295:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -57607,7 +57441,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
 const assert_1 = __nccwpck_require__(528);
 const path = __importStar(__nccwpck_require__(248));
-const ioUtil = __importStar(__nccwpck_require__(226));
+const ioUtil = __importStar(__nccwpck_require__(225));
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -57883,7 +57717,7 @@ function copyFile(srcFile, destFile, force) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.maskSecretUrls = exports.maskSigUrl = void 0;
-const core_1 = __nccwpck_require__(460);
+const core_1 = __nccwpck_require__(461);
 /**
  * Masks the `sig` parameter in a URL and sets it as a secret.
  *
@@ -57971,11 +57805,11 @@ exports.maskSecretUrls = maskSecretUrls;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(216);
 tslib_1.__exportStar(__nccwpck_require__(473), exports);
-var storageClient_js_1 = __nccwpck_require__(447);
+var storageClient_js_1 = __nccwpck_require__(448);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(167), exports);
+tslib_1.__exportStar(__nccwpck_require__(166), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -58039,9 +57873,9 @@ exports.AzureKeyCredential = AzureKeyCredential;
 const {
   InvalidArgumentError,
   NotSupportedError
-} = __nccwpck_require__(489)
+} = __nccwpck_require__(490)
 const assert = __nccwpck_require__(528)
-const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(196)
+const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(194)
 const util = __nccwpck_require__(69)
 
 // tokenRegExp and headerCharRegex have been lifted from
@@ -58847,11 +58681,11 @@ function stringifyComplexTable (prefix, indent, key, value) {
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(457)
+const { webidl } = __nccwpck_require__(458)
 const { DOMException } = __nccwpck_require__(30)
 const { URLSerializer } = __nccwpck_require__(25)
 const { getGlobalOrigin } = __nccwpck_require__(140)
-const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(466)
+const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(467)
 const {
   kWebSocketURL,
   kReadyState,
@@ -58860,13 +58694,13 @@ const {
   kResponse,
   kSentClose,
   kByteParser
-} = __nccwpck_require__(99)
+} = __nccwpck_require__(100)
 const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(57)
-const { establishWebSocketConnection } = __nccwpck_require__(366)
-const { WebsocketFrameSend } = __nccwpck_require__(188)
+const { establishWebSocketConnection } = __nccwpck_require__(367)
+const { WebsocketFrameSend } = __nccwpck_require__(186)
 const { ByteParser } = __nccwpck_require__(483)
 const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(69)
-const { getGlobalDispatcher } = __nccwpck_require__(377)
+const { getGlobalDispatcher } = __nccwpck_require__(378)
 const { types } = __nccwpck_require__(124)
 
 let experimentalWarned = false
@@ -60421,11 +60255,11 @@ exports.CredentialPolicy = CredentialPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BatchResponseParser = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 const core_http_compat_1 = __nccwpck_require__(72);
 const constants_js_1 = __nccwpck_require__(149);
 const BatchUtils_js_1 = __nccwpck_require__(258);
-const log_js_1 = __nccwpck_require__(107);
+const log_js_1 = __nccwpck_require__(108);
 const HTTP_HEADER_DELIMITER = ": ";
 const SPACE_DELIMITER = " ";
 const NOT_FOUND = -1;
@@ -61224,13 +61058,13 @@ exports.buildCreatePoller = buildCreatePoller;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 const pipeline_js_1 = __nccwpck_require__(284);
 const utils_js_1 = __nccwpck_require__(313);
-const httpClientCache_js_1 = __nccwpck_require__(399);
-const operationHelpers_js_1 = __nccwpck_require__(433);
+const httpClientCache_js_1 = __nccwpck_require__(400);
+const operationHelpers_js_1 = __nccwpck_require__(434);
 const urlHelpers_js_1 = __nccwpck_require__(238);
-const interfaceHelpers_js_1 = __nccwpck_require__(400);
+const interfaceHelpers_js_1 = __nccwpck_require__(401);
 const log_js_1 = __nccwpck_require__(482);
 /**
  * Initializes a new instance of the ServiceClient.
@@ -61423,18 +61257,18 @@ __export(createPipelineFromOptions_exports, {
   createPipelineFromOptions: () => createPipelineFromOptions
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
-var import_logPolicy = __nccwpck_require__(103);
+var import_logPolicy = __nccwpck_require__(104);
 var import_pipeline = __nccwpck_require__(526);
 var import_redirectPolicy = __nccwpck_require__(318);
-var import_userAgentPolicy = __nccwpck_require__(360);
-var import_decompressResponsePolicy = __nccwpck_require__(356);
+var import_userAgentPolicy = __nccwpck_require__(361);
+var import_decompressResponsePolicy = __nccwpck_require__(357);
 var import_defaultRetryPolicy = __nccwpck_require__(325);
 var import_formDataPolicy = __nccwpck_require__(340);
-var import_checkEnvironment = __nccwpck_require__(439);
+var import_checkEnvironment = __nccwpck_require__(440);
 var import_proxyPolicy = __nccwpck_require__(39);
-var import_agentPolicy = __nccwpck_require__(465);
-var import_tlsPolicy = __nccwpck_require__(222);
-var import_multipartPolicy = __nccwpck_require__(172);
+var import_agentPolicy = __nccwpck_require__(466);
+var import_tlsPolicy = __nccwpck_require__(221);
+var import_multipartPolicy = __nccwpck_require__(170);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_checkEnvironment.isNodeLike) {
@@ -61904,7 +61738,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(396);
+var import_exponentialRetryStrategy = __nccwpck_require__(397);
 var import_throttlingRetryStrategy = __nccwpck_require__(35);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_constants = __nccwpck_require__(48);
@@ -61933,10 +61767,10 @@ function defaultRetryPolicy(options = {}) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageRetryPolicyFactory = exports.NewRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = void 0;
-const StorageRetryPolicy_js_1 = __nccwpck_require__(81);
+const StorageRetryPolicy_js_1 = __nccwpck_require__(83);
 Object.defineProperty(exports, "StorageRetryPolicy", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.StorageRetryPolicy; } }));
 Object.defineProperty(exports, "NewRetryPolicyFactory", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.NewRetryPolicyFactory; } }));
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(418);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(419);
 Object.defineProperty(exports, "StorageRetryPolicyType", ({ enumerable: true, get: function () { return StorageRetryPolicyType_js_1.StorageRetryPolicyType; } }));
 /**
  * StorageRetryPolicyFactory is a factory class helping generating {@link StorageRetryPolicy} objects.
@@ -62242,13 +62076,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._readLinuxVersionFile = exports._getOsVersion = exports._findMatch = void 0;
-const semver = __importStar(__nccwpck_require__(180));
-const core_1 = __nccwpck_require__(460);
+const semver = __importStar(__nccwpck_require__(178));
+const core_1 = __nccwpck_require__(461);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
-const os = __nccwpck_require__(93);
+const os = __nccwpck_require__(94);
 const cp = __nccwpck_require__(165);
-const fs = __nccwpck_require__(533);
+const fs = __nccwpck_require__(534);
 function _findMatch(versionSpec, stable, candidates, archFilter) {
     return __awaiter(this, void 0, void 0, function* () {
         const platFilter = os.platform();
@@ -62527,17 +62361,17 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatch = void 0;
 const core_util_1 = __nccwpck_require__(14);
 const core_auth_1 = __nccwpck_require__(516);
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 const core_util_2 = __nccwpck_require__(14);
 const storage_common_1 = __nccwpck_require__(277);
-const Clients_js_1 = __nccwpck_require__(186);
+const Clients_js_1 = __nccwpck_require__(184);
 const Mutex_js_1 = __nccwpck_require__(520);
-const Pipeline_js_1 = __nccwpck_require__(184);
+const Pipeline_js_1 = __nccwpck_require__(182);
 const utils_common_js_1 = __nccwpck_require__(155);
-const core_xml_1 = __nccwpck_require__(195);
+const core_xml_1 = __nccwpck_require__(193);
 const constants_js_1 = __nccwpck_require__(149);
 const tracing_js_1 = __nccwpck_require__(31);
-const core_client_1 = __nccwpck_require__(440);
+const core_client_1 = __nccwpck_require__(441);
 /**
  * A BlobBatch represents an aggregated set of operations on blobs.
  * Currently, only `delete` and `setAccessTier` are supported.
@@ -62810,9 +62644,9 @@ function batchHeaderFilterPolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = exports.AvroReadable = exports.AvroReader = void 0;
-var AvroReader_js_1 = __nccwpck_require__(422);
+var AvroReader_js_1 = __nccwpck_require__(423);
 Object.defineProperty(exports, "AvroReader", ({ enumerable: true, get: function () { return AvroReader_js_1.AvroReader; } }));
-var AvroReadable_js_1 = __nccwpck_require__(388);
+var AvroReadable_js_1 = __nccwpck_require__(389);
 Object.defineProperty(exports, "AvroReadable", ({ enumerable: true, get: function () { return AvroReadable_js_1.AvroReadable; } }));
 var AvroReadableFromStream_js_1 = __nccwpck_require__(252);
 Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, get: function () { return AvroReadableFromStream_js_1.AvroReadableFromStream; } }));
@@ -62846,12 +62680,12 @@ __export(tracingPolicy_exports, {
   tracingPolicyName: () => tracingPolicyName
 });
 module.exports = __toCommonJS(tracingPolicy_exports);
-var import_core_tracing = __nccwpck_require__(82);
-var import_constants = __nccwpck_require__(160);
-var import_userAgent = __nccwpck_require__(292);
-var import_log = __nccwpck_require__(185);
+var import_core_tracing = __nccwpck_require__(84);
+var import_constants = __nccwpck_require__(159);
+var import_userAgent = __nccwpck_require__(293);
+var import_log = __nccwpck_require__(183);
 var import_core_util = __nccwpck_require__(14);
-var import_restError = __nccwpck_require__(353);
+var import_restError = __nccwpck_require__(354);
 var import_util = __nccwpck_require__(147);
 const tracingPolicyName = "tracingPolicy";
 function tracingPolicy(options = {}) {
@@ -63012,7 +62846,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.markPhase = markPhase;
 exports.finishPhase = finishPhase;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 function phaseEnvName(name) {
     const cleaned = name.replace(/[^A-Za-z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase() || "PHASE";
     return `SETUP_SOLDR_PHASE_${cleaned}_START_MS`;
@@ -63068,13 +62902,13 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher
-} = __nccwpck_require__(370)
-const Client = __nccwpck_require__(89)
+} = __nccwpck_require__(371)
+const Client = __nccwpck_require__(90)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(489)
+} = __nccwpck_require__(490)
 const util = __nccwpck_require__(69)
-const { kUrl, kInterceptors } = __nccwpck_require__(196)
+const { kUrl, kInterceptors } = __nccwpck_require__(194)
 const buildConnector = __nccwpck_require__(266)
 
 const kOptions = Symbol('options')
@@ -63198,7 +63032,7 @@ __export(oauth2AuthenticationPolicy_exports, {
   oauth2AuthenticationPolicyName: () => oauth2AuthenticationPolicyName
 });
 module.exports = __toCommonJS(oauth2AuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(436);
+var import_checkInsecureConnection = __nccwpck_require__(437);
 const oauth2AuthenticationPolicyName = "oauth2AuthenticationPolicy";
 function oauth2AuthenticationPolicy(options) {
   return {
@@ -63251,8 +63085,8 @@ __export(formDataPolicy_exports, {
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
 var import_bytesEncoding = __nccwpck_require__(287);
-var import_checkEnvironment = __nccwpck_require__(439);
-var import_httpHeaders = __nccwpck_require__(486);
+var import_checkEnvironment = __nccwpck_require__(440);
+var import_httpHeaders = __nccwpck_require__(487);
 const formDataPolicyName = "formDataPolicy";
 function formDataToFormDataMap(formData) {
   const formDataMap = {};
@@ -63383,12 +63217,12 @@ function redirectPolicy(options = {}) {
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(196)
-const { URL } = __nccwpck_require__(86)
+const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(194)
+const { URL } = __nccwpck_require__(87)
 const Agent = __nccwpck_require__(5)
 const Pool = __nccwpck_require__(338)
 const DispatcherBase = __nccwpck_require__(62)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(489)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(490)
 const buildConnector = __nccwpck_require__(266)
 
 const kAgent = Symbol('proxy agent')
@@ -63581,12 +63415,12 @@ module.exports = ProxyAgent
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonReader = void 0;
-const json_typings_1 = __nccwpck_require__(395);
+const json_typings_1 = __nccwpck_require__(396);
 const base64_1 = __nccwpck_require__(303);
-const reflection_info_1 = __nccwpck_require__(453);
+const reflection_info_1 = __nccwpck_require__(454);
 const pb_long_1 = __nccwpck_require__(118);
-const assert_1 = __nccwpck_require__(485);
-const reflection_long_convert_1 = __nccwpck_require__(159);
+const assert_1 = __nccwpck_require__(486);
+const reflection_long_convert_1 = __nccwpck_require__(158);
 /**
  * Reads proto3 messages in canonical JSON format using reflection information.
  *
@@ -63915,8 +63749,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
-const os_1 = __nccwpck_require__(93);
-const fs_1 = __nccwpck_require__(533);
+const os_1 = __nccwpck_require__(94);
+const fs_1 = __nccwpck_require__(534);
 const { access, appendFile, writeFile } = fs_1.promises;
 exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
 exports.SUMMARY_DOCS_URL = 'https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary';
@@ -64273,12 +64107,904 @@ exports.utf8read = utf8read;
 /***/ }),
 
 /***/ 346:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr entry point. Owned by Agent 2.
+//
+// Replaces the composite action's main-phase steps with a single JS
+// orchestrator. Calls the helpers in src/lib/* in the same order the
+// composite's steps fire.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(249));
+const os = __importStar(__nccwpck_require__(384));
+const path = __importStar(__nccwpck_require__(509));
+const core = __importStar(__nccwpck_require__(461));
+const cache = __importStar(__nccwpck_require__(214));
+const log_utils_js_1 = __nccwpck_require__(353);
+const resolve_setup_js_1 = __nccwpck_require__(197);
+const phase_timing_js_1 = __nccwpck_require__(337);
+const ensure_rust_toolchain_js_1 = __nccwpck_require__(513);
+const ensure_soldr_js_1 = __nccwpck_require__(365);
+const verify_soldr_js_1 = __nccwpck_require__(359);
+const install_passthrough_js_1 = __nccwpck_require__(515);
+const normalize_source_mtime_js_1 = __nccwpck_require__(80);
+const detect_shared_target_warning_js_1 = __nccwpck_require__(218);
+const ensure_shims_js_1 = __nccwpck_require__(532);
+const cache_compress_js_1 = __nccwpck_require__(529);
+const stats_collector_js_1 = __nccwpck_require__(74);
+const toolchain_snapshot_js_1 = __nccwpck_require__(460);
+const solo_toolchain_cache_js_1 = __nccwpck_require__(291);
+const cook_cache_js_1 = __nccwpck_require__(484);
+const soldr_mini_cache_js_1 = __nccwpck_require__(79);
+const diagnostics_js_1 = __nccwpck_require__(233);
+const shim_bypass_check_js_1 = __nccwpck_require__(312);
+const source_mtime_snapshot_js_1 = __nccwpck_require__(409);
+/**
+ * Map (hit, matchedKey) → workflow-visible restore-status string.
+ * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
+ * for the `<layer>-cache-restore-status` outputs declared in action.yml.
+ */
+function deriveRestoreStatus(hit, matchedKey) {
+    if (hit)
+        return "exact-hit";
+    if (matchedKey.trim())
+        return "restore-key-hit";
+    return "miss";
+}
+function writeCacheKeysManifest(result, runnerTemp, log) {
+    if (!runnerTemp)
+        return;
+    const keys = [
+        result.setupCache.key,
+        result.buildCache.key,
+        result.targetCache.key,
+        result.cargoRegistryCache.key,
+    ].filter((k) => Boolean(k));
+    if (keys.length === 0)
+        return;
+    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
+    try {
+        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
+        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
+    }
+    catch (err) {
+        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+function isTruthy(value) {
+    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
+}
+function isFalsy(value) {
+    return FALSY.has(((value ?? "").trim().toLowerCase()));
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+function dirHasContent(p) {
+    try {
+        return fs.readdirSync(p).length > 0;
+    }
+    catch {
+        return false;
+    }
+}
+function buildActionContext() {
+    const env = process.env;
+    const logger = (0, log_utils_js_1.createLogger)(env);
+    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
+    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
+    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
+    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
+    const githubSha = env["GITHUB_SHA"]?.trim() || "";
+    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
+    const parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
+    return {
+        env: { ...env },
+        workspace,
+        runnerTemp,
+        runnerOs,
+        runnerArch,
+        githubSha,
+        githubToken,
+        parentSha,
+        logger,
+    };
+}
+async function restoreCacheSafe(paths, key, restoreKeys, logger) {
+    if (paths.length === 0 || !key) {
+        return { hit: false, matchedKey: "" };
+    }
+    try {
+        const matched = await cache.restoreCache(paths, key, restoreKeys);
+        return { hit: matched === key, matchedKey: matched ?? "" };
+    }
+    catch (err) {
+        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "" };
+    }
+}
+async function run() {
+    const ctx = buildActionContext();
+    const logger = ctx.logger;
+    await (0, phase_timing_js_1.markPhase)("action");
+    // ---- resolve ----
+    await (0, phase_timing_js_1.markPhase)("resolve");
+    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
+    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
+    await (0, resolve_setup_js_1.applyResolveResult)(result);
+    await (0, phase_timing_js_1.finishPhase)("resolve");
+    // Always emit the cache-keys manifest right after resolve so workflow
+    // steps that run between main and post (e.g. actions/upload-artifact)
+    // can read it. The four keys are fully determined by resolveSetup and
+    // never change later in the run.
+    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
+    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            logger,
+            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
+        });
+    }
+    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
+    if (dryRun) {
+        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
+        await (0, phase_timing_js_1.finishPhase)("action");
+        return;
+    }
+    // Persist resolve state for the post-job step.
+    core.saveState("resolveResult", JSON.stringify(result));
+    core.saveState("buildCacheMode", result.buildCache.mode);
+    core.saveState("logging", logging ? "true" : "false");
+    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
+    const statsMode = result.stats;
+    const debugMode = result.debugMode;
+    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
+    const statsCollector = new stats_collector_js_1.StatsCollector();
+    // ---- source-mtime-normalize ----
+    if (isTruthy(inputs.sourceMtimeNormalize)) {
+        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
+    }
+    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
+    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
+    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
+    core.saveState("setupCacheExactHit", "false");
+    core.saveState("setupCacheMatchedKey", "");
+    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
+    core.saveState("targetCacheExactHit", "false");
+    core.saveState("targetCacheMatchedKey", "");
+    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
+    core.saveState("buildCacheExactHit", "false");
+    core.saveState("buildCacheMatchedKey", "");
+    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
+    core.saveState("cargoRegistryCacheExactHit", "false");
+    core.saveState("cargoRegistryCacheMatchedKey", "");
+    // ---- parallel restores ----
+    // setup-cache, target-cache, build-cache, and cargo-registry write to
+    // disjoint paths and have no inter-dependencies, so they run concurrently.
+    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
+    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
+    //
+    // Layers that must stay sequential (wired below): solo-toolchain (writes
+    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
+    // install dir, must precede ensureSoldr), cook (writes target/ and needs
+    // the soldr binary). Cargo-registry was previously after-cook — it's been
+    // moved into this parallel block because nothing the soldr install path
+    // touches depends on its hydrated cargo registry state.
+    await (0, phase_timing_js_1.markPhase)("parallel-restore");
+    let setupCacheExactHit = false;
+    // Capture target-cache match status so we can skip the redundant cook restore.
+    // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
+    // (~2.5 GB inflated) also contains compiled deps. When target-cache matched
+    // at the lockfile/shape/toolchain level (exact OR parent-SHA OR lock-prefix
+    // fallback), we have target/deps/ already populated with identical content —
+    // cook restore would just overwrite. Skipping saves ~5–10 s per warm run.
+    // A looser restoreKeyLockfile-only match (different shape) is NOT enough to
+    // skip cook, since cook output may differ across shapes.
+    let targetCacheMatchedKey = "";
+    const setupRestorePromise = (async () => {
+        if (!(cacheEnabled && result.setupCache.paths.length > 0))
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
+        setupCacheExactHit = restore.hit;
+        core.setOutput("cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("setup_cache_matched_key", restore.matchedKey);
+        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("setupCacheMatchedKey", restore.matchedKey);
+        // Expose for ensure_rust_toolchain to read via env. Must be visible by
+        // the time toolchain phase runs — guaranteed by the Promise.all below.
+        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
+        statsCollector.record({
+            label: "setup-cache", operation: "restore", hit: restore.hit,
+            key: result.setupCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.setupCache.restorePrefix],
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const targetRestorePromise = (async () => {
+        if (!result.targetCache.enabled)
+            return;
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (targetPaths.length === 0)
+            return;
+        const restoreKeys = [];
+        if (result.targetCache.restoreKeyParent)
+            restoreKeys.push(result.targetCache.restoreKeyParent);
+        if (result.targetCache.restoreKeyLock)
+            restoreKeys.push(result.targetCache.restoreKeyLock);
+        if (result.targetCache.restoreKeyLockfile)
+            restoreKeys.push(result.targetCache.restoreKeyLockfile);
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
+        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("target_cache_matched_key", restore.matchedKey);
+        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("targetCacheMatchedKey", restore.matchedKey);
+        targetCacheMatchedKey = restore.matchedKey;
+        statsCollector.record({
+            label: "target-cache", operation: "restore", hit: restore.hit,
+            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const buildRestorePromise = (async () => {
+        if (!buildCacheEnabled)
+            return;
+        const buildCachePath = result.buildCache.path;
+        const archivePath = `${buildCachePath}.tar.zst`;
+        const restoreKeys = [];
+        if (result.buildCache.restoreKeyParent)
+            restoreKeys.push(result.buildCache.restoreKeyParent);
+        if (result.buildCache.restoreKeyToolchain)
+            restoreKeys.push(result.buildCache.restoreKeyToolchain);
+        if (result.buildCache.restoreKeyOsArch)
+            restoreKeys.push(result.buildCache.restoreKeyOsArch);
+        const t0 = Date.now();
+        // @actions/cache hashes the `paths` array into a "version" key — save and
+        // restore MUST pass the same array or the lookup misses even when the
+        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
+        // restore must use the same single-path array. The decompression below
+        // unpacks archivePath → buildCachePath afterwards.
+        const restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
+        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("build_cache_matched_key", restore.matchedKey);
+        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("buildCacheMatchedKey", restore.matchedKey);
+        let buildArchiveBytes = null;
+        let buildInflatedBytes = null;
+        let buildFileCount = null;
+        if (fileExists(archivePath)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+            if (magic === "zstd" || magic === "gzip") {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({ archivePath, targetDir: buildCachePath, debug: debugMode, log: debugLog });
+                    buildArchiveBytes = dr.archiveBytes;
+                    buildInflatedBytes = dr.inflatedBytes;
+                    buildFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
+        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
+        // dir on the cold side; if it's present after decompress, walk it and
+        // set each matching source file's mtime to what cold saw. The replay
+        // is gated by (size, content-hash) match so we never overwrite a
+        // genuinely modified file's mtime — that would underbuild.
+        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
+            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
+            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
+            if (snapshot) {
+                const rt0 = Date.now();
+                try {
+                    // Match the project-root selection that post.ts uses when
+                    // writing the snapshot — the parent of the resolved target-dir,
+                    // not the (outer) GITHUB_WORKSPACE.
+                    const projectRoot = path.dirname(result.targetCache.targetPath);
+                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
+                        workspace: projectRoot,
+                        snapshot,
+                        log: (msg) => logger.log(msg),
+                    });
+                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
+                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
+                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
+                }
+                catch (err) {
+                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+            else {
+                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
+            }
+        }
+        statsCollector.record({
+            label: "build-cache", operation: "restore", hit: restore.hit,
+            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    })();
+    // Cargo-registry restore moved here from after-cook. It writes only
+    // $CARGO_HOME/registry/ and has no dependency on soldr being installed;
+    // running it in parallel with target+build trims its ~5s off the critical
+    // path.
+    const cargoRegistryRestorePromise = (async () => {
+        if (!result.cargoRegistryCache.enabled)
+            return;
+        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe([registryArchive], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
+        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
+        let regArchiveBytes = null;
+        let regInflatedBytes = null;
+        let regFileCount = null;
+        if (fileExists(registryArchive)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
+            if (magic === "zstd" || magic === "gzip") {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({
+                        archivePath: registryArchive,
+                        targetDir: result.cargoRegistryCache.path,
+                        debug: debugMode, log: debugLog,
+                    });
+                    regArchiveBytes = dr.archiveBytes;
+                    regInflatedBytes = dr.inflatedBytes;
+                    regFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        statsCollector.record({
+            label: "cargo-registry", operation: "restore", hit: restore.hit,
+            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.cargoRegistryCache.restorePrefix],
+            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    })();
+    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
+    // try/catches, so this should only see rejections for genuine programming
+    // bugs.
+    await Promise.all([
+        setupRestorePromise,
+        targetRestorePromise,
+        buildRestorePromise,
+        cargoRegistryRestorePromise,
+    ]);
+    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
+    // ---- target-tree-cache (full mode) ----
+    // The bundle path is included in target-cache restore paths above when full
+    // mode is requested, so there's no separate restore here. We keep the phase
+    // marker for parity with the composite step ordering.
+    await (0, phase_timing_js_1.markPhase)("target-tree");
+    await (0, phase_timing_js_1.finishPhase)("target-tree");
+    // Kick off soldr-mini-cache restore in the background. Same pattern as
+    // cook below: small, no inter-dependencies (writes to a fresh install
+    // dir, no toolchain or workspace state), so it overlaps with the
+    // toolchain phase that follows. Saves ~600 ms per warm run. Kept out
+    // of the BIG parallel-restore block above because the install phase
+    // needs to commit state-save side effects in a fixed order (state
+    // entries persist across pre/post and downstream readers expect them
+    // by the time `ensureSoldr` runs).
+    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
+    const miniInstallDir = path.dirname(result.soldrPath);
+    const miniArchive = `${miniInstallDir}.tar.zst`;
+    let miniHit = false;
+    let miniKey = "";
+    let miniSkipReason = "";
+    let miniRestorePromise = null;
+    if (miniEnabled) {
+        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
+            hasRef: Boolean(result.soldrRef.trim()),
+            enable: result.enabled,
+            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
+        });
+        if (eligibility.eligible) {
+            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
+            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
+                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+                soldrVersion: version,
+            });
+            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir} (background)`);
+            const miniT0 = Date.now();
+            miniRestorePromise = (async () => {
+                const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
+                    exactKey: miniKey,
+                    installDir: miniInstallDir,
+                    archivePath: miniArchive,
+                    longWindow: 27,
+                    debug: debugMode,
+                    log: (msg) => logger.log(msg),
+                });
+                return { ...restore, durationMs: Date.now() - miniT0 };
+            })();
+        }
+        else {
+            miniSkipReason = eligibility.reason;
+        }
+    }
+    // Kick off cook restore in the background. It overlaps with the
+    // sequential toolchain + soldr install + shims + verify steps that
+    // follow. By the time the cook phase runs, the restore is done — we
+    // just await the promise. Saves ~5–7 s of warm-build wall clock.
+    //
+    // Why this is safe (vs the disastrous PR #145 which added cook to the
+    // BIG parallel block): cook now races with SMALL ops (rust install
+    // ~1–2 s, soldr install ~2–3 s, shims/verify ~1–2 s). Those don't
+    // contend on disk write bandwidth the way target/build/cargo-registry
+    // restores did. Cook's 2.5 GB tar write becomes the long pole and
+    // hides behind the small ops.
+    //
+    // SAFETY: when target-cache writes to target/ (build-cache-mode: full),
+    // cook restore would race with target-cache restore on the same dir.
+    // The parallel-restore block above already finished target-cache, but
+    // we still want a runtime gate just in case the mode changes.
+    const cookGate = (0, cook_cache_js_1.decideCookGate)({
+        prebuildDeps: inputs.prebuildDeps,
+        cacheUmbrella: cacheEnabled,
+        lockfilePath: result.targetCache.lockfilePath,
+    });
+    const cookActive = cookGate.enabled && result.enabled;
+    let cookFlags = [];
+    let cookKey = "";
+    let cookProjectRoot = "";
+    let cookTargetDir = "";
+    let cookArchive = "";
+    let cookRestoreT0 = Date.now();
+    let cookRestorePromise = null;
+    // Skip cook restore when target-cache matched at the lockfile/shape level.
+    // restoreKeyLock = `${prefix}-${targetInputsHash}-${suffix}-` where
+    // targetInputsHash = sha256(toolchain, lockfile, manifest, shape). A
+    // matchedKey starting with restoreKeyLock means the cached entry was built
+    // with the same toolchain + lockfile + shape — its target/deps/ matches
+    // what cook would restore. Covers:
+    //   - exact hit  (matchedKey === current key, also startsWith restoreKeyLock)
+    //   - parent-SHA hit (matchedKey === restoreKeyParent, also startsWith)
+    //   - lock-prefix fallback (any saved entry with same lockfile+shape)
+    // Does NOT cover restoreKeyLockfile fallback (shorter prefix that drops
+    // shape) — different shape may mean different cook output, so cook still
+    // runs there as the safety net.
+    const targetCacheLockMatch = !!targetCacheMatchedKey &&
+        !!result.targetCache.restoreKeyLock &&
+        targetCacheMatchedKey.startsWith(result.targetCache.restoreKeyLock);
+    const cookSkippedDueToTargetHit = cookActive && targetCacheLockMatch;
+    if (cookActive && !cookSkippedDueToTargetHit) {
+        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
+        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
+        const lockHash = result.targetCache.lockfileHash || "no-lock";
+        cookKey = (0, cook_cache_js_1.buildCookCacheKey)({
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            flagsHash,
+            lockHash,
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        });
+        cookProjectRoot = path.dirname(result.targetCache.targetPath);
+        cookTargetDir = result.targetCache.targetPath;
+        cookArchive = `${cookTargetDir}.tar.zst`;
+        logger.log(`cook: key=${cookKey} starting background restore concurrent with install`);
+        cookRestoreT0 = Date.now();
+        cookRestorePromise = (0, cook_cache_js_1.restoreCookCache)({
+            exactKey: cookKey,
+            archivePath: cookArchive,
+            targetDir: cookTargetDir,
+            longWindow: 27,
+            debug: debugMode,
+            log: (msg) => logger.log(msg),
+        });
+    }
+    // ---- toolchain ----
+    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
+    // toolchain install so we can see which inodes setup-soldr added on
+    // top of the runner image. When solo-toolchain-cache is opted in, a
+    // third snapshot is taken *before* the cache restore so the saved
+    // tarball captures the full above-runner state — not just the
+    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
+    // lifetime axis".
+    await (0, phase_timing_js_1.markPhase)("toolchain");
+    const snapshotRoots = [
+        path.join(result.rustupHome, "toolchains"),
+        path.join(result.cargoHome, "bin"),
+    ];
+    const soloRootMap = {
+        "rustup-toolchains": snapshotRoots[0],
+        "cargo-bin": snapshotRoots[1],
+    };
+    const soloEnabled = isTruthy(inputs.soloToolchainCache);
+    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "19");
+    let soloKeys = null;
+    let soloMatchedKey = "";
+    let soloExactHit = false;
+    // Pre-restore snapshot — only needed when solo cache is enabled, so
+    // we can compute the full save-diff (post-install vs runner-image,
+    // not vs post-restore baseline).
+    const preRestoreSnapshot = soloEnabled ? await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots) : null;
+    if (soloEnabled) {
+        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
+            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        });
+        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
+        const restoreT0 = Date.now();
+        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
+        const restored = await (0, solo_toolchain_cache_js_1.restoreSoloCache)({
+            keys: soloKeys,
+            rootMap: soloRootMap,
+            stagingDir,
+            log: (msg) => logger.log(msg),
+        });
+        soloMatchedKey = restored.matchedKey;
+        let verifiedMatch = true;
+        if (restored.verified && restored.matchedKey) {
+            const expected = result.toolchain.cacheChannel.trim();
+            // The rustup home is set up so `rustc` will resolve through the
+            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
+            // the cargo bin one.
+            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
+            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
+                expectedRelease: expected,
+                rustcCommand: rustcCmd,
+                log: (msg) => logger.log(msg),
+            });
+            verifiedMatch = verify.match;
+        }
+        soloExactHit = restored.hit && verifiedMatch;
+        core.saveState("soloToolchainEnabled", "true");
+        core.saveState("soloToolchainExactKey", soloKeys.exact);
+        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
+        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
+        core.saveState("soloToolchainLevel", soloLevel);
+        statsCollector.record({
+            label: "solo-toolchain-cache",
+            operation: "restore",
+            hit: soloExactHit,
+            key: soloKeys.exact,
+            matchedKey: soloMatchedKey,
+            restoreKeys: soloKeys.fallbacks,
+            archiveBytes: restored.restoredBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - restoreT0,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    else {
+        core.saveState("soloToolchainEnabled", "false");
+    }
+    const baselineSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
+    await (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({ resolveResult: result, setupCacheExactHit });
+    const postInstallSnapshot = await (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots);
+    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
+    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
+    // When solo cache is enabled, also compute the save-diff (post-install
+    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
+    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
+        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
+        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
+        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
+        try {
+            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
+            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
+            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
+            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
+                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
+                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
+                `incremental-empty=${toolchainDiff.added.length === 0}`);
+        }
+        catch (err) {
+            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
+        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
+    if (ctx.runnerTemp) {
+        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
+        try {
+            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
+            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
+        }
+        catch (err) {
+            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    await (0, phase_timing_js_1.finishPhase)("toolchain");
+    // ---- install soldr ----
+    // soldr-mini-cache was kicked off as a background promise after the
+    // parallel-restore block; await it here so the restored binary is on
+    // disk by the time ensureSoldr's installedVersion() check runs.
+    await (0, phase_timing_js_1.markPhase)("install");
+    if (miniRestorePromise) {
+        const restore = await miniRestorePromise;
+        miniHit = restore.hit;
+        statsCollector.record({
+            label: "soldr-mini-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: miniKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: restore.durationMs,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    else if (miniSkipReason) {
+        logger.log(`soldr-mini-cache: skipped — ${miniSkipReason}`);
+    }
+    else if (!miniEnabled) {
+        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
+    }
+    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
+    core.saveState("soldrMiniExactKey", miniKey);
+    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
+    core.saveState("soldrMiniInstallDir", miniInstallDir);
+    core.saveState("soldrMiniArchive", miniArchive);
+    if (result.enabled) {
+        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
+        // restored binary at the expected path with the expected version and
+        // short-circuits — no GH fetch.
+        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
+    }
+    else {
+        (0, install_passthrough_js_1.installPassthrough)({
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
+            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
+            "verbatim, and soldr-aware caching/observability is disabled.");
+    }
+    await (0, phase_timing_js_1.finishPhase)("install");
+    // Export SOLDR_BINARY so shims can exec it directly
+    core.exportVariable("SOLDR_BINARY", result.soldrPath);
+    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
+    // ---- shims ----
+    if (result.shimsEnabled) {
+        await (0, ensure_shims_js_1.ensureShims)({
+            shimsDir: result.shimsDir,
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+    }
+    // ---- verify ----
+    await (0, phase_timing_js_1.markPhase)("verify");
+    if (result.enabled) {
+        const verify = await (0, verify_soldr_js_1.verifySoldr)({
+            soldrPath: result.soldrPath,
+            buildCacheMode: result.buildCache.mode,
+            requireRustPlan: result.targetCache.enabled,
+        });
+        core.setOutput("soldr-version", verify.soldrVersion);
+        core.setOutput("soldr_version", verify.soldrVersion);
+    }
+    else {
+        core.setOutput("soldr-version", "passthrough");
+        core.setOutput("soldr_version", "passthrough");
+    }
+    await (0, phase_timing_js_1.finishPhase)("verify");
+    // ---- cook (prebuild-deps via cargo-chef) ----
+    // The RESTORE was kicked off as a background promise right after the
+    // parallel-restore block above — we just await its result here. The
+    // RUN (actual cargo-chef invocation) still happens in this phase if
+    // the restore missed.
+    // Failures here are logged but never fail the action — the user's
+    // own cargo build will still work without the cooked deps.
+    await (0, phase_timing_js_1.markPhase)("cook");
+    if (cookActive && cookRestorePromise) {
+        const restore = await cookRestorePromise;
+        statsCollector.record({
+            label: "cook-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: cookKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        let cookRan = false;
+        if (!restore.hit) {
+            const runRes = await (0, cook_cache_js_1.runCook)({
+                soldrBinary: result.soldrPath,
+                projectRoot: cookProjectRoot,
+                flags: cookFlags,
+                log: (msg) => logger.log(msg),
+            });
+            cookRan = runRes.exitCode === 0;
+        }
+        else {
+            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
+        }
+        core.saveState("cookEnabled", "true");
+        core.saveState("cookExactKey", cookKey);
+        core.saveState("cookMatchedKey", restore.matchedKey);
+        core.saveState("cookHit", restore.hit ? "true" : "false");
+        core.saveState("cookRan", cookRan ? "true" : "false");
+        core.saveState("cookTargetDir", cookTargetDir);
+        core.saveState("cookLongWindow", "27");
+        core.saveState("cookCompressLevel", "19");
+    }
+    else if (cookSkippedDueToTargetHit) {
+        logger.log(`cook: skipped - target-cache matched at lockfile/shape level (matched=${targetCacheMatchedKey}); cook output would be redundant`);
+        core.saveState("cookEnabled", "false");
+    }
+    else {
+        logger.log(`cook: skipped - ${cookGate.reason}`);
+        core.saveState("cookEnabled", "false");
+    }
+    await (0, phase_timing_js_1.finishPhase)("cook");
+    // ---- shared-target warning ----
+    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
+        buildCacheEnabled,
+        effectiveTargetCacheEnabled: result.targetCache.enabled,
+        buildCacheMode: result.buildCache.mode,
+        targetDir: result.targetCache.targetPath,
+    });
+    // ---- shim-bypass diagnostic ----
+    // Issue #160: when shims: true is requested but the effective environment
+    // (PATH ordering, CARGO/RUSTC/RUSTC_WRAPPER overrides) would bypass them,
+    // caching looks configured but compile work runs through plain cargo.
+    // Emit advisory warnings naming each offender. Runs at the very end so it
+    // sees the final state of process.env after every prior phase.
+    if (result.shimsEnabled) {
+        const bypassWarnings = (0, shim_bypass_check_js_1.diagnoseShimBypass)({
+            shimsEnabled: true,
+            shimDir: result.shimsDir,
+            path: process.env["PATH"] ?? "",
+            cargoEnv: process.env["CARGO"],
+            rustcEnv: process.env["RUSTC"],
+            rustcWrapperEnv: process.env["RUSTC_WRAPPER"],
+            soldrBinary: result.soldrPath,
+        });
+        for (const msg of bypassWarnings) {
+            core.warning(msg);
+        }
+        if (bypassWarnings.length === 0) {
+            logger.log(`shim-bypass check clean: shim dir ${result.shimsDir} at PATH front, no competing CARGO/RUSTC/RUSTC_WRAPPER overrides`);
+        }
+    }
+    // ---- stats report ----
+    statsCollector.report(statsMode, (msg) => logger.log(msg));
+    if (statsMode === "detailed") {
+        try {
+            await statsCollector.writeFiles(ctx.runnerTemp);
+            statsCollector.setGithubOutputs();
+        }
+        catch (err) {
+            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    core.saveState("statsCollector", statsCollector.serialize());
+    core.saveState("statsMode", statsMode);
+    core.saveState("compileCacheStats", result.compileCacheStats);
+    core.saveState("runnerTemp", ctx.runnerTemp);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            cacheOutcomes: statsCollector.snapshot(),
+            logger,
+        });
+    }
+    await (0, phase_timing_js_1.finishPhase)("action");
+    // dirHasContent is exported for tests; suppress unused warning here.
+    void dirHasContent;
+}
+// Auto-invoke only when this module is run as the main entry point. This lets
+// tests import `run` (and helpers) without triggering the side-effectful
+// orchestration. The dist/main.js produced by ncc is invoked directly by the
+// Actions runtime so the check trips and the action executes normally.
+if (typeof process !== "undefined" &&
+    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
+    // import.meta.url is the file URL of this module; argv[1] is the runner
+    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
+    // the dev path — we rely on the env-var opt-out for tests instead.
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    run().catch((err) => {
+        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        core.setFailed(`setup-soldr failed: ${message}`);
+    });
+}
+
+
+/***/ }),
+
+/***/ 347:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 /* eslint-disable no-new-wrappers, no-eval, camelcase, operator-linebreak */
-module.exports = makeParserClass(__nccwpck_require__(426))
+module.exports = makeParserClass(__nccwpck_require__(427))
 module.exports.makeParserClass = makeParserClass
 
 class TomlError extends Error {
@@ -64299,10 +65025,10 @@ TomlError.wrap = err => {
 }
 module.exports.TomlError = TomlError
 
-const createDateTime = __nccwpck_require__(385)
-const createDateTimeFloat = __nccwpck_require__(173)
+const createDateTime = __nccwpck_require__(386)
+const createDateTimeFloat = __nccwpck_require__(171)
 const createDate = __nccwpck_require__(54)
-const createTime = __nccwpck_require__(348)
+const createTime = __nccwpck_require__(349)
 
 const CTRL_I = 0x09
 const CTRL_J = 0x0A
@@ -65659,7 +66385,7 @@ function makeParserClass (Parser) {
 
 /***/ }),
 
-/***/ 347:
+/***/ 348:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65668,8 +66394,8 @@ function makeParserClass (Parser) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = createTracingClient;
-const instrumenter_js_1 = __nccwpck_require__(407);
-const tracingContext_js_1 = __nccwpck_require__(371);
+const instrumenter_js_1 = __nccwpck_require__(408);
+const tracingContext_js_1 = __nccwpck_require__(372);
 /**
  * Creates a new tracing client.
  *
@@ -65747,12 +66473,12 @@ function createTracingClient(options) {
 
 /***/ }),
 
-/***/ 348:
+/***/ 349:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(404)
+const f = __nccwpck_require__(405)
 
 class Time extends Date {
   constructor (value) {
@@ -65777,7 +66503,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 349:
+/***/ 350:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65796,8 +66522,8 @@ const {
   kConnected
 } = __nccwpck_require__(472)
 const { MockInterceptor } = __nccwpck_require__(136)
-const Symbols = __nccwpck_require__(196)
-const { InvalidArgumentError } = __nccwpck_require__(489)
+const Symbols = __nccwpck_require__(194)
+const { InvalidArgumentError } = __nccwpck_require__(490)
 
 /**
  * MockPool provides an API that extends the Pool to influence the mockDispatches.
@@ -65844,7 +66570,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 350:
+/***/ 351:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -65902,7 +66628,7 @@ exports.ClientStreamingCall = ClientStreamingCall;
 
 /***/ }),
 
-/***/ 351:
+/***/ 352:
 /***/ ((module) => {
 
 module.exports = function (xs, fn) {
@@ -65922,7 +66648,7 @@ var isArray = Array.isArray || function (xs) {
 
 /***/ }),
 
-/***/ 352:
+/***/ 353:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -65970,7 +66696,7 @@ exports.createLogger = createLogger;
 exports.colorForceEnvironment = colorForceEnvironment;
 exports.formatLogLine = formatLogLine;
 exports.isTimestampsEnabled = isTimestampsEnabled;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 const fs = __importStar(__nccwpck_require__(249));
 function makeFileLogger(env) {
     const logPath = (env["SETUP_SOLDR_LOG"] ?? "").trim();
@@ -66093,7 +66819,7 @@ function isTimestampsEnabled(env) {
 
 /***/ }),
 
-/***/ 353:
+/***/ 354:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -66119,7 +66845,7 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_ts_http_runtime = __nccwpck_require__(90);
+var import_ts_http_runtime = __nccwpck_require__(91);
 const RestError = import_ts_http_runtime.RestError;
 function isRestError(e) {
   return (0, import_ts_http_runtime.isRestError)(e);
@@ -66130,7 +66856,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 354:
+/***/ 355:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66141,11 +66867,11 @@ const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(489)
+} = __nccwpck_require__(490)
 const util = __nccwpck_require__(69)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(190)
-const { AsyncResource } = __nccwpck_require__(430)
-const { addSignal, removeSignal } = __nccwpck_require__(104)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(188)
+const { AsyncResource } = __nccwpck_require__(431)
+const { addSignal, removeSignal } = __nccwpck_require__(105)
 
 class StreamHandler extends AsyncResource {
   constructor (opts, factory, callback) {
@@ -66358,7 +67084,7 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 355:
+/***/ 356:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66372,9 +67098,9 @@ module.exports = stream
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(217);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(440));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const tslib_1 = __nccwpck_require__(216);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(441));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(179));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(65));
 /** Class containing BlockBlob operations. */
 class BlockBlobImpl {
@@ -66738,7 +67464,7 @@ const getBlockListOperationSpec = {
 
 /***/ }),
 
-/***/ 356:
+/***/ 357:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -66783,7 +67509,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 357:
+/***/ 358:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66793,7 +67519,7 @@ function decompressResponsePolicy() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GenericPollOperation = void 0;
 const operation_js_1 = __nccwpck_require__(51);
-const logger_js_1 = __nccwpck_require__(192);
+const logger_js_1 = __nccwpck_require__(190);
 const createStateProxy = () => ({
     initState: (config) => ({ config, isStarted: true }),
     setCanceled: (state) => (state.isCancelled = true),
@@ -66878,7 +67604,7 @@ exports.GenericPollOperation = GenericPollOperation;
 
 /***/ }),
 
-/***/ 358:
+/***/ 359:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -66925,7 +67651,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.versionTuple = versionTuple;
 exports.verifySoldr = verifySoldr;
 const exec = __importStar(__nccwpck_require__(18));
-const log_utils_js_1 = __nccwpck_require__(352);
+const log_utils_js_1 = __nccwpck_require__(353);
 function versionTuple(value) {
     const cleaned = value.trim().replace(/^v/, "");
     const parts = cleaned.split(".");
@@ -67021,7 +67747,7 @@ async function verifySoldr(opts) {
 
 /***/ }),
 
-/***/ 359:
+/***/ 360:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67044,7 +67770,7 @@ function ipRangeToString(ipRange) {
 
 /***/ }),
 
-/***/ 360:
+/***/ 361:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67092,7 +67818,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 361:
+/***/ 362:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67112,7 +67838,7 @@ exports.getUserAgentString = getUserAgentString;
 
 /***/ }),
 
-/***/ 362:
+/***/ 363:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67182,7 +67908,7 @@ function readRawInputs(env) {
 
 /***/ }),
 
-/***/ 363:
+/***/ 364:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67192,7 +67918,7 @@ function readRawInputs(env) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BufferScheduler = void 0;
 const events_1 = __nccwpck_require__(471);
-const PooledBuffer_js_1 = __nccwpck_require__(372);
+const PooledBuffer_js_1 = __nccwpck_require__(373);
 /**
  * This class accepts a Node.js Readable stream as input, and keeps reading data
  * from the stream into the internal buffer structure, until it reaches maxBuffers.
@@ -67471,7 +68197,7 @@ exports.BufferScheduler = BufferScheduler;
 
 /***/ }),
 
-/***/ 364:
+/***/ 365:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -67517,12 +68243,12 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureSoldr = ensureSoldr;
 const fs = __importStar(__nccwpck_require__(249));
-const os = __importStar(__nccwpck_require__(383));
+const os = __importStar(__nccwpck_require__(384));
 const path = __importStar(__nccwpck_require__(509));
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 const exec = __importStar(__nccwpck_require__(18));
 const tc = __importStar(__nccwpck_require__(524));
-const log_utils_js_1 = __nccwpck_require__(352);
+const log_utils_js_1 = __nccwpck_require__(353);
 function detectTarget() {
     const machine = process.arch;
     let arch;
@@ -67863,7 +68589,7 @@ async function ensureSoldr(opts) {
 
 /***/ }),
 
-/***/ 365:
+/***/ 366:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67873,7 +68599,7 @@ const { Blob, File: NativeFile } = __nccwpck_require__(120)
 const { types } = __nccwpck_require__(124)
 const { kState } = __nccwpck_require__(15)
 const { isBlobLike } = __nccwpck_require__(519)
-const { webidl } = __nccwpck_require__(457)
+const { webidl } = __nccwpck_require__(458)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(25)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 const encoder = new TextEncoder()
@@ -68215,27 +68941,27 @@ module.exports = { File, FileLike, isFileLike }
 
 /***/ }),
 
-/***/ 366:
+/***/ 367:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const diagnosticsChannel = __nccwpck_require__(142)
-const { uid, states } = __nccwpck_require__(466)
+const { uid, states } = __nccwpck_require__(467)
 const {
   kReadyState,
   kSentClose,
   kByteParser,
   kReceivedClose
-} = __nccwpck_require__(99)
+} = __nccwpck_require__(100)
 const { fireEvent, failWebsocketConnection } = __nccwpck_require__(57)
 const { CloseEvent } = __nccwpck_require__(250)
-const { makeRequest } = __nccwpck_require__(84)
-const { fetching } = __nccwpck_require__(451)
+const { makeRequest } = __nccwpck_require__(86)
+const { fetching } = __nccwpck_require__(452)
 const { Headers } = __nccwpck_require__(518)
-const { getGlobalDispatcher } = __nccwpck_require__(377)
-const { kHeadersList } = __nccwpck_require__(196)
+const { getGlobalDispatcher } = __nccwpck_require__(378)
+const { kHeadersList } = __nccwpck_require__(194)
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -68245,7 +68971,7 @@ channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(291)
+  crypto = __nccwpck_require__(292)
 } catch {
 
 }
@@ -68514,7 +69240,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 367:
+/***/ 368:
 /***/ ((module) => {
 
 "use strict";
@@ -68530,7 +69256,7 @@ module.exports = (flag, argv = process.argv) => {
 
 /***/ }),
 
-/***/ 368:
+/***/ 369:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -68585,7 +69311,7 @@ exports.systemRustupSatisfiesRequest = systemRustupSatisfiesRequest;
 const node_crypto_1 = __nccwpck_require__(275);
 const fs = __importStar(__nccwpck_require__(249));
 const path = __importStar(__nccwpck_require__(509));
-const toml = __importStar(__nccwpck_require__(401));
+const toml = __importStar(__nccwpck_require__(402));
 const io = __importStar(__nccwpck_require__(295));
 const exec = __importStar(__nccwpck_require__(18));
 const ROLLING_TOOLCHAIN_ALIASES = ["stable", "beta", "nightly"];
@@ -68872,7 +69598,7 @@ async function defaultWhich(cmd) {
 
 /***/ }),
 
-/***/ 369:
+/***/ 370:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68897,8 +69623,8 @@ __export(restError_exports, {
   createRestError: () => createRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_restError = __nccwpck_require__(445);
-var import_httpHeaders = __nccwpck_require__(486);
+var import_restError = __nccwpck_require__(446);
+var import_httpHeaders = __nccwpck_require__(487);
 function createRestError(messageOrResponse, response) {
   const resp = typeof messageOrResponse === "string" ? response : messageOrResponse;
   const internalError = resp.body?.error ?? resp.body;
@@ -68928,15 +69654,15 @@ function statusCodeToNumber(statusCode) {
 
 /***/ }),
 
-/***/ 370:
+/***/ 371:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const DispatcherBase = __nccwpck_require__(62)
-const FixedQueue = __nccwpck_require__(197)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(196)
+const FixedQueue = __nccwpck_require__(195)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(194)
 const PoolStats = __nccwpck_require__(22)
 
 const kClients = Symbol('clients')
@@ -69130,7 +69856,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 371:
+/***/ 372:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69190,7 +69916,7 @@ exports.TracingContextImpl = TracingContextImpl;
 
 /***/ }),
 
-/***/ 372:
+/***/ 373:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69199,8 +69925,8 @@ exports.TracingContextImpl = TracingContextImpl;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
-const tslib_1 = __nccwpck_require__(217);
-const BuffersStream_js_1 = __nccwpck_require__(386);
+const tslib_1 = __nccwpck_require__(216);
+const BuffersStream_js_1 = __nccwpck_require__(387);
 const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(264));
 /**
  * maxBufferLength is max size of each buffer in the pooled buffers.
@@ -69297,7 +70023,7 @@ exports.PooledBuffer = PooledBuffer;
 
 /***/ }),
 
-/***/ 373:
+/***/ 374:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69322,7 +70048,7 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_nodeHttpClient = __nccwpck_require__(442);
+var import_nodeHttpClient = __nccwpck_require__(443);
 function createDefaultHttpClient() {
   return (0, import_nodeHttpClient.createNodeHttpClient)();
 }
@@ -69333,16 +70059,16 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 374:
+/***/ 375:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { AsyncResource } = __nccwpck_require__(430)
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(489)
+const { AsyncResource } = __nccwpck_require__(431)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(490)
 const util = __nccwpck_require__(69)
-const { addSignal, removeSignal } = __nccwpck_require__(104)
+const { addSignal, removeSignal } = __nccwpck_require__(105)
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -69445,7 +70171,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 375:
+/***/ 376:
 /***/ ((module) => {
 
 /**
@@ -69614,7 +70340,7 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 376:
+/***/ 377:
 /***/ ((module) => {
 
 "use strict";
@@ -69622,7 +70348,7 @@ module.exports = require("node:util");
 
 /***/ }),
 
-/***/ 377:
+/***/ 378:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69631,7 +70357,7 @@ module.exports = require("node:util");
 // We include a version number for the Dispatcher API. In case of breaking changes,
 // this version number must be increased to avoid conflicts.
 const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
-const { InvalidArgumentError } = __nccwpck_require__(489)
+const { InvalidArgumentError } = __nccwpck_require__(490)
 const Agent = __nccwpck_require__(5)
 
 if (getGlobalDispatcher() === undefined) {
@@ -69662,13 +70388,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 378:
+/***/ 379:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(196)
+const { kClients } = __nccwpck_require__(194)
 const Agent = __nccwpck_require__(5)
 const {
   kAgent,
@@ -69681,10 +70407,10 @@ const {
   kOptions,
   kFactory
 } = __nccwpck_require__(472)
-const MockClient = __nccwpck_require__(200)
-const MockPool = __nccwpck_require__(349)
+const MockClient = __nccwpck_require__(199)
+const MockPool = __nccwpck_require__(350)
 const { matchValue, buildMockOptions } = __nccwpck_require__(7)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(489)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(490)
 const Dispatcher = __nccwpck_require__(479)
 const Pluralizer = __nccwpck_require__(254)
 const PendingInterceptorsFormatter = __nccwpck_require__(234)
@@ -69841,7 +70567,7 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 379:
+/***/ 380:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69878,7 +70604,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 380:
+/***/ 381:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69967,7 +70693,7 @@ exports.AccountSASServices = AccountSASServices;
 
 /***/ }),
 
-/***/ 381:
+/***/ 382:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69993,7 +70719,7 @@ __export(bearerAuthenticationPolicy_exports, {
   bearerAuthenticationPolicyName: () => bearerAuthenticationPolicyName
 });
 module.exports = __toCommonJS(bearerAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(436);
+var import_checkInsecureConnection = __nccwpck_require__(437);
 const bearerAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function bearerAuthenticationPolicy(options) {
   return {
@@ -70021,7 +70747,7 @@ function bearerAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 382:
+/***/ 383:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70030,7 +70756,7 @@ function bearerAuthenticationPolicy(options) {
 const {
   BalancedPoolMissingUpstreamError,
   InvalidArgumentError
-} = __nccwpck_require__(489)
+} = __nccwpck_require__(490)
 const {
   PoolBase,
   kClients,
@@ -70038,9 +70764,9 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(370)
+} = __nccwpck_require__(371)
 const Pool = __nccwpck_require__(338)
-const { kUrl, kInterceptors } = __nccwpck_require__(196)
+const { kUrl, kInterceptors } = __nccwpck_require__(194)
 const { parseOrigin } = __nccwpck_require__(69)
 const kFactory = Symbol('factory')
 
@@ -70219,7 +70945,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 383:
+/***/ 384:
 /***/ ((module) => {
 
 "use strict";
@@ -70227,7 +70953,7 @@ module.exports = require("node:os");
 
 /***/ }),
 
-/***/ 384:
+/***/ 385:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -70271,7 +70997,7 @@ function operationOptionsToRequestParameters(options) {
 
 /***/ }),
 
-/***/ 385:
+/***/ 386:
 /***/ ((module) => {
 
 "use strict";
@@ -70289,7 +71015,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 386:
+/***/ 387:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70298,7 +71024,7 @@ module.exports = value => {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BuffersStream = void 0;
-const node_stream_1 = __nccwpck_require__(431);
+const node_stream_1 = __nccwpck_require__(432);
 /**
  * This class generates a readable stream from the data in an array of buffers.
  */
@@ -70397,15 +71123,15 @@ exports.BuffersStream = BuffersStream;
 
 /***/ }),
 
-/***/ 387:
+/***/ 388:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { parseSetCookie } = __nccwpck_require__(424)
-const { stringify } = __nccwpck_require__(410)
-const { webidl } = __nccwpck_require__(457)
+const { parseSetCookie } = __nccwpck_require__(425)
+const { stringify } = __nccwpck_require__(411)
+const { webidl } = __nccwpck_require__(458)
 const { Headers } = __nccwpck_require__(518)
 
 /**
@@ -70588,7 +71314,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 388:
+/***/ 389:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -70604,7 +71330,7 @@ exports.AvroReadable = AvroReadable;
 
 /***/ }),
 
-/***/ 389:
+/***/ 390:
 /***/ ((module) => {
 
 "use strict";
@@ -70612,7 +71338,7 @@ module.exports = require("node:https");
 
 /***/ }),
 
-/***/ 390:
+/***/ 391:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -70638,7 +71364,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(292);
+var import_userAgent = __nccwpck_require__(293);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -70659,16 +71385,16 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 391:
+/***/ 392:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const util = __nccwpck_require__(69)
-const { kBodyUsed } = __nccwpck_require__(196)
+const { kBodyUsed } = __nccwpck_require__(194)
 const assert = __nccwpck_require__(528)
-const { InvalidArgumentError } = __nccwpck_require__(489)
+const { InvalidArgumentError } = __nccwpck_require__(490)
 const EE = __nccwpck_require__(471)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
@@ -70888,7 +71614,7 @@ module.exports = RedirectHandler
 
 /***/ }),
 
-/***/ 392:
+/***/ 393:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -70914,7 +71640,7 @@ function arraysEqual(a, b) {
 
 /***/ }),
 
-/***/ 393:
+/***/ 394:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -70951,7 +71677,7 @@ function exponentialRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 394:
+/***/ 395:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -70986,7 +71712,7 @@ function randomUUID() {
 
 /***/ }),
 
-/***/ 395:
+/***/ 396:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -71019,7 +71745,7 @@ exports.isJsonObject = isJsonObject;
 
 /***/ }),
 
-/***/ 396:
+/***/ 397:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -71092,7 +71818,7 @@ function isSystemError(err) {
 
 /***/ }),
 
-/***/ 397:
+/***/ 398:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71162,7 +71888,7 @@ exports.CacheScope = new CacheScope$Type();
 
 /***/ }),
 
-/***/ 398:
+/***/ 399:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71171,8 +71897,8 @@ exports.CacheScope = new CacheScope$Type();
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredential = void 0;
-const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(94);
-const Credential_js_1 = __nccwpck_require__(96);
+const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(95);
+const Credential_js_1 = __nccwpck_require__(97);
 /**
  * AnonymousCredential provides a credentialPolicyCreator member used to create
  * AnonymousCredentialPolicy objects. AnonymousCredentialPolicy is used with
@@ -71195,7 +71921,7 @@ exports.AnonymousCredential = AnonymousCredential;
 
 /***/ }),
 
-/***/ 399:
+/***/ 400:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71204,7 +71930,7 @@ exports.AnonymousCredential = AnonymousCredential;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 let cachedHttpClient;
 function getCachedDefaultHttpClient() {
     if (!cachedHttpClient) {
@@ -71216,7 +71942,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 400:
+/***/ 401:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71266,18 +71992,18 @@ function getPathStringFromParameter(parameter) {
 
 /***/ }),
 
-/***/ 401:
+/***/ 402:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-exports.parse = __nccwpck_require__(224)
+exports.parse = __nccwpck_require__(223)
 exports.stringify = __nccwpck_require__(300)
 
 
 /***/ }),
 
-/***/ 402:
+/***/ 403:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71285,19 +72011,19 @@ exports.stringify = __nccwpck_require__(300)
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobServiceClient = void 0;
 const core_auth_1 = __nccwpck_require__(516);
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 const core_util_1 = __nccwpck_require__(14);
-const Pipeline_js_1 = __nccwpck_require__(184);
+const Pipeline_js_1 = __nccwpck_require__(182);
 const ContainerClient_js_1 = __nccwpck_require__(64);
 const utils_common_js_1 = __nccwpck_require__(155);
 const storage_common_1 = __nccwpck_require__(277);
 const utils_common_js_2 = __nccwpck_require__(155);
 const tracing_js_1 = __nccwpck_require__(31);
-const BlobBatchClient_js_1 = __nccwpck_require__(403);
-const StorageClient_js_1 = __nccwpck_require__(455);
+const BlobBatchClient_js_1 = __nccwpck_require__(404);
+const StorageClient_js_1 = __nccwpck_require__(456);
 const AccountSASPermissions_js_1 = __nccwpck_require__(58);
 const AccountSASSignatureValues_js_1 = __nccwpck_require__(289);
-const AccountSASServices_js_1 = __nccwpck_require__(380);
+const AccountSASServices_js_1 = __nccwpck_require__(381);
 /**
  * A BlobServiceClient represents a Client to the Azure Storage Blob service allowing you
  * to manipulate blob containers.
@@ -71990,7 +72716,7 @@ exports.BlobServiceClient = BlobServiceClient;
 
 /***/ }),
 
-/***/ 403:
+/***/ 404:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72005,7 +72731,7 @@ const BlobBatch_js_1 = __nccwpck_require__(334);
 const tracing_js_1 = __nccwpck_require__(31);
 const storage_common_1 = __nccwpck_require__(277);
 const StorageContextClient_js_1 = __nccwpck_require__(267);
-const Pipeline_js_1 = __nccwpck_require__(184);
+const Pipeline_js_1 = __nccwpck_require__(182);
 const utils_common_js_1 = __nccwpck_require__(155);
 /**
  * A BlobBatchClient allows you to make batched requests to the Azure Storage Blob service.
@@ -72173,7 +72899,7 @@ exports.BlobBatchClient = BlobBatchClient;
 
 /***/ }),
 
-/***/ 404:
+/***/ 405:
 /***/ ((module) => {
 
 "use strict";
@@ -72187,7 +72913,7 @@ module.exports = (d, num) => {
 
 /***/ }),
 
-/***/ 405:
+/***/ 406:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72195,7 +72921,7 @@ module.exports = (d, num) => {
 
 const Decoder = __nccwpck_require__(42)
 const decodeText = __nccwpck_require__(276)
-const getLimit = __nccwpck_require__(484)
+const getLimit = __nccwpck_require__(485)
 
 const RE_CHARSET = /^charset$/i
 
@@ -72385,7 +73111,7 @@ module.exports = UrlEncoded
 
 /***/ }),
 
-/***/ 406:
+/***/ 407:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -72403,7 +73129,7 @@ exports.MESSAGE_TYPE = Symbol.for("protobuf-ts/message-type");
 
 /***/ }),
 
-/***/ 407:
+/***/ 408:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72415,8 +73141,8 @@ exports.createDefaultTracingSpan = createDefaultTracingSpan;
 exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
-const tracingContext_js_1 = __nccwpck_require__(371);
-const state_js_1 = __nccwpck_require__(97);
+const tracingContext_js_1 = __nccwpck_require__(372);
+const state_js_1 = __nccwpck_require__(98);
 function createDefaultTracingSpan() {
     return {
         end: () => {
@@ -72479,7 +73205,7 @@ function getInstrumenter() {
 
 /***/ }),
 
-/***/ 408:
+/***/ 409:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -72547,7 +73273,7 @@ exports.readSnapshotFile = readSnapshotFile;
 const fs = __importStar(__nccwpck_require__(249));
 const path = __importStar(__nccwpck_require__(509));
 const node_crypto_1 = __nccwpck_require__(275);
-const normalize_source_mtime_js_1 = __nccwpck_require__(79);
+const normalize_source_mtime_js_1 = __nccwpck_require__(80);
 exports.SNAPSHOT_FILENAME = "setup-soldr-source-mtimes.json";
 async function hashFile(absolute) {
     // sha256 prefix (first 32 hex = 128 bits). Streaming so we don't load
@@ -72716,7 +73442,7 @@ function readSnapshotFile(filePath) {
 
 /***/ }),
 
-/***/ 409:
+/***/ 410:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72724,9 +73450,9 @@ function readSnapshotFile(filePath) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
 const binary_format_contract_1 = __nccwpck_require__(333);
-const reflection_info_1 = __nccwpck_require__(453);
-const reflection_long_convert_1 = __nccwpck_require__(159);
-const reflection_scalar_default_1 = __nccwpck_require__(463);
+const reflection_info_1 = __nccwpck_require__(454);
+const reflection_long_convert_1 = __nccwpck_require__(158);
+const reflection_scalar_default_1 = __nccwpck_require__(464);
 /**
  * Reads proto3 messages in binary format using reflection information.
  *
@@ -72907,7 +73633,7 @@ exports.ReflectionBinaryReader = ReflectionBinaryReader;
 
 /***/ }),
 
-/***/ 410:
+/***/ 411:
 /***/ ((module) => {
 
 "use strict";
@@ -73189,7 +73915,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 411:
+/***/ 412:
 /***/ ((module) => {
 
 "use strict";
@@ -73197,14 +73923,14 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 412:
+/***/ 413:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseAsync
 
-const TOMLParser = __nccwpck_require__(346)
+const TOMLParser = __nccwpck_require__(347)
 const prettyError = __nccwpck_require__(279)
 
 function parseAsync (str, opts) {
@@ -73235,7 +73961,7 @@ function parseAsync (str, opts) {
 
 /***/ }),
 
-/***/ 413:
+/***/ 414:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -73261,8 +73987,8 @@ __export(response_exports, {
   toPipelineResponse: () => toPipelineResponse
 });
 module.exports = __toCommonJS(response_exports);
-var import_core_rest_pipeline = __nccwpck_require__(102);
-var import_util = __nccwpck_require__(110);
+var import_core_rest_pipeline = __nccwpck_require__(103);
+var import_util = __nccwpck_require__(111);
 const originalResponse = /* @__PURE__ */ Symbol("Original FullOperationResponse");
 function toCompatResponse(response, options) {
   let request = (0, import_util.toWebResourceLike)(response.request);
@@ -73318,7 +74044,7 @@ function toPipelineResponse(compatResponse) {
 
 /***/ }),
 
-/***/ 414:
+/***/ 415:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -73344,7 +74070,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOptions = void 0;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 /**
  * Returns a copy with defaults filled in.
  */
@@ -73375,7 +74101,7 @@ exports.getOptions = getOptions;
 
 /***/ }),
 
-/***/ 415:
+/***/ 416:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73383,7 +74109,7 @@ exports.getOptions = getOptions;
 
 /* istanbul ignore file: only for Node 12 */
 
-const { kConnected, kSize } = __nccwpck_require__(196)
+const { kConnected, kSize } = __nccwpck_require__(194)
 
 class CompatWeakRef {
   constructor (value) {
@@ -73431,7 +74157,7 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 416:
+/***/ 417:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73559,19 +74285,19 @@ function getBlobServiceAccountAudience(storageAccountName) {
 
 /***/ }),
 
-/***/ 417:
+/***/ 418:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(431).Writable)
-const { inherits } = __nccwpck_require__(376)
+const WritableStream = (__nccwpck_require__(432).Writable)
+const { inherits } = __nccwpck_require__(377)
 const Dicer = __nccwpck_require__(13)
 
 const MultipartParser = __nccwpck_require__(0)
-const UrlencodedParser = __nccwpck_require__(405)
-const parseParams = __nccwpck_require__(193)
+const UrlencodedParser = __nccwpck_require__(406)
+const parseParams = __nccwpck_require__(191)
 
 function Busboy (opts) {
   if (!(this instanceof Busboy)) { return new Busboy(opts) }
@@ -73652,7 +74378,7 @@ module.exports.Dicer = Dicer
 
 /***/ }),
 
-/***/ 418:
+/***/ 419:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -73679,7 +74405,7 @@ var StorageRetryPolicyType;
 
 /***/ }),
 
-/***/ 419:
+/***/ 420:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -73721,7 +74447,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDetails = exports.isLinux = exports.isMacOS = exports.isWindows = exports.arch = exports.platform = void 0;
-const os_1 = __importDefault(__nccwpck_require__(93));
+const os_1 = __importDefault(__nccwpck_require__(94));
 const exec = __importStar(__nccwpck_require__(18));
 const getWindowsInfo = () => __awaiter(void 0, void 0, void 0, function* () {
     const { stdout: version } = yield exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Version"', undefined, {
@@ -73780,7 +74506,7 @@ exports.getDetails = getDetails;
 
 /***/ }),
 
-/***/ 420:
+/***/ 421:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -73888,7 +74614,7 @@ exports.parseProxyResponse = parseProxyResponse;
 
 /***/ }),
 
-/***/ 421:
+/***/ 422:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73896,7 +74622,7 @@ exports.parseProxyResponse = parseProxyResponse;
 module.exports = parseStream
 
 const stream = __nccwpck_require__(131)
-const TOMLParser = __nccwpck_require__(346)
+const TOMLParser = __nccwpck_require__(347)
 
 function parseStream (stm) {
   if (stm) {
@@ -73976,7 +74702,7 @@ function parseTransform () {
 
 /***/ }),
 
-/***/ 422:
+/***/ 423:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73987,9 +74713,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReader = void 0;
 // TODO: Do a review of non-interfaces
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
-const AvroConstants_js_1 = __nccwpck_require__(230);
+const AvroConstants_js_1 = __nccwpck_require__(229);
 const AvroParser_js_1 = __nccwpck_require__(302);
-const utils_common_js_1 = __nccwpck_require__(392);
+const utils_common_js_1 = __nccwpck_require__(393);
 class AvroReader {
     _dataStream;
     _headerStream;
@@ -74103,7 +74829,7 @@ exports.AvroReader = AvroReader;
 
 /***/ }),
 
-/***/ 423:
+/***/ 424:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74113,7 +74839,7 @@ exports.CacheService = exports.GetCacheEntryDownloadURLResponse = exports.GetCac
 // @generated by protobuf-ts 2.9.1 with parameter long_type_string,client_none,generate_dependencies
 // @generated from protobuf file "results/api/v1/cache.proto" (package "github.actions.results.api.v1", syntax proto3)
 // tslint:disable
-const runtime_rpc_1 = __nccwpck_require__(176);
+const runtime_rpc_1 = __nccwpck_require__(174);
 const runtime_1 = __nccwpck_require__(19);
 const runtime_2 = __nccwpck_require__(19);
 const runtime_3 = __nccwpck_require__(19);
@@ -74512,14 +75238,14 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 
 /***/ }),
 
-/***/ 424:
+/***/ 425:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(128)
-const { isCTLExcludingHtab } = __nccwpck_require__(410)
+const { isCTLExcludingHtab } = __nccwpck_require__(411)
 const { collectASequenceOfCodePointsFast } = __nccwpck_require__(25)
 const assert = __nccwpck_require__(528)
 
@@ -74837,7 +75563,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 425:
+/***/ 426:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -74905,7 +75631,7 @@ exports.ServerCallContextController = ServerCallContextController;
 
 /***/ }),
 
-/***/ 426:
+/***/ 427:
 /***/ ((module) => {
 
 "use strict";
@@ -75040,7 +75766,7 @@ module.exports = Parser
 
 /***/ }),
 
-/***/ 427:
+/***/ 428:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75050,7 +75776,7 @@ exports.BlobDownloadResponse = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core_util_1 = __nccwpck_require__(14);
-const RetriableReadableStream_js_1 = __nccwpck_require__(493);
+const RetriableReadableStream_js_1 = __nccwpck_require__(494);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -75516,7 +76242,7 @@ exports.BlobDownloadResponse = BlobDownloadResponse;
 
 /***/ }),
 
-/***/ 428:
+/***/ 429:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -75561,7 +76287,7 @@ function storageRequestFailureDetailsParserPolicy() {
 
 /***/ }),
 
-/***/ 429:
+/***/ 430:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -75597,7 +76323,7 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(383));
+var import_node_os = __toESM(__nccwpck_require__(384));
 var import_node_process = __toESM(__nccwpck_require__(237));
 function getHeaderName() {
   return "User-Agent";
@@ -75621,7 +76347,7 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 430:
+/***/ 431:
 /***/ ((module) => {
 
 "use strict";
@@ -75629,7 +76355,7 @@ module.exports = require("async_hooks");
 
 /***/ }),
 
-/***/ 431:
+/***/ 432:
 /***/ ((module) => {
 
 "use strict";
@@ -75637,7 +76363,7 @@ module.exports = require("node:stream");
 
 /***/ }),
 
-/***/ 432:
+/***/ 433:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -75691,12 +76417,12 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DefaultGlobber = void 0;
-const core = __importStar(__nccwpck_require__(460));
-const fs = __importStar(__nccwpck_require__(533));
-const globOptionsHelper = __importStar(__nccwpck_require__(414));
+const core = __importStar(__nccwpck_require__(461));
+const fs = __importStar(__nccwpck_require__(534));
+const globOptionsHelper = __importStar(__nccwpck_require__(415));
 const path = __importStar(__nccwpck_require__(248));
 const patternHelper = __importStar(__nccwpck_require__(43));
-const internal_match_kind_1 = __nccwpck_require__(530);
+const internal_match_kind_1 = __nccwpck_require__(531);
 const internal_pattern_1 = __nccwpck_require__(503);
 const internal_search_state_1 = __nccwpck_require__(4);
 const IS_WINDOWS = process.platform === 'win32';
@@ -75879,7 +76605,7 @@ exports.DefaultGlobber = DefaultGlobber;
 
 /***/ }),
 
-/***/ 433:
+/***/ 434:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75984,16 +76710,16 @@ function getOperationRequestInfo(request) {
 
 /***/ }),
 
-/***/ 434:
+/***/ 435:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(489)
-const { AsyncResource } = __nccwpck_require__(430)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(490)
+const { AsyncResource } = __nccwpck_require__(431)
 const util = __nccwpck_require__(69)
-const { addSignal, removeSignal } = __nccwpck_require__(104)
+const { addSignal, removeSignal } = __nccwpck_require__(105)
 const assert = __nccwpck_require__(528)
 
 class UpgradeHandler extends AsyncResource {
@@ -76097,14 +76823,14 @@ module.exports = upgrade
 
 /***/ }),
 
-/***/ 435:
+/***/ 436:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const os = __nccwpck_require__(93);
-const tty = __nccwpck_require__(183);
-const hasFlag = __nccwpck_require__(367);
+const os = __nccwpck_require__(94);
+const tty = __nccwpck_require__(181);
+const hasFlag = __nccwpck_require__(368);
 
 const {env} = process;
 
@@ -76240,7 +76966,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 436:
+/***/ 437:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76302,14 +77028,14 @@ function ensureSecureConnection(request, options) {
 
 /***/ }),
 
-/***/ 437:
+/***/ 438:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CacheServiceClientProtobuf = exports.CacheServiceClientJSON = void 0;
-const cache_1 = __nccwpck_require__(423);
+const cache_1 = __nccwpck_require__(424);
 class CacheServiceClientJSON {
     constructor(rpc) {
         this.rpc = rpc;
@@ -76377,7 +77103,7 @@ exports.CacheServiceClientProtobuf = CacheServiceClientProtobuf;
 
 /***/ }),
 
-/***/ 438:
+/***/ 439:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -76426,7 +77152,7 @@ function decodeStringToString(value) {
 
 /***/ }),
 
-/***/ 439:
+/***/ 440:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -76471,7 +77197,7 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 
 /***/ }),
 
-/***/ 440:
+/***/ 441:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76487,24 +77213,24 @@ var serviceClient_js_1 = __nccwpck_require__(315);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
 var pipeline_js_1 = __nccwpck_require__(284);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
-var interfaces_js_1 = __nccwpck_require__(100);
+var interfaces_js_1 = __nccwpck_require__(101);
 Object.defineProperty(exports, "XML_ATTRKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_ATTRKEY; } }));
 Object.defineProperty(exports, "XML_CHARKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_CHARKEY; } }));
-var deserializationPolicy_js_1 = __nccwpck_require__(87);
+var deserializationPolicy_js_1 = __nccwpck_require__(88);
 Object.defineProperty(exports, "deserializationPolicy", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicy; } }));
 Object.defineProperty(exports, "deserializationPolicyName", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicyName; } }));
-var serializationPolicy_js_1 = __nccwpck_require__(490);
+var serializationPolicy_js_1 = __nccwpck_require__(491);
 Object.defineProperty(exports, "serializationPolicy", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicy; } }));
 Object.defineProperty(exports, "serializationPolicyName", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicyName; } }));
 var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(113);
 Object.defineProperty(exports, "authorizeRequestOnClaimChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnClaimChallenge_js_1.authorizeRequestOnClaimChallenge; } }));
-var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(174);
+var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(172);
 Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnTenantChallenge_js_1.authorizeRequestOnTenantChallenge; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 441:
+/***/ 442:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -76545,7 +77271,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTar = exports.extractTar = exports.listTar = void 0;
 const exec_1 = __nccwpck_require__(18);
 const io = __importStar(__nccwpck_require__(295));
-const fs_1 = __nccwpck_require__(533);
+const fs_1 = __nccwpck_require__(534);
 const path = __importStar(__nccwpck_require__(248));
 const utils = __importStar(__nccwpck_require__(76));
 const constants_1 = __nccwpck_require__(45);
@@ -76783,7 +77509,7 @@ exports.createTar = createTar;
 
 /***/ }),
 
-/***/ 442:
+/***/ 443:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -76820,12 +77546,12 @@ __export(nodeHttpClient_exports, {
 });
 module.exports = __toCommonJS(nodeHttpClient_exports);
 var import_node_http = __toESM(__nccwpck_require__(263));
-var import_node_https = __toESM(__nccwpck_require__(389));
+var import_node_https = __toESM(__nccwpck_require__(390));
 var import_node_zlib = __toESM(__nccwpck_require__(521));
-var import_node_stream = __nccwpck_require__(431);
+var import_node_stream = __nccwpck_require__(432);
 var import_AbortError = __nccwpck_require__(10);
-var import_httpHeaders = __nccwpck_require__(486);
-var import_restError = __nccwpck_require__(445);
+var import_httpHeaders = __nccwpck_require__(487);
+var import_restError = __nccwpck_require__(446);
 var import_log = __nccwpck_require__(152);
 var import_sanitizer = __nccwpck_require__(122);
 const DEFAULT_TLS_SETTINGS = {};
@@ -77132,13 +77858,13 @@ function createNodeHttpClient() {
 
 /***/ }),
 
-/***/ 443:
+/***/ 444:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(457)
+const { webidl } = __nccwpck_require__(458)
 
 const kState = Symbol('ProgressEvent state')
 
@@ -77218,7 +77944,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 444:
+/***/ 445:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -77251,9 +77977,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const crypto = __importStar(__nccwpck_require__(291));
-const fs = __importStar(__nccwpck_require__(533));
-const os = __importStar(__nccwpck_require__(93));
+const crypto = __importStar(__nccwpck_require__(292));
+const fs = __importStar(__nccwpck_require__(534));
+const os = __importStar(__nccwpck_require__(94));
 const utils_1 = __nccwpck_require__(506);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -77287,7 +78013,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 445:
+/***/ 446:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -77389,7 +78115,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 446:
+/***/ 447:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -77442,7 +78168,7 @@ function wrapAbortSignalLike(abortSignalLike) {
 
 /***/ }),
 
-/***/ 447:
+/***/ 448:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77456,7 +78182,7 @@ function wrapAbortSignalLike(abortSignalLike) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(217);
+const tslib_1 = __nccwpck_require__(216);
 const coreHttpCompat = tslib_1.__importStar(__nccwpck_require__(72));
 const index_js_1 = __nccwpck_require__(278);
 class StorageClient extends coreHttpCompat.ExtendedServiceClient {
@@ -77515,7 +78241,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 448:
+/***/ 449:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77524,31 +78250,31 @@ exports.StorageClient = StorageClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = exports.StorageSharedKeyCredentialPolicy = exports.StorageSharedKeyCredential = exports.StorageRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = exports.Credential = exports.CredentialPolicy = exports.BaseRequestPolicy = exports.AnonymousCredentialPolicy = exports.AnonymousCredential = exports.StorageOAuthScopes = exports.newPipeline = exports.isPipelineLike = exports.Pipeline = exports.getBlobServiceAccountAudience = exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTier = exports.generateBlobSASQueryParameters = exports.generateAccountSASQueryParameters = void 0;
-const tslib_1 = __nccwpck_require__(217);
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const tslib_1 = __nccwpck_require__(216);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
-tslib_1.__exportStar(__nccwpck_require__(402), exports);
-tslib_1.__exportStar(__nccwpck_require__(186), exports);
+tslib_1.__exportStar(__nccwpck_require__(403), exports);
+tslib_1.__exportStar(__nccwpck_require__(184), exports);
 tslib_1.__exportStar(__nccwpck_require__(64), exports);
-tslib_1.__exportStar(__nccwpck_require__(205), exports);
+tslib_1.__exportStar(__nccwpck_require__(204), exports);
 tslib_1.__exportStar(__nccwpck_require__(58), exports);
 tslib_1.__exportStar(__nccwpck_require__(2), exports);
-tslib_1.__exportStar(__nccwpck_require__(380), exports);
+tslib_1.__exportStar(__nccwpck_require__(381), exports);
 var AccountSASSignatureValues_js_1 = __nccwpck_require__(289);
 Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
 tslib_1.__exportStar(__nccwpck_require__(334), exports);
-tslib_1.__exportStar(__nccwpck_require__(403), exports);
-tslib_1.__exportStar(__nccwpck_require__(175), exports);
+tslib_1.__exportStar(__nccwpck_require__(404), exports);
+tslib_1.__exportStar(__nccwpck_require__(173), exports);
 tslib_1.__exportStar(__nccwpck_require__(504), exports);
 var BlobSASSignatureValues_js_1 = __nccwpck_require__(68);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
 tslib_1.__exportStar(__nccwpck_require__(280), exports);
-var models_js_1 = __nccwpck_require__(416);
+var models_js_1 = __nccwpck_require__(417);
 Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: function () { return models_js_1.BlockBlobTier; } }));
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
 Object.defineProperty(exports, "getBlobServiceAccountAudience", ({ enumerable: true, get: function () { return models_js_1.getBlobServiceAccountAudience; } }));
-var Pipeline_js_1 = __nccwpck_require__(184);
+var Pipeline_js_1 = __nccwpck_require__(182);
 Object.defineProperty(exports, "Pipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.Pipeline; } }));
 Object.defineProperty(exports, "isPipelineLike", ({ enumerable: true, get: function () { return Pipeline_js_1.isPipelineLike; } }));
 Object.defineProperty(exports, "newPipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.newPipeline; } }));
@@ -77568,13 +78294,13 @@ Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get:
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
 tslib_1.__exportStar(__nccwpck_require__(527), exports);
 tslib_1.__exportStar(__nccwpck_require__(323), exports);
-var log_js_1 = __nccwpck_require__(107);
+var log_js_1 = __nccwpck_require__(108);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 449:
+/***/ 450:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77859,7 +78585,7 @@ exports.SPECIAL_HEADERS = {
 
 /***/ }),
 
-/***/ 450:
+/***/ 451:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -77885,10 +78611,10 @@ __export(sendRequest_exports, {
   sendRequest: () => sendRequest
 });
 module.exports = __toCommonJS(sendRequest_exports);
-var import_restError = __nccwpck_require__(445);
-var import_httpHeaders = __nccwpck_require__(486);
+var import_restError = __nccwpck_require__(446);
+var import_httpHeaders = __nccwpck_require__(487);
 var import_pipelineRequest = __nccwpck_require__(116);
-var import_clientHelpers = __nccwpck_require__(492);
+var import_clientHelpers = __nccwpck_require__(493);
 var import_typeGuards = __nccwpck_require__(498);
 var import_multipart = __nccwpck_require__(270);
 async function sendRequest(method, url, pipeline, options = {}, customHttpClient) {
@@ -78043,7 +78769,7 @@ function createParseError(response, err) {
 
 /***/ }),
 
-/***/ 451:
+/***/ 452:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -78059,8 +78785,8 @@ const {
   makeResponse
 } = __nccwpck_require__(41)
 const { Headers } = __nccwpck_require__(518)
-const { Request, makeRequest } = __nccwpck_require__(84)
-const zlib = __nccwpck_require__(411)
+const { Request, makeRequest } = __nccwpck_require__(86)
+const zlib = __nccwpck_require__(412)
 const {
   bytesMatch,
   makePolicyContainer,
@@ -78102,14 +78828,14 @@ const {
   subresourceSet,
   DOMException
 } = __nccwpck_require__(30)
-const { kHeadersList } = __nccwpck_require__(196)
+const { kHeadersList } = __nccwpck_require__(194)
 const EE = __nccwpck_require__(471)
 const { Readable, pipeline } = __nccwpck_require__(131)
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(69)
 const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(25)
 const { TransformStream } = __nccwpck_require__(257)
-const { getGlobalDispatcher } = __nccwpck_require__(377)
-const { webidl } = __nccwpck_require__(457)
+const { getGlobalDispatcher } = __nccwpck_require__(378)
+const { webidl } = __nccwpck_require__(458)
 const { STATUS_CODES } = __nccwpck_require__(329)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
@@ -80199,7 +80925,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 452:
+/***/ 453:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -80257,14 +80983,14 @@ exports.ServerStreamingCall = ServerStreamingCall;
 
 /***/ }),
 
-/***/ 453:
+/***/ 454:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.readMessageOption = exports.readFieldOption = exports.readFieldOptions = exports.normalizeFieldInfo = exports.RepeatType = exports.LongType = exports.ScalarType = void 0;
-const lower_camel_case_1 = __nccwpck_require__(454);
+const lower_camel_case_1 = __nccwpck_require__(455);
 /**
  * Scalar value types. This is a subset of field types declared by protobuf
  * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
@@ -80423,7 +81149,7 @@ exports.readMessageOption = readMessageOption;
 
 /***/ }),
 
-/***/ 454:
+/***/ 455:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -80466,7 +81192,7 @@ exports.lowerCamelCase = lowerCamelCase;
 
 /***/ }),
 
-/***/ 455:
+/***/ 456:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80476,7 +81202,7 @@ exports.lowerCamelCase = lowerCamelCase;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
 const StorageContextClient_js_1 = __nccwpck_require__(267);
-const Pipeline_js_1 = __nccwpck_require__(184);
+const Pipeline_js_1 = __nccwpck_require__(182);
 const utils_common_js_1 = __nccwpck_require__(155);
 /**
  * A StorageClient represents a based URL class for {@link BlobServiceClient}, {@link ContainerClient}
@@ -80529,7 +81255,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 456:
+/***/ 457:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -80604,7 +81330,7 @@ function parseHeaderValueAsNumber(response, headerName) {
 
 /***/ }),
 
-/***/ 457:
+/***/ 458:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -81258,14 +81984,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 458:
+/***/ 459:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /**
  * Module dependencies.
  */
 
-const tty = __nccwpck_require__(183);
+const tty = __nccwpck_require__(181);
 const util = __nccwpck_require__(124);
 
 /**
@@ -81292,7 +82018,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = __nccwpck_require__(435);
+	const supportsColor = __nccwpck_require__(436);
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [
@@ -81528,7 +82254,7 @@ formatters.O = function (v) {
 
 /***/ }),
 
-/***/ 459:
+/***/ 460:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -81582,7 +82308,7 @@ exports.walkSnapshot = walkSnapshot;
 exports.diffSnapshots = diffSnapshots;
 exports.diffStats = diffStats;
 exports.serializeManifest = serializeManifest;
-const fs = __importStar(__nccwpck_require__(109));
+const fs = __importStar(__nccwpck_require__(110));
 const path = __importStar(__nccwpck_require__(509));
 function entryKey(root, relpath) {
     return `${root}#${relpath}`;
@@ -81694,7 +82420,7 @@ function serializeManifest(diff, stats) {
 
 /***/ }),
 
-/***/ 460:
+/***/ 461:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -81733,10 +82459,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.platform = exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = exports.markdownSummary = exports.summary = exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(535);
-const file_command_1 = __nccwpck_require__(444);
+const command_1 = __nccwpck_require__(536);
+const file_command_1 = __nccwpck_require__(445);
 const utils_1 = __nccwpck_require__(506);
-const os = __importStar(__nccwpck_require__(93));
+const os = __importStar(__nccwpck_require__(94));
 const path = __importStar(__nccwpck_require__(248));
 const oidc_utils_1 = __nccwpck_require__(134);
 /**
@@ -82040,12 +82766,12 @@ Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: funct
 /**
  * Platform utilities exports
  */
-exports.platform = __importStar(__nccwpck_require__(419));
+exports.platform = __importStar(__nccwpck_require__(420));
 //# sourceMappingURL=core.js.map
 
 /***/ }),
 
-/***/ 461:
+/***/ 462:
 /***/ ((module) => {
 
 "use strict";
@@ -82063,14 +82789,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 462:
+/***/ 463:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionEquals = void 0;
-const reflection_info_1 = __nccwpck_require__(453);
+const reflection_info_1 = __nccwpck_require__(454);
 /**
  * Determines whether two message of the same type have the same field values.
  * Checks for deep equality, traversing repeated fields, oneof groups, maps
@@ -82148,15 +82874,15 @@ function repeatedMsgEq(type, a, b) {
 
 /***/ }),
 
-/***/ 463:
+/***/ 464:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
-const reflection_info_1 = __nccwpck_require__(453);
-const reflection_long_convert_1 = __nccwpck_require__(159);
+const reflection_info_1 = __nccwpck_require__(454);
+const reflection_long_convert_1 = __nccwpck_require__(158);
 const pb_long_1 = __nccwpck_require__(118);
 /**
  * Creates the default value for a scalar type.
@@ -82193,7 +82919,7 @@ exports.reflectionScalarDefault = reflectionScalarDefault;
 
 /***/ }),
 
-/***/ 464:
+/***/ 465:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82231,7 +82957,7 @@ function storageCorrectContentLengthPolicy() {
 
 /***/ }),
 
-/***/ 465:
+/***/ 466:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -82276,7 +83002,7 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 466:
+/***/ 467:
 /***/ ((module) => {
 
 "use strict";
@@ -82335,682 +83061,6 @@ module.exports = {
 
 /***/ }),
 
-/***/ 467:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Top-level resolve-setup entry point. Owned by Agent 1.
-//
-// Full port of resolve_setup.py::main(). Reads INPUT_* / GITHUB_* env vars,
-// resolves the toolchain spec, derives all cache keys, computes the env
-// exports + outputs the orchestrator needs.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.pythonDefaultJson = exports.buildOutputs = exports.detectMuslCcEnv = exports.detectUserLinkerEnv = exports.parseRustBacktrace = exports.parseCacheShutdownOnIdleSeconds = exports.readRawInputs = void 0;
-exports.resolveRustupStrategy = resolveRustupStrategy;
-exports.resolveSetup = resolveSetup;
-exports.applyResolveResult = applyResolveResult;
-const os = __importStar(__nccwpck_require__(383));
-const path = __importStar(__nccwpck_require__(509));
-const fs = __importStar(__nccwpck_require__(249));
-const core = __importStar(__nccwpck_require__(460));
-const cache_keys_js_1 = __nccwpck_require__(166);
-const log_utils_js_1 = __nccwpck_require__(352);
-const detect_musl_cc_js_1 = __nccwpck_require__(505);
-Object.defineProperty(exports, "detectMuslCcEnv", ({ enumerable: true, get: function () { return detect_musl_cc_js_1.detectMuslCcEnv; } }));
-const build_outputs_js_1 = __nccwpck_require__(268);
-Object.defineProperty(exports, "buildOutputs", ({ enumerable: true, get: function () { return build_outputs_js_1.buildOutputs; } }));
-const raw_inputs_js_1 = __nccwpck_require__(362);
-Object.defineProperty(exports, "readRawInputs", ({ enumerable: true, get: function () { return raw_inputs_js_1.readRawInputs; } }));
-const input_parsers_js_1 = __nccwpck_require__(214);
-Object.defineProperty(exports, "detectUserLinkerEnv", ({ enumerable: true, get: function () { return input_parsers_js_1.detectUserLinkerEnv; } }));
-Object.defineProperty(exports, "parseCacheShutdownOnIdleSeconds", ({ enumerable: true, get: function () { return input_parsers_js_1.parseCacheShutdownOnIdleSeconds; } }));
-Object.defineProperty(exports, "parseRustBacktrace", ({ enumerable: true, get: function () { return input_parsers_js_1.parseRustBacktrace; } }));
-const fetch_release_js_1 = __nccwpck_require__(146);
-const python_json_js_1 = __nccwpck_require__(11);
-Object.defineProperty(exports, "pythonDefaultJson", ({ enumerable: true, get: function () { return python_json_js_1.pythonDefaultJson; } }));
-const toolchain_js_1 = __nccwpck_require__(368);
-const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
-const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
-const ALLOWED_LINKER_VALUES = [
-    "default",
-    "platform-default",
-    "ld",
-    "mold",
-    "rust-lld",
-    "fast",
-];
-// CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
-// FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
-// causes "failed to connect to jobserver" warnings in every downstream step.
-// See setup-soldr#71.
-const GITHUB_ENV_DENY_LIST = new Set(["CARGO_MAKEFLAGS", "MAKEFLAGS"]);
-function expanduser(p, env) {
-    if (!p)
-        return p;
-    if (p.startsWith("~")) {
-        const home = env["HOME"] || env["USERPROFILE"] || "";
-        if (p === "~")
-            return home;
-        if (p.startsWith("~/") || p.startsWith("~\\")) {
-            return path.join(home, p.slice(2));
-        }
-    }
-    return p;
-}
-function resolveAbsolute(p, env) {
-    return path.resolve(expanduser(p, env));
-}
-function isFalsy(value) {
-    return FALSY_VALUES.has(value.trim().toLowerCase());
-}
-function isTruthy(value) {
-    return TRUTHY_VALUES.has(value.trim().toLowerCase());
-}
-function defaultHomeDir(env, name) {
-    const home = env["HOME"] || env["USERPROFILE"] || os.homedir();
-    return path.resolve(path.join(home, name));
-}
-function makeDirs(...paths) {
-    for (const p of paths) {
-        fs.mkdirSync(p, { recursive: true });
-    }
-}
-/**
- * Pure helper: decide the final rustup strategy from the requested one and
- * the host platform. On macOS we always override `system` to `managed` to
- * avoid the pre-installed rustup toolchain conflicts (see setup-soldr#105).
- *
- * GitHub-hosted `macos-15` (ARM) runners ship with a stable rustup toolchain
- * that already includes `clippy`. Downstream actions that try to install a
- * different toolchain with clippy hit
- *   detected conflict: 'bin/cargo-clippy'
- * because rustup component add refuses to overwrite the existing binary in
- * the shared rustup home. Forcing the managed strategy gives setup-soldr its
- * own private rustup home so the pre-installed components cannot collide.
- *
- * `explicit` (user-provided RUSTUP_HOME) is left untouched on every platform
- * — opting in to a specific home means accepting any conflicts that come
- * with it.
- */
-function resolveRustupStrategy(opts) {
-    const { requested, platform, warn } = opts;
-    if (platform === "darwin" && requested === "system") {
-        warn?.("setup-soldr: forcing rustup strategy to 'managed' on macOS to avoid " +
-            "pre-installed rustup toolchain component conflicts (e.g. " +
-            "\"detected conflict: 'bin/cargo-clippy'\" on macos-15 runners). " +
-            "See https://github.com/zackees/setup-soldr/issues/105 for context. " +
-            "This may change which setup-cache key is used compared to other " +
-            "platforms.");
-        return "managed";
-    }
-    return requested;
-}
-// `fetchReleaseTagDefault` and `resolveSoldrReleaseVersion` live in
-// ./fetch-release.js — used directly from resolveSetup() below.
-/**
- * Resolve setup state. The orchestrator calls this once at the start of the
- * action and uses the returned ResolveResult to drive every subsequent step.
- */
-async function resolveSetup(ctx, inputs, deps) {
-    const env = { ...ctx.env };
-    // ---- timing seed ----
-    const logStart = String(Math.floor(Date.now() / 1000));
-    const timestamps = (inputs.timestamps && inputs.timestamps.trim()) || "true";
-    env["SETUP_SOLDR_LOG_START_EPOCH"] = logStart;
-    env["SETUP_SOLDR_TIMESTAMPS"] = timestamps;
-    const logger = ctx.logger ?? (0, log_utils_js_1.createLogger)(env);
-    const log = (msg) => logger.log(msg);
-    if (!ctx.workspace) {
-        throw new Error("ACTION_WORKSPACE / ctx.workspace must be set");
-    }
-    const workspace = path.resolve(ctx.workspace);
-    const runnerTemp = ctx.runnerTemp
-        ? path.resolve(ctx.runnerTemp)
-        : path.resolve(path.join(workspace, ".tmp"));
-    // ---- cache roots ----
-    const requestedCacheDir = inputs.cacheDir.trim();
-    const cacheRoot = requestedCacheDir
-        ? resolveAbsolute(requestedCacheDir, env)
-        : path.resolve(path.join(runnerTemp, "setup-soldr"));
-    const soldrRoot = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-soldr`);
-    const cargoHomeInput = (env["CARGO_HOME"] ?? "").trim();
-    const cargoHome = cargoHomeInput
-        ? resolveAbsolute(cargoHomeInput, env)
-        : defaultHomeDir(env, ".cargo");
-    const binDir = path.join(cacheRoot, "bin");
-    const setupCachePath = cacheRoot;
-    const soldrBinCachePath = path.join(soldrRoot, "bin");
-    const zccacheCacheDir = path.join(soldrRoot, "cache", "zccache");
-    const thinTargetCacheBundlePath = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-target-thin`);
-    // When the action is disabled (`enable: false`), we write a script-based
-    // passthrough stub at soldrPath instead of installing the real binary.
-    // The stub is a bash script on Unix and a .cmd shim on Windows — Windows
-    // cannot spawn a script via the .exe extension without a real PE, so
-    // soldrPath must end in .cmd in passthrough mode.
-    const enableRaw = inputs.enable.trim() || "true";
-    if (!TRUTHY_VALUES.has(enableRaw.toLowerCase()) && !FALSY_VALUES.has(enableRaw.toLowerCase())) {
-        throw new Error(`invalid 'enable' input: '${enableRaw}'. Allowed: true | false`);
-    }
-    const enabled = !FALSY_VALUES.has(enableRaw.toLowerCase());
-    const soldrBinary = enabled
-        ? process.platform === "win32"
-            ? "soldr.exe"
-            : "soldr"
-        : process.platform === "win32"
-            ? "soldr.cmd"
-            : "soldr";
-    const soldrPath = path.join(binDir, soldrBinary);
-    // ---- toolchain ----
-    const toolchain = await (0, toolchain_js_1.loadToolchainSpec)({
-        workspace,
-        toolchainFile: inputs.toolchainFile || "rust-toolchain.toml",
-        toolchainOverride: inputs.toolchain,
-        log,
-    });
-    // ---- rustup home selection ----
-    const explicitRustupHome = (env["RUSTUP_HOME"] ?? "").trim();
-    let rustupHome;
-    let rustupStrategy;
-    if (explicitRustupHome) {
-        rustupHome = resolveAbsolute(explicitRustupHome, env);
-        rustupStrategy = "explicit";
-    }
-    else {
-        const runnerRustupHome = defaultHomeDir(env, ".rustup");
-        let satisfied = false;
-        if (deps?.systemRustupOverride) {
-            satisfied = await deps.systemRustupOverride(cargoHome, runnerRustupHome, toolchain);
-        }
-        else {
-            satisfied = await (0, toolchain_js_1.systemRustupSatisfiesRequest)({
-                cargoHome,
-                rustupHome: runnerRustupHome,
-                toolchain,
-                env,
-                logger,
-                deps: deps?.systemRustup,
-            });
-        }
-        if (satisfied) {
-            rustupHome = runnerRustupHome;
-            rustupStrategy = "system";
-        }
-        else {
-            rustupHome = path.join(cacheRoot, "rustup-home");
-            rustupStrategy = "managed";
-        }
-        // Platform override: macOS pre-installed rustup toolchains conflict with
-        // downstream component adds (setup-soldr#105). Force `managed` when the
-        // initial selection landed on `system` so we get a private rustup home.
-        const overridden = resolveRustupStrategy({
-            requested: rustupStrategy,
-            platform: process.platform,
-            warn: (msg) => logger.warning(msg),
-        });
-        if (overridden !== rustupStrategy) {
-            rustupStrategy = overridden;
-            if (rustupStrategy === "managed") {
-                rustupHome = path.join(cacheRoot, "rustup-home");
-            }
-        }
-    }
-    const setupCachePathsList = (0, cache_keys_js_1.setupCachePaths)(setupCachePath, binDir, soldrBinCachePath, rustupHome);
-    const setupCacheLayoutValue = (0, cache_keys_js_1.setupCacheLayout)(setupCachePath, rustupHome);
-    for (const dir of [
-        cacheRoot,
-        soldrRoot,
-        path.join(soldrRoot, "cache"),
-        soldrBinCachePath,
-        cargoHome,
-        path.join(cargoHome, "bin"),
-        rustupHome,
-        binDir,
-        zccacheCacheDir,
-        thinTargetCacheBundlePath,
-    ]) {
-        makeDirs(dir);
-    }
-    const soldrRepo = inputs.repo.trim() || "zackees/soldr";
-    const soldrRef = inputs.ref.trim();
-    const soldrVersionRequested = inputs.version.trim();
-    const soldrVersionResolved = await (0, fetch_release_js_1.resolveSoldrReleaseVersion)(soldrRepo, soldrVersionRequested, soldrRef, env, deps);
-    const toolchainSignature = {
-        channel: toolchain.cacheChannel,
-        profile: toolchain.profile,
-        components: toolchain.components,
-        targets: toolchain.targets,
-        source: toolchain.source,
-        file_hash: toolchain.fileHash,
-        setup_cache_layout: setupCacheLayoutValue,
-        soldr_repo: soldrRepo,
-        soldr_ref: soldrRef || "release",
-        soldr_version: soldrVersionResolved || soldrRef || "source-ref",
-    };
-    // Python uses json.dumps(sort_keys=True) without compact separators here,
-    // so canonical_json_stringify is wrong; mirror Python's default separators
-    // (", " and ": ") to match byte-for-byte.
-    const signatureString = (0, python_json_js_1.pythonDefaultJson)(toolchainSignature);
-    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 275, 23));
-    const digest = createHash("sha256").update(signatureString, "utf8").digest("hex").slice(0, 16);
-    const runnerOs = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_OS"] ?? process.platform).toLowerCase());
-    const runnerArch = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_ARCH"] ?? "unknown").toLowerCase());
-    const cachePrefix = `setup-soldr-v4-${runnerOs}-${runnerArch}`;
-    let cacheKey = `${cachePrefix}-${digest}`;
-    const wsManifestHash = await (0, cache_keys_js_1.workspaceManifestHash)(workspace);
-    const cargoConfigHashValue = await (0, cache_keys_js_1.cargoConfigHash)(workspace);
-    const suffix = inputs.cacheKeySuffix.trim();
-    const sanitizedSuffix = suffix ? (0, cache_keys_js_1.sanitizeFragment)(suffix) : "";
-    if (suffix) {
-        cacheKey = `${cacheKey}-${sanitizedSuffix}`;
-    }
-    // ---- build cache ----
-    const githubSha = (env["GITHUB_SHA"] ?? "").trim() || "nosha";
-    let parentSha = (env["ACTION_PARENT_SHA"] ?? "").trim();
-    if (parentSha === githubSha) {
-        parentSha = "";
-    }
-    const buildCachePrefix = `setup-soldr-buildcache-v2-${runnerOs}-${runnerArch}`;
-    const buildCacheToolchainPrefix = `${buildCachePrefix}-${digest}-`;
-    let buildCacheKey = `${buildCacheToolchainPrefix}${githubSha}`;
-    let buildCacheParentKey = parentSha ? `${buildCacheToolchainPrefix}${parentSha}` : "";
-    // ---- target cache ----
-    const targetDirInput = inputs.targetDir.trim() || "target";
-    let targetCachePath = expanduser(targetDirInput, env);
-    if (!path.isAbsolute(targetCachePath)) {
-        targetCachePath = path.join(workspace, targetCachePath);
-    }
-    targetCachePath = path.resolve(targetCachePath);
-    makeDirs(targetCachePath);
-    const lockfilePath = (0, cache_keys_js_1.resolveLockfilePath)(workspace, targetCachePath, inputs.lockfile);
-    const cargoLockHash = lockfilePath ? await (0, cache_keys_js_1.shortFileHash)(lockfilePath, "no-lock") : "no-lock";
-    const legacyTargetCacheModeInput = inputs.targetCacheMode;
-    const legacyTargetCacheMode = (0, cache_keys_js_1.normalizeLegacyTargetCacheMode)(legacyTargetCacheModeInput, log);
-    const targetCacheProfile = (0, cache_keys_js_1.normalizeTargetCacheProfile)(inputs.targetCacheProfile);
-    // `cache: "false"` is the umbrella switch. It originally only gated the
-    // action-managed setup-cache (soldr binary + rustup state), but consumers
-    // reasonably expect it to mean "no caching at all" — so when the umbrella
-    // is off we force every per-layer flag off too AND tell soldr to skip its
-    // zccache build-cache wrapper. See zccache#307 / zackees/setup-soldr#118
-    // follow-up.
-    const cacheUmbrellaEnabled = !isFalsy(inputs.cache.trim() || "true");
-    const targetCacheInputRaw = inputs.targetCache.trim() || "true";
-    const targetCacheRequested = cacheUmbrellaEnabled &&
-        !isFalsy(targetCacheInputRaw) &&
-        legacyTargetCacheMode !== "off";
-    const explicitBuildCacheMode = inputs.buildCacheMode.trim();
-    const buildCacheMode = (0, cache_keys_js_1.normalizeBuildCacheMode)(inputs.buildCacheMode, legacyTargetCacheModeInput, !explicitBuildCacheMode && targetCacheRequested, log);
-    const buildCacheInputRaw = inputs.buildCache.trim() || "true";
-    const buildCacheEnabled = cacheUmbrellaEnabled && !isFalsy(buildCacheInputRaw);
-    const buildCacheRuntimeMode = buildCacheMode === "once" ? "full" : buildCacheMode;
-    let targetCacheEnabled = buildCacheEnabled && targetCacheRequested;
-    if (buildCacheMode === "thin" && cargoLockHash === "no-lock") {
-        log("build-cache-mode 'thin' requires Cargo.lock; target artifact cache disabled.");
-        targetCacheEnabled = false;
-    }
-    const [targetCacheBudgetBytes, targetCacheBudgetFiles] = (0, cache_keys_js_1.targetCacheSoftBudget)(targetCacheEnabled, buildCacheMode);
-    const targetShapeHash = (0, cache_keys_js_1.shortJsonHash)({
-        target_dir: targetCachePath,
-        target_dir_input: targetDirInput,
-        target_env: (0, cache_keys_js_1.targetEnvHash)(env),
-    });
-    const targetInputsHash = (0, cache_keys_js_1.shortJsonHash)({
-        cargo_config: cargoConfigHashValue,
-        cargo_lock: cargoLockHash,
-        manifest: wsManifestHash,
-        target_shape: targetShapeHash,
-        toolchain: digest,
-    });
-    const lockfileOnlyHash = (0, cache_keys_js_1.shortJsonHash)({
-        cargo_lock: cargoLockHash,
-        toolchain: digest,
-    });
-    const targetCacheBundlePath = thinTargetCacheBundlePath;
-    const targetTreeCacheEnabled = targetCacheEnabled && buildCacheMode === "full";
-    let targetCachePaths;
-    let targetCacheEffectiveMode;
-    let targetCachePrefix;
-    let targetCacheLockPrefix;
-    let targetCacheLockfilePrefix;
-    let targetCacheKey;
-    let targetCacheParentKey;
-    if (!targetCacheEnabled) {
-        targetCachePaths = "";
-        targetCacheEffectiveMode = "off";
-        targetCachePrefix = `setup-soldr-targetcache-off-v1-${runnerOs}-${runnerArch}`;
-        targetCacheLockPrefix = "";
-        targetCacheLockfilePrefix = "";
-        targetCacheKey = `${targetCachePrefix}-${targetInputsHash}`;
-        targetCacheParentKey = "";
-    }
-    else if (targetTreeCacheEnabled) {
-        targetCachePaths = [targetCachePath, targetCacheBundlePath].join("\n");
-        targetCacheEffectiveMode = buildCacheMode;
-        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v1-${runnerOs}-${runnerArch}`;
-        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
-        targetCacheLockPrefix = `${targetCachePrefix}-${digest}-${cargoLockHash}-${targetShapeHash}-${sf}`;
-        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
-        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
-        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
-    }
-    else {
-        targetCachePaths = targetCacheBundlePath;
-        targetCacheEffectiveMode = buildCacheMode;
-        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v1-${runnerOs}-${runnerArch}`;
-        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
-        targetCacheLockPrefix = `${targetCachePrefix}-${targetInputsHash}-${sf}`;
-        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
-        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
-        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
-    }
-    if (suffix) {
-        buildCacheKey = `${buildCacheKey}-${sanitizedSuffix}`;
-        if (buildCacheParentKey) {
-            buildCacheParentKey = `${buildCacheParentKey}-${sanitizedSuffix}`;
-        }
-    }
-    // ---- cargo registry cache ----
-    const cargoRegistryCacheRequested = isTruthy(inputs.cargoRegistryCache.trim() || "true");
-    const cargoRegistryCachePath = path.join(cargoHome, "registry");
-    const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-v1-${runnerOs}-${runnerArch}`;
-    const cargoRegistryCacheRestorePrefix = `${cargoRegistryCachePrefix}-${cargoLockHash}-`;
-    let cargoRegistryCacheKey = `${cargoRegistryCacheRestorePrefix}${digest}-${githubSha}`;
-    if (suffix) {
-        cargoRegistryCacheKey = `${cargoRegistryCacheKey}-${sanitizedSuffix}`;
-    }
-    const cargoRegistryCacheEnabled = cacheUmbrellaEnabled && cargoRegistryCacheRequested;
-    if (cargoRegistryCacheEnabled) {
-        makeDirs(cargoRegistryCachePath);
-    }
-    // ---- env exports ----
-    const cacheShutdownOnIdleSeconds = (0, input_parsers_js_1.parseCacheShutdownOnIdleSeconds)(inputs.cacheShutdownOnIdle);
-    const rustBacktraceValue = (0, input_parsers_js_1.parseRustBacktrace)(inputs.rustBacktrace);
-    const envExports = {};
-    const setEnv = (name, value) => {
-        if (GITHUB_ENV_DENY_LIST.has(name))
-            return;
-        envExports[name] = value;
-    };
-    setEnv("SOLDR_CACHE_DIR", soldrRoot);
-    setEnv("CARGO_HOME", cargoHome);
-    setEnv("RUSTUP_HOME", rustupHome);
-    setEnv("ZCCACHE_CACHE_DIR", zccacheCacheDir);
-    setEnv("SETUP_SOLDR_BUILD_CACHE_MODE", cacheUmbrellaEnabled ? buildCacheMode : "off");
-    setEnv("SOLDR_BUILD_CACHE_MODE", cacheUmbrellaEnabled ? buildCacheRuntimeMode : "off");
-    setEnv("SOLDR_TARGET_CACHE_MODE", targetCacheEnabled ? buildCacheRuntimeMode : "off");
-    setEnv("SOLDR_TARGET_CACHE_DIR", targetCachePath);
-    setEnv("SOLDR_TARGET_CACHE_BUNDLE_DIR", targetCacheBundlePath);
-    setEnv("SOLDR_TARGET_CACHE_PROFILE", targetCacheProfile);
-    const stripDebug = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-strip-debuginfo", inputs.targetCacheStripDebuginfo);
-    if (stripDebug !== null) {
-        setEnv("SOLDR_TARGET_CACHE_STRIP_DEBUGINFO", stripDebug);
-    }
-    const includeIncremental = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-incremental", inputs.targetCacheIncludeIncremental);
-    if (includeIncremental !== null) {
-        setEnv("SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL", includeIncremental);
-    }
-    const includeBuildScripts = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-build-script-binaries", inputs.targetCacheIncludeBuildScriptBinaries);
-    if (includeBuildScripts !== null) {
-        setEnv("SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES", includeBuildScripts);
-    }
-    const targetCacheCompress = (0, cache_keys_js_1.normalizeTargetCacheCompress)(inputs.targetCacheCompress);
-    const targetCacheCompressLevel = (0, cache_keys_js_1.normalizeTargetCacheCompressLevel)(inputs.targetCacheCompressLevel);
-    setEnv("SOLDR_TARGET_CACHE_COMPRESS", targetCacheCompress);
-    setEnv("SOLDR_TARGET_CACHE_COMPRESS_LEVEL", targetCacheCompressLevel);
-    if (cargoRegistryCacheEnabled) {
-        setEnv("SOLDR_SKIP_CARGO_REGISTRY_SAVE", "1");
-    }
-    setEnv("SOLDR_TARGET_CACHE_BACKEND", "local");
-    setEnv("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain.channel);
-    setEnv("SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL", toolchain.cacheChannel);
-    setEnv("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain.profile);
-    setEnv("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", JSON.stringify(toolchain.components));
-    setEnv("SETUP_SOLDR_TOOLCHAIN_TARGETS", JSON.stringify(toolchain.targets));
-    setEnv("SETUP_SOLDR_LOG_START_EPOCH", logStart);
-    setEnv("SETUP_SOLDR_TIMESTAMPS", timestamps);
-    if (!FALSY_VALUES.has(timestamps.toLowerCase()) && env["NO_COLOR"] === undefined) {
-        if (!env["CARGO_TERM_COLOR"])
-            setEnv("CARGO_TERM_COLOR", "always");
-        if (!env["CLICOLOR_FORCE"])
-            setEnv("CLICOLOR_FORCE", "1");
-        if (!env["FORCE_COLOR"])
-            setEnv("FORCE_COLOR", "1");
-    }
-    if (inputs.trustMode.trim()) {
-        setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
-    }
-    const linkerRaw = inputs.linker.trim();
-    if (linkerRaw === "") {
-        const preset = (0, input_parsers_js_1.detectUserLinkerEnv)(env);
-        if (preset.length > 0) {
-            logger.info(`setup-soldr: deferring to user-set ${preset.join(", ")}; skipping default SOLDR_LINKER=fast injection. See https://github.com/zackees/setup-soldr/issues/108`);
-        }
-        else {
-            setEnv("SOLDR_LINKER", "fast");
-            logger.warning("setup-soldr: defaulting SOLDR_LINKER=fast (mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows) for faster CI links. Soldr's native default is no injection, which produces a smaller build-cache and a slower link. Set `linker: platform-default` to opt out and keep cargo/rust-toolchain.toml in charge, or set `linker: <value>` to silence this warning.");
-        }
-    }
-    else if (!ALLOWED_LINKER_VALUES.includes(linkerRaw)) {
-        throw new Error(`invalid 'linker' input: '${linkerRaw}'. Allowed: default | platform-default | ld | mold | rust-lld | fast`);
-    }
-    else if (linkerRaw !== "default" && linkerRaw !== "platform-default") {
-        setEnv("SOLDR_LINKER", linkerRaw);
-    }
-    const compilePriorityRaw = inputs.compilePriority.trim();
-    if (compilePriorityRaw !== "") {
-        setEnv("ZCCACHE_COMPILE_PRIORITY", compilePriorityRaw);
-    }
-    if (cacheShutdownOnIdleSeconds !== null) {
-        // Set both env vars. zccache reads its own, sccache reads the
-        // SCCACHE_-prefixed one; exporting both means a zccache fork that
-        // still honors only the sccache name keeps working, and a vanilla
-        // sccache invoked via this action would too.
-        const seconds = String(cacheShutdownOnIdleSeconds);
-        setEnv("ZCCACHE_IDLE_TIMEOUT", seconds);
-        setEnv("SCCACHE_IDLE_TIMEOUT", seconds);
-    }
-    if (rustBacktraceValue !== null) {
-        setEnv("RUST_BACKTRACE", rustBacktraceValue);
-    }
-    // Auto-export cc-rs cross-compile env for *-unknown-linux-musl triples
-    // when the matching `<triple>-gcc/g++/ar` binaries are on PATH. cc-rs
-    // strips the "-unknown-" segment when looking up cross compilers, so
-    // archives that ship binaries with the full triple are missed without
-    // these per-target overrides. See setup-soldr#... and the cc-rs docs.
-    const muslCcHits = (0, detect_musl_cc_js_1.detectMuslCcEnv)(env);
-    for (const hit of muslCcHits) {
-        const suffix = (0, detect_musl_cc_js_1.tripleToCcRsSuffix)(hit.triple);
-        for (const [name, value] of Object.entries(hit.exports)) {
-            setEnv(name, value);
-        }
-        logger.warning(`setup-soldr: auto-exporting cc-rs cross-compile env for ${hit.triple} ` +
-            `(CC_${suffix}=${hit.exports[`CC_${suffix}`]}, ` +
-            `CXX_${suffix}=${hit.exports[`CXX_${suffix}`]}, ` +
-            `AR_${suffix}=${hit.exports[`AR_${suffix}`]}) ` +
-            "because cc-rs strips \"-unknown-\" from the triple when probing for a " +
-            "cross compiler and would otherwise fall back to the host gcc. " +
-            `Resolved: cc=${hit.resolvedPaths.cc}, cxx=${hit.resolvedPaths.cxx}, ar=${hit.resolvedPaths.ar}. ` +
-            `Pre-set CC_${suffix} yourself to opt out.`);
-    }
-    // ---- path additions ----
-    const pathAdditions = [binDir, path.join(cargoHome, "bin")];
-    // ---- logging summary ----
-    log("setup-soldr cache plan");
-    log(`cache key=${cacheKey}`);
-    log(`cache restore-key=${cachePrefix}-`);
-    log(`build-cache key=${buildCacheKey}`);
-    log(`build-cache mode=${buildCacheMode}`);
-    log(`build-cache soldr-mode=${buildCacheRuntimeMode}`);
-    if (buildCacheParentKey) {
-        log(`build-cache restore-key-parent=${buildCacheParentKey}`);
-    }
-    log(`build-cache restore-key-toolchain=${buildCacheToolchainPrefix}`);
-    log(`build-cache restore-key-os-arch=${buildCachePrefix}-`);
-    log(`target-cache key=${targetCacheKey}`);
-    log(`target-cache enabled=${targetCacheEnabled ? "true" : "false"}`);
-    log(`target-cache mode=${targetCacheEffectiveMode}`);
-    log("target-cache backend=local");
-    if (targetCacheEnabled) {
-        log(`target-cache soft-budget-bytes=${targetCacheBudgetBytes}`);
-        log(`target-cache soft-budget-files=${targetCacheBudgetFiles}`);
-    }
-    log(`soldr repo=${soldrRepo}`);
-    log(`soldr ref=${soldrRef || "release"}`);
-    if (soldrVersionResolved) {
-        log(`soldr version=${soldrVersionResolved}`);
-    }
-    log(`toolchain channel=${toolchain.channel}`);
-    log(`toolchain cache-channel=${toolchain.cacheChannel}`);
-    log(`rustup strategy=${rustupStrategy}`);
-    log(`setup-cache layout=${setupCacheLayoutValue}`);
-    if (targetCacheParentKey) {
-        log(`target-cache restore-key-parent=${targetCacheParentKey}`);
-    }
-    log(`target-cache restore-key-lock=${targetCacheLockPrefix}`);
-    log(`target-cache restore-key-lockfile=${targetCacheLockfilePrefix}`);
-    log(`target-cache paths=${targetCachePaths}`);
-    log(`target-cache bundle-dir=${targetCacheBundlePath}`);
-    log(`target-cache lockfile=${(0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath)}`);
-    log(`target-cache lockfile-hash=${cargoLockHash}`);
-    // ---- assemble plans ----
-    const setupCache = {
-        key: cacheKey,
-        restorePrefix: `${cachePrefix}-`,
-        paths: setupCachePathsList ? setupCachePathsList.split("\n") : [],
-        setupCachePath,
-        layout: setupCacheLayoutValue,
-    };
-    const buildCache = {
-        key: buildCacheKey,
-        restoreKeyParent: buildCacheParentKey,
-        restoreKeyToolchain: buildCacheToolchainPrefix,
-        restoreKeyOsArch: `${buildCachePrefix}-`,
-        path: zccacheCacheDir,
-        mode: buildCacheMode,
-    };
-    const targetCache = {
-        enabled: targetCacheEnabled,
-        key: targetCacheKey,
-        restoreKeyParent: targetCacheParentKey,
-        restoreKeyLock: targetCacheLockPrefix,
-        restoreKeyLockfile: targetCacheLockfilePrefix,
-        paths: targetCachePaths,
-        bundlePath: targetCacheBundlePath,
-        targetPath: targetCachePath,
-        effectiveMode: targetCacheEffectiveMode,
-        profile: targetCacheProfile,
-        budgetBytes: targetCacheBudgetBytes,
-        budgetFiles: targetCacheBudgetFiles,
-        lockfilePath: (0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath),
-        lockfileHash: cargoLockHash,
-    };
-    const cargoRegistryCachePlan = {
-        enabled: cargoRegistryCacheEnabled,
-        key: cargoRegistryCacheKey,
-        restorePrefix: cargoRegistryCacheRestorePrefix,
-        path: cargoRegistryCachePath,
-    };
-    // Avoid unused warnings on alias helper.
-    void toolchain_js_1.rollingToolchainAlias;
-    void cache_keys_js_1.canonicalJsonStringify;
-    const compileCacheStats = (0, input_parsers_js_1.normalizeCompileCacheStats)(inputs.compileCacheStats);
-    const stats = (0, input_parsers_js_1.normalizeStatsMode)(inputs.stats);
-    const debugMode = isTruthy(inputs.debugMode.trim() || "false");
-    // ---- shims ----
-    const shimsRaw = inputs.shims.trim() || "false";
-    const shimsEnabled = !isFalsy(shimsRaw);
-    const shimsDir = path.join(cacheRoot, "shims");
-    return {
-        enabled,
-        workspace,
-        cacheRoot,
-        soldrRoot,
-        binDir,
-        cargoHome,
-        rustupHome,
-        soldrPath,
-        soldrBinCachePath,
-        toolchain,
-        rustupStrategy,
-        soldrRepo,
-        soldrRef,
-        soldrVersionRequested,
-        soldrVersionResolved,
-        setupCache,
-        buildCache,
-        targetCache,
-        cargoRegistryCache: cargoRegistryCachePlan,
-        targetCacheCompress,
-        targetCacheCompressLevel,
-        envExports,
-        pathAdditions,
-        logStartEpoch: logStart,
-        timestamps,
-        shimsEnabled,
-        shimsDir,
-        compileCacheStats,
-        stats,
-        debugMode,
-        cacheShutdownOnIdleSeconds,
-    };
-}
-/**
- * Apply ResolveResult to the runner: write $GITHUB_ENV, $GITHUB_PATH, and
- * $GITHUB_OUTPUT keys.
- */
-async function applyResolveResult(result) {
-    for (const [name, value] of Object.entries(result.envExports)) {
-        if (GITHUB_ENV_DENY_LIST.has(name))
-            continue;
-        core.exportVariable(name, value);
-    }
-    for (const p of result.pathAdditions) {
-        core.addPath(p);
-    }
-    const outputs = (0, build_outputs_js_1.buildOutputs)(result);
-    for (const [key, value] of Object.entries(outputs)) {
-        core.setOutput(key, value);
-    }
-}
-// `buildOutputs` and `pythonDefaultJson` are re-exported at the top of
-// this file from their dedicated submodules.
-
-
-/***/ }),
-
 /***/ 468:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -83036,7 +83086,7 @@ __export(debug_exports, {
   default: () => debug_default
 });
 module.exports = __toCommonJS(debug_exports);
-var import_log = __nccwpck_require__(488);
+var import_log = __nccwpck_require__(489);
 const debugEnvVariable = typeof process !== "undefined" && process.env && process.env.DEBUG || void 0;
 let enabledString;
 let enabledNamespaces = [];
@@ -83877,7 +83927,7 @@ exports.attachCredential = attachCredential;
 exports.httpAuthorizationToString = httpAuthorizationToString;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(103);
 const core_util_1 = __nccwpck_require__(14);
 const constants_js_1 = __nccwpck_require__(36);
 /**
@@ -84560,7 +84610,7 @@ module.exports = Dispatcher
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceType = void 0;
-const reflection_info_1 = __nccwpck_require__(529);
+const reflection_info_1 = __nccwpck_require__(530);
 class ServiceType {
     constructor(typeName, methods, options) {
         this.typeName = typeName;
@@ -84583,9 +84633,9 @@ exports.ServiceType = ServiceType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
-const tslib_1 = __nccwpck_require__(217);
-const base64 = tslib_1.__importStar(__nccwpck_require__(438));
-const interfaces_js_1 = __nccwpck_require__(100);
+const tslib_1 = __nccwpck_require__(216);
+const base64 = tslib_1.__importStar(__nccwpck_require__(439));
+const interfaces_js_1 = __nccwpck_require__(101);
 const utils_js_1 = __nccwpck_require__(313);
 class SerializerImpl {
     modelMappers;
@@ -85529,10 +85579,10 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 
 const { Writable } = __nccwpck_require__(131)
 const diagnosticsChannel = __nccwpck_require__(142)
-const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(466)
-const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(99)
+const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(467)
+const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(100)
 const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(57)
-const { WebsocketFrameSend } = __nccwpck_require__(188)
+const { WebsocketFrameSend } = __nccwpck_require__(186)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -85874,6 +85924,334 @@ module.exports = {
 /***/ }),
 
 /***/ 484:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Cook cache layer — long-lived deps tarball keyed by Cargo.lock content.
+//
+// Per CLAUDE.md "Cache-lifetime axis" + the cook simulation findings:
+// the cook cache is short-lived/large (churns on every Cargo.lock change,
+// 100s of MB to multi-GB). It must NOT include SHA in the key (causes
+// catastrophic eviction churn). Content-addressable keying gives parent-
+// to-branch sharing automatically: same Cargo.lock = same key, regardless
+// of branch or commit.
+//
+// Save path: snapshot `target/` immediately after cook completes, before
+// the user's `cargo build` adds project artifacts. We tar+zstd-19 with
+// `--long=27` because compiled rust deps have heavy cross-crate
+// redundancy that benefits from the 128 MB zstd window.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.hashCookFlags = hashCookFlags;
+exports.buildCookCacheKey = buildCookCacheKey;
+exports.decideCookGate = decideCookGate;
+exports.runCook = runCook;
+exports.restoreCookCache = restoreCookCache;
+exports.saveCookCache = saveCookCache;
+exports.parseCookFlags = parseCookFlags;
+exports.canonicalizeCookFlags = canonicalizeCookFlags;
+const node_crypto_1 = __nccwpck_require__(275);
+const fs = __importStar(__nccwpck_require__(249));
+const fsp = __importStar(__nccwpck_require__(110));
+const path = __importStar(__nccwpck_require__(509));
+const exec = __importStar(__nccwpck_require__(18));
+const cache = __importStar(__nccwpck_require__(214));
+const cache_compress_js_1 = __nccwpck_require__(529);
+const COOK_KEY_PREFIX = "cook";
+/**
+ * Compute the canonical flag fingerprint. Sorts and lowercases so flag
+ * order doesn't perturb the key, and so `--release` vs `--RELEASE`
+ * collapse. Only flags that affect cook output structure should be
+ * here; cosmetic flags must be filtered upstream.
+ */
+function hashCookFlags(flags) {
+    const sorted = [...flags.map((s) => s.trim()).filter((s) => s.length > 0)].sort();
+    if (sorted.length === 0)
+        return "none";
+    const h = (0, node_crypto_1.createHash)("sha256");
+    for (const s of sorted) {
+        h.update(s);
+        h.update("\0");
+    }
+    return h.digest("hex").slice(0, 8);
+}
+function buildCookCacheKey(parts) {
+    const release = parts.rustcRelease.trim() || "unresolved";
+    return [
+        COOK_KEY_PREFIX,
+        parts.runnerOs,
+        parts.runnerArch,
+        parts.libc,
+        `rustc${release}`,
+        `f${parts.flagsHash}`,
+        `l${parts.lockHash}`,
+        `soldr${parts.soldrVersion}`,
+    ].join("-");
+}
+/**
+ * Decide whether to run cook based on the runtime environment. Returns a
+ * reason string for diagnostic logging in both branches.
+ */
+function decideCookGate(opts) {
+    const mode = opts.prebuildDeps.trim().toLowerCase();
+    if (mode === "" || mode === "none" || mode === "off" || mode === "false") {
+        return { enabled: false, reason: `prebuild-deps=${opts.prebuildDeps || "(empty)"} - cook disabled` };
+    }
+    if (mode !== "cargo-chef") {
+        return {
+            enabled: false,
+            reason: `prebuild-deps=${opts.prebuildDeps} - unknown strategy, only "cargo-chef" supported`,
+        };
+    }
+    if (!opts.cacheUmbrella) {
+        return { enabled: false, reason: "cache: false - cook produces no value without caching" };
+    }
+    if (!opts.lockfilePath) {
+        return { enabled: false, reason: "no Cargo.lock found - cook needs a lockfile to derive recipe" };
+    }
+    if (!fs.existsSync(opts.lockfilePath)) {
+        return { enabled: false, reason: `Cargo.lock path ${opts.lockfilePath} does not exist` };
+    }
+    return { enabled: true, reason: "cook enabled" };
+}
+/**
+ * Run `soldr cook` in the project directory. Cargo-chef itself emits
+ * the recipe and runs the cook compile. We tolerate failure: cook is
+ * an optimization, not a correctness primitive, so any non-zero exit
+ * is logged and the action proceeds. The user's normal `cargo build`
+ * step will work fine without a cooked target.
+ */
+async function runCook(opts) {
+    const { soldrBinary, projectRoot, flags, log } = opts;
+    log(`cook: running '${soldrBinary} cook ${flags.join(" ")}' in ${projectRoot}`);
+    const t0 = Date.now();
+    let exitCode = 0;
+    try {
+        exitCode = await exec.exec(soldrBinary, ["cook", ...flags], {
+            cwd: projectRoot,
+            ignoreReturnCode: true,
+        });
+    }
+    catch (err) {
+        log(`cook: exec threw: ${err instanceof Error ? err.message : String(err)}`);
+        exitCode = 1;
+    }
+    const ranSeconds = (Date.now() - t0) / 1000;
+    if (exitCode !== 0) {
+        log(`cook: failed with exit ${exitCode} after ${ranSeconds.toFixed(1)}s; continuing without cooked deps`);
+    }
+    else {
+        log(`cook: completed in ${ranSeconds.toFixed(1)}s`);
+    }
+    return { exitCode, ranSeconds };
+}
+/**
+ * Attempt to restore a cooked target directory from the actions cache.
+ * Single exact key — no fallback ladder; cook is content-addressable so
+ * a fallback would either be redundant or wrong.
+ */
+async function restoreCookCache(opts) {
+    const { exactKey, archivePath, targetDir, longWindow, log } = opts;
+    await fsp.mkdir(path.dirname(archivePath), { recursive: true });
+    await fsp.rm(archivePath, { force: true });
+    let matched;
+    try {
+        matched = await cache.restoreCache([archivePath], exactKey);
+    }
+    catch (err) {
+        log(`cook-cache: restore failed: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "", archiveBytes: 0 };
+    }
+    if (!matched) {
+        log(`cook-cache: no entry for key ${exactKey}`);
+        return { hit: false, matchedKey: "", archiveBytes: 0 };
+    }
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fsp.stat(archivePath)).size;
+    }
+    catch {
+        return { hit: false, matchedKey: matched, archiveBytes: 0 };
+    }
+    const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+    if (magic !== "zstd" && magic !== "gzip") {
+        log(`cook-cache: restored archive has unknown codec, treating as miss`);
+        return { hit: false, matchedKey: matched, archiveBytes };
+    }
+    await fsp.mkdir(targetDir, { recursive: true });
+    try {
+        await (0, cache_compress_js_1.decompressCache)({
+            archivePath,
+            targetDir,
+            longWindow,
+            log,
+            debug: opts.debug,
+        });
+    }
+    catch (err) {
+        log(`cook-cache: decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: matched, archiveBytes };
+    }
+    log(`cook-cache: restored matched=${matched} archive=${archiveBytes}B target=${targetDir}`);
+    return { hit: true, matchedKey: matched, archiveBytes };
+}
+/**
+ * Tar+zstd the post-cook target directory and upload via actions cache.
+ * Caller passes the same `longWindow` as the restore side so the archive
+ * is readable on subsequent runs.
+ */
+async function saveCookCache(opts) {
+    const { targetDir, exactKey, level, longWindow, debug, log } = opts;
+    if (!fs.existsSync(targetDir)) {
+        return { status: "skipped-missing-target" };
+    }
+    // Bail if the directory is effectively empty — cook should have produced
+    // *something*; an empty target dir indicates cook failed silently or the
+    // gate let us through when it shouldn't have.
+    let entryCount = 0;
+    try {
+        entryCount = (await fsp.readdir(targetDir)).length;
+    }
+    catch { /* */ }
+    if (entryCount === 0) {
+        return { status: "skipped-empty" };
+    }
+    let archivePath = null;
+    let archiveBytes;
+    let inflatedBytes;
+    let fileCount;
+    try {
+        const compress = await (0, cache_compress_js_1.compressCache)({
+            cacheDir: targetDir,
+            codec: "zstd",
+            level,
+            longWindow,
+            debug,
+            log,
+        });
+        archivePath = compress.archivePath;
+        archiveBytes = compress.archiveBytes;
+        if (compress.inflatedBytes !== null)
+            inflatedBytes = compress.inflatedBytes;
+        if (compress.fileCount !== null)
+            fileCount = compress.fileCount;
+    }
+    catch (err) {
+        return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+    }
+    if (!archivePath) {
+        return { status: "failed", error: "compressCache returned null archive (zstd unavailable?)" };
+    }
+    try {
+        const id = await cache.saveCache([archivePath], exactKey);
+        if (id <= 0) {
+            // @actions/cache returns -1 when reserveCache fails — typically
+            // because the key already exists (parallel job got there first)
+            // or the cache budget is exhausted. Not an error: future runs
+            // will hit the entry the other job saved.
+            log(`cook-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
+                `job already saved key=${exactKey} or repo cache budget is exhausted`);
+            return {
+                status: "skipped-race",
+                cacheId: id,
+                archiveBytes,
+                inflatedBytes,
+                fileCount,
+                archivePath,
+            };
+        }
+        log(`cook-cache: saved id=${id} key=${exactKey} archive=${archivePath}`);
+        return {
+            status: "saved",
+            cacheId: id,
+            archiveBytes,
+            inflatedBytes,
+            fileCount,
+            archivePath,
+        };
+    }
+    catch (err) {
+        return {
+            status: "failed",
+            error: err instanceof Error ? err.message : String(err),
+            archivePath,
+        };
+    }
+}
+/** Tokenize a free-form flags string into a flags array. Whitespace-split. */
+function parseCookFlags(raw) {
+    return raw
+        .trim()
+        .split(/\s+/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+}
+/**
+ * From a flags array, extract only the tokens that materially affect cook
+ * output structure for hashing. Excludes verbosity / colour flags.
+ *
+ * Conservative: keep anything that isn't on a known-cosmetic list. This
+ * over-keys (extra misses on cosmetic-only changes) rather than under-keys
+ * (serving stale cooked artifacts under a key that doesn't reflect them).
+ */
+function canonicalizeCookFlags(flags) {
+    const COSMETIC = new Set([
+        "--verbose", "-v", "-vv", "--quiet", "-q",
+        "--color=auto", "--color=always", "--color=never",
+        "--no-default-features", // affects output; KEEP — moved out below
+    ]);
+    COSMETIC.delete("--no-default-features"); // safety net for the comment above
+    const out = [];
+    for (let i = 0; i < flags.length; i++) {
+        const f = flags[i];
+        if (COSMETIC.has(f))
+            continue;
+        if (f === "--color" || f === "--message-format") {
+            i += 1; // skip the value
+            continue;
+        }
+        out.push(f);
+    }
+    return out;
+}
+
+
+/***/ }),
+
+/***/ 485:
 /***/ ((module) => {
 
 "use strict";
@@ -85897,7 +86275,7 @@ module.exports = function getLimit (limits, name, defaultLimit) {
 
 /***/ }),
 
-/***/ 485:
+/***/ 486:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -85948,7 +86326,7 @@ exports.assertFloat32 = assertFloat32;
 
 /***/ }),
 
-/***/ 486:
+/***/ 487:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -86061,10 +86439,10 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 487:
+/***/ 488:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __nccwpck_require__(351);
+var concatMap = __nccwpck_require__(352);
 var balanced = __nccwpck_require__(132);
 
 module.exports = expandTop;
@@ -86271,7 +86649,7 @@ function expand(str, max, isTop) {
 
 /***/ }),
 
-/***/ 488:
+/***/ 489:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -86306,8 +86684,8 @@ __export(log_exports, {
   log: () => log
 });
 module.exports = __toCommonJS(log_exports);
-var import_node_os = __nccwpck_require__(383);
-var import_node_util = __toESM(__nccwpck_require__(376));
+var import_node_os = __nccwpck_require__(384);
+var import_node_util = __toESM(__nccwpck_require__(377));
 var import_node_process = __toESM(__nccwpck_require__(237));
 function log(message, ...args) {
   import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
@@ -86319,7 +86697,7 @@ function log(message, ...args) {
 
 /***/ }),
 
-/***/ 489:
+/***/ 490:
 /***/ ((module) => {
 
 "use strict";
@@ -86557,7 +86935,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 490:
+/***/ 491:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -86569,10 +86947,10 @@ exports.serializationPolicyName = void 0;
 exports.serializationPolicy = serializationPolicy;
 exports.serializeHeaders = serializeHeaders;
 exports.serializeRequestBody = serializeRequestBody;
-const interfaces_js_1 = __nccwpck_require__(100);
-const operationHelpers_js_1 = __nccwpck_require__(433);
+const interfaces_js_1 = __nccwpck_require__(101);
+const operationHelpers_js_1 = __nccwpck_require__(434);
 const serializer_js_1 = __nccwpck_require__(481);
-const interfaceHelpers_js_1 = __nccwpck_require__(400);
+const interfaceHelpers_js_1 = __nccwpck_require__(401);
 /**
  * The programmatic identifier of the serializationPolicy.
  */
@@ -86721,7 +87099,7 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 /***/ }),
 
-/***/ 491:
+/***/ 492:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -86993,7 +87371,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 492:
+/***/ 493:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -87019,13 +87397,13 @@ __export(clientHelpers_exports, {
   getCachedDefaultHttpsClient: () => getCachedDefaultHttpsClient
 });
 module.exports = __toCommonJS(clientHelpers_exports);
-var import_defaultHttpClient = __nccwpck_require__(373);
+var import_defaultHttpClient = __nccwpck_require__(374);
 var import_createPipelineFromOptions = __nccwpck_require__(316);
-var import_apiVersionPolicy = __nccwpck_require__(228);
-var import_credentials = __nccwpck_require__(189);
-var import_apiKeyAuthenticationPolicy = __nccwpck_require__(88);
+var import_apiVersionPolicy = __nccwpck_require__(227);
+var import_credentials = __nccwpck_require__(187);
+var import_apiKeyAuthenticationPolicy = __nccwpck_require__(89);
 var import_basicAuthenticationPolicy = __nccwpck_require__(153);
-var import_bearerAuthenticationPolicy = __nccwpck_require__(381);
+var import_bearerAuthenticationPolicy = __nccwpck_require__(382);
 var import_oauth2AuthenticationPolicy = __nccwpck_require__(339);
 let cachedHttpClient;
 function createDefaultPipeline(options = {}) {
@@ -87066,7 +87444,7 @@ function getCachedDefaultHttpsClient() {
 
 /***/ }),
 
-/***/ 493:
+/***/ 494:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -87076,7 +87454,7 @@ function getCachedDefaultHttpsClient() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetriableReadableStream = void 0;
 const abort_controller_1 = __nccwpck_require__(497);
-const node_stream_1 = __nccwpck_require__(431);
+const node_stream_1 = __nccwpck_require__(432);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -87201,317 +87579,6 @@ class RetriableReadableStream extends node_stream_1.Readable {
 }
 exports.RetriableReadableStream = RetriableReadableStream;
 //# sourceMappingURL=RetriableReadableStream.js.map
-
-/***/ }),
-
-/***/ 494:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Tar+zstd cache compression helpers. Owned by Agent 2.
-//
-// Used by src/main.ts (restore: auto-detect .tar.zst, decompress in place)
-// and src/post.ts (save: tar+zstd the cache dir).
-//
-// Acceptance criterion #1 + #2 of zackees/setup-soldr#70: post-job tar+zstd
-// at level configured by target-cache-compress-level, restore auto-detects
-// zstd vs gzip magic bytes for back-compat.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.walkDirSize = walkDirSize;
-exports.detectCompressMagic = detectCompressMagic;
-exports.decompressCache = decompressCache;
-exports.compressCache = compressCache;
-const fs = __importStar(__nccwpck_require__(109));
-const path = __importStar(__nccwpck_require__(509));
-const core = __importStar(__nccwpck_require__(460));
-const exec = __importStar(__nccwpck_require__(18));
-const io = __importStar(__nccwpck_require__(295));
-/**
- * Recursively walk a directory and sum file sizes.
- */
-async function walkDirSize(dir) {
-    let bytes = 0;
-    let files = 0;
-    async function walk(d) {
-        let entries;
-        try {
-            entries = await fs.readdir(d, { withFileTypes: true });
-        }
-        catch {
-            return;
-        }
-        for (const entry of entries) {
-            const full = path.join(d, entry.name);
-            if (entry.isDirectory()) {
-                await walk(full);
-            }
-            else if (entry.isFile()) {
-                try {
-                    bytes += (await fs.stat(full)).size;
-                    files++;
-                }
-                catch {
-                    // skip inaccessible files
-                }
-            }
-        }
-    }
-    await walk(dir);
-    return { bytes, files };
-}
-function fmtBytesDebug(n) {
-    if (n < 1024)
-        return `${n}B`;
-    if (n < 1024 * 1024)
-        return `${(n / 1024).toFixed(1)}KB`;
-    if (n < 1024 * 1024 * 1024)
-        return `${(n / 1024 / 1024).toFixed(1)}MB`;
-    return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
-}
-/**
- * Read the first 4 bytes of a file and identify the compression codec.
- *   zstd:  0x28 B5 2F FD
- *   gzip:  0x1F 8B
- */
-async function detectCompressMagic(filePath) {
-    let handle = null;
-    try {
-        handle = await fs.open(filePath, "r");
-        const buf = Buffer.alloc(4);
-        const { bytesRead } = await handle.read(buf, 0, 4, 0);
-        if (bytesRead >= 4 && buf[0] === 0x28 && buf[1] === 0xb5 && buf[2] === 0x2f && buf[3] === 0xfd) {
-            return "zstd";
-        }
-        if (bytesRead >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
-            return "gzip";
-        }
-        return "unknown";
-    }
-    catch {
-        return "unknown";
-    }
-    finally {
-        if (handle)
-            await handle.close().catch(() => undefined);
-    }
-}
-async function ensureDir(dir) {
-    await fs.mkdir(dir, { recursive: true });
-}
-async function pathExists(p) {
-    try {
-        await fs.access(p);
-        return true;
-    }
-    catch {
-        return false;
-    }
-}
-/**
- * Decompress <cache-dir>.tar.zst (or .tar.gz) into <cache-dir>.
- *
- *   zstd: `zstd -d <archive>` piped into `tar -xf - -C <extractRoot>`.
- *   gzip: `tar -xzf <archive> -C <extractRoot>`.
- *
- * `extractRoot` is `dirname(targetDir)` because compressCache writes
- * archives via `tar -cf - -C <parent> <basename>` — the archive's
- * top-level directory IS `<basename>`. If we extract into <targetDir>
- * directly, that <basename> gets nested twice and the contents end up
- * at <targetDir>/<basename>/... where zccache and cargo can't find them.
- * That double-nesting is the root cause of the long-standing zccache
- * "0 hits despite restored artifacts" symptom.
- *
- * Returns compressed/inflated byte counts and file count (the count is
- * taken from <targetDir> after extraction, so consumers see exactly
- * what landed in the cache dir).
- * When debug=true, logs diagnostics via the supplied log fn.
- */
-async function decompressCache(opts) {
-    const { archivePath, targetDir, debug = false, log = () => undefined, longWindow } = opts;
-    // Ensure both <targetDir> exists (zccache may have already populated it)
-    // and the extract root (which is the parent) is writable.
-    await ensureDir(targetDir);
-    const extractRoot = path.dirname(targetDir);
-    await ensureDir(extractRoot);
-    let archiveBytes = 0;
-    try {
-        archiveBytes = (await fs.stat(archivePath)).size;
-    }
-    catch { /* archive may not exist */ }
-    const magic = await detectCompressMagic(archivePath);
-    if (debug) {
-        log(`[debug] decompress ${path.basename(archivePath)}: magic=${magic} archive=${fmtBytesDebug(archiveBytes)}`);
-    }
-    if (magic === "gzip") {
-        if (debug)
-            log(`[debug] decompress cmd: tar -xzf ${archivePath} -C ${extractRoot}`);
-        await exec.exec("tar", ["-xzf", archivePath, "-C", extractRoot]);
-    }
-    else if (magic === "zstd") {
-        const zstdPath = await io.which("zstd", false);
-        const longFlag = typeof longWindow === "number" ? [`--long=${longWindow}`] : [];
-        if (!zstdPath) {
-            if (debug)
-                log(`[debug] decompress cmd (fallback): tar --use-compress-program "zstd -d${longFlag.length ? ` --long=${longWindow}` : ""}" -xf ${archivePath} -C ${extractRoot}`);
-            // Fall back: route the decompression through tar's --use-compress-program
-            // so we can pass through --long when the archive needs it. tar --zstd
-            // doesn't accept extra zstd flags directly.
-            const program = longFlag.length ? `zstd -d --long=${longWindow}` : "zstd -d";
-            await exec.exec("tar", ["--use-compress-program", program, "-xf", archivePath, "-C", extractRoot]);
-        }
-        else {
-            if (debug)
-                log(`[debug] decompress cmd: zstd -d ${longFlag.join(" ")} -c ${archivePath} | tar -xf - -C ${extractRoot}`);
-            await runPipe([zstdPath, ["-d", ...longFlag, "-c", archivePath]], ["tar", ["-xf", "-", "-C", extractRoot]]);
-        }
-    }
-    else {
-        throw new Error(`decompressCache: unrecognized archive magic for ${archivePath}`);
-    }
-    const { bytes: inflatedBytes, files: fileCount } = await walkDirSize(targetDir);
-    if (debug) {
-        const ratio = archiveBytes > 0 && inflatedBytes > 0 ? (archiveBytes / inflatedBytes).toFixed(2) : "n/a";
-        log(`[debug] decompress result: inflated=${fmtBytesDebug(inflatedBytes)} files=${fileCount} ratio=${ratio}`);
-    }
-    return { archiveBytes, inflatedBytes, fileCount };
-}
-/**
- * tar -cf - <cache-dir-basename> | zstd -T0 -<level> > <cache-dir>.tar.zst
- *
- * When codec=="none" or zstd is not installed, returns archivePath=null and
- * leaves the caller to use the default actions/cache compression.
- * When debug=true, walks the source dir for byte/file counts and logs ratios.
- */
-async function compressCache(opts) {
-    const { cacheDir, codec, level, debug = false, log = () => undefined, longWindow, ultra } = opts;
-    const nullResult = { archivePath: null, archiveBytes: 0, inflatedBytes: null, fileCount: null };
-    if (codec === "none")
-        return nullResult;
-    const zstdPath = await io.which("zstd", false);
-    if (!zstdPath) {
-        core.warning("setup-soldr: zstd binary not found on PATH; falling back to actions/cache default codec");
-        return nullResult;
-    }
-    if (!(await pathExists(cacheDir))) {
-        core.warning(`setup-soldr: cache dir ${cacheDir} does not exist, skipping compression`);
-        return nullResult;
-    }
-    let inflatedBytes = null;
-    let fileCount = null;
-    if (debug) {
-        const walked = await walkDirSize(cacheDir);
-        inflatedBytes = walked.bytes;
-        fileCount = walked.files;
-        log(`[debug] compress ${path.basename(cacheDir)}: input=${fmtBytesDebug(inflatedBytes)} files=${fileCount}`);
-    }
-    const parent = path.dirname(cacheDir);
-    const basename = path.basename(cacheDir);
-    const archivePath = `${cacheDir}.tar.zst`;
-    // Best-effort cleanup of any previous archive.
-    await fs.rm(archivePath, { force: true }).catch(() => undefined);
-    const levelNumeric = parseLevel(level);
-    const levelFlag = `-${levelNumeric}`;
-    const longFlag = typeof longWindow === "number" ? [`--long=${longWindow}`] : [];
-    const ultraFlag = ultra || levelNumeric >= 20 ? ["--ultra"] : [];
-    if (debug)
-        log(`[debug] compress cmd: tar -cf - -C ${parent} ${basename} | zstd -T0 ${levelFlag}${longFlag.length ? ` --long=${longWindow}` : ""}${ultraFlag.length ? " --ultra" : ""} -o ${archivePath}`);
-    await runPipe(["tar", ["-cf", "-", "-C", parent, basename]], [zstdPath, ["-T0", levelFlag, ...longFlag, ...ultraFlag, "-o", archivePath]]);
-    let archiveBytes = 0;
-    try {
-        archiveBytes = (await fs.stat(archivePath)).size;
-    }
-    catch { /* archive may not exist */ }
-    if (debug && inflatedBytes !== null && inflatedBytes > 0) {
-        log(`[debug] compress result: archive=${fmtBytesDebug(archiveBytes)} ratio=${(archiveBytes / inflatedBytes).toFixed(2)}`);
-    }
-    return { archivePath, archiveBytes, inflatedBytes, fileCount };
-}
-function parseLevel(value) {
-    const trimmed = (value ?? "").toString().trim();
-    if (!trimmed)
-        return 3;
-    const parsed = Number(trimmed);
-    if (Number.isNaN(parsed) || !Number.isFinite(parsed))
-        return 3;
-    const clamped = Math.max(1, Math.min(22, Math.floor(parsed)));
-    return clamped;
-}
-/**
- * Run two processes piped together: producer.stdout -> consumer.stdin.
- * Bubbles non-zero exit codes from either side.
- */
-async function runPipe(producer, consumer) {
-    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 198, 23));
-    const [pCmd, pArgs] = producer;
-    const [cCmd, cArgs] = consumer;
-    await new Promise((resolve, reject) => {
-        const prod = spawn(pCmd, pArgs, { stdio: ["ignore", "pipe", "inherit"] });
-        const cons = spawn(cCmd, cArgs, { stdio: ["pipe", "inherit", "inherit"] });
-        prod.on("error", (err) => reject(err));
-        cons.on("error", (err) => reject(err));
-        if (prod.stdout && cons.stdin) {
-            prod.stdout.pipe(cons.stdin);
-        }
-        let prodExit = null;
-        let consExit = null;
-        const maybeDone = () => {
-            if (prodExit !== null && consExit !== null) {
-                if (prodExit !== 0) {
-                    reject(new Error(`${pCmd} exited with code ${prodExit}`));
-                }
-                else if (consExit !== 0) {
-                    reject(new Error(`${cCmd} exited with code ${consExit}`));
-                }
-                else {
-                    resolve();
-                }
-            }
-        };
-        prod.on("close", (code) => {
-            prodExit = code ?? 0;
-            maybeDone();
-        });
-        cons.on("close", (code) => {
-            consExit = code ?? 0;
-            maybeDone();
-        });
-    });
-}
-
 
 /***/ }),
 
@@ -87736,7 +87803,7 @@ exports.AbortError = AbortError;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQuickQueryStream = void 0;
-const node_stream_1 = __nccwpck_require__(431);
+const node_stream_1 = __nccwpck_require__(432);
 const index_js_1 = __nccwpck_require__(335);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -87883,12 +87950,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
-const os = __importStar(__nccwpck_require__(93));
+const os = __importStar(__nccwpck_require__(94));
 const path = __importStar(__nccwpck_require__(248));
-const pathHelper = __importStar(__nccwpck_require__(223));
+const pathHelper = __importStar(__nccwpck_require__(222));
 const assert_1 = __importDefault(__nccwpck_require__(528));
 const minimatch_1 = __nccwpck_require__(125);
-const internal_match_kind_1 = __nccwpck_require__(530);
+const internal_match_kind_1 = __nccwpck_require__(531);
 const internal_path_1 = __nccwpck_require__(121);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
@@ -88625,11 +88692,11 @@ const Readable = __nccwpck_require__(129)
 const {
   InvalidArgumentError,
   RequestAbortedError
-} = __nccwpck_require__(489)
+} = __nccwpck_require__(490)
 const util = __nccwpck_require__(69)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(190)
-const { AsyncResource } = __nccwpck_require__(430)
-const { addSignal, removeSignal } = __nccwpck_require__(104)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(188)
+const { AsyncResource } = __nccwpck_require__(431)
+const { addSignal, removeSignal } = __nccwpck_require__(105)
 
 class RequestHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -88851,13 +88918,13 @@ exports.shouldRefreshToolchain = shouldRefreshToolchain;
 exports.shouldSkipRefreshForExactHit = shouldSkipRefreshForExactHit;
 exports.ensureRustToolchain = ensureRustToolchain;
 const fs = __importStar(__nccwpck_require__(249));
-const os = __importStar(__nccwpck_require__(383));
+const os = __importStar(__nccwpck_require__(384));
 const path = __importStar(__nccwpck_require__(509));
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 const exec = __importStar(__nccwpck_require__(18));
 const io = __importStar(__nccwpck_require__(295));
 const tc = __importStar(__nccwpck_require__(524));
-const log_utils_js_1 = __nccwpck_require__(352);
+const log_utils_js_1 = __nccwpck_require__(353);
 function rustupInitTargetTriple() {
     const system = process.platform;
     const arch = process.arch;
@@ -89156,13 +89223,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TestTransport = void 0;
-const rpc_error_1 = __nccwpck_require__(177);
+const rpc_error_1 = __nccwpck_require__(175);
 const runtime_1 = __nccwpck_require__(19);
 const rpc_output_stream_1 = __nccwpck_require__(307);
-const rpc_options_1 = __nccwpck_require__(293);
+const rpc_options_1 = __nccwpck_require__(294);
 const unary_call_1 = __nccwpck_require__(56);
-const server_streaming_call_1 = __nccwpck_require__(452);
-const client_streaming_call_1 = __nccwpck_require__(350);
+const server_streaming_call_1 = __nccwpck_require__(453);
+const client_streaming_call_1 = __nccwpck_require__(351);
 const duplex_streaming_call_1 = __nccwpck_require__(306);
 /**
  * Transport for testing.
@@ -89661,7 +89728,7 @@ Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: fu
 if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
 	module.exports = __nccwpck_require__(469);
 } else {
-	module.exports = __nccwpck_require__(458);
+	module.exports = __nccwpck_require__(459);
 }
 
 
@@ -89675,7 +89742,7 @@ if (typeof process === 'undefined' || process.type === 'renderer' || process.bro
 
 
 
-const { kHeadersList, kConstruct } = __nccwpck_require__(196)
+const { kHeadersList, kConstruct } = __nccwpck_require__(194)
 const { kGuard } = __nccwpck_require__(15)
 const { kEnumerableProperty } = __nccwpck_require__(69)
 const {
@@ -89684,7 +89751,7 @@ const {
   isValidHeaderValue
 } = __nccwpck_require__(519)
 const util = __nccwpck_require__(124)
-const { webidl } = __nccwpck_require__(457)
+const { webidl } = __nccwpck_require__(458)
 const assert = __nccwpck_require__(528)
 
 const kHeadersMap = Symbol('headers map')
@@ -90279,7 +90346,7 @@ const { getGlobalOrigin } = __nccwpck_require__(140)
 const { performance } = __nccwpck_require__(321)
 const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(69)
 const assert = __nccwpck_require__(528)
-const { isUint8Array } = __nccwpck_require__(199)
+const { isUint8Array } = __nccwpck_require__(198)
 
 let supportedHashes = []
 
@@ -90288,7 +90355,7 @@ let supportedHashes = []
 let crypto
 
 try {
-  crypto = __nccwpck_require__(291)
+  crypto = __nccwpck_require__(292)
   const possibleRelevantHashes = ['sha256', 'sha384', 'sha512']
   supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
 /* c8 ignore next 3 */
@@ -91507,7 +91574,7 @@ module.exports = require("node:zlib");
 /***/ 522:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(491);
+module.exports = __nccwpck_require__(492);
 
 
 /***/ }),
@@ -91596,15 +91663,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.evaluateVersions = exports.isExplicitVersion = exports.findFromManifest = exports.getManifestFromRepo = exports.findAllVersions = exports.find = exports.cacheFile = exports.cacheDir = exports.extractZip = exports.extractXar = exports.extractTar = exports.extract7z = exports.downloadTool = exports.HTTPError = void 0;
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 const io = __importStar(__nccwpck_require__(295));
-const crypto = __importStar(__nccwpck_require__(291));
-const fs = __importStar(__nccwpck_require__(533));
+const crypto = __importStar(__nccwpck_require__(292));
+const fs = __importStar(__nccwpck_require__(534));
 const mm = __importStar(__nccwpck_require__(331));
-const os = __importStar(__nccwpck_require__(93));
+const os = __importStar(__nccwpck_require__(94));
 const path = __importStar(__nccwpck_require__(248));
 const httpm = __importStar(__nccwpck_require__(285));
-const semver = __importStar(__nccwpck_require__(180));
+const semver = __importStar(__nccwpck_require__(178));
 const stream = __importStar(__nccwpck_require__(131));
 const util = __importStar(__nccwpck_require__(124));
 const assert_1 = __nccwpck_require__(528);
@@ -92256,7 +92323,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(396);
+var import_exponentialRetryStrategy = __nccwpck_require__(397);
 var import_retryPolicy = __nccwpck_require__(16);
 var import_constants = __nccwpck_require__(48);
 const exponentialRetryPolicyName = "exponentialRetryPolicy";
@@ -92503,7 +92570,7 @@ function createEmptyPipeline() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SASQueryParameters = exports.SASProtocol = void 0;
-const SasIPRange_js_1 = __nccwpck_require__(359);
+const SasIPRange_js_1 = __nccwpck_require__(360);
 const utils_common_js_1 = __nccwpck_require__(155);
 /**
  * Protocols for generated SAS.
@@ -92877,6 +92944,332 @@ module.exports = require("assert");
 /***/ }),
 
 /***/ 529:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Tar+zstd cache compression helpers. Owned by Agent 2.
+//
+// Used by src/main.ts (restore: auto-detect .tar.zst, decompress in place)
+// and src/post.ts (save: tar+zstd the cache dir).
+//
+// Acceptance criterion #1 + #2 of zackees/setup-soldr#70: post-job tar+zstd
+// at level configured by target-cache-compress-level, restore auto-detects
+// zstd vs gzip magic bytes for back-compat.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.walkDirSize = walkDirSize;
+exports.detectCompressMagic = detectCompressMagic;
+exports.decompressCache = decompressCache;
+exports.compressCache = compressCache;
+const fs = __importStar(__nccwpck_require__(110));
+const path = __importStar(__nccwpck_require__(509));
+const core = __importStar(__nccwpck_require__(461));
+const exec = __importStar(__nccwpck_require__(18));
+const io = __importStar(__nccwpck_require__(295));
+/**
+ * Recursively walk a directory and sum file sizes.
+ */
+async function walkDirSize(dir) {
+    let bytes = 0;
+    let files = 0;
+    async function walk(d) {
+        let entries;
+        try {
+            entries = await fs.readdir(d, { withFileTypes: true });
+        }
+        catch {
+            return;
+        }
+        for (const entry of entries) {
+            const full = path.join(d, entry.name);
+            if (entry.isDirectory()) {
+                await walk(full);
+            }
+            else if (entry.isFile()) {
+                try {
+                    bytes += (await fs.stat(full)).size;
+                    files++;
+                }
+                catch {
+                    // skip inaccessible files
+                }
+            }
+        }
+    }
+    await walk(dir);
+    return { bytes, files };
+}
+function fmtBytesDebug(n) {
+    if (n < 1024)
+        return `${n}B`;
+    if (n < 1024 * 1024)
+        return `${(n / 1024).toFixed(1)}KB`;
+    if (n < 1024 * 1024 * 1024)
+        return `${(n / 1024 / 1024).toFixed(1)}MB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
+}
+/**
+ * Read the first 4 bytes of a file and identify the compression codec.
+ *   zstd:  0x28 B5 2F FD
+ *   gzip:  0x1F 8B
+ */
+async function detectCompressMagic(filePath) {
+    let handle = null;
+    try {
+        handle = await fs.open(filePath, "r");
+        const buf = Buffer.alloc(4);
+        const { bytesRead } = await handle.read(buf, 0, 4, 0);
+        if (bytesRead >= 4 && buf[0] === 0x28 && buf[1] === 0xb5 && buf[2] === 0x2f && buf[3] === 0xfd) {
+            return "zstd";
+        }
+        if (bytesRead >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
+            return "gzip";
+        }
+        return "unknown";
+    }
+    catch {
+        return "unknown";
+    }
+    finally {
+        if (handle)
+            await handle.close().catch(() => undefined);
+    }
+}
+async function ensureDir(dir) {
+    await fs.mkdir(dir, { recursive: true });
+}
+async function pathExists(p) {
+    try {
+        await fs.access(p);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+/**
+ * Decompress <cache-dir>.tar.zst (or .tar.gz) into <cache-dir>.
+ *
+ *   zstd: `zstd -d <archive>` piped into `tar -xf - -C <extractRoot>`.
+ *   gzip: `tar -xzf <archive> -C <extractRoot>`.
+ *
+ * `extractRoot` is `dirname(targetDir)` because compressCache writes
+ * archives via `tar -cf - -C <parent> <basename>` — the archive's
+ * top-level directory IS `<basename>`. If we extract into <targetDir>
+ * directly, that <basename> gets nested twice and the contents end up
+ * at <targetDir>/<basename>/... where zccache and cargo can't find them.
+ * That double-nesting is the root cause of the long-standing zccache
+ * "0 hits despite restored artifacts" symptom.
+ *
+ * Returns compressed/inflated byte counts and file count (the count is
+ * taken from <targetDir> after extraction, so consumers see exactly
+ * what landed in the cache dir).
+ * When debug=true, logs diagnostics via the supplied log fn.
+ */
+async function decompressCache(opts) {
+    const { archivePath, targetDir, debug = false, log = () => undefined, longWindow } = opts;
+    // Ensure both <targetDir> exists (zccache may have already populated it)
+    // and the extract root (which is the parent) is writable.
+    await ensureDir(targetDir);
+    const extractRoot = path.dirname(targetDir);
+    await ensureDir(extractRoot);
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fs.stat(archivePath)).size;
+    }
+    catch { /* archive may not exist */ }
+    const magic = await detectCompressMagic(archivePath);
+    if (debug) {
+        log(`[debug] decompress ${path.basename(archivePath)}: magic=${magic} archive=${fmtBytesDebug(archiveBytes)}`);
+    }
+    if (magic === "gzip") {
+        if (debug)
+            log(`[debug] decompress cmd: tar -xzf ${archivePath} -C ${extractRoot}`);
+        await exec.exec("tar", ["-xzf", archivePath, "-C", extractRoot]);
+    }
+    else if (magic === "zstd") {
+        const zstdPath = await io.which("zstd", false);
+        const longFlag = typeof longWindow === "number" ? [`--long=${longWindow}`] : [];
+        if (!zstdPath) {
+            if (debug)
+                log(`[debug] decompress cmd (fallback): tar --use-compress-program "zstd -d${longFlag.length ? ` --long=${longWindow}` : ""}" -xf ${archivePath} -C ${extractRoot}`);
+            // Fall back: route the decompression through tar's --use-compress-program
+            // so we can pass through --long when the archive needs it. tar --zstd
+            // doesn't accept extra zstd flags directly.
+            const program = longFlag.length ? `zstd -d --long=${longWindow}` : "zstd -d";
+            await exec.exec("tar", ["--use-compress-program", program, "-xf", archivePath, "-C", extractRoot]);
+        }
+        else {
+            if (debug)
+                log(`[debug] decompress cmd: zstd -d ${longFlag.join(" ")} -c ${archivePath} | tar -xf - -C ${extractRoot}`);
+            await runPipe([zstdPath, ["-d", ...longFlag, "-c", archivePath]], ["tar", ["-xf", "-", "-C", extractRoot]]);
+        }
+    }
+    else {
+        throw new Error(`decompressCache: unrecognized archive magic for ${archivePath}`);
+    }
+    const { bytes: inflatedBytes, files: fileCount } = await walkDirSize(targetDir);
+    if (debug) {
+        const ratio = archiveBytes > 0 && inflatedBytes > 0 ? (archiveBytes / inflatedBytes).toFixed(2) : "n/a";
+        log(`[debug] decompress result: inflated=${fmtBytesDebug(inflatedBytes)} files=${fileCount} ratio=${ratio}`);
+    }
+    return { archiveBytes, inflatedBytes, fileCount };
+}
+/**
+ * tar -cf - <cache-dir-basename> | zstd -T0 -<level> > <cache-dir>.tar.zst
+ *
+ * When codec=="none" or zstd is not installed, returns archivePath=null and
+ * leaves the caller to use the default actions/cache compression.
+ * When debug=true, walks the source dir for byte/file counts and logs ratios.
+ */
+async function compressCache(opts) {
+    const { cacheDir, codec, level, debug = false, log = () => undefined, longWindow, ultra, extraBasenames = [], } = opts;
+    const nullResult = { archivePath: null, archiveBytes: 0, inflatedBytes: null, fileCount: null };
+    if (codec === "none")
+        return nullResult;
+    const zstdPath = await io.which("zstd", false);
+    if (!zstdPath) {
+        core.warning("setup-soldr: zstd binary not found on PATH; falling back to actions/cache default codec");
+        return nullResult;
+    }
+    if (!(await pathExists(cacheDir))) {
+        core.warning(`setup-soldr: cache dir ${cacheDir} does not exist, skipping compression`);
+        return nullResult;
+    }
+    let inflatedBytes = null;
+    let fileCount = null;
+    if (debug) {
+        const walked = await walkDirSize(cacheDir);
+        inflatedBytes = walked.bytes;
+        fileCount = walked.files;
+        log(`[debug] compress ${path.basename(cacheDir)}: input=${fmtBytesDebug(inflatedBytes)} files=${fileCount}`);
+    }
+    const parent = path.dirname(cacheDir);
+    const basename = path.basename(cacheDir);
+    // Filter sibling basenames to ones that actually exist under the parent —
+    // tar errors on missing inputs, and cargo-registry's `.global-cache` /
+    // `git/` may legitimately be absent on a cold checkout.
+    const presentExtras = [];
+    for (const extra of extraBasenames) {
+        if (!extra || extra === basename)
+            continue;
+        if (await pathExists(path.join(parent, extra))) {
+            presentExtras.push(extra);
+        }
+        else if (debug) {
+            log(`[debug] compress: skipping missing sibling basename '${extra}' under ${parent}`);
+        }
+    }
+    const archivePath = `${cacheDir}.tar.zst`;
+    // Best-effort cleanup of any previous archive.
+    await fs.rm(archivePath, { force: true }).catch(() => undefined);
+    const levelNumeric = parseLevel(level);
+    const levelFlag = `-${levelNumeric}`;
+    const longFlag = typeof longWindow === "number" ? [`--long=${longWindow}`] : [];
+    const ultraFlag = ultra || levelNumeric >= 20 ? ["--ultra"] : [];
+    const tarInputs = [basename, ...presentExtras];
+    if (debug)
+        log(`[debug] compress cmd: tar -cf - -C ${parent} ${tarInputs.join(" ")} | zstd -T0 ${levelFlag}${longFlag.length ? ` --long=${longWindow}` : ""}${ultraFlag.length ? " --ultra" : ""} -o ${archivePath}`);
+    await runPipe(["tar", ["-cf", "-", "-C", parent, ...tarInputs]], [zstdPath, ["-T0", levelFlag, ...longFlag, ...ultraFlag, "-o", archivePath]]);
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fs.stat(archivePath)).size;
+    }
+    catch { /* archive may not exist */ }
+    if (debug && inflatedBytes !== null && inflatedBytes > 0) {
+        log(`[debug] compress result: archive=${fmtBytesDebug(archiveBytes)} ratio=${(archiveBytes / inflatedBytes).toFixed(2)}`);
+    }
+    return { archivePath, archiveBytes, inflatedBytes, fileCount };
+}
+function parseLevel(value) {
+    const trimmed = (value ?? "").toString().trim();
+    if (!trimmed)
+        return 3;
+    const parsed = Number(trimmed);
+    if (Number.isNaN(parsed) || !Number.isFinite(parsed))
+        return 3;
+    const clamped = Math.max(1, Math.min(22, Math.floor(parsed)));
+    return clamped;
+}
+/**
+ * Run two processes piped together: producer.stdout -> consumer.stdin.
+ * Bubbles non-zero exit codes from either side.
+ */
+async function runPipe(producer, consumer) {
+    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 196, 23));
+    const [pCmd, pArgs] = producer;
+    const [cCmd, cArgs] = consumer;
+    await new Promise((resolve, reject) => {
+        const prod = spawn(pCmd, pArgs, { stdio: ["ignore", "pipe", "inherit"] });
+        const cons = spawn(cCmd, cArgs, { stdio: ["pipe", "inherit", "inherit"] });
+        prod.on("error", (err) => reject(err));
+        cons.on("error", (err) => reject(err));
+        if (prod.stdout && cons.stdin) {
+            prod.stdout.pipe(cons.stdin);
+        }
+        let prodExit = null;
+        let consExit = null;
+        const maybeDone = () => {
+            if (prodExit !== null && consExit !== null) {
+                if (prodExit !== 0) {
+                    reject(new Error(`${pCmd} exited with code ${prodExit}`));
+                }
+                else if (consExit !== 0) {
+                    reject(new Error(`${cCmd} exited with code ${consExit}`));
+                }
+                else {
+                    resolve();
+                }
+            }
+        };
+        prod.on("close", (code) => {
+            prodExit = code ?? 0;
+            maybeDone();
+        });
+        cons.on("close", (code) => {
+            consExit = code ?? 0;
+            maybeDone();
+        });
+    });
+}
+
+
+/***/ }),
+
+/***/ 530:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -92941,7 +93334,7 @@ exports.readServiceOption = readServiceOption;
 
 /***/ }),
 
-/***/ 530:
+/***/ 531:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -92966,7 +93359,7 @@ var MatchKind;
 
 /***/ }),
 
-/***/ 531:
+/***/ 532:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -93008,7 +93401,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureShims = ensureShims;
 const fs = __importStar(__nccwpck_require__(249));
 const path = __importStar(__nccwpck_require__(509));
-const core = __importStar(__nccwpck_require__(460));
+const core = __importStar(__nccwpck_require__(461));
 // Tools that route through `soldr <tool>`:
 const ROUTED_TOOLS = ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"];
 // Unix bash shim template (per tool):
@@ -93064,25 +93457,25 @@ async function ensureShims(opts) {
 
 /***/ }),
 
-/***/ 532:
+/***/ 533:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(406);
-const reflection_info_1 = __nccwpck_require__(453);
+const message_type_contract_1 = __nccwpck_require__(407);
+const reflection_info_1 = __nccwpck_require__(454);
 const reflection_type_check_1 = __nccwpck_require__(290);
 const reflection_json_reader_1 = __nccwpck_require__(343);
-const reflection_json_writer_1 = __nccwpck_require__(91);
-const reflection_binary_reader_1 = __nccwpck_require__(409);
-const reflection_binary_writer_1 = __nccwpck_require__(187);
-const reflection_create_1 = __nccwpck_require__(206);
+const reflection_json_writer_1 = __nccwpck_require__(92);
+const reflection_binary_reader_1 = __nccwpck_require__(410);
+const reflection_binary_writer_1 = __nccwpck_require__(185);
+const reflection_create_1 = __nccwpck_require__(205);
 const reflection_merge_partial_1 = __nccwpck_require__(137);
-const json_typings_1 = __nccwpck_require__(395);
+const json_typings_1 = __nccwpck_require__(396);
 const json_format_contract_1 = __nccwpck_require__(242);
-const reflection_equals_1 = __nccwpck_require__(462);
+const reflection_equals_1 = __nccwpck_require__(463);
 const binary_writer_1 = __nccwpck_require__(251);
 const binary_reader_1 = __nccwpck_require__(135);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
@@ -93249,7 +93642,7 @@ exports.MessageType = MessageType;
 
 /***/ }),
 
-/***/ 533:
+/***/ 534:
 /***/ ((module) => {
 
 "use strict";
@@ -93257,7 +93650,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 534:
+/***/ 535:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -93339,7 +93732,7 @@ exports.stackDuplexStreamingInterceptors = stackDuplexStreamingInterceptors;
 
 /***/ }),
 
-/***/ 535:
+/***/ 536:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -93369,7 +93762,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(93));
+const os = __importStar(__nccwpck_require__(94));
 const utils_1 = __nccwpck_require__(506);
 /**
  * Commands
@@ -93442,357 +93835,6 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 536:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Read + summarize zccache's per-rustc-invocation JSONL journal so
-// `dumpDiagnostics` can emit a `[compile_journal]` section telling
-// the reader (or future-me) *what* was cached and *why* every miss
-// missed. Without this, "warm reports hits=0 misses=206" is true but
-// useless — we can't tell whether the cache lookups all returned
-// "no cache file with this key" (genuinely-new fingerprint) or "the
-// cached entry's recorded inputs don't match my current inputs"
-// (content/path/env drift between cold and warm). The journal records
-// the per-invocation `outcome` and `miss_reason`; soldr's
-// `cache report --json` already returns `zccache analyze --json`'s
-// rollups under `report.rollups`. We just have to parse them.
-//
-// Pure-functional: no `core.*` here, no side effects beyond reading
-// the journal file. Easier to unit-test that way.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.readJournal = readJournal;
-exports.summarize = summarize;
-exports.formatJournalSection = formatJournalSection;
-exports.formatRollupsSection = formatRollupsSection;
-const fs = __importStar(__nccwpck_require__(249));
-const diagnostics_js_1 = __nccwpck_require__(112);
-const SLOWEST_TOP_N = 20;
-/**
- * Read a `last-session.jsonl` file. Returns `null` if it doesn't exist
- * (the common "no build happened" case); throws nothing for malformed
- * lines — they're silently skipped so a single garbled record doesn't
- * blank the whole dump.
- */
-function readJournal(path) {
-    let raw;
-    try {
-        raw = fs.readFileSync(path, "utf8");
-    }
-    catch (err) {
-        if (err.code === "ENOENT")
-            return null;
-        throw err;
-    }
-    const out = [];
-    for (const line of raw.split(/\r?\n/)) {
-        if (line.trim() === "")
-            continue;
-        try {
-            const obj = JSON.parse(line);
-            if (obj && typeof obj === "object")
-                out.push(obj);
-        }
-        catch {
-            // Skip malformed lines.
-        }
-    }
-    return out;
-}
-/**
- * Pure summary. Stable across runs given the same input order so the
- * dump diffs cleanly across CI runs.
- */
-function summarize(records) {
-    const outcomes = {};
-    const miss_reasons = {};
-    const per_extension = {};
-    const misses = [];
-    for (const r of records) {
-        const outcome = r.outcome ?? "unknown";
-        outcomes[outcome] = (outcomes[outcome] ?? 0) + 1;
-        if (outcome === "miss") {
-            const reason = r.miss_reason ?? "unknown";
-            miss_reasons[reason] = (miss_reasons[reason] ?? 0) + 1;
-            misses.push(r);
-        }
-        const ext = r.output_ext ?? "?";
-        if (!per_extension[ext])
-            per_extension[ext] = { hit: 0, miss: 0 };
-        if (outcome === "hit" || outcome === "link_hit")
-            per_extension[ext].hit += 1;
-        else if (outcome === "miss" || outcome === "link_miss")
-            per_extension[ext].miss += 1;
-    }
-    // Sort misses by latency descending and take top N.
-    const slowest_misses = [...misses]
-        .sort((a, b) => (b.latency_ns ?? 0) - (a.latency_ns ?? 0))
-        .slice(0, SLOWEST_TOP_N)
-        .map((r) => ({
-        crate: r.crate_name ?? "?",
-        reason: r.miss_reason ?? "?",
-        ext: r.output_ext ?? "?",
-        latency_ms: Math.round((r.latency_ns ?? 0) / 1_000_000),
-        diff: r.miss_diff ?? null,
-    }));
-    // One sample per distinct miss_reason (covers the long-tail rarer
-    // reasons even when ContentChanged dominates the histogram).
-    const seenReasons = new Set();
-    const sample_records = [];
-    for (const r of misses) {
-        const reason = r.miss_reason ?? "unknown";
-        if (seenReasons.has(reason))
-            continue;
-        seenReasons.add(reason);
-        sample_records.push(r);
-        if (sample_records.length >= 5)
-            break;
-    }
-    // Also include one hit sample if we have any, so cold/warm diffs are
-    // diffable in both directions.
-    const firstHit = records.find((r) => r.outcome === "hit" || r.outcome === "link_hit");
-    if (firstHit && sample_records.length < 6)
-        sample_records.push(firstHit);
-    return {
-        total: records.length,
-        outcomes,
-        miss_reasons,
-        per_extension,
-        slowest_misses,
-        sample_records,
-    };
-}
-// ---------- formatters ----------
-function pad(left, right, label, value) {
-    return `${label.padEnd(left)}${String(value).padStart(right)}`;
-}
-/**
- * Normalise zccache's `env` field into a plain `{key: value}` map.
- * The wire format is array-of-pairs (`Array<[string, string]>`) in
- * current zccache builds; older / future builds may use a plain
- * object. We tolerate both — and crucially, when given the array
- * form we DO NOT use array indices as keys (the previous bug:
- * indices like "0", "1" don't match the redaction regex so secrets
- * leaked verbatim).
- */
-function normaliseEnv(env) {
-    if (!env)
-        return {};
-    if (Array.isArray(env)) {
-        const out = {};
-        for (const pair of env) {
-            if (Array.isArray(pair) && pair.length >= 2 && typeof pair[0] === "string") {
-                out[pair[0]] = String(pair[1] ?? "");
-            }
-        }
-        return out;
-    }
-    // Plain object form. Defend against the legacy index-keyed shape that
-    // sneaks in if some intermediate code stringifies an array via
-    // `Object.fromEntries(arr.entries())` — detect that and recover.
-    const entries = Object.entries(env);
-    const looksLikeIndexedArray = entries.length > 0 &&
-        entries.every(([k, v]) => /^\d+$/.test(k) &&
-            Array.isArray(v) &&
-            v.length >= 2 &&
-            typeof v[0] === "string");
-    if (looksLikeIndexedArray) {
-        const out = {};
-        for (const [, v] of entries) {
-            const pair = v;
-            out[pair[0]] = String(pair[1] ?? "");
-        }
-        return out;
-    }
-    return env;
-}
-function redactEnv(env) {
-    const norm = normaliseEnv(env);
-    const out = {};
-    for (const [k, v] of Object.entries(norm))
-        out[k] = (0, diagnostics_js_1.redactValue)(k, v);
-    return out;
-}
-function envIsNonEmpty(env) {
-    if (!env)
-        return false;
-    if (Array.isArray(env))
-        return env.length > 0;
-    return Object.keys(env).length > 0;
-}
-function formatRecord(r) {
-    // Hand-shape JSON to keep one record-per-line readable: top-level keys
-    // on one line, then args/env/miss_diff (if present) on their own.
-    const summary = {
-        outcome: r.outcome,
-        miss_reason: r.miss_reason,
-        crate_name: r.crate_name,
-        crate_type: r.crate_type,
-        output_ext: r.output_ext,
-        latency_ms: r.latency_ns !== undefined ? Math.round(r.latency_ns / 1_000_000) : undefined,
-        cwd: r.cwd,
-    };
-    const parts = [];
-    parts.push(`    summary: ${JSON.stringify(summary)}`);
-    if (r.args && r.args.length > 0) {
-        parts.push(`    args: ${JSON.stringify(r.args)}`);
-    }
-    if (envIsNonEmpty(r.env)) {
-        parts.push(`    env (redacted): ${JSON.stringify(redactEnv(r.env))}`);
-    }
-    if (r.miss_diff && Object.keys(r.miss_diff).length > 0) {
-        parts.push(`    miss_diff: ${JSON.stringify(r.miss_diff)}`);
-    }
-    if (r.self_profile_ns) {
-        parts.push(`    self_profile_ns: ${JSON.stringify(r.self_profile_ns)}`);
-    }
-    return parts.join("\n");
-}
-/**
- * Format a `[compile_journal]` section's body lines (without the
- * surrounding header/footer — those are added by `dumpDiagnostics`).
- */
-function formatJournalSection(summary) {
-    const lines = [];
-    lines.push(`[compile_journal]`);
-    lines.push(`  total_records=${summary.total}`);
-    lines.push(`  outcomes:`);
-    const outcomeEntries = Object.entries(summary.outcomes).sort((a, b) => b[1] - a[1]);
-    if (outcomeEntries.length === 0)
-        lines.push(`    (none)`);
-    for (const [k, v] of outcomeEntries)
-        lines.push(`    ${pad(16, 8, k, v)}`);
-    lines.push(`  miss_reasons (zccache fingerprint divergence; the answer to "why warm missed"):`);
-    const missEntries = Object.entries(summary.miss_reasons).sort((a, b) => b[1] - a[1]);
-    if (missEntries.length === 0)
-        lines.push(`    (none)`);
-    for (const [k, v] of missEntries)
-        lines.push(`    ${pad(28, 8, k, v)}`);
-    lines.push(`  per_output_ext (hit/miss split per artifact kind):`);
-    const extEntries = Object.entries(summary.per_extension).sort((a, b) => a[0] < b[0] ? -1 : 1);
-    if (extEntries.length === 0)
-        lines.push(`    (none)`);
-    for (const [ext, c] of extEntries) {
-        lines.push(`    ${ext.padEnd(10)}hit=${String(c.hit).padStart(5)}  miss=${String(c.miss).padStart(5)}`);
-    }
-    lines.push(`  slowest_misses (top ${summary.slowest_misses.length} by wall-clock):`);
-    if (summary.slowest_misses.length === 0)
-        lines.push(`    (none)`);
-    for (const m of summary.slowest_misses) {
-        lines.push(`    ${String(m.latency_ms + "ms").padStart(7)}  ${m.reason.padEnd(20)}  ${m.ext.padEnd(8)}  ${m.crate}`);
-        if (m.diff && typeof m.diff === "object" && Object.keys(m.diff).length > 0) {
-            lines.push(`        diff: ${JSON.stringify(m.diff)}`);
-        }
-    }
-    lines.push(`  sample_records (one verbatim per distinct outcome, env redacted):`);
-    if (summary.sample_records.length === 0)
-        lines.push(`    (none)`);
-    for (let i = 0; i < summary.sample_records.length; i += 1) {
-        lines.push(`  --- record ${i + 1} ---`);
-        lines.push(formatRecord(summary.sample_records[i]));
-    }
-    return lines;
-}
-/**
- * Format the `rollups` field returned by `soldr cache report --json`
- * (i.e. `zccache analyze --json` output). Tolerates missing /
- * malformed fields — older soldr versions or error paths just yield
- * an empty section.
- */
-function formatRollupsSection(report) {
-    const lines = [];
-    lines.push(`[compile_rollups (zccache analyze --json)]`);
-    if (!report || typeof report !== "object") {
-        lines.push(`  (no report payload)`);
-        return lines;
-    }
-    const rollups = report.rollups;
-    if (!rollups || typeof rollups !== "object") {
-        lines.push(`  (no rollups field)`);
-        return lines;
-    }
-    const r = rollups;
-    // by_extension: { ext: { hits, misses, total_ns } }
-    const byExt = r.by_extension;
-    lines.push(`  by_extension:`);
-    if (!byExt || Object.keys(byExt).length === 0)
-        lines.push(`    (none)`);
-    else {
-        for (const [ext, v] of Object.entries(byExt)) {
-            const hits = v?.hits ?? 0;
-            const misses = v?.misses ?? 0;
-            const totalMs = Math.round((v?.total_ns ?? 0) / 1_000_000);
-            const denom = hits + misses;
-            const rate = denom > 0 ? ((hits / denom) * 100).toFixed(1) : "n/a";
-            lines.push(`    ${ext.padEnd(10)}hits=${String(hits).padStart(5)}  misses=${String(misses).padStart(5)}  rate=${rate.padStart(5)}%  total=${totalMs}ms`);
-        }
-    }
-    // slowest_entries: [{outcome, crate_name, latency_ns}, ...]
-    const slowest = r.slowest_entries;
-    lines.push(`  slowest_entries (analyze top-N):`);
-    if (!slowest || slowest.length === 0)
-        lines.push(`    (none)`);
-    else {
-        for (const e of slowest.slice(0, 20)) {
-            const latencyMs = Math.round(Number(e.latency_ns ?? 0) / 1_000_000);
-            const outcome = String(e.outcome ?? "?");
-            const crate = String(e.crate_name ?? "?");
-            lines.push(`    ${String(latencyMs + "ms").padStart(7)}  ${outcome.padEnd(10)}  ${crate}`);
-        }
-    }
-    // miss_crate_counts: { crate: N }
-    const missByCrate = r.miss_crate_counts;
-    lines.push(`  miss_crate_counts (top 20):`);
-    if (!missByCrate || Object.keys(missByCrate).length === 0)
-        lines.push(`    (none)`);
-    else {
-        const sorted = Object.entries(missByCrate)
-            .sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))
-            .slice(0, 20);
-        for (const [crate, count] of sorted) {
-            lines.push(`    ${String(count).padStart(5)}  ${crate}`);
-        }
-    }
-    return lines;
-}
-
-
-/***/ }),
-
 /***/ 537:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -93803,7 +93845,7 @@ function formatRollupsSection(report) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBeginCopyFromUrlPoller = void 0;
 const core_util_1 = __nccwpck_require__(14);
-const core_lro_1 = __nccwpck_require__(227);
+const core_lro_1 = __nccwpck_require__(226);
 /**
  * This is the poller returned by {@link BlobClient.beginCopyFromURL}.
  * This can not be instantiated directly outside of this package.
@@ -94038,7 +94080,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(85);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(346);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/dist/post.js
+++ b/dist/post.js
@@ -19,10 +19,10 @@ const { inherits } = __nccwpck_require__(355)
 
 const Dicer = __nccwpck_require__(11)
 
-const parseParams = __nccwpck_require__(187)
+const parseParams = __nccwpck_require__(185)
 const decodeText = __nccwpck_require__(266)
 const basename = __nccwpck_require__(449)
-const getLimit = __nccwpck_require__(455)
+const getLimit = __nccwpck_require__(456)
 
 const RE_BOUNDARY = /^boundary$/i
 const RE_FIELD = /^form-data$/i
@@ -472,14 +472,14 @@ exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = ex
 const core = __importStar(__nccwpck_require__(432));
 const http_client_1 = __nccwpck_require__(274);
 const storage_blob_1 = __nccwpck_require__(421);
-const buffer = __importStar(__nccwpck_require__(116));
-const fs = __importStar(__nccwpck_require__(500));
-const stream = __importStar(__nccwpck_require__(127));
-const util = __importStar(__nccwpck_require__(120));
+const buffer = __importStar(__nccwpck_require__(117));
+const fs = __importStar(__nccwpck_require__(501));
+const stream = __importStar(__nccwpck_require__(128));
+const util = __importStar(__nccwpck_require__(121));
 const utils = __importStar(__nccwpck_require__(73));
 const constants_1 = __nccwpck_require__(43);
 const requestUtils_1 = __nccwpck_require__(252);
-const abort_controller_1 = __nccwpck_require__(220);
+const abort_controller_1 = __nccwpck_require__(219);
 /**
  * Pipes the body of a HTTP response to a stream
  *
@@ -839,11 +839,11 @@ exports.SearchState = SearchState;
 "use strict";
 
 
-const { InvalidArgumentError } = __nccwpck_require__(460)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(190)
+const { InvalidArgumentError } = __nccwpck_require__(461)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(188)
 const DispatcherBase = __nccwpck_require__(59)
 const Pool = __nccwpck_require__(322)
-const Client = __nccwpck_require__(85)
+const Client = __nccwpck_require__(87)
 const util = __nccwpck_require__(66)
 const createRedirectInterceptor = __nccwpck_require__(246)
 const { WeakRef, FinalizationRegistry } = __nccwpck_require__(390)()
@@ -1071,7 +1071,7 @@ function isNamedKeyCredential(credential) {
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(224)
+const { MockNotMatchedError } = __nccwpck_require__(223)
 const {
   kDispatches,
   kMockAgent,
@@ -1085,7 +1085,7 @@ const {
   types: {
     isPromise
   }
-} = __nccwpck_require__(120)
+} = __nccwpck_require__(121)
 
 function matchValue (match, value) {
   if (typeof match === 'string') {
@@ -1516,12 +1516,12 @@ class AbortError extends Error {
 
 
 const { kConstruct } = __nccwpck_require__(153)
-const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(77)
+const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(78)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(66)
-const { kHeadersList } = __nccwpck_require__(190)
+const { kHeadersList } = __nccwpck_require__(188)
 const { webidl } = __nccwpck_require__(430)
 const { Response, cloneResponse } = __nccwpck_require__(39)
-const { Request } = __nccwpck_require__(81)
+const { Request } = __nccwpck_require__(83)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(13)
 const { fetching } = __nccwpck_require__(424)
 const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(487)
@@ -2364,10 +2364,10 @@ module.exports = {
 const WritableStream = (__nccwpck_require__(404).Writable)
 const inherits = (__nccwpck_require__(355).inherits)
 
-const StreamSearch = __nccwpck_require__(111)
+const StreamSearch = __nccwpck_require__(112)
 
 const PartStream = __nccwpck_require__(63)
-const HeaderParser = __nccwpck_require__(104)
+const HeaderParser = __nccwpck_require__(106)
 
 const DASH = 45
 const B_ONEDASH = Buffer.from('-')
@@ -2594,17 +2594,17 @@ exports.isObject = isObject;
 exports.randomUUID = randomUUID;
 exports.uint8ArrayToString = uint8ArrayToString;
 exports.stringToUint8Array = stringToUint8Array;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const tspRuntime = tslib_1.__importStar(__nccwpck_require__(143));
-var aborterUtils_js_1 = __nccwpck_require__(97);
+var aborterUtils_js_1 = __nccwpck_require__(99);
 Object.defineProperty(exports, "cancelablePromiseRace", ({ enumerable: true, get: function () { return aborterUtils_js_1.cancelablePromiseRace; } }));
 var createAbortablePromise_js_1 = __nccwpck_require__(251);
 Object.defineProperty(exports, "createAbortablePromise", ({ enumerable: true, get: function () { return createAbortablePromise_js_1.createAbortablePromise; } }));
-var delay_js_1 = __nccwpck_require__(110);
+var delay_js_1 = __nccwpck_require__(111);
 Object.defineProperty(exports, "delay", ({ enumerable: true, get: function () { return delay_js_1.delay; } }));
-var error_js_1 = __nccwpck_require__(207);
+var error_js_1 = __nccwpck_require__(206);
 Object.defineProperty(exports, "getErrorMessage", ({ enumerable: true, get: function () { return error_js_1.getErrorMessage; } }));
-var typeGuards_js_1 = __nccwpck_require__(107);
+var typeGuards_js_1 = __nccwpck_require__(109);
 Object.defineProperty(exports, "isDefined", ({ enumerable: true, get: function () { return typeGuards_js_1.isDefined; } }));
 Object.defineProperty(exports, "isObjectWithProperties", ({ enumerable: true, get: function () { return typeGuards_js_1.isObjectWithProperties; } }));
 Object.defineProperty(exports, "objectHasProperty", ({ enumerable: true, get: function () { return typeGuards_js_1.objectHasProperty; } }));
@@ -2938,7 +2938,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
 const string_decoder_1 = __nccwpck_require__(146);
-const tr = __importStar(__nccwpck_require__(122));
+const tr = __importStar(__nccwpck_require__(123));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -3038,7 +3038,7 @@ Object.defineProperty(exports, "WireType", ({ enumerable: true, get: function ()
 Object.defineProperty(exports, "mergeBinaryOptions", ({ enumerable: true, get: function () { return binary_format_contract_1.mergeBinaryOptions; } }));
 Object.defineProperty(exports, "UnknownFieldHandler", ({ enumerable: true, get: function () { return binary_format_contract_1.UnknownFieldHandler; } }));
 // Standard IBinaryReader implementation
-var binary_reader_1 = __nccwpck_require__(131);
+var binary_reader_1 = __nccwpck_require__(132);
 Object.defineProperty(exports, "BinaryReader", ({ enumerable: true, get: function () { return binary_reader_1.BinaryReader; } }));
 Object.defineProperty(exports, "binaryReadOptions", ({ enumerable: true, get: function () { return binary_reader_1.binaryReadOptions; } }));
 // Standard IBinaryWriter implementation
@@ -3046,7 +3046,7 @@ var binary_writer_1 = __nccwpck_require__(242);
 Object.defineProperty(exports, "BinaryWriter", ({ enumerable: true, get: function () { return binary_writer_1.BinaryWriter; } }));
 Object.defineProperty(exports, "binaryWriteOptions", ({ enumerable: true, get: function () { return binary_writer_1.binaryWriteOptions; } }));
 // Int64 and UInt64 implementations required for the binary format
-var pb_long_1 = __nccwpck_require__(114);
+var pb_long_1 = __nccwpck_require__(115);
 Object.defineProperty(exports, "PbLong", ({ enumerable: true, get: function () { return pb_long_1.PbLong; } }));
 Object.defineProperty(exports, "PbULong", ({ enumerable: true, get: function () { return pb_long_1.PbULong; } }));
 // JSON format contracts, options for reading and writing, for example
@@ -3058,7 +3058,7 @@ Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: fun
 var message_type_contract_1 = __nccwpck_require__(382);
 Object.defineProperty(exports, "MESSAGE_TYPE", ({ enumerable: true, get: function () { return message_type_contract_1.MESSAGE_TYPE; } }));
 // Message type implementation via reflection
-var message_type_1 = __nccwpck_require__(499);
+var message_type_1 = __nccwpck_require__(500);
 Object.defineProperty(exports, "MessageType", ({ enumerable: true, get: function () { return message_type_1.MessageType; } }));
 // Reflection info, generated by the plugin, exposed to the user, used by reflection ops
 var reflection_info_1 = __nccwpck_require__(426);
@@ -3072,26 +3072,26 @@ Object.defineProperty(exports, "readMessageOption", ({ enumerable: true, get: fu
 // Message operations via reflection
 var reflection_type_check_1 = __nccwpck_require__(278);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
-var reflection_create_1 = __nccwpck_require__(200);
+var reflection_create_1 = __nccwpck_require__(199);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
 var reflection_scalar_default_1 = __nccwpck_require__(435);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
-var reflection_merge_partial_1 = __nccwpck_require__(133);
+var reflection_merge_partial_1 = __nccwpck_require__(134);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
 var reflection_equals_1 = __nccwpck_require__(434);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
 var reflection_binary_reader_1 = __nccwpck_require__(385);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
-var reflection_binary_writer_1 = __nccwpck_require__(181);
+var reflection_binary_writer_1 = __nccwpck_require__(179);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
 var reflection_json_reader_1 = __nccwpck_require__(327);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
-var reflection_json_writer_1 = __nccwpck_require__(87);
+var reflection_json_writer_1 = __nccwpck_require__(89);
 Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get: function () { return reflection_json_writer_1.ReflectionJsonWriter; } }));
 var reflection_contains_message_type_1 = __nccwpck_require__(48);
 Object.defineProperty(exports, "containsMessageType", ({ enumerable: true, get: function () { return reflection_contains_message_type_1.containsMessageType; } }));
 // Oneof helpers
-var oneof_1 = __nccwpck_require__(185);
+var oneof_1 = __nccwpck_require__(183);
 Object.defineProperty(exports, "isOneofGroup", ({ enumerable: true, get: function () { return oneof_1.isOneofGroup; } }));
 Object.defineProperty(exports, "setOneofValue", ({ enumerable: true, get: function () { return oneof_1.setOneofValue; } }));
 Object.defineProperty(exports, "getOneofValue", ({ enumerable: true, get: function () { return oneof_1.getOneofValue; } }));
@@ -3107,7 +3107,7 @@ Object.defineProperty(exports, "isEnumObject", ({ enumerable: true, get: functio
 var lower_camel_case_1 = __nccwpck_require__(427);
 Object.defineProperty(exports, "lowerCamelCase", ({ enumerable: true, get: function () { return lower_camel_case_1.lowerCamelCase; } }));
 // assertion functions are exported for plugin, may also be useful to user
-var assert_1 = __nccwpck_require__(456);
+var assert_1 = __nccwpck_require__(457);
 Object.defineProperty(exports, "assert", ({ enumerable: true, get: function () { return assert_1.assert; } }));
 Object.defineProperty(exports, "assertNever", ({ enumerable: true, get: function () { return assert_1.assertNever; } }));
 Object.defineProperty(exports, "assertInt32", ({ enumerable: true, get: function () { return assert_1.assertInt32; } }));
@@ -3142,7 +3142,7 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_ts_http_runtime = __nccwpck_require__(86);
+var import_ts_http_runtime = __nccwpck_require__(88);
 function createPipelineRequest(options) {
   return (0, import_ts_http_runtime.createPipelineRequest)(options);
 }
@@ -3190,7 +3190,7 @@ const XML_CHARKEY = "_";
 /***/ 20:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(190)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(188)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -3281,15 +3281,15 @@ const {
   createDeferredPromise,
   fullyReadBody
 } = __nccwpck_require__(487)
-const { FormData } = __nccwpck_require__(202)
+const { FormData } = __nccwpck_require__(201)
 const { kState } = __nccwpck_require__(13)
 const { webidl } = __nccwpck_require__(430)
 const { DOMException, structuredClone } = __nccwpck_require__(28)
-const { Blob, File: NativeFile } = __nccwpck_require__(116)
-const { kBodyUsed } = __nccwpck_require__(190)
+const { Blob, File: NativeFile } = __nccwpck_require__(117)
+const { kBodyUsed } = __nccwpck_require__(188)
 const assert = __nccwpck_require__(495)
 const { isErrored } = __nccwpck_require__(66)
-const { isUint8Array, isArrayBuffer } = __nccwpck_require__(193)
+const { isUint8Array, isArrayBuffer } = __nccwpck_require__(192)
 const { File: UndiciFile } = __nccwpck_require__(345)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(23)
 
@@ -3890,7 +3890,7 @@ module.exports = {
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(495)
-const { atob } = __nccwpck_require__(116)
+const { atob } = __nccwpck_require__(117)
 const { isomorphicDecode } = __nccwpck_require__(487)
 
 const encoder = new TextEncoder()
@@ -4534,9 +4534,9 @@ module.exports = {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(413));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(173));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing AppendBlob operations. */
 class AppendBlobImpl {
@@ -5105,7 +5105,7 @@ module.exports = {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tracingClient = void 0;
-const core_tracing_1 = __nccwpck_require__(79);
+const core_tracing_1 = __nccwpck_require__(81);
 const constants_js_1 = __nccwpck_require__(145);
 /**
  * Creates a span using the global tracer.
@@ -5233,10 +5233,10 @@ exports.saveCache = exports.reserveCache = exports.downloadCache = exports.getCa
 const core = __importStar(__nccwpck_require__(432));
 const http_client_1 = __nccwpck_require__(274);
 const auth_1 = __nccwpck_require__(25);
-const fs = __importStar(__nccwpck_require__(500));
-const url_1 = __nccwpck_require__(82);
+const fs = __importStar(__nccwpck_require__(501));
+const url_1 = __nccwpck_require__(84);
 const utils = __importStar(__nccwpck_require__(73));
-const uploadUtils_1 = __nccwpck_require__(157);
+const uploadUtils_1 = __nccwpck_require__(156);
 const downloadUtils_1 = __nccwpck_require__(3);
 const options_1 = __nccwpck_require__(256);
 const requestUtils_1 = __nccwpck_require__(252);
@@ -5695,8 +5695,8 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_https_proxy_agent = __nccwpck_require__(129);
-var import_http_proxy_agent = __nccwpck_require__(216);
+var import_https_proxy_agent = __nccwpck_require__(130);
+var import_http_proxy_agent = __nccwpck_require__(215);
 var import_log = __nccwpck_require__(148);
 const HTTPS_PROXY = "HTTPS_PROXY";
 const HTTP_PROXY = "HTTP_PROXY";
@@ -5890,12 +5890,12 @@ const {
 } = __nccwpck_require__(28)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(13)
 const { webidl } = __nccwpck_require__(430)
-const { FormData } = __nccwpck_require__(202)
-const { getGlobalOrigin } = __nccwpck_require__(136)
+const { FormData } = __nccwpck_require__(201)
+const { getGlobalOrigin } = __nccwpck_require__(137)
 const { URLSerializer } = __nccwpck_require__(23)
-const { kHeadersList, kConstruct } = __nccwpck_require__(190)
+const { kHeadersList, kConstruct } = __nccwpck_require__(188)
 const assert = __nccwpck_require__(495)
-const { types } = __nccwpck_require__(120)
+const { types } = __nccwpck_require__(121)
 
 const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(248).ReadableStream)
 const textEncoder = new TextEncoder('utf-8')
@@ -6531,8 +6531,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
-const pathHelper = __importStar(__nccwpck_require__(215));
-const internal_match_kind_1 = __nccwpck_require__(497);
+const pathHelper = __importStar(__nccwpck_require__(214));
+const internal_match_kind_1 = __nccwpck_require__(498);
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Given an array of patterns, returns an array of paths to search.
@@ -6770,9 +6770,9 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(413));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(173));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing Blob operations. */
 class BlobImpl {
@@ -7922,8 +7922,8 @@ exports.containsMessageType = containsMessageType;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollHttpOperation = exports.isOperationError = exports.getResourceLocation = exports.getOperationStatus = exports.getOperationLocation = exports.initHttpOperation = exports.getStatusFromInitialResponse = exports.getErrorFromResponse = exports.parseRetryAfter = exports.inferLroMode = void 0;
-const operation_js_1 = __nccwpck_require__(137);
-const logger_js_1 = __nccwpck_require__(186);
+const operation_js_1 = __nccwpck_require__(138);
+const logger_js_1 = __nccwpck_require__(184);
 function getOperationLocationPollingUrl(inputs) {
     const { azureAsyncOperation, operationLocation } = inputs;
     return operationLocation !== null && operationLocation !== void 0 ? operationLocation : azureAsyncOperation;
@@ -8323,12 +8323,12 @@ const {
   kLastProgressEventFired
 } = __nccwpck_require__(433)
 const { ProgressEvent } = __nccwpck_require__(416)
-const { getEncoding } = __nccwpck_require__(94)
+const { getEncoding } = __nccwpck_require__(96)
 const { DOMException } = __nccwpck_require__(28)
 const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(23)
-const { types } = __nccwpck_require__(120)
+const { types } = __nccwpck_require__(121)
 const { StringDecoder } = __nccwpck_require__(146)
-const { btoa } = __nccwpck_require__(116)
+const { btoa } = __nccwpck_require__(117)
 
 /** @type {PropertyDescriptor} */
 const staticPropertyDescriptors = {
@@ -8809,7 +8809,7 @@ exports.UnaryCall = UnaryCall;
 "use strict";
 
 
-const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(95)
+const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(97)
 const { states, opcodes } = __nccwpck_require__(438)
 const { MessageEvent, ErrorEvent } = __nccwpck_require__(241)
 
@@ -9456,8 +9456,8 @@ const {
   ClientDestroyedError,
   ClientClosedError,
   InvalidArgumentError
-} = __nccwpck_require__(460)
-const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(190)
+} = __nccwpck_require__(461)
+const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(188)
 
 const kDestroyed = Symbol('destroyed')
 const kClosed = Symbol('closed')
@@ -9672,7 +9672,7 @@ __export(requestPolicyFactoryPolicy_exports, {
   requestPolicyFactoryPolicyName: () => requestPolicyFactoryPolicyName
 });
 module.exports = __toCommonJS(requestPolicyFactoryPolicy_exports);
-var import_util = __nccwpck_require__(106);
+var import_util = __nccwpck_require__(108);
 var import_response = __nccwpck_require__(388);
 var HttpPipelineLogLevel = /* @__PURE__ */ ((HttpPipelineLogLevel2) => {
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["ERROR"] = 1] = "ERROR";
@@ -9723,17 +9723,17 @@ function createRequestPolicyFactoryPolicy(factories) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(12);
 const core_auth_1 = __nccwpck_require__(484);
 const storage_common_1 = __nccwpck_require__(267);
-const Pipeline_js_1 = __nccwpck_require__(178);
+const Pipeline_js_1 = __nccwpck_require__(176);
 const StorageClient_js_1 = __nccwpck_require__(428);
 const tracing_js_1 = __nccwpck_require__(29);
 const utils_common_js_1 = __nccwpck_require__(151);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(65);
-const BlobLeaseClient_js_1 = __nccwpck_require__(199);
-const Clients_js_1 = __nccwpck_require__(180);
+const BlobLeaseClient_js_1 = __nccwpck_require__(198);
+const Clients_js_1 = __nccwpck_require__(178);
 const BlobBatchClient_js_1 = __nccwpck_require__(380);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
@@ -11036,7 +11036,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.action3 = exports.action2 = exports.leaseId1 = exports.action1 = exports.proposedLeaseId = exports.duration = exports.action = exports.comp10 = exports.sourceLeaseId = exports.sourceContainerName = exports.comp9 = exports.deletedContainerVersion = exports.deletedContainerName = exports.comp8 = exports.containerAcl = exports.comp7 = exports.comp6 = exports.ifUnmodifiedSince = exports.ifModifiedSince = exports.leaseId = exports.preventEncryptionScopeOverride = exports.defaultEncryptionScope = exports.access = exports.metadata = exports.restype2 = exports.where = exports.comp5 = exports.multipartContentType = exports.contentLength = exports.comp4 = exports.body = exports.restype1 = exports.comp3 = exports.keyInfo = exports.include = exports.maxPageSize = exports.marker = exports.prefix = exports.comp2 = exports.comp1 = exports.accept1 = exports.requestId = exports.version = exports.timeoutInSeconds = exports.comp = exports.restype = exports.url = exports.accept = exports.blobServiceProperties = exports.contentType = void 0;
 exports.copySourceTags = exports.copySourceAuthorization = exports.sourceContentMD5 = exports.xMsRequiresSync = exports.legalHold1 = exports.sealBlob = exports.blobTagsString = exports.copySource = exports.sourceIfTags = exports.sourceIfNoneMatch = exports.sourceIfMatch = exports.sourceIfUnmodifiedSince = exports.sourceIfModifiedSince = exports.rehydratePriority = exports.tier = exports.comp14 = exports.encryptionScope = exports.legalHold = exports.comp13 = exports.immutabilityPolicyMode = exports.immutabilityPolicyExpiry = exports.comp12 = exports.blobContentDisposition = exports.blobContentLanguage = exports.blobContentEncoding = exports.blobContentMD5 = exports.blobContentType = exports.blobCacheControl = exports.expiresOn = exports.expiryOptions = exports.comp11 = exports.blobDeleteType = exports.deleteSnapshots = exports.ifTags = exports.ifNoneMatch = exports.ifMatch = exports.encryptionAlgorithm = exports.encryptionKeySha256 = exports.encryptionKey = exports.rangeGetContentCRC64 = exports.rangeGetContentMD5 = exports.range = exports.versionId = exports.snapshot = exports.delimiter = exports.startFrom = exports.include1 = exports.proposedLeaseId1 = exports.action4 = exports.breakPeriod = void 0;
 exports.listType = exports.comp25 = exports.blocks = exports.blockId = exports.comp24 = exports.copySourceBlobProperties = exports.blobType2 = exports.comp23 = exports.sourceRange1 = exports.appendPosition = exports.maxSize = exports.comp22 = exports.blobType1 = exports.comp21 = exports.sequenceNumberAction = exports.prevSnapshotUrl = exports.prevsnapshot = exports.comp20 = exports.range1 = exports.sourceContentCrc64 = exports.sourceRange = exports.sourceUrl = exports.pageWrite1 = exports.ifSequenceNumberEqualTo = exports.ifSequenceNumberLessThan = exports.ifSequenceNumberLessThanOrEqualTo = exports.pageWrite = exports.comp19 = exports.accept2 = exports.body1 = exports.contentType1 = exports.blobSequenceNumber = exports.blobContentLength = exports.blobType = exports.transactionalContentCrc64 = exports.transactionalContentMD5 = exports.tags = exports.ifNoneMatch1 = exports.ifMatch1 = exports.ifUnmodifiedSince1 = exports.ifModifiedSince1 = exports.comp18 = exports.comp17 = exports.queryRequest = exports.tier1 = exports.comp16 = exports.copyId = exports.copyActionAbortConstant = exports.comp15 = exports.fileRequestIntent = void 0;
-const mappers_js_1 = __nccwpck_require__(175);
+const mappers_js_1 = __nccwpck_require__(173);
 exports.contentType = {
     parameterPath: ["options", "contentType"],
     mapper: {
@@ -13419,14 +13419,14 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 
 
 const assert = __nccwpck_require__(495)
-const { kDestroyed, kBodyUsed } = __nccwpck_require__(190)
+const { kDestroyed, kBodyUsed } = __nccwpck_require__(188)
 const { IncomingMessage } = __nccwpck_require__(315)
-const stream = __nccwpck_require__(127)
+const stream = __nccwpck_require__(128)
 const net = __nccwpck_require__(480)
-const { InvalidArgumentError } = __nccwpck_require__(460)
-const { Blob } = __nccwpck_require__(116)
-const nodeUtil = __nccwpck_require__(120)
-const { stringify } = __nccwpck_require__(126)
+const { InvalidArgumentError } = __nccwpck_require__(461)
+const { Blob } = __nccwpck_require__(117)
+const nodeUtil = __nccwpck_require__(121)
+const { stringify } = __nccwpck_require__(127)
 const { headerNameLowerCasedRecord } = __nccwpck_require__(70)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
@@ -13976,7 +13976,7 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(179);
+var import_log = __nccwpck_require__(177);
 var import_policies = __nccwpck_require__(275);
 const logPolicyName = import_policies.logPolicyName;
 function logPolicy(options = {}) {
@@ -14023,12 +14023,12 @@ __export(src_exports, {
   toHttpHeadersLike: () => import_util.toHttpHeadersLike
 });
 module.exports = __toCommonJS(src_exports);
-var import_extendedClient = __nccwpck_require__(209);
+var import_extendedClient = __nccwpck_require__(208);
 var import_response = __nccwpck_require__(388);
 var import_requestPolicyFactoryPolicy = __nccwpck_require__(60);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_httpClientAdapter = __nccwpck_require__(205);
-var import_util = __nccwpck_require__(106);
+var import_httpClientAdapter = __nccwpck_require__(204);
+var import_util = __nccwpck_require__(108);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -14202,7 +14202,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StatsCollector = void 0;
-const fs = __importStar(__nccwpck_require__(105));
+const fs = __importStar(__nccwpck_require__(107));
 const path = __importStar(__nccwpck_require__(479));
 const core = __importStar(__nccwpck_require__(432));
 function fmtBytes(n) {
@@ -14820,13 +14820,13 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
 const core = __importStar(__nccwpck_require__(432));
 const exec = __importStar(__nccwpck_require__(16));
-const glob = __importStar(__nccwpck_require__(164));
+const glob = __importStar(__nccwpck_require__(163));
 const io = __importStar(__nccwpck_require__(283));
-const crypto = __importStar(__nccwpck_require__(279));
-const fs = __importStar(__nccwpck_require__(500));
+const crypto = __importStar(__nccwpck_require__(280));
+const fs = __importStar(__nccwpck_require__(501));
 const path = __importStar(__nccwpck_require__(239));
-const semver = __importStar(__nccwpck_require__(174));
-const util = __importStar(__nccwpck_require__(120));
+const semver = __importStar(__nccwpck_require__(172));
+const util = __importStar(__nccwpck_require__(121));
 const constants_1 = __nccwpck_require__(43);
 const versionSalt = '1.0';
 // From https://github.com/actions/toolkit/blob/main/packages/tool-cache/src/tool-cache.ts#L23
@@ -15016,7 +15016,7 @@ exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
 const node_crypto_1 = __nccwpck_require__(265);
 const constants_js_1 = __nccwpck_require__(34);
 const utils_common_js_1 = __nccwpck_require__(446);
-const SharedKeyComparator_js_1 = __nccwpck_require__(172);
+const SharedKeyComparator_js_1 = __nccwpck_require__(170);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
  */
@@ -15147,6 +15147,248 @@ function storageSharedKeyCredentialPolicy(options) {
 /***/ }),
 
 /***/ 76:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Soldr-mini-cache — the narrowest cache layer: just the soldr binary,
+// keyed only on (version, platform, arch, libc).
+//
+// Per CLAUDE.md "Layer per change cadence" + "Coarse keys, shared across
+// workflows": the soldr binary's invalidation rhythm is per-soldr-release
+// (~1×/week). Mixing it into the existing setup-cache (which is keyed on
+// toolchain hash + cache-key-suffix) means it re-downloads whenever those
+// move — even though the binary content didn't change.
+//
+// This layer caches *only* the install dir contents (binary + optional
+// source-metadata sidecar), keyed coarsely so every workflow in the repo
+// pinned to the same soldr version hits the same entry.
+//
+// Position in the lifecycle:
+//   main.ts: try restore → if hit, soldrPath is pre-populated and
+//   ensureSoldr's installedVersion check short-circuits the GH fetch.
+//   post.ts: if restore missed AND ensureSoldr fetched, save the binary
+//   for next time.
+//
+// Refs (rebuild-from-source) are skipped: the binary content depends on
+// the commit, not the version tag, so the cache key would be wrong.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.buildMiniCacheKey = buildMiniCacheKey;
+exports.restoreMiniCache = restoreMiniCache;
+exports.saveMiniCache = saveMiniCache;
+exports.isEligibleForMiniCache = isEligibleForMiniCache;
+const fs = __importStar(__nccwpck_require__(240));
+const fsp = __importStar(__nccwpck_require__(107));
+const path = __importStar(__nccwpck_require__(479));
+const cache = __importStar(__nccwpck_require__(207));
+const cache_compress_js_1 = __nccwpck_require__(496);
+const MINI_KEY_PREFIX = "soldr-mini";
+/**
+ * Build the mini-cache key. Deliberately coarse — only the dimensions
+ * that change soldr's binary content. No toolchain hash, no Cargo.lock,
+ * no cache-key-suffix, no SHA. Cross-workflow sharing within a repo.
+ */
+function buildMiniCacheKey(parts) {
+    const v = parts.soldrVersion.trim().replace(/^v/, "") || "unresolved";
+    return [
+        MINI_KEY_PREFIX,
+        parts.runnerOs,
+        parts.runnerArch,
+        parts.libc,
+        `v${v}`,
+    ].join("-");
+}
+/**
+ * Try to restore the soldr install dir from the mini-cache. Single exact
+ * key — content-addressable so a fallback would be wrong. On hit, the
+ * caller's normal ensureSoldr() will see the binary already present at
+ * the expected path and skip the GH Releases fetch.
+ */
+async function restoreMiniCache(opts) {
+    const { exactKey, installDir, archivePath, longWindow, log } = opts;
+    await fsp.mkdir(installDir, { recursive: true });
+    await fsp.mkdir(path.dirname(archivePath), { recursive: true });
+    await fsp.rm(archivePath, { force: true });
+    let matched;
+    try {
+        matched = await cache.restoreCache([archivePath], exactKey);
+    }
+    catch (err) {
+        log(`soldr-mini-cache: restore threw: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "", archiveBytes: 0 };
+    }
+    if (!matched) {
+        log(`soldr-mini-cache: no entry for key ${exactKey}`);
+        return { hit: false, matchedKey: "", archiveBytes: 0 };
+    }
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fsp.stat(archivePath)).size;
+    }
+    catch {
+        return { hit: false, matchedKey: matched, archiveBytes: 0 };
+    }
+    const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+    if (magic !== "zstd" && magic !== "gzip") {
+        log(`soldr-mini-cache: archive has unknown codec, treating as miss`);
+        return { hit: false, matchedKey: matched, archiveBytes };
+    }
+    try {
+        await (0, cache_compress_js_1.decompressCache)({
+            archivePath,
+            targetDir: installDir,
+            longWindow,
+            log,
+            debug: opts.debug,
+        });
+    }
+    catch (err) {
+        log(`soldr-mini-cache: decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: matched, archiveBytes };
+    }
+    log(`soldr-mini-cache: restored matched=${matched} archive=${archiveBytes}B target=${installDir}`);
+    return { hit: true, matchedKey: matched, archiveBytes };
+}
+/**
+ * Tar+zstd the soldr install dir and upload to cache. Caller should only
+ * call this when restore missed AND ensureSoldr actually fetched (otherwise
+ * we'd be re-saving the same content).
+ */
+async function saveMiniCache(opts) {
+    const { installDir, archivePath, exactKey, level, longWindow, debug, log } = opts;
+    if (!fs.existsSync(installDir)) {
+        return { status: "skipped-missing-dir" };
+    }
+    let entryCount = 0;
+    try {
+        entryCount = (await fsp.readdir(installDir)).length;
+    }
+    catch { /* */ }
+    if (entryCount === 0) {
+        return { status: "skipped-empty" };
+    }
+    // compressCache writes to `${cacheDir}.tar.zst` by default. We pass
+    // installDir as cacheDir, so the archive ends up at
+    // `${installDir}.tar.zst`. The caller's main.ts side uses the same
+    // path so @actions/cache hashes the paths array identically on save
+    // and restore (mirrors the cook-cache lesson from #141).
+    let outputArchivePath = null;
+    let archiveBytes;
+    let inflatedBytes;
+    let fileCount;
+    try {
+        const compress = await (0, cache_compress_js_1.compressCache)({
+            cacheDir: installDir,
+            codec: "zstd",
+            level,
+            longWindow,
+            debug,
+            log,
+        });
+        outputArchivePath = compress.archivePath;
+        archiveBytes = compress.archiveBytes;
+        if (compress.inflatedBytes !== null)
+            inflatedBytes = compress.inflatedBytes;
+        if (compress.fileCount !== null)
+            fileCount = compress.fileCount;
+    }
+    catch (err) {
+        return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+    }
+    if (!outputArchivePath) {
+        return { status: "failed", error: "compressCache returned null archive (zstd unavailable?)" };
+    }
+    if (path.resolve(outputArchivePath) !== path.resolve(archivePath)) {
+        log(`soldr-mini-cache: WARNING archive path mismatch — compress wrote ${outputArchivePath}, ` +
+            `expected ${archivePath}. Future restore may miss due to paths-version hash.`);
+    }
+    try {
+        const id = await cache.saveCache([outputArchivePath], exactKey);
+        if (id <= 0) {
+            log(`soldr-mini-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
+                `job already saved key=${exactKey}`);
+            return {
+                status: "skipped-race",
+                cacheId: id,
+                archiveBytes,
+                inflatedBytes,
+                fileCount,
+            };
+        }
+        log(`soldr-mini-cache: saved id=${id} key=${exactKey} archive=${outputArchivePath}`);
+        return {
+            status: "saved",
+            cacheId: id,
+            archiveBytes,
+            inflatedBytes,
+            fileCount,
+        };
+    }
+    catch (err) {
+        return {
+            status: "failed",
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+}
+/**
+ * Should we use the mini-cache for this run? Independent of the
+ * `soldr-mini-cache` input flag (that gate is checked in main.ts).
+ * Returns false when building from source — binary content depends on
+ * the commit SHA, not the version tag.
+ */
+function isEligibleForMiniCache(opts) {
+    if (!opts.enable)
+        return { eligible: false, reason: "enable=false (passthrough stub mode)" };
+    if (opts.hasRef) {
+        return {
+            eligible: false,
+            reason: "ref is set — building from source, binary depends on commit not version",
+        };
+    }
+    if (!opts.resolvedVersion.trim()) {
+        return { eligible: false, reason: "no resolved version available" };
+    }
+    return { eligible: true, reason: "eligible" };
+}
+
+
+/***/ }),
+
+/***/ 77:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -15432,7 +15674,7 @@ exports._internal = {
 
 /***/ }),
 
-/***/ 77:
+/***/ 78:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15489,7 +15731,358 @@ module.exports = {
 
 /***/ }),
 
-/***/ 78:
+/***/ 79:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Read + summarize zccache's per-rustc-invocation JSONL journal so
+// `dumpDiagnostics` can emit a `[compile_journal]` section telling
+// the reader (or future-me) *what* was cached and *why* every miss
+// missed. Without this, "warm reports hits=0 misses=206" is true but
+// useless — we can't tell whether the cache lookups all returned
+// "no cache file with this key" (genuinely-new fingerprint) or "the
+// cached entry's recorded inputs don't match my current inputs"
+// (content/path/env drift between cold and warm). The journal records
+// the per-invocation `outcome` and `miss_reason`; soldr's
+// `cache report --json` already returns `zccache analyze --json`'s
+// rollups under `report.rollups`. We just have to parse them.
+//
+// Pure-functional: no `core.*` here, no side effects beyond reading
+// the journal file. Easier to unit-test that way.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.readJournal = readJournal;
+exports.summarize = summarize;
+exports.formatJournalSection = formatJournalSection;
+exports.formatRollupsSection = formatRollupsSection;
+const fs = __importStar(__nccwpck_require__(240));
+const diagnostics_js_1 = __nccwpck_require__(224);
+const SLOWEST_TOP_N = 20;
+/**
+ * Read a `last-session.jsonl` file. Returns `null` if it doesn't exist
+ * (the common "no build happened" case); throws nothing for malformed
+ * lines — they're silently skipped so a single garbled record doesn't
+ * blank the whole dump.
+ */
+function readJournal(path) {
+    let raw;
+    try {
+        raw = fs.readFileSync(path, "utf8");
+    }
+    catch (err) {
+        if (err.code === "ENOENT")
+            return null;
+        throw err;
+    }
+    const out = [];
+    for (const line of raw.split(/\r?\n/)) {
+        if (line.trim() === "")
+            continue;
+        try {
+            const obj = JSON.parse(line);
+            if (obj && typeof obj === "object")
+                out.push(obj);
+        }
+        catch {
+            // Skip malformed lines.
+        }
+    }
+    return out;
+}
+/**
+ * Pure summary. Stable across runs given the same input order so the
+ * dump diffs cleanly across CI runs.
+ */
+function summarize(records) {
+    const outcomes = {};
+    const miss_reasons = {};
+    const per_extension = {};
+    const misses = [];
+    for (const r of records) {
+        const outcome = r.outcome ?? "unknown";
+        outcomes[outcome] = (outcomes[outcome] ?? 0) + 1;
+        if (outcome === "miss") {
+            const reason = r.miss_reason ?? "unknown";
+            miss_reasons[reason] = (miss_reasons[reason] ?? 0) + 1;
+            misses.push(r);
+        }
+        const ext = r.output_ext ?? "?";
+        if (!per_extension[ext])
+            per_extension[ext] = { hit: 0, miss: 0 };
+        if (outcome === "hit" || outcome === "link_hit")
+            per_extension[ext].hit += 1;
+        else if (outcome === "miss" || outcome === "link_miss")
+            per_extension[ext].miss += 1;
+    }
+    // Sort misses by latency descending and take top N.
+    const slowest_misses = [...misses]
+        .sort((a, b) => (b.latency_ns ?? 0) - (a.latency_ns ?? 0))
+        .slice(0, SLOWEST_TOP_N)
+        .map((r) => ({
+        crate: r.crate_name ?? "?",
+        reason: r.miss_reason ?? "?",
+        ext: r.output_ext ?? "?",
+        latency_ms: Math.round((r.latency_ns ?? 0) / 1_000_000),
+        diff: r.miss_diff ?? null,
+    }));
+    // One sample per distinct miss_reason (covers the long-tail rarer
+    // reasons even when ContentChanged dominates the histogram).
+    const seenReasons = new Set();
+    const sample_records = [];
+    for (const r of misses) {
+        const reason = r.miss_reason ?? "unknown";
+        if (seenReasons.has(reason))
+            continue;
+        seenReasons.add(reason);
+        sample_records.push(r);
+        if (sample_records.length >= 5)
+            break;
+    }
+    // Also include one hit sample if we have any, so cold/warm diffs are
+    // diffable in both directions.
+    const firstHit = records.find((r) => r.outcome === "hit" || r.outcome === "link_hit");
+    if (firstHit && sample_records.length < 6)
+        sample_records.push(firstHit);
+    return {
+        total: records.length,
+        outcomes,
+        miss_reasons,
+        per_extension,
+        slowest_misses,
+        sample_records,
+    };
+}
+// ---------- formatters ----------
+function pad(left, right, label, value) {
+    return `${label.padEnd(left)}${String(value).padStart(right)}`;
+}
+/**
+ * Normalise zccache's `env` field into a plain `{key: value}` map.
+ * The wire format is array-of-pairs (`Array<[string, string]>`) in
+ * current zccache builds; older / future builds may use a plain
+ * object. We tolerate both — and crucially, when given the array
+ * form we DO NOT use array indices as keys (the previous bug:
+ * indices like "0", "1" don't match the redaction regex so secrets
+ * leaked verbatim).
+ */
+function normaliseEnv(env) {
+    if (!env)
+        return {};
+    if (Array.isArray(env)) {
+        const out = {};
+        for (const pair of env) {
+            if (Array.isArray(pair) && pair.length >= 2 && typeof pair[0] === "string") {
+                out[pair[0]] = String(pair[1] ?? "");
+            }
+        }
+        return out;
+    }
+    // Plain object form. Defend against the legacy index-keyed shape that
+    // sneaks in if some intermediate code stringifies an array via
+    // `Object.fromEntries(arr.entries())` — detect that and recover.
+    const entries = Object.entries(env);
+    const looksLikeIndexedArray = entries.length > 0 &&
+        entries.every(([k, v]) => /^\d+$/.test(k) &&
+            Array.isArray(v) &&
+            v.length >= 2 &&
+            typeof v[0] === "string");
+    if (looksLikeIndexedArray) {
+        const out = {};
+        for (const [, v] of entries) {
+            const pair = v;
+            out[pair[0]] = String(pair[1] ?? "");
+        }
+        return out;
+    }
+    return env;
+}
+function redactEnv(env) {
+    const norm = normaliseEnv(env);
+    const out = {};
+    for (const [k, v] of Object.entries(norm))
+        out[k] = (0, diagnostics_js_1.redactValue)(k, v);
+    return out;
+}
+function envIsNonEmpty(env) {
+    if (!env)
+        return false;
+    if (Array.isArray(env))
+        return env.length > 0;
+    return Object.keys(env).length > 0;
+}
+function formatRecord(r) {
+    // Hand-shape JSON to keep one record-per-line readable: top-level keys
+    // on one line, then args/env/miss_diff (if present) on their own.
+    const summary = {
+        outcome: r.outcome,
+        miss_reason: r.miss_reason,
+        crate_name: r.crate_name,
+        crate_type: r.crate_type,
+        output_ext: r.output_ext,
+        latency_ms: r.latency_ns !== undefined ? Math.round(r.latency_ns / 1_000_000) : undefined,
+        cwd: r.cwd,
+    };
+    const parts = [];
+    parts.push(`    summary: ${JSON.stringify(summary)}`);
+    if (r.args && r.args.length > 0) {
+        parts.push(`    args: ${JSON.stringify(r.args)}`);
+    }
+    if (envIsNonEmpty(r.env)) {
+        parts.push(`    env (redacted): ${JSON.stringify(redactEnv(r.env))}`);
+    }
+    if (r.miss_diff && Object.keys(r.miss_diff).length > 0) {
+        parts.push(`    miss_diff: ${JSON.stringify(r.miss_diff)}`);
+    }
+    if (r.self_profile_ns) {
+        parts.push(`    self_profile_ns: ${JSON.stringify(r.self_profile_ns)}`);
+    }
+    return parts.join("\n");
+}
+/**
+ * Format a `[compile_journal]` section's body lines (without the
+ * surrounding header/footer — those are added by `dumpDiagnostics`).
+ */
+function formatJournalSection(summary) {
+    const lines = [];
+    lines.push(`[compile_journal]`);
+    lines.push(`  total_records=${summary.total}`);
+    lines.push(`  outcomes:`);
+    const outcomeEntries = Object.entries(summary.outcomes).sort((a, b) => b[1] - a[1]);
+    if (outcomeEntries.length === 0)
+        lines.push(`    (none)`);
+    for (const [k, v] of outcomeEntries)
+        lines.push(`    ${pad(16, 8, k, v)}`);
+    lines.push(`  miss_reasons (zccache fingerprint divergence; the answer to "why warm missed"):`);
+    const missEntries = Object.entries(summary.miss_reasons).sort((a, b) => b[1] - a[1]);
+    if (missEntries.length === 0)
+        lines.push(`    (none)`);
+    for (const [k, v] of missEntries)
+        lines.push(`    ${pad(28, 8, k, v)}`);
+    lines.push(`  per_output_ext (hit/miss split per artifact kind):`);
+    const extEntries = Object.entries(summary.per_extension).sort((a, b) => a[0] < b[0] ? -1 : 1);
+    if (extEntries.length === 0)
+        lines.push(`    (none)`);
+    for (const [ext, c] of extEntries) {
+        lines.push(`    ${ext.padEnd(10)}hit=${String(c.hit).padStart(5)}  miss=${String(c.miss).padStart(5)}`);
+    }
+    lines.push(`  slowest_misses (top ${summary.slowest_misses.length} by wall-clock):`);
+    if (summary.slowest_misses.length === 0)
+        lines.push(`    (none)`);
+    for (const m of summary.slowest_misses) {
+        lines.push(`    ${String(m.latency_ms + "ms").padStart(7)}  ${m.reason.padEnd(20)}  ${m.ext.padEnd(8)}  ${m.crate}`);
+        if (m.diff && typeof m.diff === "object" && Object.keys(m.diff).length > 0) {
+            lines.push(`        diff: ${JSON.stringify(m.diff)}`);
+        }
+    }
+    lines.push(`  sample_records (one verbatim per distinct outcome, env redacted):`);
+    if (summary.sample_records.length === 0)
+        lines.push(`    (none)`);
+    for (let i = 0; i < summary.sample_records.length; i += 1) {
+        lines.push(`  --- record ${i + 1} ---`);
+        lines.push(formatRecord(summary.sample_records[i]));
+    }
+    return lines;
+}
+/**
+ * Format the `rollups` field returned by `soldr cache report --json`
+ * (i.e. `zccache analyze --json` output). Tolerates missing /
+ * malformed fields — older soldr versions or error paths just yield
+ * an empty section.
+ */
+function formatRollupsSection(report) {
+    const lines = [];
+    lines.push(`[compile_rollups (zccache analyze --json)]`);
+    if (!report || typeof report !== "object") {
+        lines.push(`  (no report payload)`);
+        return lines;
+    }
+    const rollups = report.rollups;
+    if (!rollups || typeof rollups !== "object") {
+        lines.push(`  (no rollups field)`);
+        return lines;
+    }
+    const r = rollups;
+    // by_extension: { ext: { hits, misses, total_ns } }
+    const byExt = r.by_extension;
+    lines.push(`  by_extension:`);
+    if (!byExt || Object.keys(byExt).length === 0)
+        lines.push(`    (none)`);
+    else {
+        for (const [ext, v] of Object.entries(byExt)) {
+            const hits = v?.hits ?? 0;
+            const misses = v?.misses ?? 0;
+            const totalMs = Math.round((v?.total_ns ?? 0) / 1_000_000);
+            const denom = hits + misses;
+            const rate = denom > 0 ? ((hits / denom) * 100).toFixed(1) : "n/a";
+            lines.push(`    ${ext.padEnd(10)}hits=${String(hits).padStart(5)}  misses=${String(misses).padStart(5)}  rate=${rate.padStart(5)}%  total=${totalMs}ms`);
+        }
+    }
+    // slowest_entries: [{outcome, crate_name, latency_ns}, ...]
+    const slowest = r.slowest_entries;
+    lines.push(`  slowest_entries (analyze top-N):`);
+    if (!slowest || slowest.length === 0)
+        lines.push(`    (none)`);
+    else {
+        for (const e of slowest.slice(0, 20)) {
+            const latencyMs = Math.round(Number(e.latency_ns ?? 0) / 1_000_000);
+            const outcome = String(e.outcome ?? "?");
+            const crate = String(e.crate_name ?? "?");
+            lines.push(`    ${String(latencyMs + "ms").padStart(7)}  ${outcome.padEnd(10)}  ${crate}`);
+        }
+    }
+    // miss_crate_counts: { crate: N }
+    const missByCrate = r.miss_crate_counts;
+    lines.push(`  miss_crate_counts (top 20):`);
+    if (!missByCrate || Object.keys(missByCrate).length === 0)
+        lines.push(`    (none)`);
+    else {
+        const sorted = Object.entries(missByCrate)
+            .sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))
+            .slice(0, 20);
+        for (const [crate, count] of sorted) {
+            lines.push(`    ${String(count).padStart(5)}  ${crate}`);
+        }
+    }
+    return lines;
+}
+
+
+/***/ }),
+
+/***/ 80:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15720,7 +16313,7 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 
 /***/ }),
 
-/***/ 79:
+/***/ 81:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15737,7 +16330,7 @@ Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: 
 
 /***/ }),
 
-/***/ 80:
+/***/ 82:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -15749,7 +16342,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 81:
+/***/ 83:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15781,9 +16374,9 @@ const {
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(13)
 const { webidl } = __nccwpck_require__(430)
-const { getGlobalOrigin } = __nccwpck_require__(136)
+const { getGlobalOrigin } = __nccwpck_require__(137)
 const { URLSerializer } = __nccwpck_require__(23)
-const { kHeadersList, kConstruct } = __nccwpck_require__(190)
+const { kHeadersList, kConstruct } = __nccwpck_require__(188)
 const assert = __nccwpck_require__(495)
 const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(442)
 
@@ -16703,7 +17296,7 @@ module.exports = { Request, makeRequest }
 
 /***/ }),
 
-/***/ 82:
+/***/ 84:
 /***/ ((module) => {
 
 "use strict";
@@ -16711,7 +17304,7 @@ module.exports = require("url");
 
 /***/ }),
 
-/***/ 83:
+/***/ 85:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16721,8 +17314,8 @@ module.exports = require("url");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.deserializationPolicyName = void 0;
 exports.deserializationPolicy = deserializationPolicy;
-const interfaces_js_1 = __nccwpck_require__(96);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const interfaces_js_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const serializer_js_1 = __nccwpck_require__(452);
 const operationHelpers_js_1 = __nccwpck_require__(406);
 const defaultJsonContentTypes = ["application/json", "text/json"];
@@ -16952,7 +17545,7 @@ async function parse(jsonContentTypes, xmlContentTypes, operationResponse, opts,
 
 /***/ }),
 
-/***/ 84:
+/***/ 86:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -17004,7 +17597,7 @@ function apiKeyAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 85:
+/***/ 87:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -17017,7 +17610,7 @@ function apiKeyAuthenticationPolicy(options) {
 const assert = __nccwpck_require__(495)
 const net = __nccwpck_require__(480)
 const http = __nccwpck_require__(315)
-const { pipeline } = __nccwpck_require__(127)
+const { pipeline } = __nccwpck_require__(128)
 const util = __nccwpck_require__(66)
 const timers = __nccwpck_require__(314)
 const Request = __nccwpck_require__(287)
@@ -17035,7 +17628,7 @@ const {
   HTTPParserError,
   ResponseExceededMaxSizeError,
   ClientDestroyedError
-} = __nccwpck_require__(460)
+} = __nccwpck_require__(461)
 const buildConnector = __nccwpck_require__(257)
 const {
   kUrl,
@@ -17088,7 +17681,7 @@ const {
   kHTTP2BuildRequest,
   kHTTP2CopyHeaders,
   kHTTP1BuildRequest
-} = __nccwpck_require__(190)
+} = __nccwpck_require__(188)
 
 /** @type {import('http2')} */
 let http2
@@ -17121,7 +17714,7 @@ const kClosedResolve = Symbol('kClosedResolve')
 const channels = {}
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(138)
+  const diagnosticsChannel = __nccwpck_require__(139)
   channels.sendHeaders = diagnosticsChannel.channel('undici:client:sendHeaders')
   channels.beforeConnect = diagnosticsChannel.channel('undici:client:beforeConnect')
   channels.connectError = diagnosticsChannel.channel('undici:client:connectError')
@@ -19295,7 +19888,7 @@ module.exports = Client
 
 /***/ }),
 
-/***/ 86:
+/***/ 88:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -19337,13 +19930,13 @@ __export(src_exports, {
 module.exports = __toCommonJS(src_exports);
 var import_AbortError = __nccwpck_require__(9);
 var import_logger = __nccwpck_require__(237);
-var import_httpHeaders = __nccwpck_require__(457);
-var import_pipelineRequest = __nccwpck_require__(112);
+var import_httpHeaders = __nccwpck_require__(458);
+var import_pipelineRequest = __nccwpck_require__(113);
 var import_pipeline = __nccwpck_require__(493);
 var import_restError = __nccwpck_require__(418);
 var import_bytesEncoding = __nccwpck_require__(276);
 var import_defaultHttpClient = __nccwpck_require__(352);
-var import_getClient = __nccwpck_require__(204);
+var import_getClient = __nccwpck_require__(203);
 var import_operationOptionHelpers = __nccwpck_require__(363);
 var import_restError2 = __nccwpck_require__(348);
 // Annotate the CommonJS export names for ESM import in node:
@@ -19353,7 +19946,7 @@ var import_restError2 = __nccwpck_require__(348);
 
 /***/ }),
 
-/***/ 87:
+/***/ 89:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19361,9 +19954,9 @@ var import_restError2 = __nccwpck_require__(348);
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
 const base64_1 = __nccwpck_require__(290);
-const pb_long_1 = __nccwpck_require__(114);
+const pb_long_1 = __nccwpck_require__(115);
 const reflection_info_1 = __nccwpck_require__(426);
-const assert_1 = __nccwpck_require__(456);
+const assert_1 = __nccwpck_require__(457);
 /**
  * Writes proto3 messages in canonical JSON format using reflection
  * information.
@@ -19591,7 +20184,7 @@ exports.ReflectionJsonWriter = ReflectionJsonWriter;
 
 /***/ }),
 
-/***/ 88:
+/***/ 90:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19732,7 +20325,7 @@ exports.Batch = Batch;
 
 /***/ }),
 
-/***/ 89:
+/***/ 91:
 /***/ ((module) => {
 
 "use strict";
@@ -19740,7 +20333,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 90:
+/***/ 92:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19771,7 +20364,7 @@ exports.AnonymousCredentialPolicy = AnonymousCredentialPolicy;
 
 /***/ }),
 
-/***/ 91:
+/***/ 93:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20123,7 +20716,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 92:
+/***/ 94:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20152,7 +20745,7 @@ exports.Credential = Credential;
 
 /***/ }),
 
-/***/ 93:
+/***/ 95:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20173,7 +20766,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 94:
+/***/ 96:
 /***/ ((module) => {
 
 "use strict";
@@ -20471,7 +21064,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 95:
+/***/ 97:
 /***/ ((module) => {
 
 "use strict";
@@ -20491,7 +21084,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 96:
+/***/ 98:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20512,7 +21105,7 @@ exports.XML_CHARKEY = "_";
 
 /***/ }),
 
-/***/ 97:
+/***/ 99:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20542,7 +21135,7 @@ async function cancelablePromiseRace(abortablePromiseBuilders, options) {
 
 /***/ }),
 
-/***/ 98:
+/***/ 100:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -20625,18 +21218,18 @@ var import_logPolicy = __nccwpck_require__(68);
 var import_multipartPolicy = __nccwpck_require__(262);
 var import_proxyPolicy = __nccwpck_require__(445);
 var import_redirectPolicy = __nccwpck_require__(325);
-var import_systemErrorRetryPolicy = __nccwpck_require__(212);
+var import_systemErrorRetryPolicy = __nccwpck_require__(211);
 var import_throttlingRetryPolicy = __nccwpck_require__(21);
-var import_retryPolicy = __nccwpck_require__(206);
+var import_retryPolicy = __nccwpck_require__(205);
 var import_tracingPolicy = __nccwpck_require__(321);
 var import_defaultRetryPolicy = __nccwpck_require__(52);
 var import_userAgentPolicy = __nccwpck_require__(368);
 var import_tlsPolicy = __nccwpck_require__(358);
 var import_formDataPolicy = __nccwpck_require__(259);
-var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(211);
+var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(210);
 var import_ndJsonPolicy = __nccwpck_require__(231);
-var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(188);
-var import_agentPolicy = __nccwpck_require__(223);
+var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(186);
+var import_agentPolicy = __nccwpck_require__(222);
 var import_file = __nccwpck_require__(313);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -20644,7 +21237,7 @@ var import_file = __nccwpck_require__(313);
 
 /***/ }),
 
-/***/ 99:
+/***/ 101:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -20671,7 +21264,7 @@ __export(logPolicy_exports, {
 });
 module.exports = __toCommonJS(logPolicy_exports);
 var import_log = __nccwpck_require__(148);
-var import_sanitizer = __nccwpck_require__(118);
+var import_sanitizer = __nccwpck_require__(119);
 const logPolicyName = "logPolicy";
 function logPolicy(options = {}) {
   const logger = options.logger ?? import_log.logger.info;
@@ -20700,11 +21293,11 @@ function logPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 100:
+/***/ 102:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const { addAbortListener } = __nccwpck_require__(66)
-const { RequestAbortedError } = __nccwpck_require__(460)
+const { RequestAbortedError } = __nccwpck_require__(461)
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')
@@ -20761,7 +21354,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 101:
+/***/ 103:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20792,7 +21385,7 @@ function rangeToString(iRange) {
 
 /***/ }),
 
-/***/ 102:
+/***/ 104:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20802,15 +21395,15 @@ const {
   Readable,
   Duplex,
   PassThrough
-} = __nccwpck_require__(127)
+} = __nccwpck_require__(128)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(460)
+} = __nccwpck_require__(461)
 const util = __nccwpck_require__(66)
 const { AsyncResource } = __nccwpck_require__(403)
-const { addSignal, removeSignal } = __nccwpck_require__(100)
+const { addSignal, removeSignal } = __nccwpck_require__(102)
 const assert = __nccwpck_require__(495)
 
 const kResume = Symbol('resume')
@@ -21049,7 +21642,7 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 103:
+/***/ 105:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21067,17 +21660,17 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 
 /***/ }),
 
-/***/ 104:
+/***/ 106:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = (__nccwpck_require__(140).EventEmitter)
+const EventEmitter = (__nccwpck_require__(141).EventEmitter)
 const inherits = (__nccwpck_require__(355).inherits)
-const getLimit = __nccwpck_require__(455)
+const getLimit = __nccwpck_require__(456)
 
-const StreamSearch = __nccwpck_require__(111)
+const StreamSearch = __nccwpck_require__(112)
 
 const B_DCRLF = Buffer.from('\r\n\r\n')
 const RE_CRLF = /\r\n/g
@@ -21175,7 +21768,7 @@ module.exports = HeaderParser
 
 /***/ }),
 
-/***/ 105:
+/***/ 107:
 /***/ ((module) => {
 
 "use strict";
@@ -21183,7 +21776,7 @@ module.exports = require("node:fs/promises");
 
 /***/ }),
 
-/***/ 106:
+/***/ 108:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -21211,7 +21804,7 @@ __export(util_exports, {
   toWebResourceLike: () => toWebResourceLike
 });
 module.exports = __toCommonJS(util_exports);
-var import_core_rest_pipeline = __nccwpck_require__(98);
+var import_core_rest_pipeline = __nccwpck_require__(100);
 const originalRequestSymbol = /* @__PURE__ */ Symbol("Original PipelineRequest");
 const originalClientRequestSymbol = /* @__PURE__ */ Symbol.for("@azure/core-client original request");
 function toPipelineRequest(webResource, options = {}) {
@@ -21453,7 +22046,7 @@ class HttpHeaders {
 
 /***/ }),
 
-/***/ 107:
+/***/ 109:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21499,375 +22092,7 @@ function objectHasProperty(thing, property) {
 
 /***/ }),
 
-/***/ 108:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Verbose diagnostic dump emitted when the action receives `logging: true`.
-//
-// The goal is to make cache-behavior surprises trivially debuggable from a
-// single CI run. The dump bundles:
-//   - every observed INPUT_* env var (so the kebab-vs-underscore plumbing
-//     bug that motivated this module is visible without re-running)
-//   - the parsed RawInputs struct
-//   - every constructed cache key with restore-key fallbacks
-//   - resolved env exports (SOLDR_*, ZCCACHE_*, SETUP_SOLDR_*)
-//   - cache restore/save outcomes recorded so far
-//   - the final cache summary + compile-cache report in post phase
-//
-// Token-shaped values are redacted before printing.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.redactValue = redactValue;
-exports.captureProcessSnapshot = captureProcessSnapshot;
-exports.dumpDiagnostics = dumpDiagnostics;
-exports.loggingEnabled = loggingEnabled;
-const fs = __importStar(__nccwpck_require__(240));
-const node_child_process_1 = __nccwpck_require__(192);
-const compile_journal_js_1 = __nccwpck_require__(503);
-const ENV_KEY_PREFIXES = [
-    "INPUT_",
-    "SOLDR_",
-    "ZCCACHE_",
-    "SCCACHE_",
-    "SETUP_SOLDR_",
-    "GITHUB_",
-    "RUNNER_",
-    "ACTION_",
-    "CARGO_",
-    "RUSTUP_",
-    "RUSTC_",
-];
-const SECRET_KEY_PATTERN = /(token|secret|password|^.*_pass$|api[_-]?key|client[_-]?secret|webhook)/i;
-// Cache-key fields look secret-y but never are; never redact them.
-const NEVER_REDACT_PATTERN = /(_key$|cache[-_]key|cache[-_]keys$|key[-_]suffix$|public[-_]key)/i;
-function redactValue(key, value) {
-    if (NEVER_REDACT_PATTERN.test(key))
-        return value;
-    if (SECRET_KEY_PATTERN.test(key))
-        return value ? "<redacted>" : "";
-    return value;
-}
-function pickEnv(env) {
-    const pairs = [];
-    for (const [k, v] of Object.entries(env)) {
-        if (v === undefined)
-            continue;
-        if (!ENV_KEY_PREFIXES.some((p) => k.startsWith(p)))
-            continue;
-        pairs.push([k, redactValue(k, v)]);
-    }
-    pairs.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
-    return pairs;
-}
-function rawInputsLines(inputs) {
-    const lines = [];
-    const entries = Object.entries(inputs).sort((a, b) => (a[0] < b[0] ? -1 : 1));
-    for (const [k, v] of entries) {
-        lines.push(`  ${k}=${JSON.stringify(v)}`);
-    }
-    return lines;
-}
-function cachePlanLines(result) {
-    const lines = [];
-    lines.push("  setup_cache:");
-    lines.push(`    key=${result.setupCache.key}`);
-    lines.push(`    restore_prefix=${result.setupCache.restorePrefix}`);
-    lines.push(`    paths=${JSON.stringify(result.setupCache.paths)}`);
-    lines.push(`    layout=${result.setupCache.layout}`);
-    lines.push("  build_cache:");
-    lines.push(`    key=${result.buildCache.key}`);
-    lines.push(`    restore_key_parent=${result.buildCache.restoreKeyParent || "(none)"}`);
-    lines.push(`    restore_key_toolchain=${result.buildCache.restoreKeyToolchain}`);
-    lines.push(`    restore_key_os_arch=${result.buildCache.restoreKeyOsArch}`);
-    lines.push(`    path=${result.buildCache.path}`);
-    lines.push(`    mode=${result.buildCache.mode}`);
-    lines.push("  target_cache:");
-    lines.push(`    enabled=${result.targetCache.enabled}`);
-    lines.push(`    key=${result.targetCache.key}`);
-    lines.push(`    restore_key_parent=${result.targetCache.restoreKeyParent || "(none)"}`);
-    lines.push(`    restore_key_lock=${result.targetCache.restoreKeyLock || "(none)"}`);
-    lines.push(`    restore_key_lockfile=${result.targetCache.restoreKeyLockfile || "(none)"}`);
-    lines.push(`    paths=${result.targetCache.paths}`);
-    lines.push(`    bundle_path=${result.targetCache.bundlePath}`);
-    lines.push(`    target_path=${result.targetCache.targetPath}`);
-    lines.push(`    effective_mode=${result.targetCache.effectiveMode}`);
-    lines.push(`    profile=${result.targetCache.profile}`);
-    lines.push("  cargo_registry_cache:");
-    lines.push(`    enabled=${result.cargoRegistryCache.enabled}`);
-    lines.push(`    key=${result.cargoRegistryCache.key}`);
-    lines.push(`    restore_prefix=${result.cargoRegistryCache.restorePrefix}`);
-    lines.push(`    path=${result.cargoRegistryCache.path}`);
-    return lines;
-}
-function envExportLines(result) {
-    const entries = Object.entries(result.envExports).sort((a, b) => (a[0] < b[0] ? -1 : 1));
-    return entries.map(([k, v]) => `  ${k}=${redactValue(k, v)}`);
-}
-function cacheOutcomeLines(outcomes) {
-    if (outcomes.length === 0)
-        return ["  (no outcomes recorded yet)"];
-    const lines = [];
-    for (const o of outcomes) {
-        lines.push(`  [${o.operation}] ${o.label}: hit=${o.hit} matched=${o.matchedKey || "(none)"} ` +
-            `key=${o.key} duration_ms=${o.durationMs}`);
-        if (o.archiveBytes !== null) {
-            lines.push(`    archive_bytes=${o.archiveBytes} inflated_bytes=${o.inflatedBytes ?? "?"} files=${o.fileCount ?? "?"}`);
-        }
-    }
-    return lines;
-}
-/**
- * Capture a runtime process snapshot via `ps` (Unix) or `tasklist`
- * (Windows). Returns null only on an actual exec failure (binary
- * missing, etc.); a non-zero exit is reported in the result so the
- * stderr can be inspected.
- *
- * Why this lives here: the post step uses it to expose orphan daemons
- * (e.g. zccache-daemon processes that survive `soldr cache shutdown`
- * and get SIGKILL'd by the runner) so root-cause analysis doesn't
- * require another build.
- */
-function captureProcessSnapshot() {
-    const isWindows = process.platform === "win32";
-    const cmd = isWindows ? "tasklist" : "ps";
-    // Unix: print pid, ppid, user, state, command-name, full-args.
-    // BSD ps (macOS) supports the same -o keys but uses `command` instead
-    // of `args` — accept both via the column listing.
-    const args = isWindows
-        ? ["/V", "/FO", "CSV", "/NH"]
-        : ["-eo", "pid,ppid,user,stat,comm,args"];
-    try {
-        const result = (0, node_child_process_1.spawnSync)(cmd, args, {
-            encoding: "utf8",
-            maxBuffer: 8 * 1024 * 1024,
-            timeout: 15_000,
-        });
-        return {
-            cmd: `${cmd} ${args.join(" ")}`,
-            stdout: result.stdout ?? "",
-            stderr: result.stderr ?? "",
-            exitCode: result.status,
-        };
-    }
-    catch {
-        return null;
-    }
-}
-/**
- * Emit the full diagnostic dump to the logger and (optionally) the step summary.
- * Safe to call when `result`, `cacheOutcomes`, or `finalSummary` are missing —
- * each section is independent.
- */
-function dumpDiagnostics(opts) {
-    const lines = [];
-    const header = `=== DIAGNOSTIC DUMP (phase=${opts.phase}) ===`;
-    const footer = "=== END DIAGNOSTIC DUMP ===";
-    lines.push(header);
-    lines.push("[env: observed INPUT_/SOLDR_/ZCCACHE_/SETUP_SOLDR_/GITHUB_/RUNNER_/ACTION_/CARGO_/RUSTUP_/RUSTC_]");
-    const envPairs = pickEnv(opts.env);
-    if (envPairs.length === 0) {
-        lines.push("  (none observed)");
-    }
-    else {
-        for (const [k, v] of envPairs) {
-            lines.push(`  ${k}=${v}`);
-        }
-    }
-    if (opts.rawInputs) {
-        lines.push("[raw_inputs: parsed RawInputs after kebab-case lookup]");
-        lines.push(...rawInputsLines(opts.rawInputs));
-    }
-    if (opts.result) {
-        lines.push("[cache_plans: every constructed cache key + restore-key fallbacks]");
-        lines.push(...cachePlanLines(opts.result));
-        lines.push("[env_exports: resolved SOLDR_/ZCCACHE_/etc env exports]");
-        if (Object.keys(opts.result.envExports).length === 0) {
-            lines.push("  (none)");
-        }
-        else {
-            lines.push(...envExportLines(opts.result));
-        }
-        lines.push("[resolved_state]");
-        lines.push(`  enabled=${opts.result.enabled}`);
-        lines.push(`  workspace=${opts.result.workspace}`);
-        lines.push(`  cache_root=${opts.result.cacheRoot}`);
-        lines.push(`  soldr_root=${opts.result.soldrRoot}`);
-        lines.push(`  cargo_home=${opts.result.cargoHome}`);
-        lines.push(`  rustup_home=${opts.result.rustupHome}`);
-        lines.push(`  soldr_path=${opts.result.soldrPath}`);
-        lines.push(`  soldr_repo=${opts.result.soldrRepo}`);
-        lines.push(`  soldr_ref=${opts.result.soldrRef || "(release)"}`);
-        lines.push(`  soldr_version_requested=${opts.result.soldrVersionRequested}`);
-        lines.push(`  soldr_version_resolved=${opts.result.soldrVersionResolved}`);
-        lines.push(`  toolchain_channel=${opts.result.toolchain.channel}`);
-        lines.push(`  toolchain_cache_channel=${opts.result.toolchain.cacheChannel}`);
-        lines.push(`  rustup_strategy=${opts.result.rustupStrategy}`);
-        lines.push(`  shims_enabled=${opts.result.shimsEnabled}`);
-        lines.push(`  shims_dir=${opts.result.shimsDir}`);
-        lines.push(`  stats=${opts.result.stats}`);
-        lines.push(`  compile_cache_stats=${opts.result.compileCacheStats}`);
-        lines.push(`  debug_mode=${opts.result.debugMode}`);
-        lines.push(`  cache_shutdown_on_idle_seconds=${opts.result.cacheShutdownOnIdleSeconds ?? "(unset)"}`);
-    }
-    if (opts.cacheOutcomes !== undefined) {
-        lines.push("[cache_outcomes: per-layer restore/save results]");
-        lines.push(...cacheOutcomeLines(opts.cacheOutcomes));
-    }
-    if (opts.finalSummary) {
-        lines.push("[final_cache_summary]");
-        const json = JSON.stringify(opts.finalSummary, null, 2);
-        for (const line of json.split("\n")) {
-            lines.push(`  ${line}`);
-        }
-    }
-    // Per-compilation zccache journal — the answer to "warm reports
-    // hits=0; WHY did each lookup miss?". Reads the JSONL emitted by
-    // zccache for the just-finished session, summarizes it (outcome +
-    // miss_reason histograms, slowest misses with their miss_diff, a
-    // handful of verbatim records), and prints. Silently no-ops when
-    // the journal file isn't present.
-    if (opts.journalPath) {
-        try {
-            const records = (0, compile_journal_js_1.readJournal)(opts.journalPath);
-            if (records === null) {
-                lines.push(`[compile_journal]`);
-                lines.push(`  (journal file not found at ${opts.journalPath})`);
-            }
-            else if (records.length === 0) {
-                lines.push(`[compile_journal]`);
-                lines.push(`  (journal file empty at ${opts.journalPath})`);
-            }
-            else {
-                lines.push(...(0, compile_journal_js_1.formatJournalSection)((0, compile_journal_js_1.summarize)(records)));
-            }
-        }
-        catch (err) {
-            lines.push(`[compile_journal]`);
-            lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
-        }
-        // Raw JSONL dump — verbatim file contents under the summary. Only
-        // emitted when the caller opts in (debug=true) because it's huge
-        // (one record per rustc invocation, frequently MBs of output).
-        if (opts.journalPrintRaw) {
-            try {
-                const raw = fs.readFileSync(opts.journalPath, "utf8");
-                const rawLines = raw.split(/\r?\n/).filter((l) => l.length > 0);
-                lines.push(`[compile_journal_raw: verbatim JSONL from ${opts.journalPath} — ${rawLines.length} records]`);
-                for (const rawLine of rawLines) {
-                    lines.push(`  ${rawLine}`);
-                }
-            }
-            catch (err) {
-                const code = err.code;
-                if (code === "ENOENT") {
-                    // Already noted by the summary section above; no need to repeat.
-                }
-                else {
-                    lines.push(`[compile_journal_raw]`);
-                    lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
-                }
-            }
-        }
-    }
-    // Rollups (per-extension / per-crate) from `soldr cache report --json`.
-    // The raw report is already parsed into finalSummary's
-    // compile_cache_report.report; we accept it as a separate
-    // `cacheReport` so callers can pass it without rebuilding the
-    // FinalCacheSummary shape.
-    if (opts.cacheReport) {
-        lines.push(...(0, compile_journal_js_1.formatRollupsSection)(opts.cacheReport));
-    }
-    // Process snapshot — captured by the caller via captureProcessSnapshot()
-    // when debug mode is on. Useful for spotting orphan daemons (e.g.
-    // zccache-daemon survivors after `soldr cache shutdown`) that the runner
-    // SIGKILLs at job cleanup.
-    if (opts.processSnapshot) {
-        const snap = opts.processSnapshot;
-        lines.push(`[processes: snapshot via \`${snap.cmd}\` exit=${snap.exitCode ?? "null"}]`);
-        if (snap.stderr.trim().length > 0) {
-            lines.push(`  stderr: ${snap.stderr.trim().replace(/\n+/g, " | ")}`);
-        }
-        const trimmed = snap.stdout.replace(/\r\n/g, "\n").trimEnd();
-        if (trimmed.length === 0) {
-            lines.push("  (no stdout)");
-        }
-        else {
-            for (const line of trimmed.split("\n")) {
-                lines.push(`  ${line}`);
-            }
-        }
-    }
-    lines.push(footer);
-    for (const line of lines) {
-        opts.logger.log(line);
-    }
-    if (opts.stepSummaryPath) {
-        appendToStepSummary(opts.stepSummaryPath, opts.phase, lines, opts.logger);
-    }
-}
-function appendToStepSummary(summaryPath, phase, lines, logger) {
-    const block = [
-        `### setup-soldr diagnostic dump (phase=${phase})`,
-        "",
-        "```",
-        ...lines,
-        "```",
-        "",
-    ];
-    try {
-        fs.appendFileSync(summaryPath, block.join("\n") + "\n", "utf8");
-    }
-    catch (err) {
-        logger.log(`diagnostics: failed to append to step summary: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-/**
- * Truthy check matching the rest of the action: "1", "true", "yes", "on".
- * Empty / unset / anything else is false.
- */
-function loggingEnabled(value) {
-    const v = (value ?? "").trim().toLowerCase();
-    return v === "1" || v === "true" || v === "yes" || v === "on";
-}
-
-
-/***/ }),
-
-/***/ 109:
+/***/ 110:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21950,7 +22175,7 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 
 /***/ }),
 
-/***/ 110:
+/***/ 111:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22000,7 +22225,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 111:
+/***/ 112:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22032,7 +22257,7 @@ function calculateRetryDelay(retryAttempt, config) {
  * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
-const EventEmitter = (__nccwpck_require__(140).EventEmitter)
+const EventEmitter = (__nccwpck_require__(141).EventEmitter)
 const inherits = (__nccwpck_require__(355).inherits)
 
 function SBMH (needle) {
@@ -22236,7 +22461,7 @@ module.exports = SBMH
 
 /***/ }),
 
-/***/ 112:
+/***/ 113:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -22261,7 +22486,7 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_httpHeaders = __nccwpck_require__(457);
+var import_httpHeaders = __nccwpck_require__(458);
 var import_uuidUtils = __nccwpck_require__(372);
 class PipelineRequestImpl {
   url;
@@ -22315,7 +22540,7 @@ function createPipelineRequest(options) {
 
 /***/ }),
 
-/***/ 113:
+/***/ 114:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -22375,14 +22600,14 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 114:
+/***/ 115:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PbLong = exports.PbULong = exports.detectBi = void 0;
-const goog_varint_1 = __nccwpck_require__(198);
+const goog_varint_1 = __nccwpck_require__(197);
 let BI;
 function detectBi() {
     const dv = new DataView(new ArrayBuffer(8));
@@ -22621,7 +22846,7 @@ PbLong.ZERO = new PbLong(0, 0);
 
 /***/ }),
 
-/***/ 115:
+/***/ 116:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22638,7 +22863,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 116:
+/***/ 117:
 /***/ ((module) => {
 
 "use strict";
@@ -22646,7 +22871,7 @@ module.exports = require("buffer");
 
 /***/ }),
 
-/***/ 117:
+/***/ 118:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -22676,7 +22901,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
 const path = __importStar(__nccwpck_require__(239));
-const pathHelper = __importStar(__nccwpck_require__(215));
+const pathHelper = __importStar(__nccwpck_require__(214));
 const assert_1 = __importDefault(__nccwpck_require__(495));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -22766,7 +22991,7 @@ exports.Path = Path;
 
 /***/ }),
 
-/***/ 118:
+/***/ 119:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -22791,7 +23016,7 @@ __export(sanitizer_exports, {
   Sanitizer: () => Sanitizer
 });
 module.exports = __toCommonJS(sanitizer_exports);
-var import_object = __nccwpck_require__(141);
+var import_object = __nccwpck_require__(142);
 const RedactedString = "REDACTED";
 const defaultAllowedHeaderNames = [
   "x-ms-client-request-id",
@@ -22940,7 +23165,7 @@ class Sanitizer {
 
 /***/ }),
 
-/***/ 119:
+/***/ 120:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22957,7 +23182,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 120:
+/***/ 121:
 /***/ ((module) => {
 
 "use strict";
@@ -22965,7 +23190,7 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 121:
+/***/ 122:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
@@ -22977,7 +23202,7 @@ var path = (function () { try { return __nccwpck_require__(239) } catch (e) {}}(
 minimatch.sep = path.sep
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __nccwpck_require__(458)
+var expand = __nccwpck_require__(459)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -23977,7 +24202,7 @@ function regExpEscape (s) {
 
 /***/ }),
 
-/***/ 122:
+/***/ 123:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -24012,12 +24237,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
-const os = __importStar(__nccwpck_require__(89));
+const os = __importStar(__nccwpck_require__(91));
 const events = __importStar(__nccwpck_require__(442));
-const child = __importStar(__nccwpck_require__(161));
+const child = __importStar(__nccwpck_require__(160));
 const path = __importStar(__nccwpck_require__(239));
 const io = __importStar(__nccwpck_require__(283));
-const ioUtil = __importStar(__nccwpck_require__(217));
+const ioUtil = __importStar(__nccwpck_require__(216));
 const timers_1 = __nccwpck_require__(481);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
@@ -24602,7 +24827,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 123:
+/***/ 124:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24614,7 +24839,7 @@ exports.StorageSharedKeyCredentialPolicy = void 0;
 const constants_js_1 = __nccwpck_require__(34);
 const utils_common_js_1 = __nccwpck_require__(446);
 const CredentialPolicy_js_1 = __nccwpck_require__(296);
-const SharedKeyComparator_js_1 = __nccwpck_require__(172);
+const SharedKeyComparator_js_1 = __nccwpck_require__(170);
 /**
  * StorageSharedKeyCredentialPolicy is a policy used to sign HTTP request with a shared key.
  */
@@ -24758,7 +24983,7 @@ exports.StorageSharedKeyCredentialPolicy = StorageSharedKeyCredentialPolicy;
 
 /***/ }),
 
-/***/ 124:
+/***/ 125:
 /***/ ((module) => {
 
 "use strict";
@@ -24778,7 +25003,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 125:
+/***/ 126:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24787,8 +25012,8 @@ module.exports = {
 
 
 const assert = __nccwpck_require__(495)
-const { Readable } = __nccwpck_require__(127)
-const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(460)
+const { Readable } = __nccwpck_require__(128)
+const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(461)
 const util = __nccwpck_require__(66)
 const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(66)
 
@@ -25070,7 +25295,7 @@ function consumeEnd (consume) {
       resolve(dst.buffer)
     } else if (type === 'blob') {
       if (!Blob) {
-        Blob = (__nccwpck_require__(116).Blob)
+        Blob = (__nccwpck_require__(117).Blob)
       }
       resolve(new Blob(body, { type: stream[kContentType] }))
     }
@@ -25108,7 +25333,7 @@ function consumeFinish (consume, err) {
 
 /***/ }),
 
-/***/ 126:
+/***/ 127:
 /***/ ((module) => {
 
 "use strict";
@@ -25116,7 +25341,7 @@ module.exports = require("querystring");
 
 /***/ }),
 
-/***/ 127:
+/***/ 128:
 /***/ ((module) => {
 
 "use strict";
@@ -25124,7 +25349,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 128:
+/***/ 129:
 /***/ ((module) => {
 
 "use strict";
@@ -25194,7 +25419,7 @@ function range(a, b, str) {
 
 /***/ }),
 
-/***/ 129:
+/***/ 130:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -25232,7 +25457,7 @@ const tls = __importStar(__nccwpck_require__(477));
 const assert_1 = __importDefault(__nccwpck_require__(495));
 const debug_1 = __importDefault(__nccwpck_require__(485));
 const agent_base_1 = __nccwpck_require__(232);
-const url_1 = __nccwpck_require__(82);
+const url_1 = __nccwpck_require__(84);
 const parse_proxy_response_1 = __nccwpck_require__(395);
 const debug = (0, debug_1.default)('https-proxy-agent');
 const setServernameFromNonIpHost = (options) => {
@@ -25381,7 +25606,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 130:
+/***/ 131:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -25465,7 +25690,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 131:
+/***/ 132:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25473,8 +25698,8 @@ exports.OidcClient = OidcClient;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
 const binary_format_contract_1 = __nccwpck_require__(318);
-const pb_long_1 = __nccwpck_require__(114);
-const goog_varint_1 = __nccwpck_require__(198);
+const pb_long_1 = __nccwpck_require__(115);
+const goog_varint_1 = __nccwpck_require__(197);
 const defaultsRead = {
     readUnknownField: true,
     readerFactory: bytes => new BinaryReader(bytes),
@@ -25656,7 +25881,7 @@ exports.BinaryReader = BinaryReader;
 
 /***/ }),
 
-/***/ 132:
+/***/ 133:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25671,7 +25896,7 @@ const {
   kContentLength,
   kMockDispatch
 } = __nccwpck_require__(443)
-const { InvalidArgumentError } = __nccwpck_require__(460)
+const { InvalidArgumentError } = __nccwpck_require__(461)
 const { buildURL } = __nccwpck_require__(66)
 
 /**
@@ -25870,7 +26095,7 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 133:
+/***/ 134:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -25968,7 +26193,7 @@ exports.reflectionMergePartial = reflectionMergePartial;
 
 /***/ }),
 
-/***/ 134:
+/***/ 135:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26061,7 +26286,7 @@ async function parseXML(str, opts = {}) {
 
 /***/ }),
 
-/***/ 135:
+/***/ 136:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26069,14 +26294,14 @@ async function parseXML(str, opts = {}) {
 
 module.exports.request = __nccwpck_require__(482)
 module.exports.stream = __nccwpck_require__(336)
-module.exports.pipeline = __nccwpck_require__(102)
+module.exports.pipeline = __nccwpck_require__(104)
 module.exports.upgrade = __nccwpck_require__(407)
 module.exports.connect = __nccwpck_require__(353)
 
 
 /***/ }),
 
-/***/ 136:
+/***/ 137:
 /***/ ((module) => {
 
 "use strict";
@@ -26124,7 +26349,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 137:
+/***/ 138:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26133,7 +26358,7 @@ module.exports = {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollOperation = exports.initOperation = exports.deserializeState = void 0;
-const logger_js_1 = __nccwpck_require__(186);
+const logger_js_1 = __nccwpck_require__(184);
 const constants_js_1 = __nccwpck_require__(57);
 /**
  * Deserializes the state
@@ -26303,7 +26528,7 @@ exports.pollOperation = pollOperation;
 
 /***/ }),
 
-/***/ 138:
+/***/ 139:
 /***/ ((module) => {
 
 "use strict";
@@ -26311,7 +26536,7 @@ module.exports = require("diagnostics_channel");
 
 /***/ }),
 
-/***/ 139:
+/***/ 140:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -26610,7 +26835,7 @@ module.exports = setup;
 
 /***/ }),
 
-/***/ 140:
+/***/ 141:
 /***/ ((module) => {
 
 "use strict";
@@ -26618,7 +26843,7 @@ module.exports = require("node:events");
 
 /***/ }),
 
-/***/ 141:
+/***/ 142:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -26649,1108 +26874,6 @@ function isObject(input) {
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=object.js.map
-
-
-/***/ }),
-
-/***/ 142:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// setup-soldr post-job entry point. Owned by Agent 2.
-//
-// Runs in the post-job phase via action.yml's `post: dist/post.js`. This is
-// the architectural fix for zackees/setup-soldr#70 — it lets us tar+zstd
-// the build-cache (and optionally cargo-registry) directories BEFORE
-// @actions/cache's post-save uploads them, so the wire format is zstd on
-// every platform (including Windows-x64 where actions/cache@v5 still
-// falls back to gzip).
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.resolveJournalPrintRaw = resolveJournalPrintRaw;
-exports.buildFinalCacheSummary = buildFinalCacheSummary;
-exports.formatFinalCacheSummaryMarkdown = formatFinalCacheSummaryMarkdown;
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(240));
-const path = __importStar(__nccwpck_require__(479));
-const node_child_process_1 = __nccwpck_require__(192);
-const core = __importStar(__nccwpck_require__(432));
-const cache = __importStar(__nccwpck_require__(208));
-const cache_compress_js_1 = __nccwpck_require__(465);
-const solo_toolchain_cache_js_1 = __nccwpck_require__(282);
-const cook_cache_js_1 = __nccwpck_require__(166);
-const soldr_mini_cache_js_1 = __nccwpck_require__(154);
-const log_utils_js_1 = __nccwpck_require__(334);
-const shutdown_cache_js_1 = __nccwpck_require__(498);
-const stats_collector_js_1 = __nccwpck_require__(71);
-const diagnostics_js_1 = __nccwpck_require__(108);
-const raw_inputs_js_1 = __nccwpck_require__(343);
-const source_mtime_snapshot_js_1 = __nccwpck_require__(384);
-function dirExists(p) {
-    try {
-        return fs.statSync(p).isDirectory();
-    }
-    catch {
-        return false;
-    }
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
-    }
-}
-function stateBool(name, fallback = false) {
-    const value = core.getState(name).trim().toLowerCase();
-    if (value === "true")
-        return true;
-    if (value === "false")
-        return false;
-    return fallback;
-}
-/**
- * Decide whether the post-phase diagnostic dump includes the verbatim
- * per-rustc-invocation JSONL stream. The raw stream is large (thousands
- * of records / 20-30 MB on the demo warm build) and dominates Post Setup
- * Soldr wall-clock when emitted. Default: mirror debug mode (preserves
- * pre-existing behavior for workflows that already opted into debug).
- * Explicit values "true"/"false"/"on"/"off"/"yes"/"no"/"1"/"0" override.
- */
-function resolveJournalPrintRaw(rawValue, debugMode) {
-    const v = (rawValue ?? "").trim().toLowerCase();
-    if (v === "")
-        return debugMode;
-    if (v === "true" || v === "1" || v === "yes" || v === "on")
-        return true;
-    if (v === "false" || v === "0" || v === "no" || v === "off")
-        return false;
-    return debugMode;
-}
-function readRestoreState() {
-    return {
-        setupCacheEnabled: stateBool("setupCacheEnabled"),
-        setupCacheExactHit: stateBool("setupCacheExactHit"),
-        setupCacheMatchedKey: core.getState("setupCacheMatchedKey"),
-        targetCacheEnabled: stateBool("targetCacheEnabled"),
-        targetCacheExactHit: stateBool("targetCacheExactHit"),
-        targetCacheMatchedKey: core.getState("targetCacheMatchedKey"),
-        buildCacheEnabled: stateBool("buildCacheEnabled"),
-        buildCacheExactHit: stateBool("buildCacheExactHit"),
-        buildCacheMatchedKey: core.getState("buildCacheMatchedKey"),
-        cargoRegistryCacheEnabled: stateBool("cargoRegistryCacheEnabled"),
-        cargoRegistryCacheExactHit: stateBool("cargoRegistryCacheExactHit"),
-        cargoRegistryCacheMatchedKey: core.getState("cargoRegistryCacheMatchedKey"),
-    };
-}
-function disabledSave() {
-    return { status: "disabled" };
-}
-// setup-cache is intentionally restore-only. Its restore is kept so the
-// action's `cache-hit` output (wired from setupCacheExactHit in main.ts)
-// retains its public contract for downstream workflows, but the save path
-// is permanently inert: the soldr binary moved to soldr-mini-cache (#142)
-// and the rustup toolchain state moved to solo-toolchain-cache (#139),
-// both of which are content-addressable and coarser-keyed. Wiring a save
-// here would re-introduce a duplicate path and defeat those layers' LRU
-// access pattern. See setup-soldr#151 for the full decision rationale.
-function notManagedSave() {
-    return { status: "not-managed-in-post" };
-}
-function restoreStatus(enabled, exactHit, matchedKey) {
-    if (!enabled)
-        return "disabled";
-    if (exactHit)
-        return "exact-hit";
-    if (matchedKey.trim())
-        return "restore-key-hit";
-    return "miss";
-}
-async function saveOne(opts) {
-    const { cacheDir, codec, level, key, matchedKey, label, debug, log } = opts;
-    const withBytes = (r) => Object.assign(r, { archiveBytes: null });
-    if (!dirExists(cacheDir)) {
-        log(`${label}: cache dir ${cacheDir} does not exist, skipping save`);
-        return withBytes({ status: "missing-dir-skip", cache_dir: cacheDir });
-    }
-    if (matchedKey === key) {
-        log(`${label}: exact cache hit on ${key}, skipping save`);
-        return withBytes({ status: "exact-hit-skip", cache_dir: cacheDir });
-    }
-    let archiveBytes = null;
-    let archivePath = null;
-    try {
-        const result = await (0, cache_compress_js_1.compressCache)({ cacheDir, codec, level, debug, log });
-        archivePath = result.archivePath;
-        archiveBytes = result.archiveBytes || null;
-    }
-    catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        log(`${label}: compression failed: ${message}`);
-        return withBytes({ status: "failed", cache_dir: cacheDir, error: message });
-    }
-    const pathsToSave = archivePath ? [archivePath] : [cacheDir];
-    try {
-        const id = await cache.saveCache(pathsToSave, key);
-        log(`${label}: saved cache id=${id} key=${key} via ${archivePath ? "tar.zst" : "default"}`);
-        return {
-            status: "saved",
-            cache_dir: cacheDir,
-            archive_path: archivePath ?? undefined,
-            saved_paths: pathsToSave,
-            cache_id: id,
-            archiveBytes,
-        };
-    }
-    catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        log(`${label}: save failed: ${message}`);
-        return {
-            status: "failed",
-            cache_dir: cacheDir,
-            archive_path: archivePath ?? undefined,
-            saved_paths: pathsToSave,
-            error: message,
-            archiveBytes,
-        };
-    }
-}
-function cacheLayerSummary(opts) {
-    const matchedKey = opts.matchedKey.trim();
-    return {
-        enabled: opts.enabled,
-        key: opts.key,
-        matched_key: matchedKey,
-        exact_hit: opts.enabled ? opts.exactHit : false,
-        restore_status: restoreStatus(opts.enabled, opts.exactHit, matchedKey),
-        save: opts.save,
-    };
-}
-function readSoldrCacheReport(soldrBinary, passthrough) {
-    if (passthrough) {
-        // Short-circuit when the main step installed a passthrough stub
-        // (enable=false). Skips spawning a .cmd on Windows (where
-        // child_process.spawnSync can't launch shell scripts directly) and
-        // documents the passthrough state in the post-step summary.
-        return {
-            status: "ok",
-            soldr_version: "passthrough",
-            report: {
-                notes: ["setup-soldr enable=false: soldr passthrough stub"],
-                last_session: null,
-                rollups: null,
-            },
-        };
-    }
-    if (!soldrBinary || !fileExists(soldrBinary)) {
-        return {
-            status: "missing-binary",
-            error: soldrBinary === undefined
-                ? "SOLDR_BINARY env var not set"
-                : `soldr binary at ${soldrBinary} does not exist`,
-        };
-    }
-    // Use spawnSync so the post step has no async dependencies. The
-    // report subcommand is fast (sub-100ms) — never worth pulling in
-    // @actions/exec just for one shell-out.
-    const child = (0, node_child_process_1.spawnSync)(soldrBinary, ["cache", "report", "--json"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-        windowsHide: true,
-    });
-    if (child.error) {
-        return {
-            status: "error",
-            error: `failed to spawn soldr: ${child.error.message}`,
-        };
-    }
-    const stdout = (child.stdout || "").trim();
-    const stderr = (child.stderr || "").trim();
-    if (child.status !== 0) {
-        const combined = `${stderr}\n${stdout}`;
-        if (/unrecognized subcommand|invalid value for|unknown sub[- ]?command/i.test(combined) &&
-            /\breport\b/.test(combined)) {
-            return {
-                status: "unsupported",
-                error: stderr || stdout || `soldr exited ${child.status}`,
-            };
-        }
-        return {
-            status: "error",
-            error: stderr || stdout || `soldr exited ${child.status}`,
-        };
-    }
-    let report;
-    try {
-        const parsed = JSON.parse(stdout);
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-            return {
-                status: "error",
-                error: "soldr cache report --json returned a non-object payload",
-            };
-        }
-        report = parsed;
-    }
-    catch (err) {
-        return {
-            status: "error",
-            error: `failed to parse soldr cache report JSON: ${err instanceof Error ? err.message : String(err)}`,
-        };
-    }
-    const soldrVersion = typeof report["soldr_version"] === "string" ? report["soldr_version"] : undefined;
-    const zccacheVersion = typeof report["managed_zccache_version"] === "string"
-        ? report["managed_zccache_version"]
-        : undefined;
-    return {
-        status: "ok",
-        soldr_version: soldrVersion,
-        managed_zccache_version: zccacheVersion,
-        report,
-    };
-}
-function readZccacheSessionSummary(buildCachePath) {
-    const statsPath = path.join(buildCachePath, "logs", "last-session-stats.json");
-    if (!fileExists(statsPath)) {
-        return { stats_path: statsPath, present: false, status: "missing" };
-    }
-    try {
-        const parsed = JSON.parse(fs.readFileSync(statsPath, "utf8"));
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-            return {
-                stats_path: statsPath,
-                present: true,
-                status: "invalid",
-                error: "stats JSON was not an object",
-            };
-        }
-        const stats = parsed;
-        const status = typeof stats["status"] === "string" ? stats["status"] : "unknown";
-        return { stats_path: statsPath, present: true, status, stats };
-    }
-    catch (err) {
-        return {
-            stats_path: statsPath,
-            present: true,
-            status: "invalid",
-            error: err instanceof Error ? err.message : String(err),
-        };
-    }
-}
-function buildFinalCacheSummary(result, state, saves, passthrough = false) {
-    return {
-        schema_version: 1,
-        setup_cache: cacheLayerSummary({
-            enabled: state.setupCacheEnabled,
-            key: result.setupCache.key,
-            exactHit: state.setupCacheExactHit,
-            matchedKey: state.setupCacheMatchedKey,
-            save: notManagedSave(),
-        }),
-        target_cache: cacheLayerSummary({
-            enabled: state.targetCacheEnabled,
-            key: result.targetCache.key,
-            exactHit: state.targetCacheExactHit,
-            matchedKey: state.targetCacheMatchedKey,
-            save: saves.targetCache,
-        }),
-        build_cache: cacheLayerSummary({
-            enabled: state.buildCacheEnabled,
-            key: result.buildCache.key,
-            exactHit: state.buildCacheExactHit,
-            matchedKey: state.buildCacheMatchedKey,
-            save: saves.buildCache,
-        }),
-        cargo_registry_cache: cacheLayerSummary({
-            enabled: state.cargoRegistryCacheEnabled,
-            key: result.cargoRegistryCache.key,
-            exactHit: state.cargoRegistryCacheExactHit,
-            matchedKey: state.cargoRegistryCacheMatchedKey,
-            save: saves.cargoRegistryCache,
-        }),
-        zccache_session: readZccacheSessionSummary(result.buildCache.path),
-        compile_cache_report: readSoldrCacheReport(process.env["SOLDR_BINARY"]?.trim(), passthrough),
-    };
-}
-function numberStat(stats, key) {
-    const value = stats?.[key];
-    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-function zccacheOneLine(summary) {
-    if (!summary.present)
-        return `missing (${summary.stats_path})`;
-    if (summary.status !== "ok") {
-        return summary.error ? `${summary.status} (${summary.error})` : summary.status;
-    }
-    const hits = numberStat(summary.stats, "hits") ?? 0;
-    const misses = numberStat(summary.stats, "misses") ?? 0;
-    const compilations = numberStat(summary.stats, "compilations") ?? hits + misses;
-    const nonCacheable = numberStat(summary.stats, "non_cacheable") ?? 0;
-    const errors = numberStat(summary.stats, "errors") ?? 0;
-    const hitRate = numberStat(summary.stats, "hit_rate");
-    const hitRateText = hitRate === undefined ? "n/a" : `${(hitRate * 100).toFixed(1)}%`;
-    return `hits=${hits} misses=${misses} compilations=${compilations} non_cacheable=${nonCacheable} errors=${errors} hit_rate=${hitRateText}`;
-}
-function restoreText(layer) {
-    if (!layer.enabled)
-        return "disabled";
-    if (layer.restore_status === "exact-hit")
-        return "exact hit";
-    if (layer.restore_status === "restore-key-hit")
-        return "restore-key hit";
-    return "miss";
-}
-function saveText(save) {
-    switch (save.status) {
-        case "saved":
-            return save.cache_id === undefined ? "saved" : `saved id=${save.cache_id}`;
-        case "exact-hit-skip":
-            return "skipped exact hit";
-        case "missing-dir-skip":
-            return "skipped missing dir";
-        case "failed":
-            return save.error ? `failed: ${save.error}` : "failed";
-        case "disabled":
-            return "disabled";
-        case "not-managed-in-post":
-            return "not managed in post";
-    }
-}
-function markdownCell(value) {
-    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
-}
-function tableRow(label, layer) {
-    return [
-        label,
-        restoreText(layer),
-        layer.key,
-        layer.matched_key || "",
-        saveText(layer.save),
-    ]
-        .map(markdownCell)
-        .join(" | ");
-}
-function fmtBytes(n) {
-    if (n >= 1_073_741_824)
-        return `${(n / 1_073_741_824).toFixed(1)} GB`;
-    if (n >= 1_048_576)
-        return `${(n / 1_048_576).toFixed(1)} MB`;
-    if (n >= 1_024)
-        return `${(n / 1_024).toFixed(1)} KB`;
-    return `${n} B`;
-}
-function setCompileCacheOutputs(report, mode) {
-    core.setOutput("compile-cache-session-status", report.status);
-    if (report.status !== "ok" || !report.report)
-        return;
-    core.setOutput("compile-cache-summary-json", JSON.stringify(report.report));
-    const lastSession = report.report["last_session"];
-    if (lastSession) {
-        const hits = numberStat(lastSession, "hits") ?? 0;
-        const misses = numberStat(lastSession, "misses") ?? 0;
-        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
-        const hitRate = numberStat(lastSession, "hit_rate");
-        const timeSavedMs = numberStat(lastSession, "time_saved_ms");
-        const bytesRead = numberStat(lastSession, "bytes_read");
-        const bytesWritten = numberStat(lastSession, "bytes_written");
-        core.setOutput("compile-cache-hits", String(hits));
-        core.setOutput("compile-cache-misses", String(misses));
-        core.setOutput("compile-cache-compilations", String(compilations));
-        if (hitRate !== undefined)
-            core.setOutput("compile-cache-hit-rate", String(hitRate));
-        if (timeSavedMs !== undefined)
-            core.setOutput("compile-cache-time-saved-ms", String(timeSavedMs));
-        if (bytesRead !== undefined)
-            core.setOutput("compile-cache-bytes-read", String(bytesRead));
-        if (bytesWritten !== undefined)
-            core.setOutput("compile-cache-bytes-written", String(bytesWritten));
-    }
-    if (mode === "detailed") {
-        const rollups = report.report["rollups"];
-        if (rollups)
-            core.setOutput("compile-cache-rollups-json", JSON.stringify(rollups));
-    }
-}
-function compileCacheReportSection(report, mode) {
-    if (mode === "none")
-        return [];
-    const lines = ["", "### Compile cache (zccache)", ""];
-    if (report.status !== "ok" || !report.report) {
-        lines.push(`| Status | ${markdownCell(report.status)} |`);
-        if (report.error)
-            lines.push(`| Detail | ${markdownCell(report.error)} |`);
-        return lines;
-    }
-    const body = report.report;
-    const lastSession = body["last_session"] ?? null;
-    const rollups = body["rollups"] ?? null;
-    if (lastSession) {
-        const hits = numberStat(lastSession, "hits") ?? 0;
-        const misses = numberStat(lastSession, "misses") ?? 0;
-        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
-        const rate = numberStat(lastSession, "hit_rate");
-        const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
-        const saved = numberStat(lastSession, "time_saved_ms");
-        const bytesRead = numberStat(lastSession, "bytes_read");
-        const bytesWritten = numberStat(lastSession, "bytes_written");
-        lines.push("| Metric | Value |", "| --- | --- |");
-        lines.push(`| Compilations | ${compilations} |`);
-        lines.push(`| Hits | ${hits} |`);
-        lines.push(`| Misses | ${misses} |`);
-        lines.push(`| Hit rate | ${rateText} |`);
-        if (saved !== undefined)
-            lines.push(`| Time saved (est.) | ${(saved / 1000).toFixed(1)}s |`);
-        if (bytesRead !== undefined)
-            lines.push(`| Bytes read | ${fmtBytes(bytesRead)} |`);
-        if (bytesWritten !== undefined)
-            lines.push(`| Bytes written | ${fmtBytes(bytesWritten)} |`);
-        if (report.soldr_version)
-            lines.push(`| soldr | ${markdownCell(report.soldr_version)} |`);
-        if (report.managed_zccache_version)
-            lines.push(`| zccache | ${markdownCell(report.managed_zccache_version)} |`);
-    }
-    else {
-        lines.push("_(no last\\_session yet — run a cache-enabled build first)_");
-    }
-    if (mode === "detailed" && rollups) {
-        const byExt = rollups["by_extension"];
-        if (byExt && typeof byExt === "object" && !Array.isArray(byExt)) {
-            const rows = Object.entries(byExt);
-            if (rows.length > 0) {
-                lines.push("", "#### By output extension", "");
-                lines.push("| Extension | Hits | Misses | Total ms |", "| --- | --- | --- | --- |");
-                for (const [ext, bucket] of rows) {
-                    const b = bucket ?? {};
-                    const h = numberStat(b, "hits") ?? 0;
-                    const m = numberStat(b, "misses") ?? 0;
-                    const t = numberStat(b, "total_ms") ?? 0;
-                    lines.push(`| ${markdownCell(ext)} | ${h} | ${m} | ${t} |`);
-                }
-            }
-        }
-        const byTool = rollups["by_tool_total_ms"];
-        if (byTool && typeof byTool === "object" && !Array.isArray(byTool)) {
-            const rows = Object.entries(byTool)
-                .map(([tool, ms]) => [tool, typeof ms === "number" ? ms : 0])
-                .sort((a, b) => b[1] - a[1])
-                .slice(0, 10);
-            if (rows.length > 0) {
-                lines.push("", "#### By tool (wall-clock)", "");
-                lines.push("| Tool | ms |", "| --- | --- |");
-                for (const [tool, ms] of rows) {
-                    lines.push(`| ${markdownCell(tool)} | ${ms} |`);
-                }
-            }
-        }
-    }
-    const notes = body["notes"];
-    if (Array.isArray(notes) && notes.length > 0) {
-        lines.push("", "<details><summary>Notes from soldr</summary>", "");
-        for (const note of notes) {
-            if (typeof note === "string")
-                lines.push(`- ${markdownCell(note)}`);
-        }
-        lines.push("", "</details>");
-    }
-    return lines;
-}
-function formatFinalCacheSummaryMarkdown(summary, compileCacheStats = "summarize") {
-    const lines = [
-        "## setup-soldr final cache summary",
-        "",
-        "| Layer | Restore | Primary key | Matched key | Save |",
-        "| --- | --- | --- | --- | --- |",
-        `| ${tableRow("setup cache", summary.setup_cache)} |`,
-        `| ${tableRow("target cache", summary.target_cache)} |`,
-        `| ${tableRow("build cache", summary.build_cache)} |`,
-        `| ${tableRow("cargo registry cache", summary.cargo_registry_cache)} |`,
-        "",
-        "### zccache session",
-        "",
-        `- Stats: ${zccacheOneLine(summary.zccache_session)}`,
-        `- Stats file: ${summary.zccache_session.stats_path}`,
-        ...compileCacheReportSection(summary.compile_cache_report, compileCacheStats),
-        "",
-        "<details><summary>Final cache summary JSON</summary>",
-        "",
-        "```json",
-        JSON.stringify(summary, null, 2),
-        "```",
-        "",
-        "</details>",
-        "",
-    ];
-    return `${lines.join("\n")}\n`;
-}
-function logFinalCacheSummary(summary, log) {
-    log(`final cache summary: setup=${restoreText(summary.setup_cache)} target=${restoreText(summary.target_cache)} ` +
-        `build=${restoreText(summary.build_cache)}/${saveText(summary.build_cache.save)} ` +
-        `cargo-registry=${restoreText(summary.cargo_registry_cache)}/${saveText(summary.cargo_registry_cache.save)}`);
-    log(`final zccache session stats: ${zccacheOneLine(summary.zccache_session)}`);
-    log(`compile cache report: ${compileCacheReportOneLine(summary.compile_cache_report)}`);
-}
-function compileCacheReportOneLine(report) {
-    if (report.status !== "ok" || !report.report) {
-        return report.error ? `${report.status} (${report.error})` : report.status;
-    }
-    const lastSession = report.report["last_session"];
-    if (!lastSession) {
-        return `ok (no last_session yet, soldr ${report.soldr_version ?? "?"})`;
-    }
-    const hits = numberStat(lastSession, "hits") ?? 0;
-    const misses = numberStat(lastSession, "misses") ?? 0;
-    const rate = numberStat(lastSession, "hit_rate");
-    const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
-    return `ok hits=${hits} misses=${misses} hit_rate=${rateText} soldr=${report.soldr_version ?? "?"}`;
-}
-function writeCompileCacheReportFile(report, runnerTemp, log) {
-    if (!runnerTemp)
-        return undefined;
-    const outPath = path.join(runnerTemp, "setup-soldr-compile-cache-report.json");
-    try {
-        fs.writeFileSync(outPath, JSON.stringify(report, null, 2), "utf8");
-        return outPath;
-    }
-    catch (err) {
-        log(`post: failed to write compile-cache-report.json: ${err instanceof Error ? err.message : String(err)}`);
-        return undefined;
-    }
-}
-function writeStepSummary(markdown, log) {
-    const summaryPath = process.env["GITHUB_STEP_SUMMARY"]?.trim();
-    if (!summaryPath)
-        return;
-    try {
-        fs.appendFileSync(summaryPath, markdown, "utf8");
-    }
-    catch (err) {
-        log(`post: failed to write GitHub step summary: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-async function run() {
-    const logger = (0, log_utils_js_1.createLogger)(process.env);
-    const log = (msg) => logger.log(msg);
-    const state = core.getState("resolveResult");
-    if (!state) {
-        log("post: no resolve state available, exiting");
-        return;
-    }
-    let result;
-    try {
-        result = JSON.parse(state);
-    }
-    catch (err) {
-        log(`post: failed to parse resolve state: ${err instanceof Error ? err.message : String(err)}`);
-        return;
-    }
-    const buildCacheMatched = core.getState("buildCacheMatchedKey");
-    const registryMatched = core.getState("cargoRegistryCacheMatchedKey");
-    const passthrough = stateBool("setupSoldrPassthrough");
-    const restoreState = readRestoreState();
-    const statsMode = (core.getState("statsMode") || "summarize");
-    const compileCacheStats = (core.getState("compileCacheStats") || "summarize");
-    const runnerTemp = core.getState("runnerTemp") || "";
-    const debugMode = result.debugMode ?? false;
-    const debugLog = debugMode ? log : () => undefined;
-    const postCollector = new stats_collector_js_1.StatsCollector();
-    // Always stop long-running cache daemons before packing the build
-    // cache so file locks release and the tarball reflects a quiescent
-    // on-disk view. Best-effort; failures are logged, not raised.
-    //
-    // Wire `--archive-logs <build-cache>/logs/archive` through so soldr
-    // (post-#379) stashes the just-ended session's logs into a
-    // per-session subdirectory inside the build-cache. Setup-soldr's
-    // existing tar.zst flow already picks up the entire build-cache
-    // subtree, so the archived logs ride the cache cycle for free and
-    // survive across runs (see issue #126).
-    const logsArchiveDir = restoreState.buildCacheEnabled
-        ? path.join(result.buildCache.path, "logs", "archive")
-        : undefined;
-    await (0, shutdown_cache_js_1.shutdownCacheDaemons)({
-        soldrPath: process.env["SOLDR_BINARY"]?.trim() || undefined,
-        logsArchiveDir,
-        log,
-    });
-    // Source-mtime snapshot (preserve-source-mtimes opt-in). Walk tracked
-    // sources, capture each (mtime, size, content-hash), and drop the JSON
-    // INSIDE the build-cache directory so it gets bundled into the same
-    // tar.zst the build-cache save will upload. main.ts replays the
-    // mtimes on warm after the build-cache decompresses, gated on each
-    // file's content matching what we snapshotted here.
-    const preserveSourceMtimes = core.getState("preserveSourceMtimes") === "true";
-    if (preserveSourceMtimes && restoreState.buildCacheEnabled) {
-        const t0 = Date.now();
-        // The "project root" — where the Cargo workspace being built actually
-        // lives — is the parent of the resolved target-dir, NOT result.workspace
-        // (which is GITHUB_WORKSPACE — usually the outer checkout containing
-        // the action itself plus one or more sub-repos). For the demo,
-        // result.workspace=/home/runner/work/setup-soldr/setup-soldr but the
-        // zccache project being built is at .../setup-soldr/zccache.
-        const projectRoot = path.dirname(result.targetCache.targetPath);
-        try {
-            const r = await (0, source_mtime_snapshot_js_1.snapshotSourceMtimes)({ workspace: projectRoot, log });
-            const out = path.join(result.buildCache.path, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
-            try {
-                fs.mkdirSync(path.dirname(out), { recursive: true });
-                (0, source_mtime_snapshot_js_1.writeSnapshotFile)(r.snapshot, out);
-                log(`source-mtime-snapshot: wrote ${out} scanned=${r.scanned} hashed=${r.hashed} skipped=${r.skipped} elapsed_ms=${Date.now() - t0}`);
-            }
-            catch (err) {
-                log(`source-mtime-snapshot: failed to write ${out}: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-        catch (err) {
-            log(`source-mtime-snapshot: scan failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    // Build cache
-    const buildSaveStart = Date.now();
-    const buildSave = restoreState.buildCacheEnabled
-        ? await saveOne({
-            cacheDir: result.buildCache.path,
-            codec: result.targetCacheCompress,
-            level: result.targetCacheCompressLevel,
-            key: result.buildCache.key,
-            matchedKey: buildCacheMatched,
-            label: "build-cache",
-            debug: debugMode,
-            log: debugLog,
-        })
-        : Object.assign(disabledSave(), { archiveBytes: null });
-    if (buildSave.status === "saved") {
-        postCollector.record({
-            label: "build-cache", operation: "save", hit: false,
-            key: result.buildCache.key, matchedKey: buildCacheMatched, restoreKeys: [],
-            archiveBytes: buildSave.archiveBytes, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - buildSaveStart, timestamp: new Date().toISOString(),
-        });
-    }
-    // Target cache. Previously slotted as `notManagedSave()` in the
-    // finalSummary — i.e. restored in main.ts but never saved here. That
-    // meant every commit cold-rebuilt `target/` (or the rust-plan bundle)
-    // because no entry was ever written for the restore-key prefix to
-    // fall back to. This block fixes the gap.
-    //
-    // Behavior:
-    // - Skip when target-cache layer is disabled (`target-cache: false`
-    //   or umbrella `cache: false`).
-    // - Skip on exact-hit (re-saving the same content under the same key
-    //   wastes time and triggers @actions/cache's "reservation already
-    //   exists" path).
-    // - Use `cache.saveCache` directly with the multi-path array (one
-    //   path in `thin`/`once` modes, two in `full`). @actions/cache will
-    //   tar+compress with its default codec — we don't route through
-    //   compressCache because target-cache may legitimately carry
-    //   multiple roots and compressCache is single-dir-shaped.
-    // - Paths array must match the one passed to restoreCache in main.ts
-    //   (the @actions/cache "version" hash depends on it — same gotcha
-    //   that bit cook-cache in #141).
-    let targetCacheSave = Object.assign(disabledSave(), { archiveBytes: null });
-    if (restoreState.targetCacheEnabled) {
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        const targetKey = result.targetCache.key;
-        const targetMatched = restoreState.targetCacheMatchedKey;
-        if (targetPaths.length === 0) {
-            log("target-cache: no paths configured, skipping save");
-            targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: "(no paths)" }, { archiveBytes: null });
-        }
-        else if (restoreState.targetCacheExactHit) {
-            log(`target-cache: exact cache hit on ${targetKey}, skipping save`);
-            targetCacheSave = Object.assign({ status: "exact-hit-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
-        }
-        else {
-            const existingPaths = targetPaths.filter((p) => fs.existsSync(p));
-            if (existingPaths.length === 0) {
-                log(`target-cache: none of the configured paths exist on disk (${targetPaths.join(", ")}), skipping save`);
-                targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
-            }
-            else {
-                const targetSaveStart = Date.now();
-                try {
-                    const id = await cache.saveCache(existingPaths, targetKey);
-                    if (id <= 0) {
-                        log(`target-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
-                            `job already saved key=${targetKey}`);
-                        targetCacheSave = Object.assign({
-                            status: "failed",
-                            cache_dir: existingPaths.join(","),
-                            saved_paths: existingPaths,
-                            error: `saveCache returned id=${id} (reserve failed; race or quota)`,
-                        }, { archiveBytes: null });
-                    }
-                    else {
-                        log(`target-cache: saved cache id=${id} key=${targetKey} paths=${existingPaths.join(",")}`);
-                        targetCacheSave = Object.assign({
-                            status: "saved",
-                            cache_dir: existingPaths.join(","),
-                            saved_paths: existingPaths,
-                            cache_id: id,
-                        }, { archiveBytes: null });
-                        postCollector.record({
-                            label: "target-cache",
-                            operation: "save",
-                            hit: false,
-                            key: targetKey,
-                            matchedKey: targetMatched,
-                            restoreKeys: [],
-                            archiveBytes: null,
-                            inflatedBytes: null,
-                            fileCount: null,
-                            durationMs: Date.now() - targetSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                }
-                catch (err) {
-                    const message = err instanceof Error ? err.message : String(err);
-                    log(`target-cache: save failed: ${message}`);
-                    targetCacheSave = Object.assign({
-                        status: "failed",
-                        cache_dir: existingPaths.join(","),
-                        saved_paths: existingPaths,
-                        error: message,
-                    }, { archiveBytes: null });
-                }
-            }
-        }
-    }
-    // Cargo registry cache (only when enabled)
-    let cargoRegistrySave = Object.assign(disabledSave(), { archiveBytes: null });
-    if (result.cargoRegistryCache.enabled) {
-        const regSaveStart = Date.now();
-        cargoRegistrySave = await saveOne({
-            cacheDir: result.cargoRegistryCache.path,
-            codec: result.targetCacheCompress,
-            level: result.targetCacheCompressLevel,
-            key: result.cargoRegistryCache.key,
-            matchedKey: registryMatched,
-            label: "cargo-registry-cache",
-            debug: debugMode,
-            log: debugLog,
-        });
-        if (cargoRegistrySave.status === "saved") {
-            postCollector.record({
-                label: "cargo-registry", operation: "save", hit: false,
-                key: result.cargoRegistryCache.key, matchedKey: registryMatched, restoreKeys: [],
-                archiveBytes: cargoRegistrySave.archiveBytes, inflatedBytes: null, fileCount: null,
-                durationMs: Date.now() - regSaveStart, timestamp: new Date().toISOString(),
-            });
-        }
-    }
-    // Solo toolchain cache save. Opt-in via the `solo-toolchain-cache`
-    // input. Skip the save when the install delta is empty (the common
-    // case on hosted runners that already provide the requested
-    // toolchain) — per CLAUDE.md "Default-stable workflows should
-    // produce zero cache writes."
-    const soloEnabled = core.getState("soloToolchainEnabled") === "true";
-    if (soloEnabled) {
-        const soloExactKey = core.getState("soloToolchainExactKey");
-        const soloMatchedKey = core.getState("soloToolchainMatchedKey");
-        const soloExactHit = core.getState("soloToolchainExactHit") === "true";
-        const soloIncrementalEmpty = core.getState("soloToolchainIncrementalEmpty") === "true";
-        const soloSaveDiffPath = core.getState("soloToolchainSaveDiffPath");
-        const soloLevel = core.getState("soloToolchainLevel") || "19";
-        log(`solo-toolchain-cache: post-step exactKey=${soloExactKey} matched=${soloMatchedKey} ` +
-            `exactHit=${soloExactHit} incrementalEmpty=${soloIncrementalEmpty} saveDiffPath=${soloSaveDiffPath}`);
-        if (soloExactHit && soloIncrementalEmpty) {
-            log("solo-toolchain-cache: exact hit and no install delta — skipping save");
-        }
-        else if (!soloSaveDiffPath || !fs.existsSync(soloSaveDiffPath)) {
-            log("solo-toolchain-cache: no save-diff manifest available, skipping save");
-        }
-        else {
-            try {
-                const manifest = JSON.parse(fs.readFileSync(soloSaveDiffPath, "utf8"));
-                const added = Array.isArray(manifest.added) ? manifest.added : [];
-                if (added.length === 0) {
-                    log("solo-toolchain-cache: empty save-diff manifest, skipping save");
-                }
-                else {
-                    const soloRootMap = {
-                        "rustup-toolchains": path.join(result.rustupHome, "toolchains"),
-                        "cargo-bin": path.join(result.cargoHome, "bin"),
-                    };
-                    const stagingDir = path.join(runnerTemp, "setup-soldr-solo-stage-save");
-                    const soloSaveStart = Date.now();
-                    const staged = await (0, solo_toolchain_cache_js_1.stageDiffForSave)({ added, removed: [], changed: [] }, soloRootMap, stagingDir);
-                    log(`solo-toolchain-cache: staged ${staged.stagedFiles} files (missing=${staged.missingFiles})`);
-                    const saveResult = await (0, solo_toolchain_cache_js_1.saveSoloCache)({
-                        stagingDir,
-                        key: soloExactKey,
-                        level: soloLevel,
-                        debug: debugMode,
-                        log,
-                    });
-                    if (saveResult.status === "saved") {
-                        postCollector.record({
-                            label: "solo-toolchain-cache",
-                            operation: "save",
-                            hit: false,
-                            key: soloExactKey,
-                            matchedKey: soloMatchedKey,
-                            restoreKeys: [],
-                            archiveBytes: saveResult.archiveBytes ?? null,
-                            inflatedBytes: saveResult.inflatedBytes ?? null,
-                            fileCount: saveResult.fileCount ?? null,
-                            durationMs: Date.now() - soloSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                    else {
-                        log(`solo-toolchain-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
-                    }
-                }
-            }
-            catch (err) {
-                log(`solo-toolchain-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    }
-    // Cook cache save. Default-on layer; skipped when cook didn't run
-    // (cache hit, gate disabled, or run failed). zstd-19 + --long=27 per
-    // CLAUDE.md "Compression" + the cook simulation findings.
-    const cookEnabled = core.getState("cookEnabled") === "true";
-    if (cookEnabled) {
-        const cookHit = core.getState("cookHit") === "true";
-        const cookRan = core.getState("cookRan") === "true";
-        const cookExactKey = core.getState("cookExactKey");
-        const cookTargetDir = core.getState("cookTargetDir");
-        const cookLongWindow = parseInt(core.getState("cookLongWindow") || "27", 10);
-        const cookLevel = core.getState("cookCompressLevel") || "19";
-        log(`cook-cache: post-step key=${cookExactKey} hit=${cookHit} ran=${cookRan} target=${cookTargetDir}`);
-        if (cookHit) {
-            log("cook-cache: exact hit - skipping save");
-        }
-        else if (!cookRan) {
-            log("cook-cache: cook did not run successfully - skipping save");
-        }
-        else if (!cookTargetDir || !fs.existsSync(cookTargetDir)) {
-            log(`cook-cache: target dir ${cookTargetDir} missing - skipping save`);
-        }
-        else {
-            const cookSaveStart = Date.now();
-            try {
-                const saveResult = await (0, cook_cache_js_1.saveCookCache)({
-                    targetDir: cookTargetDir,
-                    exactKey: cookExactKey,
-                    level: cookLevel,
-                    longWindow: cookLongWindow,
-                    debug: debugMode,
-                    log,
-                });
-                if (saveResult.status === "saved") {
-                    postCollector.record({
-                        label: "cook-cache",
-                        operation: "save",
-                        hit: false,
-                        key: cookExactKey,
-                        matchedKey: "",
-                        restoreKeys: [],
-                        archiveBytes: saveResult.archiveBytes ?? null,
-                        inflatedBytes: saveResult.inflatedBytes ?? null,
-                        fileCount: saveResult.fileCount ?? null,
-                        durationMs: Date.now() - cookSaveStart,
-                        timestamp: new Date().toISOString(),
-                    });
-                }
-                else {
-                    log(`cook-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
-                }
-            }
-            catch (err) {
-                log(`cook-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    }
-    // Soldr-mini-cache save. Default-on; skipped when restore already hit
-    // (binary is byte-identical, no point re-saving), when disabled, or
-    // when running in passthrough mode.
-    const soldrMiniEnabled = core.getState("soldrMiniEnabled") === "true";
-    if (soldrMiniEnabled && !passthrough) {
-        const miniHit = core.getState("soldrMiniHit") === "true";
-        const miniExactKey = core.getState("soldrMiniExactKey");
-        const miniInstallDir = core.getState("soldrMiniInstallDir");
-        const miniArchive = core.getState("soldrMiniArchive");
-        log(`soldr-mini-cache: post-step key=${miniExactKey} hit=${miniHit} installDir=${miniInstallDir}`);
-        if (miniHit) {
-            log("soldr-mini-cache: exact hit — skipping save");
-        }
-        else if (!miniExactKey) {
-            log("soldr-mini-cache: no key (ineligible at main-time) — skipping save");
-        }
-        else if (!miniInstallDir || !fs.existsSync(miniInstallDir)) {
-            log(`soldr-mini-cache: install dir ${miniInstallDir} missing — skipping save`);
-        }
-        else {
-            const miniSaveStart = Date.now();
-            try {
-                const saveResult = await (0, soldr_mini_cache_js_1.saveMiniCache)({
-                    installDir: miniInstallDir,
-                    archivePath: miniArchive,
-                    exactKey: miniExactKey,
-                    level: "19",
-                    longWindow: 27,
-                    debug: debugMode,
-                    log,
-                });
-                if (saveResult.status === "saved") {
-                    postCollector.record({
-                        label: "soldr-mini-cache",
-                        operation: "save",
-                        hit: false,
-                        key: miniExactKey,
-                        matchedKey: "",
-                        restoreKeys: [],
-                        archiveBytes: saveResult.archiveBytes ?? null,
-                        inflatedBytes: saveResult.inflatedBytes ?? null,
-                        fileCount: saveResult.fileCount ?? null,
-                        durationMs: Date.now() - miniSaveStart,
-                        timestamp: new Date().toISOString(),
-                    });
-                }
-                else {
-                    log(`soldr-mini-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
-                }
-            }
-            catch (err) {
-                log(`soldr-mini-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    }
-    const finalSummary = buildFinalCacheSummary(result, restoreState, {
-        buildCache: buildSave,
-        cargoRegistryCache: cargoRegistrySave,
-        targetCache: targetCacheSave,
-    }, passthrough);
-    logFinalCacheSummary(finalSummary, log);
-    if (compileCacheStats !== "none") {
-        setCompileCacheOutputs(finalSummary.compile_cache_report, compileCacheStats);
-    }
-    writeStepSummary(formatFinalCacheSummaryMarkdown(finalSummary, compileCacheStats), log);
-    const reportPath = writeCompileCacheReportFile(finalSummary.compile_cache_report, runnerTemp, log);
-    if (reportPath) {
-        log(`compile-cache-report.json written to ${reportPath}`);
-    }
-    // Note: setup-soldr-cache-keys.txt is written in main.ts (right after
-    // resolveSetup) so workflow steps that run between main and post —
-    // notably actions/upload-artifact — can read it. Re-write it here
-    // anyway as a safety net in case main.ts crashed before writing.
-    if (runnerTemp) {
-        writeCacheKeysManifestFromSummary(finalSummary, runnerTemp, log);
-    }
-    // Append save ops to detailed session log if requested
-    if (statsMode === "detailed" && runnerTemp) {
-        try {
-            await postCollector.appendSavesToSessionLog(runnerTemp);
-        }
-        catch (err) {
-            log(`post: stats log append failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    // Optional verbose diagnostic dump. Gated on `logging: true` which
-    // main.ts persists into action state.
-    const loggingState = core.getState("logging");
-    if ((0, diagnostics_js_1.loggingEnabled)(loggingState)) {
-        const rawInputs = (0, raw_inputs_js_1.readRawInputs)(process.env);
-        // zccache writes its per-rustc-invocation JSONL journal under the
-        // build-cache directory (which == ZCCACHE_CACHE_DIR per
-        // resolve-setup.ts's env exports). When `logging: true` is on we
-        // surface its contents so the reader can answer "warm reported 0
-        // hits — why did each lookup miss" without another build.
-        const journalPath = path.join(result.buildCache.path, "logs", "last-session.jsonl");
-        // Forward the verbatim `report` field from `soldr cache report --json`
-        // so dumpDiagnostics can format its `rollups` (per-extension /
-        // per-crate / slowest_entries) breakdown.
-        const cacheReport = finalSummary.compile_cache_report.report;
-        // Capture a process snapshot only when debug mode is on — `ps` /
-        // `tasklist` are cheap but the output is large and only useful when
-        // you're investigating cache-state weirdness (e.g. orphan daemons).
-        const processSnapshot = debugMode ? (0, diagnostics_js_1.captureProcessSnapshot)() ?? undefined : undefined;
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "post",
-            env: process.env,
-            rawInputs,
-            result,
-            cacheOutcomes: postCollector.snapshot(),
-            finalSummary: finalSummary,
-            journalPath,
-            // Raw JSONL stream — one record per rustc invocation, often
-            // thousands of lines / 20-30 MB of stdout per warm build. Default
-            // gate is `debug:true` (backwards compat with #134 era), but a
-            // workflow can explicitly opt out via `journal-print-raw: false`
-            // when it already uploads the JSONL as an artifact and doesn't
-            // want to pay the post-step log-writer cost (~30-50 s on the
-            // hosted ubuntu demo).
-            journalPrintRaw: resolveJournalPrintRaw(rawInputs.journalPrintRaw, debugMode),
-            cacheReport,
-            processSnapshot,
-            logger,
-            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
-        });
-    }
-}
-function writeCacheKeysManifestFromSummary(summary, runnerTemp, log) {
-    const keys = [
-        summary.setup_cache.key,
-        summary.build_cache.key,
-        summary.target_cache.key,
-        summary.cargo_registry_cache.key,
-    ].filter((k) => Boolean(k));
-    if (keys.length === 0)
-        return;
-    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
-    try {
-        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
-        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
-    }
-    catch (err) {
-        log(`post: failed to write cache-keys manifest: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-// See main.ts for the rationale behind the test-import escape hatch.
-if (typeof process !== "undefined" &&
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.warning(`setup-soldr post-job step failed: ${message}`);
-    });
-}
 
 
 /***/ }),
@@ -27798,13 +26921,13 @@ __export(internal_exports, {
 module.exports = __toCommonJS(internal_exports);
 var import_delay = __nccwpck_require__(447);
 var import_random = __nccwpck_require__(478);
-var import_object = __nccwpck_require__(141);
+var import_object = __nccwpck_require__(142);
 var import_error = __nccwpck_require__(150);
-var import_sha256 = __nccwpck_require__(195);
+var import_sha256 = __nccwpck_require__(194);
 var import_uuidUtils = __nccwpck_require__(372);
 var import_checkEnvironment = __nccwpck_require__(412);
 var import_bytesEncoding = __nccwpck_require__(276);
-var import_sanitizer = __nccwpck_require__(118);
+var import_sanitizer = __nccwpck_require__(119);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -28249,7 +27372,7 @@ __export(error_exports, {
   isError: () => isError
 });
 module.exports = __toCommonJS(error_exports);
-var import_object = __nccwpck_require__(141);
+var import_object = __nccwpck_require__(142);
 function isError(e) {
   if ((0, import_object.isObject)(e)) {
     const hasName = typeof e.name === "string";
@@ -28309,7 +27432,7 @@ exports.ConvertInternalResponseOfListBlobHierarchy = ConvertInternalResponseOfLi
 exports.ExtractPageRangeInfoItems = ExtractPageRangeInfoItems;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(12);
 const constants_js_1 = __nccwpck_require__(145);
 /**
@@ -29116,255 +28239,13 @@ exports.StorageBrowserPolicyFactory = StorageBrowserPolicyFactory;
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(190).kConstruct)
+  kConstruct: (__nccwpck_require__(188).kConstruct)
 }
 
 
 /***/ }),
 
 /***/ 154:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Soldr-mini-cache — the narrowest cache layer: just the soldr binary,
-// keyed only on (version, platform, arch, libc).
-//
-// Per CLAUDE.md "Layer per change cadence" + "Coarse keys, shared across
-// workflows": the soldr binary's invalidation rhythm is per-soldr-release
-// (~1×/week). Mixing it into the existing setup-cache (which is keyed on
-// toolchain hash + cache-key-suffix) means it re-downloads whenever those
-// move — even though the binary content didn't change.
-//
-// This layer caches *only* the install dir contents (binary + optional
-// source-metadata sidecar), keyed coarsely so every workflow in the repo
-// pinned to the same soldr version hits the same entry.
-//
-// Position in the lifecycle:
-//   main.ts: try restore → if hit, soldrPath is pre-populated and
-//   ensureSoldr's installedVersion check short-circuits the GH fetch.
-//   post.ts: if restore missed AND ensureSoldr fetched, save the binary
-//   for next time.
-//
-// Refs (rebuild-from-source) are skipped: the binary content depends on
-// the commit, not the version tag, so the cache key would be wrong.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.buildMiniCacheKey = buildMiniCacheKey;
-exports.restoreMiniCache = restoreMiniCache;
-exports.saveMiniCache = saveMiniCache;
-exports.isEligibleForMiniCache = isEligibleForMiniCache;
-const fs = __importStar(__nccwpck_require__(240));
-const fsp = __importStar(__nccwpck_require__(105));
-const path = __importStar(__nccwpck_require__(479));
-const cache = __importStar(__nccwpck_require__(208));
-const cache_compress_js_1 = __nccwpck_require__(465);
-const MINI_KEY_PREFIX = "soldr-mini";
-/**
- * Build the mini-cache key. Deliberately coarse — only the dimensions
- * that change soldr's binary content. No toolchain hash, no Cargo.lock,
- * no cache-key-suffix, no SHA. Cross-workflow sharing within a repo.
- */
-function buildMiniCacheKey(parts) {
-    const v = parts.soldrVersion.trim().replace(/^v/, "") || "unresolved";
-    return [
-        MINI_KEY_PREFIX,
-        parts.runnerOs,
-        parts.runnerArch,
-        parts.libc,
-        `v${v}`,
-    ].join("-");
-}
-/**
- * Try to restore the soldr install dir from the mini-cache. Single exact
- * key — content-addressable so a fallback would be wrong. On hit, the
- * caller's normal ensureSoldr() will see the binary already present at
- * the expected path and skip the GH Releases fetch.
- */
-async function restoreMiniCache(opts) {
-    const { exactKey, installDir, archivePath, longWindow, log } = opts;
-    await fsp.mkdir(installDir, { recursive: true });
-    await fsp.mkdir(path.dirname(archivePath), { recursive: true });
-    await fsp.rm(archivePath, { force: true });
-    let matched;
-    try {
-        matched = await cache.restoreCache([archivePath], exactKey);
-    }
-    catch (err) {
-        log(`soldr-mini-cache: restore threw: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "", archiveBytes: 0 };
-    }
-    if (!matched) {
-        log(`soldr-mini-cache: no entry for key ${exactKey}`);
-        return { hit: false, matchedKey: "", archiveBytes: 0 };
-    }
-    let archiveBytes = 0;
-    try {
-        archiveBytes = (await fsp.stat(archivePath)).size;
-    }
-    catch {
-        return { hit: false, matchedKey: matched, archiveBytes: 0 };
-    }
-    const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-    if (magic !== "zstd" && magic !== "gzip") {
-        log(`soldr-mini-cache: archive has unknown codec, treating as miss`);
-        return { hit: false, matchedKey: matched, archiveBytes };
-    }
-    try {
-        await (0, cache_compress_js_1.decompressCache)({
-            archivePath,
-            targetDir: installDir,
-            longWindow,
-            log,
-            debug: opts.debug,
-        });
-    }
-    catch (err) {
-        log(`soldr-mini-cache: decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: matched, archiveBytes };
-    }
-    log(`soldr-mini-cache: restored matched=${matched} archive=${archiveBytes}B target=${installDir}`);
-    return { hit: true, matchedKey: matched, archiveBytes };
-}
-/**
- * Tar+zstd the soldr install dir and upload to cache. Caller should only
- * call this when restore missed AND ensureSoldr actually fetched (otherwise
- * we'd be re-saving the same content).
- */
-async function saveMiniCache(opts) {
-    const { installDir, archivePath, exactKey, level, longWindow, debug, log } = opts;
-    if (!fs.existsSync(installDir)) {
-        return { status: "skipped-missing-dir" };
-    }
-    let entryCount = 0;
-    try {
-        entryCount = (await fsp.readdir(installDir)).length;
-    }
-    catch { /* */ }
-    if (entryCount === 0) {
-        return { status: "skipped-empty" };
-    }
-    // compressCache writes to `${cacheDir}.tar.zst` by default. We pass
-    // installDir as cacheDir, so the archive ends up at
-    // `${installDir}.tar.zst`. The caller's main.ts side uses the same
-    // path so @actions/cache hashes the paths array identically on save
-    // and restore (mirrors the cook-cache lesson from #141).
-    let outputArchivePath = null;
-    let archiveBytes;
-    let inflatedBytes;
-    let fileCount;
-    try {
-        const compress = await (0, cache_compress_js_1.compressCache)({
-            cacheDir: installDir,
-            codec: "zstd",
-            level,
-            longWindow,
-            debug,
-            log,
-        });
-        outputArchivePath = compress.archivePath;
-        archiveBytes = compress.archiveBytes;
-        if (compress.inflatedBytes !== null)
-            inflatedBytes = compress.inflatedBytes;
-        if (compress.fileCount !== null)
-            fileCount = compress.fileCount;
-    }
-    catch (err) {
-        return { status: "failed", error: err instanceof Error ? err.message : String(err) };
-    }
-    if (!outputArchivePath) {
-        return { status: "failed", error: "compressCache returned null archive (zstd unavailable?)" };
-    }
-    if (path.resolve(outputArchivePath) !== path.resolve(archivePath)) {
-        log(`soldr-mini-cache: WARNING archive path mismatch — compress wrote ${outputArchivePath}, ` +
-            `expected ${archivePath}. Future restore may miss due to paths-version hash.`);
-    }
-    try {
-        const id = await cache.saveCache([outputArchivePath], exactKey);
-        if (id <= 0) {
-            log(`soldr-mini-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
-                `job already saved key=${exactKey}`);
-            return {
-                status: "skipped-race",
-                cacheId: id,
-                archiveBytes,
-                inflatedBytes,
-                fileCount,
-            };
-        }
-        log(`soldr-mini-cache: saved id=${id} key=${exactKey} archive=${outputArchivePath}`);
-        return {
-            status: "saved",
-            cacheId: id,
-            archiveBytes,
-            inflatedBytes,
-            fileCount,
-        };
-    }
-    catch (err) {
-        return {
-            status: "failed",
-            error: err instanceof Error ? err.message : String(err),
-        };
-    }
-}
-/**
- * Should we use the mini-cache for this run? Independent of the
- * `soldr-mini-cache` input flag (that gate is checked in main.ts).
- * Returns false when building from source — binary content depends on
- * the commit SHA, not the version tag.
- */
-function isEligibleForMiniCache(opts) {
-    if (!opts.enable)
-        return { eligible: false, reason: "enable=false (passthrough stub mode)" };
-    if (opts.hasRef) {
-        return {
-            eligible: false,
-            reason: "ref is set — building from source, binary depends on commit not version",
-        };
-    }
-    if (!opts.resolvedVersion.trim()) {
-        return { eligible: false, reason: "no resolved version available" };
-    }
-    return { eligible: true, reason: "eligible" };
-}
-
-
-/***/ }),
-
-/***/ 155:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29396,7 +28277,7 @@ exports.reflectionLongConvert = reflectionLongConvert;
 
 /***/ }),
 
-/***/ 156:
+/***/ 155:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -29430,7 +28311,7 @@ const DEFAULT_RETRY_POLICY_COUNT = 3;
 
 /***/ }),
 
-/***/ 157:
+/***/ 156:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29604,7 +28485,7 @@ exports.uploadCacheArchiveSDK = uploadCacheArchiveSDK;
 
 /***/ }),
 
-/***/ 158:
+/***/ 157:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29677,7 +28558,7 @@ exports.req = req;
 
 /***/ }),
 
-/***/ 159:
+/***/ 158:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -29815,26 +28696,26 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 
 /***/ }),
 
-/***/ 160:
+/***/ 159:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Client = __nccwpck_require__(85)
+const Client = __nccwpck_require__(87)
 const Dispatcher = __nccwpck_require__(450)
-const errors = __nccwpck_require__(460)
+const errors = __nccwpck_require__(461)
 const Pool = __nccwpck_require__(322)
 const BalancedPool = __nccwpck_require__(361)
 const Agent = __nccwpck_require__(5)
 const util = __nccwpck_require__(66)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(135)
+const api = __nccwpck_require__(136)
 const buildConnector = __nccwpck_require__(257)
-const MockClient = __nccwpck_require__(194)
+const MockClient = __nccwpck_require__(193)
 const MockAgent = __nccwpck_require__(357)
 const MockPool = __nccwpck_require__(331)
-const mockErrors = __nccwpck_require__(224)
+const mockErrors = __nccwpck_require__(223)
 const ProxyAgent = __nccwpck_require__(326)
 const RetryHandler = __nccwpck_require__(264)
 const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(356)
@@ -29844,7 +28725,7 @@ const createRedirectInterceptor = __nccwpck_require__(246)
 
 let hasCrypto
 try {
-  __nccwpck_require__(279)
+  __nccwpck_require__(280)
   hasCrypto = true
 } catch {
   hasCrypto = false
@@ -29938,12 +28819,12 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   }
   module.exports.Headers = __nccwpck_require__(486).Headers
   module.exports.Response = __nccwpck_require__(39).Response
-  module.exports.Request = __nccwpck_require__(81).Request
-  module.exports.FormData = __nccwpck_require__(202).FormData
+  module.exports.Request = __nccwpck_require__(83).Request
+  module.exports.FormData = __nccwpck_require__(201).FormData
   module.exports.File = __nccwpck_require__(345).File
-  module.exports.FileReader = __nccwpck_require__(91).FileReader
+  module.exports.FileReader = __nccwpck_require__(93).FileReader
 
-  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(136)
+  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(137)
 
   module.exports.setGlobalOrigin = setGlobalOrigin
   module.exports.getGlobalOrigin = getGlobalOrigin
@@ -29990,7 +28871,7 @@ module.exports.mockErrors = mockErrors
 
 /***/ }),
 
-/***/ 161:
+/***/ 160:
 /***/ ((module) => {
 
 "use strict";
@@ -29998,7 +28879,7 @@ module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 162:
+/***/ 161:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30011,18 +28892,18 @@ module.exports = require("child_process");
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(210);
-tslib_1.__exportStar(__nccwpck_require__(115), exports);
-tslib_1.__exportStar(__nccwpck_require__(176), exports);
-tslib_1.__exportStar(__nccwpck_require__(119), exports);
+const tslib_1 = __nccwpck_require__(209);
+tslib_1.__exportStar(__nccwpck_require__(116), exports);
+tslib_1.__exportStar(__nccwpck_require__(174), exports);
+tslib_1.__exportStar(__nccwpck_require__(120), exports);
 tslib_1.__exportStar(__nccwpck_require__(303), exports);
-tslib_1.__exportStar(__nccwpck_require__(203), exports);
+tslib_1.__exportStar(__nccwpck_require__(202), exports);
 tslib_1.__exportStar(__nccwpck_require__(261), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 163:
+/***/ 162:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30033,7 +28914,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageRetryPolicyName = void 0;
 exports.storageRetryPolicy = storageRetryPolicy;
 const abort_controller_1 = __nccwpck_require__(467);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(12);
 const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(312);
 const constants_js_1 = __nccwpck_require__(34);
@@ -30197,7 +29078,7 @@ function storageRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 164:
+/***/ 163:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -30230,7 +29111,7 @@ exports.create = create;
 
 /***/ }),
 
-/***/ 165:
+/***/ 164:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30284,335 +29165,7 @@ exports.UserDelegationKeyCredential = UserDelegationKeyCredential;
 
 /***/ }),
 
-/***/ 166:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Cook cache layer — long-lived deps tarball keyed by Cargo.lock content.
-//
-// Per CLAUDE.md "Cache-lifetime axis" + the cook simulation findings:
-// the cook cache is short-lived/large (churns on every Cargo.lock change,
-// 100s of MB to multi-GB). It must NOT include SHA in the key (causes
-// catastrophic eviction churn). Content-addressable keying gives parent-
-// to-branch sharing automatically: same Cargo.lock = same key, regardless
-// of branch or commit.
-//
-// Save path: snapshot `target/` immediately after cook completes, before
-// the user's `cargo build` adds project artifacts. We tar+zstd-19 with
-// `--long=27` because compiled rust deps have heavy cross-crate
-// redundancy that benefits from the 128 MB zstd window.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.hashCookFlags = hashCookFlags;
-exports.buildCookCacheKey = buildCookCacheKey;
-exports.decideCookGate = decideCookGate;
-exports.runCook = runCook;
-exports.restoreCookCache = restoreCookCache;
-exports.saveCookCache = saveCookCache;
-exports.parseCookFlags = parseCookFlags;
-exports.canonicalizeCookFlags = canonicalizeCookFlags;
-const node_crypto_1 = __nccwpck_require__(265);
-const fs = __importStar(__nccwpck_require__(240));
-const fsp = __importStar(__nccwpck_require__(105));
-const path = __importStar(__nccwpck_require__(479));
-const exec = __importStar(__nccwpck_require__(16));
-const cache = __importStar(__nccwpck_require__(208));
-const cache_compress_js_1 = __nccwpck_require__(465);
-const COOK_KEY_PREFIX = "cook";
-/**
- * Compute the canonical flag fingerprint. Sorts and lowercases so flag
- * order doesn't perturb the key, and so `--release` vs `--RELEASE`
- * collapse. Only flags that affect cook output structure should be
- * here; cosmetic flags must be filtered upstream.
- */
-function hashCookFlags(flags) {
-    const sorted = [...flags.map((s) => s.trim()).filter((s) => s.length > 0)].sort();
-    if (sorted.length === 0)
-        return "none";
-    const h = (0, node_crypto_1.createHash)("sha256");
-    for (const s of sorted) {
-        h.update(s);
-        h.update("\0");
-    }
-    return h.digest("hex").slice(0, 8);
-}
-function buildCookCacheKey(parts) {
-    const release = parts.rustcRelease.trim() || "unresolved";
-    return [
-        COOK_KEY_PREFIX,
-        parts.runnerOs,
-        parts.runnerArch,
-        parts.libc,
-        `rustc${release}`,
-        `f${parts.flagsHash}`,
-        `l${parts.lockHash}`,
-        `soldr${parts.soldrVersion}`,
-    ].join("-");
-}
-/**
- * Decide whether to run cook based on the runtime environment. Returns a
- * reason string for diagnostic logging in both branches.
- */
-function decideCookGate(opts) {
-    const mode = opts.prebuildDeps.trim().toLowerCase();
-    if (mode === "" || mode === "none" || mode === "off" || mode === "false") {
-        return { enabled: false, reason: `prebuild-deps=${opts.prebuildDeps || "(empty)"} - cook disabled` };
-    }
-    if (mode !== "cargo-chef") {
-        return {
-            enabled: false,
-            reason: `prebuild-deps=${opts.prebuildDeps} - unknown strategy, only "cargo-chef" supported`,
-        };
-    }
-    if (!opts.cacheUmbrella) {
-        return { enabled: false, reason: "cache: false - cook produces no value without caching" };
-    }
-    if (!opts.lockfilePath) {
-        return { enabled: false, reason: "no Cargo.lock found - cook needs a lockfile to derive recipe" };
-    }
-    if (!fs.existsSync(opts.lockfilePath)) {
-        return { enabled: false, reason: `Cargo.lock path ${opts.lockfilePath} does not exist` };
-    }
-    return { enabled: true, reason: "cook enabled" };
-}
-/**
- * Run `soldr cook` in the project directory. Cargo-chef itself emits
- * the recipe and runs the cook compile. We tolerate failure: cook is
- * an optimization, not a correctness primitive, so any non-zero exit
- * is logged and the action proceeds. The user's normal `cargo build`
- * step will work fine without a cooked target.
- */
-async function runCook(opts) {
-    const { soldrBinary, projectRoot, flags, log } = opts;
-    log(`cook: running '${soldrBinary} cook ${flags.join(" ")}' in ${projectRoot}`);
-    const t0 = Date.now();
-    let exitCode = 0;
-    try {
-        exitCode = await exec.exec(soldrBinary, ["cook", ...flags], {
-            cwd: projectRoot,
-            ignoreReturnCode: true,
-        });
-    }
-    catch (err) {
-        log(`cook: exec threw: ${err instanceof Error ? err.message : String(err)}`);
-        exitCode = 1;
-    }
-    const ranSeconds = (Date.now() - t0) / 1000;
-    if (exitCode !== 0) {
-        log(`cook: failed with exit ${exitCode} after ${ranSeconds.toFixed(1)}s; continuing without cooked deps`);
-    }
-    else {
-        log(`cook: completed in ${ranSeconds.toFixed(1)}s`);
-    }
-    return { exitCode, ranSeconds };
-}
-/**
- * Attempt to restore a cooked target directory from the actions cache.
- * Single exact key — no fallback ladder; cook is content-addressable so
- * a fallback would either be redundant or wrong.
- */
-async function restoreCookCache(opts) {
-    const { exactKey, archivePath, targetDir, longWindow, log } = opts;
-    await fsp.mkdir(path.dirname(archivePath), { recursive: true });
-    await fsp.rm(archivePath, { force: true });
-    let matched;
-    try {
-        matched = await cache.restoreCache([archivePath], exactKey);
-    }
-    catch (err) {
-        log(`cook-cache: restore failed: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "", archiveBytes: 0 };
-    }
-    if (!matched) {
-        log(`cook-cache: no entry for key ${exactKey}`);
-        return { hit: false, matchedKey: "", archiveBytes: 0 };
-    }
-    let archiveBytes = 0;
-    try {
-        archiveBytes = (await fsp.stat(archivePath)).size;
-    }
-    catch {
-        return { hit: false, matchedKey: matched, archiveBytes: 0 };
-    }
-    const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-    if (magic !== "zstd" && magic !== "gzip") {
-        log(`cook-cache: restored archive has unknown codec, treating as miss`);
-        return { hit: false, matchedKey: matched, archiveBytes };
-    }
-    await fsp.mkdir(targetDir, { recursive: true });
-    try {
-        await (0, cache_compress_js_1.decompressCache)({
-            archivePath,
-            targetDir,
-            longWindow,
-            log,
-            debug: opts.debug,
-        });
-    }
-    catch (err) {
-        log(`cook-cache: decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: matched, archiveBytes };
-    }
-    log(`cook-cache: restored matched=${matched} archive=${archiveBytes}B target=${targetDir}`);
-    return { hit: true, matchedKey: matched, archiveBytes };
-}
-/**
- * Tar+zstd the post-cook target directory and upload via actions cache.
- * Caller passes the same `longWindow` as the restore side so the archive
- * is readable on subsequent runs.
- */
-async function saveCookCache(opts) {
-    const { targetDir, exactKey, level, longWindow, debug, log } = opts;
-    if (!fs.existsSync(targetDir)) {
-        return { status: "skipped-missing-target" };
-    }
-    // Bail if the directory is effectively empty — cook should have produced
-    // *something*; an empty target dir indicates cook failed silently or the
-    // gate let us through when it shouldn't have.
-    let entryCount = 0;
-    try {
-        entryCount = (await fsp.readdir(targetDir)).length;
-    }
-    catch { /* */ }
-    if (entryCount === 0) {
-        return { status: "skipped-empty" };
-    }
-    let archivePath = null;
-    let archiveBytes;
-    let inflatedBytes;
-    let fileCount;
-    try {
-        const compress = await (0, cache_compress_js_1.compressCache)({
-            cacheDir: targetDir,
-            codec: "zstd",
-            level,
-            longWindow,
-            debug,
-            log,
-        });
-        archivePath = compress.archivePath;
-        archiveBytes = compress.archiveBytes;
-        if (compress.inflatedBytes !== null)
-            inflatedBytes = compress.inflatedBytes;
-        if (compress.fileCount !== null)
-            fileCount = compress.fileCount;
-    }
-    catch (err) {
-        return { status: "failed", error: err instanceof Error ? err.message : String(err) };
-    }
-    if (!archivePath) {
-        return { status: "failed", error: "compressCache returned null archive (zstd unavailable?)" };
-    }
-    try {
-        const id = await cache.saveCache([archivePath], exactKey);
-        if (id <= 0) {
-            // @actions/cache returns -1 when reserveCache fails — typically
-            // because the key already exists (parallel job got there first)
-            // or the cache budget is exhausted. Not an error: future runs
-            // will hit the entry the other job saved.
-            log(`cook-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
-                `job already saved key=${exactKey} or repo cache budget is exhausted`);
-            return {
-                status: "skipped-race",
-                cacheId: id,
-                archiveBytes,
-                inflatedBytes,
-                fileCount,
-                archivePath,
-            };
-        }
-        log(`cook-cache: saved id=${id} key=${exactKey} archive=${archivePath}`);
-        return {
-            status: "saved",
-            cacheId: id,
-            archiveBytes,
-            inflatedBytes,
-            fileCount,
-            archivePath,
-        };
-    }
-    catch (err) {
-        return {
-            status: "failed",
-            error: err instanceof Error ? err.message : String(err),
-            archivePath,
-        };
-    }
-}
-/** Tokenize a free-form flags string into a flags array. Whitespace-split. */
-function parseCookFlags(raw) {
-    return raw
-        .trim()
-        .split(/\s+/)
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
-}
-/**
- * From a flags array, extract only the tokens that materially affect cook
- * output structure for hashing. Excludes verbosity / colour flags.
- *
- * Conservative: keep anything that isn't on a known-cosmetic list. This
- * over-keys (extra misses on cosmetic-only changes) rather than under-keys
- * (serving stale cooked artifacts under a key that doesn't reflect them).
- */
-function canonicalizeCookFlags(flags) {
-    const COSMETIC = new Set([
-        "--verbose", "-v", "-vv", "--quiet", "-q",
-        "--color=auto", "--color=always", "--color=never",
-        "--no-default-features", // affects output; KEEP — moved out below
-    ]);
-    COSMETIC.delete("--no-default-features"); // safety net for the comment above
-    const out = [];
-    for (let i = 0; i < flags.length; i++) {
-        const f = flags[i];
-        if (COSMETIC.has(f))
-            continue;
-        if (f === "--color" || f === "--message-format") {
-            i += 1; // skip the value
-            continue;
-        }
-        out.push(f);
-    }
-    return out;
-}
-
-
-/***/ }),
-
-/***/ 167:
+/***/ 165:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30750,7 +29303,7 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 168:
+/***/ 166:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30877,7 +29430,7 @@ function requestToOptions(request) {
 
 /***/ }),
 
-/***/ 169:
+/***/ 167:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30889,7 +29442,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 170:
+/***/ 168:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30900,13 +29453,13 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 var service_type_1 = __nccwpck_require__(451);
 Object.defineProperty(exports, "ServiceType", ({ enumerable: true, get: function () { return service_type_1.ServiceType; } }));
-var reflection_info_1 = __nccwpck_require__(496);
+var reflection_info_1 = __nccwpck_require__(497);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
 Object.defineProperty(exports, "readMethodOption", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOption; } }));
 Object.defineProperty(exports, "readServiceOption", ({ enumerable: true, get: function () { return reflection_info_1.readServiceOption; } }));
-var rpc_error_1 = __nccwpck_require__(171);
+var rpc_error_1 = __nccwpck_require__(169);
 Object.defineProperty(exports, "RpcError", ({ enumerable: true, get: function () { return rpc_error_1.RpcError; } }));
-var rpc_options_1 = __nccwpck_require__(281);
+var rpc_options_1 = __nccwpck_require__(282);
 Object.defineProperty(exports, "mergeRpcOptions", ({ enumerable: true, get: function () { return rpc_options_1.mergeRpcOptions; } }));
 var rpc_output_stream_1 = __nccwpck_require__(294);
 Object.defineProperty(exports, "RpcOutputStreamController", ({ enumerable: true, get: function () { return rpc_output_stream_1.RpcOutputStreamController; } }));
@@ -30923,7 +29476,7 @@ var server_streaming_call_1 = __nccwpck_require__(425);
 Object.defineProperty(exports, "ServerStreamingCall", ({ enumerable: true, get: function () { return server_streaming_call_1.ServerStreamingCall; } }));
 var unary_call_1 = __nccwpck_require__(53);
 Object.defineProperty(exports, "UnaryCall", ({ enumerable: true, get: function () { return unary_call_1.UnaryCall; } }));
-var rpc_interceptor_1 = __nccwpck_require__(501);
+var rpc_interceptor_1 = __nccwpck_require__(502);
 Object.defineProperty(exports, "stackIntercept", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackIntercept; } }));
 Object.defineProperty(exports, "stackDuplexStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackDuplexStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackClientStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackClientStreamingInterceptors; } }));
@@ -30935,7 +29488,7 @@ Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: tru
 
 /***/ }),
 
-/***/ 171:
+/***/ 169:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30979,7 +29532,7 @@ exports.RpcError = RpcError;
 
 /***/ }),
 
-/***/ 172:
+/***/ 170:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -31062,7 +29615,7 @@ function isLessThan(lhs, rhs) {
 
 /***/ }),
 
-/***/ 173:
+/***/ 171:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31074,7 +29627,7 @@ exports.LroEngine = void 0;
 const operation_js_1 = __nccwpck_require__(339);
 const constants_js_1 = __nccwpck_require__(57);
 const poller_js_1 = __nccwpck_require__(72);
-const operation_js_2 = __nccwpck_require__(137);
+const operation_js_2 = __nccwpck_require__(138);
 /**
  * The LRO Engine, a class that performs polling.
  */
@@ -31102,7 +29655,7 @@ exports.LroEngine = LroEngine;
 
 /***/ }),
 
-/***/ 174:
+/***/ 172:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -32752,7 +31305,7 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 175:
+/***/ 173:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -41095,7 +39648,7 @@ exports.BlockBlobGetBlockListExceptionHeaders = {
 
 /***/ }),
 
-/***/ 176:
+/***/ 174:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -41112,7 +39665,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 177:
+/***/ 175:
 /***/ ((module) => {
 
 "use strict";
@@ -41120,7 +39673,7 @@ module.exports = require("tty");
 
 /***/ }),
 
-/***/ 178:
+/***/ 176:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -41134,11 +39687,11 @@ exports.newPipeline = newPipeline;
 exports.getCoreClientOptions = getCoreClientOptions;
 exports.getCredentialFromPipeline = getCredentialFromPipeline;
 const core_http_compat_1 = __nccwpck_require__(69);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_client_1 = __nccwpck_require__(413);
-const core_xml_1 = __nccwpck_require__(189);
+const core_xml_1 = __nccwpck_require__(187);
 const core_auth_1 = __nccwpck_require__(484);
-const log_js_1 = __nccwpck_require__(103);
+const log_js_1 = __nccwpck_require__(105);
 const storage_common_1 = __nccwpck_require__(267);
 const constants_js_1 = __nccwpck_require__(145);
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return constants_js_1.StorageOAuthScopes; } }));
@@ -41404,7 +39957,7 @@ function isCoreHttpPolicyFactory(factory) {
 
 /***/ }),
 
-/***/ 179:
+/***/ 177:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -41437,7 +39990,7 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 
 /***/ }),
 
-/***/ 180:
+/***/ 178:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -41446,27 +39999,27 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobClient = exports.BlockBlobClient = exports.AppendBlobClient = exports.BlobClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_auth_1 = __nccwpck_require__(484);
 const core_util_1 = __nccwpck_require__(12);
 const core_util_2 = __nccwpck_require__(12);
 const BlobDownloadResponse_js_1 = __nccwpck_require__(400);
-const BlobQueryResponse_js_1 = __nccwpck_require__(196);
+const BlobQueryResponse_js_1 = __nccwpck_require__(195);
 const storage_common_1 = __nccwpck_require__(267);
 const models_js_1 = __nccwpck_require__(391);
 const PageBlobRangeResponse_js_1 = __nccwpck_require__(27);
-const Pipeline_js_1 = __nccwpck_require__(178);
+const Pipeline_js_1 = __nccwpck_require__(176);
 const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(504);
-const Range_js_1 = __nccwpck_require__(101);
+const Range_js_1 = __nccwpck_require__(103);
 const StorageClient_js_1 = __nccwpck_require__(428);
-const Batch_js_1 = __nccwpck_require__(88);
+const Batch_js_1 = __nccwpck_require__(90);
 const storage_common_2 = __nccwpck_require__(267);
 const constants_js_1 = __nccwpck_require__(145);
 const tracing_js_1 = __nccwpck_require__(29);
 const utils_common_js_1 = __nccwpck_require__(151);
-const utils_js_1 = __nccwpck_require__(197);
+const utils_js_1 = __nccwpck_require__(196);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(65);
-const BlobLeaseClient_js_1 = __nccwpck_require__(199);
+const BlobLeaseClient_js_1 = __nccwpck_require__(198);
 /**
  * A BlobClient represents a URL to an Azure Storage blob; the blob may be a block blob,
  * append blob, or page blob.
@@ -44296,7 +42849,7 @@ exports.PageBlobClient = PageBlobClient;
 
 /***/ }),
 
-/***/ 181:
+/***/ 179:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44305,8 +42858,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryWriter = void 0;
 const binary_format_contract_1 = __nccwpck_require__(318);
 const reflection_info_1 = __nccwpck_require__(426);
-const assert_1 = __nccwpck_require__(456);
-const pb_long_1 = __nccwpck_require__(114);
+const assert_1 = __nccwpck_require__(457);
+const pb_long_1 = __nccwpck_require__(115);
 /**
  * Writes proto3 messages in binary format using reflection information.
  *
@@ -44537,7 +43090,7 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 
 /***/ }),
 
-/***/ 182:
+/***/ 180:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44548,7 +43101,7 @@ const { maxUnsigned16Bit } = __nccwpck_require__(438)
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(279)
+  crypto = __nccwpck_require__(280)
 } catch {
 
 }
@@ -44618,7 +43171,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 183:
+/***/ 181:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -44665,13 +43218,13 @@ function isApiKeyCredential(credential) {
 
 /***/ }),
 
-/***/ 184:
+/***/ 182:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(495)
 const {
   ResponseStatusCodeError
-} = __nccwpck_require__(460)
+} = __nccwpck_require__(461)
 const { toUSVString } = __nccwpck_require__(66)
 
 async function getResolveErrorBodyCallback ({ callback, body, contentType, statusCode, statusMessage, headers }) {
@@ -44718,7 +43271,7 @@ module.exports = { getResolveErrorBodyCallback }
 
 /***/ }),
 
-/***/ 185:
+/***/ 183:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -44840,7 +43393,7 @@ exports.getSelectedOneofValue = getSelectedOneofValue;
 
 /***/ }),
 
-/***/ 186:
+/***/ 184:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44859,7 +43412,7 @@ exports.logger = (0, logger_1.createClientLogger)("core-lro");
 
 /***/ }),
 
-/***/ 187:
+/***/ 185:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45063,7 +43616,7 @@ module.exports = parseParams
 
 /***/ }),
 
-/***/ 188:
+/***/ 186:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45089,8 +43642,8 @@ __export(auxiliaryAuthenticationHeaderPolicy_exports, {
   auxiliaryAuthenticationHeaderPolicyName: () => auxiliaryAuthenticationHeaderPolicyName
 });
 module.exports = __toCommonJS(auxiliaryAuthenticationHeaderPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(159);
-var import_log = __nccwpck_require__(179);
+var import_tokenCycler = __nccwpck_require__(158);
+var import_log = __nccwpck_require__(177);
 const auxiliaryAuthenticationHeaderPolicyName = "auxiliaryAuthenticationHeaderPolicy";
 const AUTHORIZATION_AUXILIARY_HEADER = "x-ms-authorization-auxiliary";
 async function sendAuthorizeRequest(options) {
@@ -45156,7 +43709,7 @@ function auxiliaryAuthenticationHeaderPolicy(options) {
 
 /***/ }),
 
-/***/ 189:
+/***/ 187:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45184,7 +43737,7 @@ __export(src_exports, {
   stringifyXML: () => import_xml.stringifyXML
 });
 module.exports = __toCommonJS(src_exports);
-var import_xml = __nccwpck_require__(134);
+var import_xml = __nccwpck_require__(135);
 var import_xml_common = __nccwpck_require__(19);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -45193,7 +43746,7 @@ var import_xml_common = __nccwpck_require__(19);
 
 /***/ }),
 
-/***/ 190:
+/***/ 188:
 /***/ ((module) => {
 
 module.exports = {
@@ -45263,7 +43816,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 191:
+/***/ 189:
 /***/ ((module) => {
 
 "use strict";
@@ -45388,7 +43941,7 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 192:
+/***/ 190:
 /***/ ((module) => {
 
 "use strict";
@@ -45396,7 +43949,1114 @@ module.exports = require("node:child_process");
 
 /***/ }),
 
-/***/ 193:
+/***/ 191:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr post-job entry point. Owned by Agent 2.
+//
+// Runs in the post-job phase via action.yml's `post: dist/post.js`. This is
+// the architectural fix for zackees/setup-soldr#70 — it lets us tar+zstd
+// the build-cache (and optionally cargo-registry) directories BEFORE
+// @actions/cache's post-save uploads them, so the wire format is zstd on
+// every platform (including Windows-x64 where actions/cache@v5 still
+// falls back to gzip).
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.resolveJournalPrintRaw = resolveJournalPrintRaw;
+exports.buildFinalCacheSummary = buildFinalCacheSummary;
+exports.formatFinalCacheSummaryMarkdown = formatFinalCacheSummaryMarkdown;
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(240));
+const path = __importStar(__nccwpck_require__(479));
+const node_child_process_1 = __nccwpck_require__(190);
+const core = __importStar(__nccwpck_require__(432));
+const cache = __importStar(__nccwpck_require__(207));
+const cache_compress_js_1 = __nccwpck_require__(496);
+const solo_toolchain_cache_js_1 = __nccwpck_require__(279);
+const cook_cache_js_1 = __nccwpck_require__(455);
+const soldr_mini_cache_js_1 = __nccwpck_require__(76);
+const log_utils_js_1 = __nccwpck_require__(334);
+const shutdown_cache_js_1 = __nccwpck_require__(499);
+const stats_collector_js_1 = __nccwpck_require__(71);
+const diagnostics_js_1 = __nccwpck_require__(224);
+const raw_inputs_js_1 = __nccwpck_require__(343);
+const source_mtime_snapshot_js_1 = __nccwpck_require__(384);
+function dirExists(p) {
+    try {
+        return fs.statSync(p).isDirectory();
+    }
+    catch {
+        return false;
+    }
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+function stateBool(name, fallback = false) {
+    const value = core.getState(name).trim().toLowerCase();
+    if (value === "true")
+        return true;
+    if (value === "false")
+        return false;
+    return fallback;
+}
+/**
+ * Decide whether the post-phase diagnostic dump includes the verbatim
+ * per-rustc-invocation JSONL stream. The raw stream is large (thousands
+ * of records / 20-30 MB on the demo warm build) and dominates Post Setup
+ * Soldr wall-clock when emitted. Default: mirror debug mode (preserves
+ * pre-existing behavior for workflows that already opted into debug).
+ * Explicit values "true"/"false"/"on"/"off"/"yes"/"no"/"1"/"0" override.
+ */
+function resolveJournalPrintRaw(rawValue, debugMode) {
+    const v = (rawValue ?? "").trim().toLowerCase();
+    if (v === "")
+        return debugMode;
+    if (v === "true" || v === "1" || v === "yes" || v === "on")
+        return true;
+    if (v === "false" || v === "0" || v === "no" || v === "off")
+        return false;
+    return debugMode;
+}
+function readRestoreState() {
+    return {
+        setupCacheEnabled: stateBool("setupCacheEnabled"),
+        setupCacheExactHit: stateBool("setupCacheExactHit"),
+        setupCacheMatchedKey: core.getState("setupCacheMatchedKey"),
+        targetCacheEnabled: stateBool("targetCacheEnabled"),
+        targetCacheExactHit: stateBool("targetCacheExactHit"),
+        targetCacheMatchedKey: core.getState("targetCacheMatchedKey"),
+        buildCacheEnabled: stateBool("buildCacheEnabled"),
+        buildCacheExactHit: stateBool("buildCacheExactHit"),
+        buildCacheMatchedKey: core.getState("buildCacheMatchedKey"),
+        cargoRegistryCacheEnabled: stateBool("cargoRegistryCacheEnabled"),
+        cargoRegistryCacheExactHit: stateBool("cargoRegistryCacheExactHit"),
+        cargoRegistryCacheMatchedKey: core.getState("cargoRegistryCacheMatchedKey"),
+    };
+}
+function disabledSave() {
+    return { status: "disabled" };
+}
+// setup-cache is intentionally restore-only. Its restore is kept so the
+// action's `cache-hit` output (wired from setupCacheExactHit in main.ts)
+// retains its public contract for downstream workflows, but the save path
+// is permanently inert: the soldr binary moved to soldr-mini-cache (#142)
+// and the rustup toolchain state moved to solo-toolchain-cache (#139),
+// both of which are content-addressable and coarser-keyed. Wiring a save
+// here would re-introduce a duplicate path and defeat those layers' LRU
+// access pattern. See setup-soldr#151 for the full decision rationale.
+function notManagedSave() {
+    return { status: "not-managed-in-post" };
+}
+function restoreStatus(enabled, exactHit, matchedKey) {
+    if (!enabled)
+        return "disabled";
+    if (exactHit)
+        return "exact-hit";
+    if (matchedKey.trim())
+        return "restore-key-hit";
+    return "miss";
+}
+async function saveOne(opts) {
+    const { cacheDir, codec, level, key, matchedKey, label, debug, log, extraBasenames } = opts;
+    const withBytes = (r) => Object.assign(r, { archiveBytes: null });
+    if (!dirExists(cacheDir)) {
+        log(`${label}: cache dir ${cacheDir} does not exist, skipping save`);
+        return withBytes({ status: "missing-dir-skip", cache_dir: cacheDir });
+    }
+    if (matchedKey === key) {
+        log(`${label}: exact cache hit on ${key}, skipping save`);
+        return withBytes({ status: "exact-hit-skip", cache_dir: cacheDir });
+    }
+    let archiveBytes = null;
+    let archivePath = null;
+    try {
+        const result = await (0, cache_compress_js_1.compressCache)({ cacheDir, codec, level, debug, log, extraBasenames });
+        archivePath = result.archivePath;
+        archiveBytes = result.archiveBytes || null;
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log(`${label}: compression failed: ${message}`);
+        return withBytes({ status: "failed", cache_dir: cacheDir, error: message });
+    }
+    const pathsToSave = archivePath ? [archivePath] : [cacheDir];
+    try {
+        const id = await cache.saveCache(pathsToSave, key);
+        log(`${label}: saved cache id=${id} key=${key} via ${archivePath ? "tar.zst" : "default"}`);
+        return {
+            status: "saved",
+            cache_dir: cacheDir,
+            archive_path: archivePath ?? undefined,
+            saved_paths: pathsToSave,
+            cache_id: id,
+            archiveBytes,
+        };
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log(`${label}: save failed: ${message}`);
+        return {
+            status: "failed",
+            cache_dir: cacheDir,
+            archive_path: archivePath ?? undefined,
+            saved_paths: pathsToSave,
+            error: message,
+            archiveBytes,
+        };
+    }
+}
+function cacheLayerSummary(opts) {
+    const matchedKey = opts.matchedKey.trim();
+    return {
+        enabled: opts.enabled,
+        key: opts.key,
+        matched_key: matchedKey,
+        exact_hit: opts.enabled ? opts.exactHit : false,
+        restore_status: restoreStatus(opts.enabled, opts.exactHit, matchedKey),
+        save: opts.save,
+    };
+}
+function readSoldrCacheReport(soldrBinary, passthrough) {
+    if (passthrough) {
+        // Short-circuit when the main step installed a passthrough stub
+        // (enable=false). Skips spawning a .cmd on Windows (where
+        // child_process.spawnSync can't launch shell scripts directly) and
+        // documents the passthrough state in the post-step summary.
+        return {
+            status: "ok",
+            soldr_version: "passthrough",
+            report: {
+                notes: ["setup-soldr enable=false: soldr passthrough stub"],
+                last_session: null,
+                rollups: null,
+            },
+        };
+    }
+    if (!soldrBinary || !fileExists(soldrBinary)) {
+        return {
+            status: "missing-binary",
+            error: soldrBinary === undefined
+                ? "SOLDR_BINARY env var not set"
+                : `soldr binary at ${soldrBinary} does not exist`,
+        };
+    }
+    // Use spawnSync so the post step has no async dependencies. The
+    // report subcommand is fast (sub-100ms) — never worth pulling in
+    // @actions/exec just for one shell-out.
+    const child = (0, node_child_process_1.spawnSync)(soldrBinary, ["cache", "report", "--json"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+    });
+    if (child.error) {
+        return {
+            status: "error",
+            error: `failed to spawn soldr: ${child.error.message}`,
+        };
+    }
+    const stdout = (child.stdout || "").trim();
+    const stderr = (child.stderr || "").trim();
+    if (child.status !== 0) {
+        const combined = `${stderr}\n${stdout}`;
+        if (/unrecognized subcommand|invalid value for|unknown sub[- ]?command/i.test(combined) &&
+            /\breport\b/.test(combined)) {
+            return {
+                status: "unsupported",
+                error: stderr || stdout || `soldr exited ${child.status}`,
+            };
+        }
+        return {
+            status: "error",
+            error: stderr || stdout || `soldr exited ${child.status}`,
+        };
+    }
+    let report;
+    try {
+        const parsed = JSON.parse(stdout);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            return {
+                status: "error",
+                error: "soldr cache report --json returned a non-object payload",
+            };
+        }
+        report = parsed;
+    }
+    catch (err) {
+        return {
+            status: "error",
+            error: `failed to parse soldr cache report JSON: ${err instanceof Error ? err.message : String(err)}`,
+        };
+    }
+    const soldrVersion = typeof report["soldr_version"] === "string" ? report["soldr_version"] : undefined;
+    const zccacheVersion = typeof report["managed_zccache_version"] === "string"
+        ? report["managed_zccache_version"]
+        : undefined;
+    return {
+        status: "ok",
+        soldr_version: soldrVersion,
+        managed_zccache_version: zccacheVersion,
+        report,
+    };
+}
+function readZccacheSessionSummary(buildCachePath) {
+    const statsPath = path.join(buildCachePath, "logs", "last-session-stats.json");
+    if (!fileExists(statsPath)) {
+        return { stats_path: statsPath, present: false, status: "missing" };
+    }
+    try {
+        const parsed = JSON.parse(fs.readFileSync(statsPath, "utf8"));
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            return {
+                stats_path: statsPath,
+                present: true,
+                status: "invalid",
+                error: "stats JSON was not an object",
+            };
+        }
+        const stats = parsed;
+        const status = typeof stats["status"] === "string" ? stats["status"] : "unknown";
+        return { stats_path: statsPath, present: true, status, stats };
+    }
+    catch (err) {
+        return {
+            stats_path: statsPath,
+            present: true,
+            status: "invalid",
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+}
+function buildFinalCacheSummary(result, state, saves, passthrough = false) {
+    return {
+        schema_version: 1,
+        setup_cache: cacheLayerSummary({
+            enabled: state.setupCacheEnabled,
+            key: result.setupCache.key,
+            exactHit: state.setupCacheExactHit,
+            matchedKey: state.setupCacheMatchedKey,
+            save: notManagedSave(),
+        }),
+        target_cache: cacheLayerSummary({
+            enabled: state.targetCacheEnabled,
+            key: result.targetCache.key,
+            exactHit: state.targetCacheExactHit,
+            matchedKey: state.targetCacheMatchedKey,
+            save: saves.targetCache,
+        }),
+        build_cache: cacheLayerSummary({
+            enabled: state.buildCacheEnabled,
+            key: result.buildCache.key,
+            exactHit: state.buildCacheExactHit,
+            matchedKey: state.buildCacheMatchedKey,
+            save: saves.buildCache,
+        }),
+        cargo_registry_cache: cacheLayerSummary({
+            enabled: state.cargoRegistryCacheEnabled,
+            key: result.cargoRegistryCache.key,
+            exactHit: state.cargoRegistryCacheExactHit,
+            matchedKey: state.cargoRegistryCacheMatchedKey,
+            save: saves.cargoRegistryCache,
+        }),
+        zccache_session: readZccacheSessionSummary(result.buildCache.path),
+        compile_cache_report: readSoldrCacheReport(process.env["SOLDR_BINARY"]?.trim(), passthrough),
+    };
+}
+function numberStat(stats, key) {
+    const value = stats?.[key];
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+function zccacheOneLine(summary) {
+    if (!summary.present)
+        return `missing (${summary.stats_path})`;
+    if (summary.status !== "ok") {
+        return summary.error ? `${summary.status} (${summary.error})` : summary.status;
+    }
+    const hits = numberStat(summary.stats, "hits") ?? 0;
+    const misses = numberStat(summary.stats, "misses") ?? 0;
+    const compilations = numberStat(summary.stats, "compilations") ?? hits + misses;
+    const nonCacheable = numberStat(summary.stats, "non_cacheable") ?? 0;
+    const errors = numberStat(summary.stats, "errors") ?? 0;
+    const hitRate = numberStat(summary.stats, "hit_rate");
+    const hitRateText = hitRate === undefined ? "n/a" : `${(hitRate * 100).toFixed(1)}%`;
+    return `hits=${hits} misses=${misses} compilations=${compilations} non_cacheable=${nonCacheable} errors=${errors} hit_rate=${hitRateText}`;
+}
+function restoreText(layer) {
+    if (!layer.enabled)
+        return "disabled";
+    if (layer.restore_status === "exact-hit")
+        return "exact hit";
+    if (layer.restore_status === "restore-key-hit")
+        return "restore-key hit";
+    return "miss";
+}
+function saveText(save) {
+    switch (save.status) {
+        case "saved":
+            return save.cache_id === undefined ? "saved" : `saved id=${save.cache_id}`;
+        case "exact-hit-skip":
+            return "skipped exact hit";
+        case "missing-dir-skip":
+            return "skipped missing dir";
+        case "failed":
+            return save.error ? `failed: ${save.error}` : "failed";
+        case "disabled":
+            return "disabled";
+        case "not-managed-in-post":
+            return "not managed in post";
+    }
+}
+function markdownCell(value) {
+    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+function tableRow(label, layer) {
+    return [
+        label,
+        restoreText(layer),
+        layer.key,
+        layer.matched_key || "",
+        saveText(layer.save),
+    ]
+        .map(markdownCell)
+        .join(" | ");
+}
+function fmtBytes(n) {
+    if (n >= 1_073_741_824)
+        return `${(n / 1_073_741_824).toFixed(1)} GB`;
+    if (n >= 1_048_576)
+        return `${(n / 1_048_576).toFixed(1)} MB`;
+    if (n >= 1_024)
+        return `${(n / 1_024).toFixed(1)} KB`;
+    return `${n} B`;
+}
+function setCompileCacheOutputs(report, mode) {
+    core.setOutput("compile-cache-session-status", report.status);
+    if (report.status !== "ok" || !report.report)
+        return;
+    core.setOutput("compile-cache-summary-json", JSON.stringify(report.report));
+    const lastSession = report.report["last_session"];
+    if (lastSession) {
+        const hits = numberStat(lastSession, "hits") ?? 0;
+        const misses = numberStat(lastSession, "misses") ?? 0;
+        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
+        const hitRate = numberStat(lastSession, "hit_rate");
+        const timeSavedMs = numberStat(lastSession, "time_saved_ms");
+        const bytesRead = numberStat(lastSession, "bytes_read");
+        const bytesWritten = numberStat(lastSession, "bytes_written");
+        core.setOutput("compile-cache-hits", String(hits));
+        core.setOutput("compile-cache-misses", String(misses));
+        core.setOutput("compile-cache-compilations", String(compilations));
+        if (hitRate !== undefined)
+            core.setOutput("compile-cache-hit-rate", String(hitRate));
+        if (timeSavedMs !== undefined)
+            core.setOutput("compile-cache-time-saved-ms", String(timeSavedMs));
+        if (bytesRead !== undefined)
+            core.setOutput("compile-cache-bytes-read", String(bytesRead));
+        if (bytesWritten !== undefined)
+            core.setOutput("compile-cache-bytes-written", String(bytesWritten));
+    }
+    if (mode === "detailed") {
+        const rollups = report.report["rollups"];
+        if (rollups)
+            core.setOutput("compile-cache-rollups-json", JSON.stringify(rollups));
+    }
+}
+function compileCacheReportSection(report, mode) {
+    if (mode === "none")
+        return [];
+    const lines = ["", "### Compile cache (zccache)", ""];
+    if (report.status !== "ok" || !report.report) {
+        lines.push(`| Status | ${markdownCell(report.status)} |`);
+        if (report.error)
+            lines.push(`| Detail | ${markdownCell(report.error)} |`);
+        return lines;
+    }
+    const body = report.report;
+    const lastSession = body["last_session"] ?? null;
+    const rollups = body["rollups"] ?? null;
+    if (lastSession) {
+        const hits = numberStat(lastSession, "hits") ?? 0;
+        const misses = numberStat(lastSession, "misses") ?? 0;
+        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
+        const rate = numberStat(lastSession, "hit_rate");
+        const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
+        const saved = numberStat(lastSession, "time_saved_ms");
+        const bytesRead = numberStat(lastSession, "bytes_read");
+        const bytesWritten = numberStat(lastSession, "bytes_written");
+        lines.push("| Metric | Value |", "| --- | --- |");
+        lines.push(`| Compilations | ${compilations} |`);
+        lines.push(`| Hits | ${hits} |`);
+        lines.push(`| Misses | ${misses} |`);
+        lines.push(`| Hit rate | ${rateText} |`);
+        if (saved !== undefined)
+            lines.push(`| Time saved (est.) | ${(saved / 1000).toFixed(1)}s |`);
+        if (bytesRead !== undefined)
+            lines.push(`| Bytes read | ${fmtBytes(bytesRead)} |`);
+        if (bytesWritten !== undefined)
+            lines.push(`| Bytes written | ${fmtBytes(bytesWritten)} |`);
+        if (report.soldr_version)
+            lines.push(`| soldr | ${markdownCell(report.soldr_version)} |`);
+        if (report.managed_zccache_version)
+            lines.push(`| zccache | ${markdownCell(report.managed_zccache_version)} |`);
+    }
+    else {
+        lines.push("_(no last\\_session yet — run a cache-enabled build first)_");
+    }
+    if (mode === "detailed" && rollups) {
+        const byExt = rollups["by_extension"];
+        if (byExt && typeof byExt === "object" && !Array.isArray(byExt)) {
+            const rows = Object.entries(byExt);
+            if (rows.length > 0) {
+                lines.push("", "#### By output extension", "");
+                lines.push("| Extension | Hits | Misses | Total ms |", "| --- | --- | --- | --- |");
+                for (const [ext, bucket] of rows) {
+                    const b = bucket ?? {};
+                    const h = numberStat(b, "hits") ?? 0;
+                    const m = numberStat(b, "misses") ?? 0;
+                    const t = numberStat(b, "total_ms") ?? 0;
+                    lines.push(`| ${markdownCell(ext)} | ${h} | ${m} | ${t} |`);
+                }
+            }
+        }
+        const byTool = rollups["by_tool_total_ms"];
+        if (byTool && typeof byTool === "object" && !Array.isArray(byTool)) {
+            const rows = Object.entries(byTool)
+                .map(([tool, ms]) => [tool, typeof ms === "number" ? ms : 0])
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 10);
+            if (rows.length > 0) {
+                lines.push("", "#### By tool (wall-clock)", "");
+                lines.push("| Tool | ms |", "| --- | --- |");
+                for (const [tool, ms] of rows) {
+                    lines.push(`| ${markdownCell(tool)} | ${ms} |`);
+                }
+            }
+        }
+    }
+    const notes = body["notes"];
+    if (Array.isArray(notes) && notes.length > 0) {
+        lines.push("", "<details><summary>Notes from soldr</summary>", "");
+        for (const note of notes) {
+            if (typeof note === "string")
+                lines.push(`- ${markdownCell(note)}`);
+        }
+        lines.push("", "</details>");
+    }
+    return lines;
+}
+function formatFinalCacheSummaryMarkdown(summary, compileCacheStats = "summarize") {
+    const lines = [
+        "## setup-soldr final cache summary",
+        "",
+        "| Layer | Restore | Primary key | Matched key | Save |",
+        "| --- | --- | --- | --- | --- |",
+        `| ${tableRow("setup cache", summary.setup_cache)} |`,
+        `| ${tableRow("target cache", summary.target_cache)} |`,
+        `| ${tableRow("build cache", summary.build_cache)} |`,
+        `| ${tableRow("cargo registry cache", summary.cargo_registry_cache)} |`,
+        "",
+        "### zccache session",
+        "",
+        `- Stats: ${zccacheOneLine(summary.zccache_session)}`,
+        `- Stats file: ${summary.zccache_session.stats_path}`,
+        ...compileCacheReportSection(summary.compile_cache_report, compileCacheStats),
+        "",
+        "<details><summary>Final cache summary JSON</summary>",
+        "",
+        "```json",
+        JSON.stringify(summary, null, 2),
+        "```",
+        "",
+        "</details>",
+        "",
+    ];
+    return `${lines.join("\n")}\n`;
+}
+function logFinalCacheSummary(summary, log) {
+    log(`final cache summary: setup=${restoreText(summary.setup_cache)} target=${restoreText(summary.target_cache)} ` +
+        `build=${restoreText(summary.build_cache)}/${saveText(summary.build_cache.save)} ` +
+        `cargo-registry=${restoreText(summary.cargo_registry_cache)}/${saveText(summary.cargo_registry_cache.save)}`);
+    log(`final zccache session stats: ${zccacheOneLine(summary.zccache_session)}`);
+    log(`compile cache report: ${compileCacheReportOneLine(summary.compile_cache_report)}`);
+}
+function compileCacheReportOneLine(report) {
+    if (report.status !== "ok" || !report.report) {
+        return report.error ? `${report.status} (${report.error})` : report.status;
+    }
+    const lastSession = report.report["last_session"];
+    if (!lastSession) {
+        return `ok (no last_session yet, soldr ${report.soldr_version ?? "?"})`;
+    }
+    const hits = numberStat(lastSession, "hits") ?? 0;
+    const misses = numberStat(lastSession, "misses") ?? 0;
+    const rate = numberStat(lastSession, "hit_rate");
+    const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
+    return `ok hits=${hits} misses=${misses} hit_rate=${rateText} soldr=${report.soldr_version ?? "?"}`;
+}
+function writeCompileCacheReportFile(report, runnerTemp, log) {
+    if (!runnerTemp)
+        return undefined;
+    const outPath = path.join(runnerTemp, "setup-soldr-compile-cache-report.json");
+    try {
+        fs.writeFileSync(outPath, JSON.stringify(report, null, 2), "utf8");
+        return outPath;
+    }
+    catch (err) {
+        log(`post: failed to write compile-cache-report.json: ${err instanceof Error ? err.message : String(err)}`);
+        return undefined;
+    }
+}
+function writeStepSummary(markdown, log) {
+    const summaryPath = process.env["GITHUB_STEP_SUMMARY"]?.trim();
+    if (!summaryPath)
+        return;
+    try {
+        fs.appendFileSync(summaryPath, markdown, "utf8");
+    }
+    catch (err) {
+        log(`post: failed to write GitHub step summary: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+async function run() {
+    const logger = (0, log_utils_js_1.createLogger)(process.env);
+    const log = (msg) => logger.log(msg);
+    const state = core.getState("resolveResult");
+    if (!state) {
+        log("post: no resolve state available, exiting");
+        return;
+    }
+    let result;
+    try {
+        result = JSON.parse(state);
+    }
+    catch (err) {
+        log(`post: failed to parse resolve state: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+    }
+    const buildCacheMatched = core.getState("buildCacheMatchedKey");
+    const registryMatched = core.getState("cargoRegistryCacheMatchedKey");
+    const passthrough = stateBool("setupSoldrPassthrough");
+    const restoreState = readRestoreState();
+    const statsMode = (core.getState("statsMode") || "summarize");
+    const compileCacheStats = (core.getState("compileCacheStats") || "summarize");
+    const runnerTemp = core.getState("runnerTemp") || "";
+    const debugMode = result.debugMode ?? false;
+    const debugLog = debugMode ? log : () => undefined;
+    const postCollector = new stats_collector_js_1.StatsCollector();
+    // Always stop long-running cache daemons before packing the build
+    // cache so file locks release and the tarball reflects a quiescent
+    // on-disk view. Best-effort; failures are logged, not raised.
+    //
+    // Wire `--archive-logs <build-cache>/logs/archive` through so soldr
+    // (post-#379) stashes the just-ended session's logs into a
+    // per-session subdirectory inside the build-cache. Setup-soldr's
+    // existing tar.zst flow already picks up the entire build-cache
+    // subtree, so the archived logs ride the cache cycle for free and
+    // survive across runs (see issue #126).
+    const logsArchiveDir = restoreState.buildCacheEnabled
+        ? path.join(result.buildCache.path, "logs", "archive")
+        : undefined;
+    await (0, shutdown_cache_js_1.shutdownCacheDaemons)({
+        soldrPath: process.env["SOLDR_BINARY"]?.trim() || undefined,
+        logsArchiveDir,
+        log,
+    });
+    // Source-mtime snapshot (preserve-source-mtimes opt-in). Walk tracked
+    // sources, capture each (mtime, size, content-hash), and drop the JSON
+    // INSIDE the build-cache directory so it gets bundled into the same
+    // tar.zst the build-cache save will upload. main.ts replays the
+    // mtimes on warm after the build-cache decompresses, gated on each
+    // file's content matching what we snapshotted here.
+    const preserveSourceMtimes = core.getState("preserveSourceMtimes") === "true";
+    if (preserveSourceMtimes && restoreState.buildCacheEnabled) {
+        const t0 = Date.now();
+        // The "project root" — where the Cargo workspace being built actually
+        // lives — is the parent of the resolved target-dir, NOT result.workspace
+        // (which is GITHUB_WORKSPACE — usually the outer checkout containing
+        // the action itself plus one or more sub-repos). For the demo,
+        // result.workspace=/home/runner/work/setup-soldr/setup-soldr but the
+        // zccache project being built is at .../setup-soldr/zccache.
+        const projectRoot = path.dirname(result.targetCache.targetPath);
+        try {
+            const r = await (0, source_mtime_snapshot_js_1.snapshotSourceMtimes)({ workspace: projectRoot, log });
+            const out = path.join(result.buildCache.path, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
+            try {
+                fs.mkdirSync(path.dirname(out), { recursive: true });
+                (0, source_mtime_snapshot_js_1.writeSnapshotFile)(r.snapshot, out);
+                log(`source-mtime-snapshot: wrote ${out} scanned=${r.scanned} hashed=${r.hashed} skipped=${r.skipped} elapsed_ms=${Date.now() - t0}`);
+            }
+            catch (err) {
+                log(`source-mtime-snapshot: failed to write ${out}: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+        catch (err) {
+            log(`source-mtime-snapshot: scan failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    // Build cache
+    const buildSaveStart = Date.now();
+    const buildSave = restoreState.buildCacheEnabled
+        ? await saveOne({
+            cacheDir: result.buildCache.path,
+            codec: result.targetCacheCompress,
+            level: result.targetCacheCompressLevel,
+            key: result.buildCache.key,
+            matchedKey: buildCacheMatched,
+            label: "build-cache",
+            debug: debugMode,
+            log: debugLog,
+        })
+        : Object.assign(disabledSave(), { archiveBytes: null });
+    if (buildSave.status === "saved") {
+        postCollector.record({
+            label: "build-cache", operation: "save", hit: false,
+            key: result.buildCache.key, matchedKey: buildCacheMatched, restoreKeys: [],
+            archiveBytes: buildSave.archiveBytes, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - buildSaveStart, timestamp: new Date().toISOString(),
+        });
+    }
+    // Target cache. Previously slotted as `notManagedSave()` in the
+    // finalSummary — i.e. restored in main.ts but never saved here. That
+    // meant every commit cold-rebuilt `target/` (or the rust-plan bundle)
+    // because no entry was ever written for the restore-key prefix to
+    // fall back to. This block fixes the gap.
+    //
+    // Behavior:
+    // - Skip when target-cache layer is disabled (`target-cache: false`
+    //   or umbrella `cache: false`).
+    // - Skip on exact-hit (re-saving the same content under the same key
+    //   wastes time and triggers @actions/cache's "reservation already
+    //   exists" path).
+    // - Use `cache.saveCache` directly with the multi-path array (one
+    //   path in `thin`/`once` modes, two in `full`). @actions/cache will
+    //   tar+compress with its default codec — we don't route through
+    //   compressCache because target-cache may legitimately carry
+    //   multiple roots and compressCache is single-dir-shaped.
+    // - Paths array must match the one passed to restoreCache in main.ts
+    //   (the @actions/cache "version" hash depends on it — same gotcha
+    //   that bit cook-cache in #141).
+    let targetCacheSave = Object.assign(disabledSave(), { archiveBytes: null });
+    if (restoreState.targetCacheEnabled) {
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        const targetKey = result.targetCache.key;
+        const targetMatched = restoreState.targetCacheMatchedKey;
+        if (targetPaths.length === 0) {
+            log("target-cache: no paths configured, skipping save");
+            targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: "(no paths)" }, { archiveBytes: null });
+        }
+        else if (restoreState.targetCacheExactHit) {
+            log(`target-cache: exact cache hit on ${targetKey}, skipping save`);
+            targetCacheSave = Object.assign({ status: "exact-hit-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
+        }
+        else {
+            const existingPaths = targetPaths.filter((p) => fs.existsSync(p));
+            if (existingPaths.length === 0) {
+                log(`target-cache: none of the configured paths exist on disk (${targetPaths.join(", ")}), skipping save`);
+                targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
+            }
+            else {
+                const targetSaveStart = Date.now();
+                try {
+                    const id = await cache.saveCache(existingPaths, targetKey);
+                    if (id <= 0) {
+                        log(`target-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
+                            `job already saved key=${targetKey}`);
+                        targetCacheSave = Object.assign({
+                            status: "failed",
+                            cache_dir: existingPaths.join(","),
+                            saved_paths: existingPaths,
+                            error: `saveCache returned id=${id} (reserve failed; race or quota)`,
+                        }, { archiveBytes: null });
+                    }
+                    else {
+                        log(`target-cache: saved cache id=${id} key=${targetKey} paths=${existingPaths.join(",")}`);
+                        targetCacheSave = Object.assign({
+                            status: "saved",
+                            cache_dir: existingPaths.join(","),
+                            saved_paths: existingPaths,
+                            cache_id: id,
+                        }, { archiveBytes: null });
+                        postCollector.record({
+                            label: "target-cache",
+                            operation: "save",
+                            hit: false,
+                            key: targetKey,
+                            matchedKey: targetMatched,
+                            restoreKeys: [],
+                            archiveBytes: null,
+                            inflatedBytes: null,
+                            fileCount: null,
+                            durationMs: Date.now() - targetSaveStart,
+                            timestamp: new Date().toISOString(),
+                        });
+                    }
+                }
+                catch (err) {
+                    const message = err instanceof Error ? err.message : String(err);
+                    log(`target-cache: save failed: ${message}`);
+                    targetCacheSave = Object.assign({
+                        status: "failed",
+                        cache_dir: existingPaths.join(","),
+                        saved_paths: existingPaths,
+                        error: message,
+                    }, { archiveBytes: null });
+                }
+            }
+        }
+    }
+    // Cargo registry cache (only when enabled).
+    // setup-soldr#102: bundle `.global-cache` (cargo's RFC-3413 GC db) and the
+    // `git/` directory (bare mirrors + checkouts for git-source crate deps)
+    // into the same archive alongside `registry/`. Cache key + archive path
+    // are unchanged — the extras simply ride inside the existing tarball.
+    let cargoRegistrySave = Object.assign(disabledSave(), { archiveBytes: null });
+    if (result.cargoRegistryCache.enabled) {
+        const regSaveStart = Date.now();
+        cargoRegistrySave = await saveOne({
+            cacheDir: result.cargoRegistryCache.path,
+            codec: result.targetCacheCompress,
+            level: result.targetCacheCompressLevel,
+            key: result.cargoRegistryCache.key,
+            matchedKey: registryMatched,
+            label: "cargo-registry-cache",
+            debug: debugMode,
+            log: debugLog,
+            extraBasenames: result.cargoRegistryCache.extraBasenames,
+        });
+        if (cargoRegistrySave.status === "saved") {
+            postCollector.record({
+                label: "cargo-registry", operation: "save", hit: false,
+                key: result.cargoRegistryCache.key, matchedKey: registryMatched, restoreKeys: [],
+                archiveBytes: cargoRegistrySave.archiveBytes, inflatedBytes: null, fileCount: null,
+                durationMs: Date.now() - regSaveStart, timestamp: new Date().toISOString(),
+            });
+        }
+    }
+    // Solo toolchain cache save. Opt-in via the `solo-toolchain-cache`
+    // input. Skip the save when the install delta is empty (the common
+    // case on hosted runners that already provide the requested
+    // toolchain) — per CLAUDE.md "Default-stable workflows should
+    // produce zero cache writes."
+    const soloEnabled = core.getState("soloToolchainEnabled") === "true";
+    if (soloEnabled) {
+        const soloExactKey = core.getState("soloToolchainExactKey");
+        const soloMatchedKey = core.getState("soloToolchainMatchedKey");
+        const soloExactHit = core.getState("soloToolchainExactHit") === "true";
+        const soloIncrementalEmpty = core.getState("soloToolchainIncrementalEmpty") === "true";
+        const soloSaveDiffPath = core.getState("soloToolchainSaveDiffPath");
+        const soloLevel = core.getState("soloToolchainLevel") || "19";
+        log(`solo-toolchain-cache: post-step exactKey=${soloExactKey} matched=${soloMatchedKey} ` +
+            `exactHit=${soloExactHit} incrementalEmpty=${soloIncrementalEmpty} saveDiffPath=${soloSaveDiffPath}`);
+        if (soloExactHit && soloIncrementalEmpty) {
+            log("solo-toolchain-cache: exact hit and no install delta — skipping save");
+        }
+        else if (!soloSaveDiffPath || !fs.existsSync(soloSaveDiffPath)) {
+            log("solo-toolchain-cache: no save-diff manifest available, skipping save");
+        }
+        else {
+            try {
+                const manifest = JSON.parse(fs.readFileSync(soloSaveDiffPath, "utf8"));
+                const added = Array.isArray(manifest.added) ? manifest.added : [];
+                if (added.length === 0) {
+                    log("solo-toolchain-cache: empty save-diff manifest, skipping save");
+                }
+                else {
+                    const soloRootMap = {
+                        "rustup-toolchains": path.join(result.rustupHome, "toolchains"),
+                        "cargo-bin": path.join(result.cargoHome, "bin"),
+                    };
+                    const stagingDir = path.join(runnerTemp, "setup-soldr-solo-stage-save");
+                    const soloSaveStart = Date.now();
+                    const staged = await (0, solo_toolchain_cache_js_1.stageDiffForSave)({ added, removed: [], changed: [] }, soloRootMap, stagingDir);
+                    log(`solo-toolchain-cache: staged ${staged.stagedFiles} files (missing=${staged.missingFiles})`);
+                    const saveResult = await (0, solo_toolchain_cache_js_1.saveSoloCache)({
+                        stagingDir,
+                        key: soloExactKey,
+                        level: soloLevel,
+                        debug: debugMode,
+                        log,
+                    });
+                    if (saveResult.status === "saved") {
+                        postCollector.record({
+                            label: "solo-toolchain-cache",
+                            operation: "save",
+                            hit: false,
+                            key: soloExactKey,
+                            matchedKey: soloMatchedKey,
+                            restoreKeys: [],
+                            archiveBytes: saveResult.archiveBytes ?? null,
+                            inflatedBytes: saveResult.inflatedBytes ?? null,
+                            fileCount: saveResult.fileCount ?? null,
+                            durationMs: Date.now() - soloSaveStart,
+                            timestamp: new Date().toISOString(),
+                        });
+                    }
+                    else {
+                        log(`solo-toolchain-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
+                    }
+                }
+            }
+            catch (err) {
+                log(`solo-toolchain-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    }
+    // Cook cache save. Default-on layer; skipped when cook didn't run
+    // (cache hit, gate disabled, or run failed). zstd-19 + --long=27 per
+    // CLAUDE.md "Compression" + the cook simulation findings.
+    const cookEnabled = core.getState("cookEnabled") === "true";
+    if (cookEnabled) {
+        const cookHit = core.getState("cookHit") === "true";
+        const cookRan = core.getState("cookRan") === "true";
+        const cookExactKey = core.getState("cookExactKey");
+        const cookTargetDir = core.getState("cookTargetDir");
+        const cookLongWindow = parseInt(core.getState("cookLongWindow") || "27", 10);
+        const cookLevel = core.getState("cookCompressLevel") || "19";
+        log(`cook-cache: post-step key=${cookExactKey} hit=${cookHit} ran=${cookRan} target=${cookTargetDir}`);
+        if (cookHit) {
+            log("cook-cache: exact hit - skipping save");
+        }
+        else if (!cookRan) {
+            log("cook-cache: cook did not run successfully - skipping save");
+        }
+        else if (!cookTargetDir || !fs.existsSync(cookTargetDir)) {
+            log(`cook-cache: target dir ${cookTargetDir} missing - skipping save`);
+        }
+        else {
+            const cookSaveStart = Date.now();
+            try {
+                const saveResult = await (0, cook_cache_js_1.saveCookCache)({
+                    targetDir: cookTargetDir,
+                    exactKey: cookExactKey,
+                    level: cookLevel,
+                    longWindow: cookLongWindow,
+                    debug: debugMode,
+                    log,
+                });
+                if (saveResult.status === "saved") {
+                    postCollector.record({
+                        label: "cook-cache",
+                        operation: "save",
+                        hit: false,
+                        key: cookExactKey,
+                        matchedKey: "",
+                        restoreKeys: [],
+                        archiveBytes: saveResult.archiveBytes ?? null,
+                        inflatedBytes: saveResult.inflatedBytes ?? null,
+                        fileCount: saveResult.fileCount ?? null,
+                        durationMs: Date.now() - cookSaveStart,
+                        timestamp: new Date().toISOString(),
+                    });
+                }
+                else {
+                    log(`cook-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
+                }
+            }
+            catch (err) {
+                log(`cook-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    }
+    // Soldr-mini-cache save. Default-on; skipped when restore already hit
+    // (binary is byte-identical, no point re-saving), when disabled, or
+    // when running in passthrough mode.
+    const soldrMiniEnabled = core.getState("soldrMiniEnabled") === "true";
+    if (soldrMiniEnabled && !passthrough) {
+        const miniHit = core.getState("soldrMiniHit") === "true";
+        const miniExactKey = core.getState("soldrMiniExactKey");
+        const miniInstallDir = core.getState("soldrMiniInstallDir");
+        const miniArchive = core.getState("soldrMiniArchive");
+        log(`soldr-mini-cache: post-step key=${miniExactKey} hit=${miniHit} installDir=${miniInstallDir}`);
+        if (miniHit) {
+            log("soldr-mini-cache: exact hit — skipping save");
+        }
+        else if (!miniExactKey) {
+            log("soldr-mini-cache: no key (ineligible at main-time) — skipping save");
+        }
+        else if (!miniInstallDir || !fs.existsSync(miniInstallDir)) {
+            log(`soldr-mini-cache: install dir ${miniInstallDir} missing — skipping save`);
+        }
+        else {
+            const miniSaveStart = Date.now();
+            try {
+                const saveResult = await (0, soldr_mini_cache_js_1.saveMiniCache)({
+                    installDir: miniInstallDir,
+                    archivePath: miniArchive,
+                    exactKey: miniExactKey,
+                    level: "19",
+                    longWindow: 27,
+                    debug: debugMode,
+                    log,
+                });
+                if (saveResult.status === "saved") {
+                    postCollector.record({
+                        label: "soldr-mini-cache",
+                        operation: "save",
+                        hit: false,
+                        key: miniExactKey,
+                        matchedKey: "",
+                        restoreKeys: [],
+                        archiveBytes: saveResult.archiveBytes ?? null,
+                        inflatedBytes: saveResult.inflatedBytes ?? null,
+                        fileCount: saveResult.fileCount ?? null,
+                        durationMs: Date.now() - miniSaveStart,
+                        timestamp: new Date().toISOString(),
+                    });
+                }
+                else {
+                    log(`soldr-mini-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
+                }
+            }
+            catch (err) {
+                log(`soldr-mini-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    }
+    const finalSummary = buildFinalCacheSummary(result, restoreState, {
+        buildCache: buildSave,
+        cargoRegistryCache: cargoRegistrySave,
+        targetCache: targetCacheSave,
+    }, passthrough);
+    logFinalCacheSummary(finalSummary, log);
+    if (compileCacheStats !== "none") {
+        setCompileCacheOutputs(finalSummary.compile_cache_report, compileCacheStats);
+    }
+    writeStepSummary(formatFinalCacheSummaryMarkdown(finalSummary, compileCacheStats), log);
+    const reportPath = writeCompileCacheReportFile(finalSummary.compile_cache_report, runnerTemp, log);
+    if (reportPath) {
+        log(`compile-cache-report.json written to ${reportPath}`);
+    }
+    // Note: setup-soldr-cache-keys.txt is written in main.ts (right after
+    // resolveSetup) so workflow steps that run between main and post —
+    // notably actions/upload-artifact — can read it. Re-write it here
+    // anyway as a safety net in case main.ts crashed before writing.
+    if (runnerTemp) {
+        writeCacheKeysManifestFromSummary(finalSummary, runnerTemp, log);
+    }
+    // Append save ops to detailed session log if requested
+    if (statsMode === "detailed" && runnerTemp) {
+        try {
+            await postCollector.appendSavesToSessionLog(runnerTemp);
+        }
+        catch (err) {
+            log(`post: stats log append failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    // Optional verbose diagnostic dump. Gated on `logging: true` which
+    // main.ts persists into action state.
+    const loggingState = core.getState("logging");
+    if ((0, diagnostics_js_1.loggingEnabled)(loggingState)) {
+        const rawInputs = (0, raw_inputs_js_1.readRawInputs)(process.env);
+        // zccache writes its per-rustc-invocation JSONL journal under the
+        // build-cache directory (which == ZCCACHE_CACHE_DIR per
+        // resolve-setup.ts's env exports). When `logging: true` is on we
+        // surface its contents so the reader can answer "warm reported 0
+        // hits — why did each lookup miss" without another build.
+        const journalPath = path.join(result.buildCache.path, "logs", "last-session.jsonl");
+        // Forward the verbatim `report` field from `soldr cache report --json`
+        // so dumpDiagnostics can format its `rollups` (per-extension /
+        // per-crate / slowest_entries) breakdown.
+        const cacheReport = finalSummary.compile_cache_report.report;
+        // Capture a process snapshot only when debug mode is on — `ps` /
+        // `tasklist` are cheap but the output is large and only useful when
+        // you're investigating cache-state weirdness (e.g. orphan daemons).
+        const processSnapshot = debugMode ? (0, diagnostics_js_1.captureProcessSnapshot)() ?? undefined : undefined;
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "post",
+            env: process.env,
+            rawInputs,
+            result,
+            cacheOutcomes: postCollector.snapshot(),
+            finalSummary: finalSummary,
+            journalPath,
+            // Raw JSONL stream — one record per rustc invocation, often
+            // thousands of lines / 20-30 MB of stdout per warm build. Default
+            // gate is `debug:true` (backwards compat with #134 era), but a
+            // workflow can explicitly opt out via `journal-print-raw: false`
+            // when it already uploads the JSONL as an artifact and doesn't
+            // want to pay the post-step log-writer cost (~30-50 s on the
+            // hosted ubuntu demo).
+            journalPrintRaw: resolveJournalPrintRaw(rawInputs.journalPrintRaw, debugMode),
+            cacheReport,
+            processSnapshot,
+            logger,
+            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
+        });
+    }
+}
+function writeCacheKeysManifestFromSummary(summary, runnerTemp, log) {
+    const keys = [
+        summary.setup_cache.key,
+        summary.build_cache.key,
+        summary.target_cache.key,
+        summary.cargo_registry_cache.key,
+    ].filter((k) => Boolean(k));
+    if (keys.length === 0)
+        return;
+    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
+    try {
+        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
+        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
+    }
+    catch (err) {
+        log(`post: failed to write cache-keys manifest: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+// See main.ts for the rationale behind the test-import escape hatch.
+if (typeof process !== "undefined" &&
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    run().catch((err) => {
+        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        core.warning(`setup-soldr post-job step failed: ${message}`);
+    });
+}
+
+
+/***/ }),
+
+/***/ 192:
 /***/ ((module) => {
 
 "use strict";
@@ -45404,14 +45064,14 @@ module.exports = require("util/types");
 
 /***/ }),
 
-/***/ 194:
+/***/ 193:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(120)
-const Client = __nccwpck_require__(85)
+const { promisify } = __nccwpck_require__(121)
+const Client = __nccwpck_require__(87)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
   kDispatches,
@@ -45422,9 +45082,9 @@ const {
   kOriginalDispatch,
   kConnected
 } = __nccwpck_require__(443)
-const { MockInterceptor } = __nccwpck_require__(132)
-const Symbols = __nccwpck_require__(190)
-const { InvalidArgumentError } = __nccwpck_require__(460)
+const { MockInterceptor } = __nccwpck_require__(133)
+const Symbols = __nccwpck_require__(188)
+const { InvalidArgumentError } = __nccwpck_require__(461)
 
 /**
  * MockClient provides an API that extends the Client to influence the mockDispatches.
@@ -45471,7 +45131,7 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 195:
+/***/ 194:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45512,7 +45172,7 @@ async function computeSha256Hash(content, encoding) {
 
 /***/ }),
 
-/***/ 196:
+/***/ 195:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45892,7 +45552,7 @@ exports.BlobQueryResponse = BlobQueryResponse;
 
 /***/ }),
 
-/***/ 197:
+/***/ 196:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45905,7 +45565,7 @@ exports.streamToBuffer = streamToBuffer;
 exports.streamToBuffer2 = streamToBuffer2;
 exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(240));
 const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(355));
 const constants_js_1 = __nccwpck_require__(145);
@@ -46039,7 +45699,7 @@ exports.fsCreateReadStream = node_fs_1.default.createReadStream;
 
 /***/ }),
 
-/***/ 198:
+/***/ 197:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -46321,7 +45981,7 @@ exports.varint32read = varint32read;
 
 /***/ }),
 
-/***/ 199:
+/***/ 198:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46533,7 +46193,7 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 /***/ }),
 
-/***/ 200:
+/***/ 199:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46589,7 +46249,7 @@ exports.reflectionCreate = reflectionCreate;
 
 /***/ }),
 
-/***/ 201:
+/***/ 200:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46631,7 +46291,7 @@ function storageBrowserPolicy() {
 
 /***/ }),
 
-/***/ 202:
+/***/ 201:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46641,7 +46301,7 @@ const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(487)
 const { kState } = __nccwpck_require__(13)
 const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(345)
 const { webidl } = __nccwpck_require__(430)
-const { Blob, File: NativeFile } = __nccwpck_require__(116)
+const { Blob, File: NativeFile } = __nccwpck_require__(117)
 
 /** @type {globalThis['File']} */
 const File = NativeFile ?? UndiciFile
@@ -46904,7 +46564,7 @@ module.exports = { FormData }
 
 /***/ }),
 
-/***/ 203:
+/***/ 202:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -46921,7 +46581,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 204:
+/***/ 203:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -46946,7 +46606,7 @@ __export(getClient_exports, {
   getClient: () => getClient
 });
 module.exports = __toCommonJS(getClient_exports);
-var import_clientHelpers = __nccwpck_require__(463);
+var import_clientHelpers = __nccwpck_require__(464);
 var import_sendRequest = __nccwpck_require__(423);
 var import_urlHelpers = __nccwpck_require__(310);
 var import_checkEnvironment = __nccwpck_require__(412);
@@ -47104,7 +46764,7 @@ function buildOperation(method, url, pipeline, options, allowInsecureConnection,
 
 /***/ }),
 
-/***/ 205:
+/***/ 204:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47130,7 +46790,7 @@ __export(httpClientAdapter_exports, {
 });
 module.exports = __toCommonJS(httpClientAdapter_exports);
 var import_response = __nccwpck_require__(388);
-var import_util = __nccwpck_require__(106);
+var import_util = __nccwpck_require__(108);
 function convertHttpClient(requestPolicyClient) {
   return {
     sendRequest: async (request) => {
@@ -47148,7 +46808,7 @@ function convertHttpClient(requestPolicyClient) {
 
 /***/ }),
 
-/***/ 206:
+/***/ 205:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47174,7 +46834,7 @@ __export(retryPolicy_exports, {
 });
 module.exports = __toCommonJS(retryPolicy_exports);
 var import_logger = __nccwpck_require__(42);
-var import_constants = __nccwpck_require__(156);
+var import_constants = __nccwpck_require__(155);
 var import_policies = __nccwpck_require__(275);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("core-rest-pipeline retryPolicy");
 function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAULT_RETRY_POLICY_COUNT }) {
@@ -47189,7 +46849,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 
 /***/ }),
 
-/***/ 207:
+/***/ 206:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47229,7 +46889,7 @@ function getErrorMessage(e) {
 
 /***/ }),
 
-/***/ 208:
+/***/ 207:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -47755,7 +47415,7 @@ function saveCacheV2(paths, key, options, enableCrossOsArchive = false) {
 
 /***/ }),
 
-/***/ 209:
+/***/ 208:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47781,7 +47441,7 @@ __export(extendedClient_exports, {
 });
 module.exports = __toCommonJS(extendedClient_exports);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_core_rest_pipeline = __nccwpck_require__(98);
+var import_core_rest_pipeline = __nccwpck_require__(100);
 var import_core_client = __nccwpck_require__(413);
 var import_response = __nccwpck_require__(388);
 class ExtendedServiceClient extends import_core_client.ServiceClient {
@@ -47832,7 +47492,7 @@ class ExtendedServiceClient extends import_core_client.ServiceClient {
 
 /***/ }),
 
-/***/ 210:
+/***/ 209:
 /***/ ((module) => {
 
 /******************************************************************************
@@ -48290,7 +47950,7 @@ var __rewriteRelativeImportExtension;
 
 /***/ }),
 
-/***/ 211:
+/***/ 210:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48317,8 +47977,8 @@ __export(bearerTokenAuthenticationPolicy_exports, {
   parseChallenges: () => parseChallenges
 });
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(159);
-var import_log = __nccwpck_require__(179);
+var import_tokenCycler = __nccwpck_require__(158);
+var import_log = __nccwpck_require__(177);
 var import_restError = __nccwpck_require__(335);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
@@ -48509,7 +48169,7 @@ function getCaeChallengeClaims(challenges) {
 
 /***/ }),
 
-/***/ 212:
+/***/ 211:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48546,7 +48206,7 @@ function systemErrorRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 213:
+/***/ 212:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -48560,9 +48220,9 @@ function systemErrorRetryPolicy(options = {}) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(413));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(173));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing Container operations. */
 class ContainerImpl {
@@ -49274,7 +48934,7 @@ const getAccountInfoOperationSpec = {
 
 /***/ }),
 
-/***/ 214:
+/***/ 213:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -49319,7 +48979,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 215:
+/***/ 214:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49524,7 +49184,7 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 
 /***/ }),
 
-/***/ 216:
+/***/ 215:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49562,7 +49222,7 @@ const tls = __importStar(__nccwpck_require__(477));
 const debug_1 = __importDefault(__nccwpck_require__(485));
 const events_1 = __nccwpck_require__(442);
 const agent_base_1 = __nccwpck_require__(232);
-const url_1 = __nccwpck_require__(82);
+const url_1 = __nccwpck_require__(84);
 const debug = (0, debug_1.default)('http-proxy-agent');
 /**
  * The `HttpProxyAgent` implements an HTTP Agent subclass that connects
@@ -49679,7 +49339,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 217:
+/***/ 216:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49715,7 +49375,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
-const fs = __importStar(__nccwpck_require__(500));
+const fs = __importStar(__nccwpck_require__(501));
 const path = __importStar(__nccwpck_require__(239));
 _a = fs.promises
 // export const {open} = 'fs'
@@ -49869,7 +49529,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 218:
+/***/ 217:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49878,7 +49538,7 @@ exports.getCmdPath = getCmdPath;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 var poller_js_1 = __nccwpck_require__(306);
 Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: function () { return poller_js_1.createHttpPoller; } }));
 /**
@@ -49900,7 +49560,7 @@ tslib_1.__exportStar(__nccwpck_require__(38), exports);
 
 /***/ }),
 
-/***/ 219:
+/***/ 218:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -49946,7 +49606,7 @@ function apiVersionPolicy(options) {
 
 /***/ }),
 
-/***/ 220:
+/***/ 219:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50193,7 +49853,7 @@ exports.AbortSignal = AbortSignal;
 
 /***/ }),
 
-/***/ 221:
+/***/ 220:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50210,7 +49870,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 
 /***/ }),
 
-/***/ 222:
+/***/ 221:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50224,9 +49884,9 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(413));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(173));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing Service operations. */
 class ServiceImpl {
@@ -50546,7 +50206,7 @@ const filterBlobsOperationSpec = {
 
 /***/ }),
 
-/***/ 223:
+/***/ 222:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -50583,13 +50243,13 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 224:
+/***/ 223:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { UndiciError } = __nccwpck_require__(460)
+const { UndiciError } = __nccwpck_require__(461)
 
 class MockNotMatchedError extends UndiciError {
   constructor (message) {
@@ -50608,13 +50268,384 @@ module.exports = {
 
 /***/ }),
 
+/***/ 224:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Verbose diagnostic dump emitted when the action receives `logging: true`.
+//
+// The goal is to make cache-behavior surprises trivially debuggable from a
+// single CI run. The dump bundles:
+//   - every observed INPUT_* env var (so the kebab-vs-underscore plumbing
+//     bug that motivated this module is visible without re-running)
+//   - the parsed RawInputs struct
+//   - every constructed cache key with restore-key fallbacks
+//   - resolved env exports (SOLDR_*, ZCCACHE_*, SETUP_SOLDR_*)
+//   - cache restore/save outcomes recorded so far
+//   - the final cache summary + compile-cache report in post phase
+//
+// Token-shaped values are redacted before printing.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.redactValue = redactValue;
+exports.captureProcessSnapshot = captureProcessSnapshot;
+exports.dumpDiagnostics = dumpDiagnostics;
+exports.loggingEnabled = loggingEnabled;
+const fs = __importStar(__nccwpck_require__(240));
+const node_child_process_1 = __nccwpck_require__(190);
+const compile_journal_js_1 = __nccwpck_require__(79);
+const ENV_KEY_PREFIXES = [
+    "INPUT_",
+    "SOLDR_",
+    "ZCCACHE_",
+    "SCCACHE_",
+    "SETUP_SOLDR_",
+    "GITHUB_",
+    "RUNNER_",
+    "ACTION_",
+    "CARGO_",
+    "RUSTUP_",
+    "RUSTC_",
+];
+const SECRET_KEY_PATTERN = /(token|secret|password|^.*_pass$|api[_-]?key|client[_-]?secret|webhook)/i;
+// Cache-key fields look secret-y but never are; never redact them.
+const NEVER_REDACT_PATTERN = /(_key$|cache[-_]key|cache[-_]keys$|key[-_]suffix$|public[-_]key)/i;
+function redactValue(key, value) {
+    if (NEVER_REDACT_PATTERN.test(key))
+        return value;
+    if (SECRET_KEY_PATTERN.test(key))
+        return value ? "<redacted>" : "";
+    return value;
+}
+function pickEnv(env) {
+    const pairs = [];
+    for (const [k, v] of Object.entries(env)) {
+        if (v === undefined)
+            continue;
+        if (!ENV_KEY_PREFIXES.some((p) => k.startsWith(p)))
+            continue;
+        pairs.push([k, redactValue(k, v)]);
+    }
+    pairs.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+    return pairs;
+}
+function rawInputsLines(inputs) {
+    const lines = [];
+    const entries = Object.entries(inputs).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+    for (const [k, v] of entries) {
+        lines.push(`  ${k}=${JSON.stringify(v)}`);
+    }
+    return lines;
+}
+function cachePlanLines(result) {
+    const lines = [];
+    lines.push("  setup_cache:");
+    lines.push(`    key=${result.setupCache.key}`);
+    lines.push(`    restore_prefix=${result.setupCache.restorePrefix}`);
+    lines.push(`    paths=${JSON.stringify(result.setupCache.paths)}`);
+    lines.push(`    layout=${result.setupCache.layout}`);
+    lines.push("  build_cache:");
+    lines.push(`    key=${result.buildCache.key}`);
+    lines.push(`    restore_key_parent=${result.buildCache.restoreKeyParent || "(none)"}`);
+    lines.push(`    restore_key_toolchain=${result.buildCache.restoreKeyToolchain}`);
+    lines.push(`    restore_key_os_arch=${result.buildCache.restoreKeyOsArch}`);
+    lines.push(`    path=${result.buildCache.path}`);
+    lines.push(`    mode=${result.buildCache.mode}`);
+    lines.push("  target_cache:");
+    lines.push(`    enabled=${result.targetCache.enabled}`);
+    lines.push(`    key=${result.targetCache.key}`);
+    lines.push(`    restore_key_parent=${result.targetCache.restoreKeyParent || "(none)"}`);
+    lines.push(`    restore_key_lock=${result.targetCache.restoreKeyLock || "(none)"}`);
+    lines.push(`    restore_key_lockfile=${result.targetCache.restoreKeyLockfile || "(none)"}`);
+    lines.push(`    paths=${result.targetCache.paths}`);
+    lines.push(`    bundle_path=${result.targetCache.bundlePath}`);
+    lines.push(`    target_path=${result.targetCache.targetPath}`);
+    lines.push(`    effective_mode=${result.targetCache.effectiveMode}`);
+    lines.push(`    profile=${result.targetCache.profile}`);
+    lines.push("  cargo_registry_cache:");
+    lines.push(`    enabled=${result.cargoRegistryCache.enabled}`);
+    lines.push(`    key=${result.cargoRegistryCache.key}`);
+    lines.push(`    restore_prefix=${result.cargoRegistryCache.restorePrefix}`);
+    lines.push(`    path=${result.cargoRegistryCache.path}`);
+    // setup-soldr#102: sibling basenames bundled into the same archive.
+    const extras = result.cargoRegistryCache.extraBasenames;
+    lines.push(`    extra_basenames=${extras.length > 0 ? extras.join(",") : "(none)"}`);
+    return lines;
+}
+function envExportLines(result) {
+    const entries = Object.entries(result.envExports).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+    return entries.map(([k, v]) => `  ${k}=${redactValue(k, v)}`);
+}
+function cacheOutcomeLines(outcomes) {
+    if (outcomes.length === 0)
+        return ["  (no outcomes recorded yet)"];
+    const lines = [];
+    for (const o of outcomes) {
+        lines.push(`  [${o.operation}] ${o.label}: hit=${o.hit} matched=${o.matchedKey || "(none)"} ` +
+            `key=${o.key} duration_ms=${o.durationMs}`);
+        if (o.archiveBytes !== null) {
+            lines.push(`    archive_bytes=${o.archiveBytes} inflated_bytes=${o.inflatedBytes ?? "?"} files=${o.fileCount ?? "?"}`);
+        }
+    }
+    return lines;
+}
+/**
+ * Capture a runtime process snapshot via `ps` (Unix) or `tasklist`
+ * (Windows). Returns null only on an actual exec failure (binary
+ * missing, etc.); a non-zero exit is reported in the result so the
+ * stderr can be inspected.
+ *
+ * Why this lives here: the post step uses it to expose orphan daemons
+ * (e.g. zccache-daemon processes that survive `soldr cache shutdown`
+ * and get SIGKILL'd by the runner) so root-cause analysis doesn't
+ * require another build.
+ */
+function captureProcessSnapshot() {
+    const isWindows = process.platform === "win32";
+    const cmd = isWindows ? "tasklist" : "ps";
+    // Unix: print pid, ppid, user, state, command-name, full-args.
+    // BSD ps (macOS) supports the same -o keys but uses `command` instead
+    // of `args` — accept both via the column listing.
+    const args = isWindows
+        ? ["/V", "/FO", "CSV", "/NH"]
+        : ["-eo", "pid,ppid,user,stat,comm,args"];
+    try {
+        const result = (0, node_child_process_1.spawnSync)(cmd, args, {
+            encoding: "utf8",
+            maxBuffer: 8 * 1024 * 1024,
+            timeout: 15_000,
+        });
+        return {
+            cmd: `${cmd} ${args.join(" ")}`,
+            stdout: result.stdout ?? "",
+            stderr: result.stderr ?? "",
+            exitCode: result.status,
+        };
+    }
+    catch {
+        return null;
+    }
+}
+/**
+ * Emit the full diagnostic dump to the logger and (optionally) the step summary.
+ * Safe to call when `result`, `cacheOutcomes`, or `finalSummary` are missing —
+ * each section is independent.
+ */
+function dumpDiagnostics(opts) {
+    const lines = [];
+    const header = `=== DIAGNOSTIC DUMP (phase=${opts.phase}) ===`;
+    const footer = "=== END DIAGNOSTIC DUMP ===";
+    lines.push(header);
+    lines.push("[env: observed INPUT_/SOLDR_/ZCCACHE_/SETUP_SOLDR_/GITHUB_/RUNNER_/ACTION_/CARGO_/RUSTUP_/RUSTC_]");
+    const envPairs = pickEnv(opts.env);
+    if (envPairs.length === 0) {
+        lines.push("  (none observed)");
+    }
+    else {
+        for (const [k, v] of envPairs) {
+            lines.push(`  ${k}=${v}`);
+        }
+    }
+    if (opts.rawInputs) {
+        lines.push("[raw_inputs: parsed RawInputs after kebab-case lookup]");
+        lines.push(...rawInputsLines(opts.rawInputs));
+    }
+    if (opts.result) {
+        lines.push("[cache_plans: every constructed cache key + restore-key fallbacks]");
+        lines.push(...cachePlanLines(opts.result));
+        lines.push("[env_exports: resolved SOLDR_/ZCCACHE_/etc env exports]");
+        if (Object.keys(opts.result.envExports).length === 0) {
+            lines.push("  (none)");
+        }
+        else {
+            lines.push(...envExportLines(opts.result));
+        }
+        lines.push("[resolved_state]");
+        lines.push(`  enabled=${opts.result.enabled}`);
+        lines.push(`  workspace=${opts.result.workspace}`);
+        lines.push(`  cache_root=${opts.result.cacheRoot}`);
+        lines.push(`  soldr_root=${opts.result.soldrRoot}`);
+        lines.push(`  cargo_home=${opts.result.cargoHome}`);
+        lines.push(`  rustup_home=${opts.result.rustupHome}`);
+        lines.push(`  soldr_path=${opts.result.soldrPath}`);
+        lines.push(`  soldr_repo=${opts.result.soldrRepo}`);
+        lines.push(`  soldr_ref=${opts.result.soldrRef || "(release)"}`);
+        lines.push(`  soldr_version_requested=${opts.result.soldrVersionRequested}`);
+        lines.push(`  soldr_version_resolved=${opts.result.soldrVersionResolved}`);
+        lines.push(`  toolchain_channel=${opts.result.toolchain.channel}`);
+        lines.push(`  toolchain_cache_channel=${opts.result.toolchain.cacheChannel}`);
+        lines.push(`  rustup_strategy=${opts.result.rustupStrategy}`);
+        lines.push(`  shims_enabled=${opts.result.shimsEnabled}`);
+        lines.push(`  shims_dir=${opts.result.shimsDir}`);
+        lines.push(`  stats=${opts.result.stats}`);
+        lines.push(`  compile_cache_stats=${opts.result.compileCacheStats}`);
+        lines.push(`  debug_mode=${opts.result.debugMode}`);
+        lines.push(`  cache_shutdown_on_idle_seconds=${opts.result.cacheShutdownOnIdleSeconds ?? "(unset)"}`);
+    }
+    if (opts.cacheOutcomes !== undefined) {
+        lines.push("[cache_outcomes: per-layer restore/save results]");
+        lines.push(...cacheOutcomeLines(opts.cacheOutcomes));
+    }
+    if (opts.finalSummary) {
+        lines.push("[final_cache_summary]");
+        const json = JSON.stringify(opts.finalSummary, null, 2);
+        for (const line of json.split("\n")) {
+            lines.push(`  ${line}`);
+        }
+    }
+    // Per-compilation zccache journal — the answer to "warm reports
+    // hits=0; WHY did each lookup miss?". Reads the JSONL emitted by
+    // zccache for the just-finished session, summarizes it (outcome +
+    // miss_reason histograms, slowest misses with their miss_diff, a
+    // handful of verbatim records), and prints. Silently no-ops when
+    // the journal file isn't present.
+    if (opts.journalPath) {
+        try {
+            const records = (0, compile_journal_js_1.readJournal)(opts.journalPath);
+            if (records === null) {
+                lines.push(`[compile_journal]`);
+                lines.push(`  (journal file not found at ${opts.journalPath})`);
+            }
+            else if (records.length === 0) {
+                lines.push(`[compile_journal]`);
+                lines.push(`  (journal file empty at ${opts.journalPath})`);
+            }
+            else {
+                lines.push(...(0, compile_journal_js_1.formatJournalSection)((0, compile_journal_js_1.summarize)(records)));
+            }
+        }
+        catch (err) {
+            lines.push(`[compile_journal]`);
+            lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
+        }
+        // Raw JSONL dump — verbatim file contents under the summary. Only
+        // emitted when the caller opts in (debug=true) because it's huge
+        // (one record per rustc invocation, frequently MBs of output).
+        if (opts.journalPrintRaw) {
+            try {
+                const raw = fs.readFileSync(opts.journalPath, "utf8");
+                const rawLines = raw.split(/\r?\n/).filter((l) => l.length > 0);
+                lines.push(`[compile_journal_raw: verbatim JSONL from ${opts.journalPath} — ${rawLines.length} records]`);
+                for (const rawLine of rawLines) {
+                    lines.push(`  ${rawLine}`);
+                }
+            }
+            catch (err) {
+                const code = err.code;
+                if (code === "ENOENT") {
+                    // Already noted by the summary section above; no need to repeat.
+                }
+                else {
+                    lines.push(`[compile_journal_raw]`);
+                    lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
+                }
+            }
+        }
+    }
+    // Rollups (per-extension / per-crate) from `soldr cache report --json`.
+    // The raw report is already parsed into finalSummary's
+    // compile_cache_report.report; we accept it as a separate
+    // `cacheReport` so callers can pass it without rebuilding the
+    // FinalCacheSummary shape.
+    if (opts.cacheReport) {
+        lines.push(...(0, compile_journal_js_1.formatRollupsSection)(opts.cacheReport));
+    }
+    // Process snapshot — captured by the caller via captureProcessSnapshot()
+    // when debug mode is on. Useful for spotting orphan daemons (e.g.
+    // zccache-daemon survivors after `soldr cache shutdown`) that the runner
+    // SIGKILLs at job cleanup.
+    if (opts.processSnapshot) {
+        const snap = opts.processSnapshot;
+        lines.push(`[processes: snapshot via \`${snap.cmd}\` exit=${snap.exitCode ?? "null"}]`);
+        if (snap.stderr.trim().length > 0) {
+            lines.push(`  stderr: ${snap.stderr.trim().replace(/\n+/g, " | ")}`);
+        }
+        const trimmed = snap.stdout.replace(/\r\n/g, "\n").trimEnd();
+        if (trimmed.length === 0) {
+            lines.push("  (no stdout)");
+        }
+        else {
+            for (const line of trimmed.split("\n")) {
+                lines.push(`  ${line}`);
+            }
+        }
+    }
+    lines.push(footer);
+    for (const line of lines) {
+        opts.logger.log(line);
+    }
+    if (opts.stepSummaryPath) {
+        appendToStepSummary(opts.stepSummaryPath, opts.phase, lines, opts.logger);
+    }
+}
+function appendToStepSummary(summaryPath, phase, lines, logger) {
+    const block = [
+        `### setup-soldr diagnostic dump (phase=${phase})`,
+        "",
+        "```",
+        ...lines,
+        "```",
+        "",
+    ];
+    try {
+        fs.appendFileSync(summaryPath, block.join("\n") + "\n", "utf8");
+    }
+    catch (err) {
+        logger.log(`diagnostics: failed to append to step summary: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+/**
+ * Truthy check matching the rest of the action: "1", "true", "yes", "on".
+ * Empty / unset / anything else is false.
+ */
+function loggingEnabled(value) {
+    const v = (value ?? "").trim().toLowerCase();
+    return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+
+/***/ }),
+
 /***/ 225:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Transform } = __nccwpck_require__(127)
+const { Transform } = __nccwpck_require__(128)
 const { Console } = __nccwpck_require__(30)
 
 /**
@@ -50752,7 +50783,7 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_ts_http_runtime = __nccwpck_require__(86);
+var import_ts_http_runtime = __nccwpck_require__(88);
 var import_wrapAbortSignal = __nccwpck_require__(419);
 function createDefaultHttpClient() {
   const client = (0, import_ts_http_runtime.createDefaultHttpClient)();
@@ -51146,7 +51177,7 @@ exports.Agent = void 0;
 const net = __importStar(__nccwpck_require__(480));
 const http = __importStar(__nccwpck_require__(315));
 const https_1 = __nccwpck_require__(67);
-__exportStar(__nccwpck_require__(158), exports);
+__exportStar(__nccwpck_require__(157), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
 class Agent extends http.Agent {
     constructor(opts) {
@@ -51363,7 +51394,7 @@ __export(httpHeaders_exports, {
   createHttpHeaders: () => createHttpHeaders
 });
 module.exports = __toCommonJS(httpHeaders_exports);
-var import_ts_http_runtime = __nccwpck_require__(86);
+var import_ts_http_runtime = __nccwpck_require__(88);
 function createHttpHeaders(rawHeaders) {
   return (0, import_ts_http_runtime.createHttpHeaders)(rawHeaders);
 }
@@ -51382,7 +51413,7 @@ function createHttpHeaders(rawHeaders) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-var lroEngine_js_1 = __nccwpck_require__(173);
+var lroEngine_js_1 = __nccwpck_require__(171);
 Object.defineProperty(exports, "LroEngine", ({ enumerable: true, get: function () { return lroEngine_js_1.LroEngine; } }));
 //# sourceMappingURL=index.js.map
 
@@ -51413,7 +51444,7 @@ __export(pipeline_exports, {
   createEmptyPipeline: () => createEmptyPipeline
 });
 module.exports = __toCommonJS(pipeline_exports);
-var import_ts_http_runtime = __nccwpck_require__(86);
+var import_ts_http_runtime = __nccwpck_require__(88);
 function createEmptyPipeline() {
   return (0, import_ts_http_runtime.createEmptyPipeline)();
 }
@@ -51949,9 +51980,9 @@ module.exports = {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryWriter = exports.binaryWriteOptions = void 0;
-const pb_long_1 = __nccwpck_require__(114);
-const goog_varint_1 = __nccwpck_require__(198);
-const assert_1 = __nccwpck_require__(456);
+const pb_long_1 = __nccwpck_require__(115);
+const goog_varint_1 = __nccwpck_require__(197);
+const assert_1 = __nccwpck_require__(457);
 const defaultsWrite = {
     writeUnknownFields: true,
     writerFactory: () => new BinaryWriter(),
@@ -52193,7 +52224,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
 const AvroReadable_js_1 = __nccwpck_require__(366);
 const abort_controller_1 = __nccwpck_require__(468);
-const buffer_1 = __nccwpck_require__(116);
+const buffer_1 = __nccwpck_require__(117);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
 class AvroReadableFromStream extends AvroReadable_js_1.AvroReadable {
     _position;
@@ -52288,7 +52319,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 let _defaultHttpClient;
 function getCachedDefaultHttpClient() {
     if (!_defaultHttpClient) {
@@ -52438,7 +52469,7 @@ module.exports = require("stream/web");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getBodyAsText = getBodyAsText;
 exports.utf8ByteLength = utf8ByteLength;
-const utils_js_1 = __nccwpck_require__(197);
+const utils_js_1 = __nccwpck_require__(196);
 const constants_js_1 = __nccwpck_require__(145);
 async function getBodyAsText(batchResponse) {
     let buffer = Buffer.alloc(constants_js_1.BATCH_MAX_PAYLOAD_IN_BYTES);
@@ -52711,8 +52742,8 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredential = void 0;
 const node_crypto_1 = __nccwpck_require__(265);
-const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(123);
-const Credential_js_1 = __nccwpck_require__(92);
+const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(124);
+const Credential_js_1 = __nccwpck_require__(94);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -52909,7 +52940,7 @@ exports.getDownloadOptions = getDownloadOptions;
 const net = __nccwpck_require__(480)
 const assert = __nccwpck_require__(495)
 const util = __nccwpck_require__(66)
-const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(460)
+const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(461)
 
 let tls // include tls conditionally since it is not always available
 
@@ -53189,7 +53220,7 @@ __export(multipart_exports, {
 });
 module.exports = __toCommonJS(multipart_exports);
 var import_restError = __nccwpck_require__(418);
-var import_httpHeaders = __nccwpck_require__(457);
+var import_httpHeaders = __nccwpck_require__(458);
 var import_bytesEncoding = __nccwpck_require__(276);
 var import_typeGuards = __nccwpck_require__(469);
 function getHeaderValue(descriptor, headerName) {
@@ -53468,8 +53499,8 @@ exports.listEnumNumbers = listEnumNumbers;
 
 const assert = __nccwpck_require__(495)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(190)
-const { RequestRetryError } = __nccwpck_require__(460)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(188)
+const { RequestRetryError } = __nccwpck_require__(461)
 const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(66)
 
 function calculateRetryAfterHeader (retryAfter) {
@@ -53945,27 +53976,27 @@ module.exports = decodeText
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 tslib_1.__exportStar(__nccwpck_require__(344), exports);
 var cache_js_1 = __nccwpck_require__(244);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(80), exports);
+tslib_1.__exportStar(__nccwpck_require__(82), exports);
 tslib_1.__exportStar(__nccwpck_require__(152), exports);
 tslib_1.__exportStar(__nccwpck_require__(376), exports);
-tslib_1.__exportStar(__nccwpck_require__(92), exports);
+tslib_1.__exportStar(__nccwpck_require__(94), exports);
 tslib_1.__exportStar(__nccwpck_require__(253), exports);
 tslib_1.__exportStar(__nccwpck_require__(312), exports);
 var RequestPolicy_js_1 = __nccwpck_require__(44);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
-tslib_1.__exportStar(__nccwpck_require__(90), exports);
+tslib_1.__exportStar(__nccwpck_require__(92), exports);
 tslib_1.__exportStar(__nccwpck_require__(296), exports);
-tslib_1.__exportStar(__nccwpck_require__(201), exports);
+tslib_1.__exportStar(__nccwpck_require__(200), exports);
 tslib_1.__exportStar(__nccwpck_require__(436), exports);
-tslib_1.__exportStar(__nccwpck_require__(163), exports);
-tslib_1.__exportStar(__nccwpck_require__(123), exports);
+tslib_1.__exportStar(__nccwpck_require__(162), exports);
+tslib_1.__exportStar(__nccwpck_require__(124), exports);
 tslib_1.__exportStar(__nccwpck_require__(75), exports);
 tslib_1.__exportStar(__nccwpck_require__(401), exports);
-tslib_1.__exportStar(__nccwpck_require__(165), exports);
+tslib_1.__exportStar(__nccwpck_require__(164), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -53983,9 +54014,9 @@ tslib_1.__exportStar(__nccwpck_require__(165), exports);
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(210);
-tslib_1.__exportStar(__nccwpck_require__(222), exports);
-tslib_1.__exportStar(__nccwpck_require__(213), exports);
+const tslib_1 = __nccwpck_require__(209);
+tslib_1.__exportStar(__nccwpck_require__(221), exports);
+tslib_1.__exportStar(__nccwpck_require__(212), exports);
 tslib_1.__exportStar(__nccwpck_require__(45), exports);
 tslib_1.__exportStar(__nccwpck_require__(271), exports);
 tslib_1.__exportStar(__nccwpck_require__(24), exports);
@@ -54260,7 +54291,7 @@ var import_formDataPolicy = __nccwpck_require__(259);
 var import_core_util = __nccwpck_require__(12);
 var import_proxyPolicy = __nccwpck_require__(445);
 var import_setClientRequestIdPolicy = __nccwpck_require__(147);
-var import_agentPolicy = __nccwpck_require__(223);
+var import_agentPolicy = __nccwpck_require__(222);
 var import_tlsPolicy = __nccwpck_require__(358);
 var import_tracingPolicy = __nccwpck_require__(321);
 var import_wrapAbortSignalLikePolicy = __nccwpck_require__(250);
@@ -54311,9 +54342,9 @@ function createPipelineFromOptions(options) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(413));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(173));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing PageBlob operations. */
 class PageBlobImpl {
@@ -54928,9 +54959,9 @@ module.exports = {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createClientPipeline = createClientPipeline;
-const deserializationPolicy_js_1 = __nccwpck_require__(83);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
-const serializationPolicy_js_1 = __nccwpck_require__(461);
+const deserializationPolicy_js_1 = __nccwpck_require__(85);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
+const serializationPolicy_js_1 = __nccwpck_require__(462);
 /**
  * Creates a new Pipeline for use with a Service Client.
  * Adds in deserializationPolicy by default.
@@ -54999,7 +55030,7 @@ const http = __importStar(__nccwpck_require__(315));
 const https = __importStar(__nccwpck_require__(67));
 const pm = __importStar(__nccwpck_require__(298));
 const tunnel = __importStar(__nccwpck_require__(490));
-const undici_1 = __nccwpck_require__(160);
+const undici_1 = __nccwpck_require__(159);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -55674,11 +55705,11 @@ var import_retryPolicy = __nccwpck_require__(14);
 var import_systemErrorRetryPolicy = __nccwpck_require__(26);
 var import_throttlingRetryPolicy = __nccwpck_require__(491);
 var import_formDataPolicy = __nccwpck_require__(324);
-var import_logPolicy = __nccwpck_require__(99);
-var import_multipartPolicy = __nccwpck_require__(167);
+var import_logPolicy = __nccwpck_require__(101);
+var import_multipartPolicy = __nccwpck_require__(165);
 var import_proxyPolicy = __nccwpck_require__(37);
 var import_redirectPolicy = __nccwpck_require__(304);
-var import_tlsPolicy = __nccwpck_require__(214);
+var import_tlsPolicy = __nccwpck_require__(213);
 var import_userAgentPolicy = __nccwpck_require__(341);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -55845,7 +55876,7 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
 const reflection_info_1 = __nccwpck_require__(426);
-const oneof_1 = __nccwpck_require__(185);
+const oneof_1 = __nccwpck_require__(183);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
     constructor(info) {
@@ -56076,141 +56107,6 @@ exports.ReflectionTypeCheck = ReflectionTypeCheck;
 /***/ }),
 
 /***/ 279:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("crypto");
-
-/***/ }),
-
-/***/ 280:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-var __defProp = Object.defineProperty;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __export = (target, all) => {
-  for (var name in all)
-    __defProp(target, name, { get: all[name], enumerable: true });
-};
-var __copyProps = (to, from, except, desc) => {
-  if (from && typeof from === "object" || typeof from === "function") {
-    for (let key of __getOwnPropNames(from))
-      if (!__hasOwnProp.call(to, key) && key !== except)
-        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
-  }
-  return to;
-};
-var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
-var userAgent_exports = {};
-__export(userAgent_exports, {
-  getUserAgentHeaderName: () => getUserAgentHeaderName,
-  getUserAgentValue: () => getUserAgentValue
-});
-module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(113);
-var import_constants = __nccwpck_require__(156);
-function getUserAgentString(telemetryInfo) {
-  const parts = [];
-  for (const [key, value] of telemetryInfo) {
-    const token = value ? `${key}/${value}` : key;
-    parts.push(token);
-  }
-  return parts.join(" ");
-}
-function getUserAgentHeaderName() {
-  return (0, import_userAgentPlatform.getHeaderName)();
-}
-async function getUserAgentValue(prefix) {
-  const runtimeInfo = /* @__PURE__ */ new Map();
-  runtimeInfo.set("core-rest-pipeline", import_constants.SDK_VERSION);
-  await (0, import_userAgentPlatform.setPlatformSpecificData)(runtimeInfo);
-  const defaultAgent = getUserAgentString(runtimeInfo);
-  const userAgentValue = prefix ? `${prefix} ${defaultAgent}` : defaultAgent;
-  return userAgentValue;
-}
-// Annotate the CommonJS export names for ESM import in node:
-0 && (0);
-
-
-/***/ }),
-
-/***/ 281:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.mergeRpcOptions = void 0;
-const runtime_1 = __nccwpck_require__(17);
-/**
- * Merges custom RPC options with defaults. Returns a new instance and keeps
- * the "defaults" and the "options" unmodified.
- *
- * Merges `RpcMetadata` "meta", overwriting values from "defaults" with
- * values from "options". Does not append values to existing entries.
- *
- * Merges "jsonOptions", including "jsonOptions.typeRegistry", by creating
- * a new array that contains types from "options.jsonOptions.typeRegistry"
- * first, then types from "defaults.jsonOptions.typeRegistry".
- *
- * Merges "binaryOptions".
- *
- * Merges "interceptors" by creating a new array that contains interceptors
- * from "defaults" first, then interceptors from "options".
- *
- * Works with objects that extend `RpcOptions`, but only if the added
- * properties are of type Date, primitive like string, boolean, or Array
- * of primitives. If you have other property types, you have to merge them
- * yourself.
- */
-function mergeRpcOptions(defaults, options) {
-    if (!options)
-        return defaults;
-    let o = {};
-    copy(defaults, o);
-    copy(options, o);
-    for (let key of Object.keys(options)) {
-        let val = options[key];
-        switch (key) {
-            case "jsonOptions":
-                o.jsonOptions = runtime_1.mergeJsonOptions(defaults.jsonOptions, o.jsonOptions);
-                break;
-            case "binaryOptions":
-                o.binaryOptions = runtime_1.mergeBinaryOptions(defaults.binaryOptions, o.binaryOptions);
-                break;
-            case "meta":
-                o.meta = {};
-                copy(defaults.meta, o.meta);
-                copy(options.meta, o.meta);
-                break;
-            case "interceptors":
-                o.interceptors = defaults.interceptors ? defaults.interceptors.concat(val) : val.concat();
-                break;
-        }
-    }
-    return o;
-}
-exports.mergeRpcOptions = mergeRpcOptions;
-function copy(a, into) {
-    if (!a)
-        return;
-    let c = into;
-    for (let [k, v] of Object.entries(a)) {
-        if (v instanceof Date)
-            c[k] = new Date(v.getTime());
-        else if (Array.isArray(v))
-            c[k] = v.concat();
-        else
-            c[k] = v;
-    }
-}
-
-
-/***/ }),
-
-/***/ 282:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -56272,11 +56168,11 @@ exports.restoreSoloCache = restoreSoloCache;
 exports.verifyRestoredToolchain = verifyRestoredToolchain;
 const node_crypto_1 = __nccwpck_require__(265);
 const fs = __importStar(__nccwpck_require__(240));
-const fsp = __importStar(__nccwpck_require__(105));
+const fsp = __importStar(__nccwpck_require__(107));
 const path = __importStar(__nccwpck_require__(479));
-const cache = __importStar(__nccwpck_require__(208));
+const cache = __importStar(__nccwpck_require__(207));
 const exec = __importStar(__nccwpck_require__(16));
-const cache_compress_js_1 = __nccwpck_require__(465);
+const cache_compress_js_1 = __nccwpck_require__(496);
 /**
  * The two live roots whose deltas this cache layer tracks. The string keys
  * are also the directory names used inside the tarball staging layout.
@@ -56602,6 +56498,141 @@ async function verifyRestoredToolchain(opts) {
 
 /***/ }),
 
+/***/ 280:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("crypto");
+
+/***/ }),
+
+/***/ 281:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var userAgent_exports = {};
+__export(userAgent_exports, {
+  getUserAgentHeaderName: () => getUserAgentHeaderName,
+  getUserAgentValue: () => getUserAgentValue
+});
+module.exports = __toCommonJS(userAgent_exports);
+var import_userAgentPlatform = __nccwpck_require__(114);
+var import_constants = __nccwpck_require__(155);
+function getUserAgentString(telemetryInfo) {
+  const parts = [];
+  for (const [key, value] of telemetryInfo) {
+    const token = value ? `${key}/${value}` : key;
+    parts.push(token);
+  }
+  return parts.join(" ");
+}
+function getUserAgentHeaderName() {
+  return (0, import_userAgentPlatform.getHeaderName)();
+}
+async function getUserAgentValue(prefix) {
+  const runtimeInfo = /* @__PURE__ */ new Map();
+  runtimeInfo.set("core-rest-pipeline", import_constants.SDK_VERSION);
+  await (0, import_userAgentPlatform.setPlatformSpecificData)(runtimeInfo);
+  const defaultAgent = getUserAgentString(runtimeInfo);
+  const userAgentValue = prefix ? `${prefix} ${defaultAgent}` : defaultAgent;
+  return userAgentValue;
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (0);
+
+
+/***/ }),
+
+/***/ 282:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.mergeRpcOptions = void 0;
+const runtime_1 = __nccwpck_require__(17);
+/**
+ * Merges custom RPC options with defaults. Returns a new instance and keeps
+ * the "defaults" and the "options" unmodified.
+ *
+ * Merges `RpcMetadata` "meta", overwriting values from "defaults" with
+ * values from "options". Does not append values to existing entries.
+ *
+ * Merges "jsonOptions", including "jsonOptions.typeRegistry", by creating
+ * a new array that contains types from "options.jsonOptions.typeRegistry"
+ * first, then types from "defaults.jsonOptions.typeRegistry".
+ *
+ * Merges "binaryOptions".
+ *
+ * Merges "interceptors" by creating a new array that contains interceptors
+ * from "defaults" first, then interceptors from "options".
+ *
+ * Works with objects that extend `RpcOptions`, but only if the added
+ * properties are of type Date, primitive like string, boolean, or Array
+ * of primitives. If you have other property types, you have to merge them
+ * yourself.
+ */
+function mergeRpcOptions(defaults, options) {
+    if (!options)
+        return defaults;
+    let o = {};
+    copy(defaults, o);
+    copy(options, o);
+    for (let key of Object.keys(options)) {
+        let val = options[key];
+        switch (key) {
+            case "jsonOptions":
+                o.jsonOptions = runtime_1.mergeJsonOptions(defaults.jsonOptions, o.jsonOptions);
+                break;
+            case "binaryOptions":
+                o.binaryOptions = runtime_1.mergeBinaryOptions(defaults.binaryOptions, o.binaryOptions);
+                break;
+            case "meta":
+                o.meta = {};
+                copy(defaults.meta, o.meta);
+                copy(options.meta, o.meta);
+                break;
+            case "interceptors":
+                o.interceptors = defaults.interceptors ? defaults.interceptors.concat(val) : val.concat();
+                break;
+        }
+    }
+    return o;
+}
+exports.mergeRpcOptions = mergeRpcOptions;
+function copy(a, into) {
+    if (!a)
+        return;
+    let c = into;
+    for (let [k, v] of Object.entries(a)) {
+        if (v instanceof Date)
+            c[k] = new Date(v.getTime());
+        else if (Array.isArray(v))
+            c[k] = v.concat();
+        else
+            c[k] = v;
+    }
+}
+
+
+/***/ }),
+
 /***/ 283:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -56639,7 +56670,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
 const assert_1 = __nccwpck_require__(495);
 const path = __importStar(__nccwpck_require__(239));
-const ioUtil = __importStar(__nccwpck_require__(217));
+const ioUtil = __importStar(__nccwpck_require__(216));
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -57003,11 +57034,11 @@ exports.maskSecretUrls = maskSecretUrls;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 tslib_1.__exportStar(__nccwpck_require__(444), exports);
 var storageClient_js_1 = __nccwpck_require__(420);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(162), exports);
+tslib_1.__exportStar(__nccwpck_require__(161), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -57071,9 +57102,9 @@ exports.AzureKeyCredential = AzureKeyCredential;
 const {
   InvalidArgumentError,
   NotSupportedError
-} = __nccwpck_require__(460)
+} = __nccwpck_require__(461)
 const assert = __nccwpck_require__(495)
-const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(190)
+const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(188)
 const util = __nccwpck_require__(66)
 
 // tokenRegExp and headerCharRegex have been lifted from
@@ -57104,7 +57135,7 @@ const channels = {}
 let extractBody
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(138)
+  const diagnosticsChannel = __nccwpck_require__(139)
   channels.create = diagnosticsChannel.channel('undici:request:create')
   channels.bodySent = diagnosticsChannel.channel('undici:request:bodySent')
   channels.headers = diagnosticsChannel.channel('undici:request:headers')
@@ -57578,7 +57609,7 @@ module.exports = Request
 const { webidl } = __nccwpck_require__(430)
 const { DOMException } = __nccwpck_require__(28)
 const { URLSerializer } = __nccwpck_require__(23)
-const { getGlobalOrigin } = __nccwpck_require__(136)
+const { getGlobalOrigin } = __nccwpck_require__(137)
 const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(438)
 const {
   kWebSocketURL,
@@ -57588,14 +57619,14 @@ const {
   kResponse,
   kSentClose,
   kByteParser
-} = __nccwpck_require__(95)
+} = __nccwpck_require__(97)
 const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(54)
 const { establishWebSocketConnection } = __nccwpck_require__(346)
-const { WebsocketFrameSend } = __nccwpck_require__(182)
+const { WebsocketFrameSend } = __nccwpck_require__(180)
 const { ByteParser } = __nccwpck_require__(454)
 const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(66)
 const { getGlobalDispatcher } = __nccwpck_require__(356)
-const { types } = __nccwpck_require__(120)
+const { types } = __nccwpck_require__(121)
 
 let experimentalWarned = false
 
@@ -58704,7 +58735,7 @@ __export(concat_exports, {
   concat: () => concat
 });
 module.exports = __toCommonJS(concat_exports);
-var import_stream = __nccwpck_require__(127);
+var import_stream = __nccwpck_require__(128);
 var import_typeGuards = __nccwpck_require__(469);
 async function* streamAsyncIterator() {
   const reader = this.getReader();
@@ -59149,11 +59180,11 @@ exports.CredentialPolicy = CredentialPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BatchResponseParser = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_http_compat_1 = __nccwpck_require__(69);
 const constants_js_1 = __nccwpck_require__(145);
 const BatchUtils_js_1 = __nccwpck_require__(249);
-const log_js_1 = __nccwpck_require__(103);
+const log_js_1 = __nccwpck_require__(105);
 const HTTP_HEADER_DELIMITER = ": ";
 const SPACE_DELIMITER = " ";
 const NOT_FOUND = -1;
@@ -59545,7 +59576,7 @@ function flattenResponse(fullResponse, responseSpec) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.buildCreatePoller = void 0;
-const operation_js_1 = __nccwpck_require__(137);
+const operation_js_1 = __nccwpck_require__(138);
 const constants_js_1 = __nccwpck_require__(57);
 const core_util_1 = __nccwpck_require__(12);
 const createStateProxy = () => ({
@@ -59726,7 +59757,7 @@ exports.buildCreatePoller = buildCreatePoller;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const pipeline_js_1 = __nccwpck_require__(273);
 const utils_js_1 = __nccwpck_require__(299);
 const httpClientCache_js_1 = __nccwpck_require__(377);
@@ -59925,7 +59956,7 @@ __export(createPipelineFromOptions_exports, {
   createPipelineFromOptions: () => createPipelineFromOptions
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
-var import_logPolicy = __nccwpck_require__(99);
+var import_logPolicy = __nccwpck_require__(101);
 var import_pipeline = __nccwpck_require__(493);
 var import_redirectPolicy = __nccwpck_require__(304);
 var import_userAgentPolicy = __nccwpck_require__(341);
@@ -59935,8 +59966,8 @@ var import_formDataPolicy = __nccwpck_require__(324);
 var import_checkEnvironment = __nccwpck_require__(412);
 var import_proxyPolicy = __nccwpck_require__(37);
 var import_agentPolicy = __nccwpck_require__(437);
-var import_tlsPolicy = __nccwpck_require__(214);
-var import_multipartPolicy = __nccwpck_require__(167);
+var import_tlsPolicy = __nccwpck_require__(213);
+var import_multipartPolicy = __nccwpck_require__(165);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_checkEnvironment.isNodeLike) {
@@ -60435,7 +60466,7 @@ function defaultRetryPolicy(options = {}) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageRetryPolicyFactory = exports.NewRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = void 0;
-const StorageRetryPolicy_js_1 = __nccwpck_require__(78);
+const StorageRetryPolicy_js_1 = __nccwpck_require__(80);
 Object.defineProperty(exports, "StorageRetryPolicy", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.StorageRetryPolicy; } }));
 Object.defineProperty(exports, "NewRetryPolicyFactory", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.NewRetryPolicyFactory; } }));
 const StorageRetryPolicyType_js_1 = __nccwpck_require__(393);
@@ -60893,14 +60924,14 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatch = void 0;
 const core_util_1 = __nccwpck_require__(12);
 const core_auth_1 = __nccwpck_require__(484);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_2 = __nccwpck_require__(12);
 const storage_common_1 = __nccwpck_require__(267);
-const Clients_js_1 = __nccwpck_require__(180);
+const Clients_js_1 = __nccwpck_require__(178);
 const Mutex_js_1 = __nccwpck_require__(488);
-const Pipeline_js_1 = __nccwpck_require__(178);
+const Pipeline_js_1 = __nccwpck_require__(176);
 const utils_common_js_1 = __nccwpck_require__(151);
-const core_xml_1 = __nccwpck_require__(189);
+const core_xml_1 = __nccwpck_require__(187);
 const constants_js_1 = __nccwpck_require__(145);
 const tracing_js_1 = __nccwpck_require__(29);
 const core_client_1 = __nccwpck_require__(413);
@@ -61212,10 +61243,10 @@ __export(tracingPolicy_exports, {
   tracingPolicyName: () => tracingPolicyName
 });
 module.exports = __toCommonJS(tracingPolicy_exports);
-var import_core_tracing = __nccwpck_require__(79);
-var import_constants = __nccwpck_require__(156);
-var import_userAgent = __nccwpck_require__(280);
-var import_log = __nccwpck_require__(179);
+var import_core_tracing = __nccwpck_require__(81);
+var import_constants = __nccwpck_require__(155);
+var import_userAgent = __nccwpck_require__(281);
+var import_log = __nccwpck_require__(177);
 var import_core_util = __nccwpck_require__(12);
 var import_restError = __nccwpck_require__(335);
 var import_util = __nccwpck_require__(143);
@@ -61345,12 +61376,12 @@ const {
   kAddClient,
   kGetDispatcher
 } = __nccwpck_require__(349)
-const Client = __nccwpck_require__(85)
+const Client = __nccwpck_require__(87)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(460)
+} = __nccwpck_require__(461)
 const util = __nccwpck_require__(66)
-const { kUrl, kInterceptors } = __nccwpck_require__(190)
+const { kUrl, kInterceptors } = __nccwpck_require__(188)
 const buildConnector = __nccwpck_require__(257)
 
 const kOptions = Symbol('options')
@@ -61528,7 +61559,7 @@ __export(formDataPolicy_exports, {
 module.exports = __toCommonJS(formDataPolicy_exports);
 var import_bytesEncoding = __nccwpck_require__(276);
 var import_checkEnvironment = __nccwpck_require__(412);
-var import_httpHeaders = __nccwpck_require__(457);
+var import_httpHeaders = __nccwpck_require__(458);
 const formDataPolicyName = "formDataPolicy";
 function formDataToFormDataMap(formData) {
   const formDataMap = {};
@@ -61659,12 +61690,12 @@ function redirectPolicy(options = {}) {
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(190)
-const { URL } = __nccwpck_require__(82)
+const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(188)
+const { URL } = __nccwpck_require__(84)
 const Agent = __nccwpck_require__(5)
 const Pool = __nccwpck_require__(322)
 const DispatcherBase = __nccwpck_require__(59)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(460)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(461)
 const buildConnector = __nccwpck_require__(257)
 
 const kAgent = Symbol('proxy agent')
@@ -61860,9 +61891,9 @@ exports.ReflectionJsonReader = void 0;
 const json_typings_1 = __nccwpck_require__(373);
 const base64_1 = __nccwpck_require__(290);
 const reflection_info_1 = __nccwpck_require__(426);
-const pb_long_1 = __nccwpck_require__(114);
-const assert_1 = __nccwpck_require__(456);
-const reflection_long_convert_1 = __nccwpck_require__(155);
+const pb_long_1 = __nccwpck_require__(115);
+const assert_1 = __nccwpck_require__(457);
+const reflection_long_convert_1 = __nccwpck_require__(154);
 /**
  * Reads proto3 messages in canonical JSON format using reflection information.
  *
@@ -62191,8 +62222,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
-const os_1 = __nccwpck_require__(89);
-const fs_1 = __nccwpck_require__(500);
+const os_1 = __nccwpck_require__(91);
+const fs_1 = __nccwpck_require__(501);
 const { access, appendFile, writeFile } = fs_1.promises;
 exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
 exports.SUMMARY_DOCS_URL = 'https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary';
@@ -62642,7 +62673,7 @@ function createTracingClient(options) {
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(120)
+const { promisify } = __nccwpck_require__(121)
 const Pool = __nccwpck_require__(322)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
@@ -62654,9 +62685,9 @@ const {
   kOriginalDispatch,
   kConnected
 } = __nccwpck_require__(443)
-const { MockInterceptor } = __nccwpck_require__(132)
-const Symbols = __nccwpck_require__(190)
-const { InvalidArgumentError } = __nccwpck_require__(460)
+const { MockInterceptor } = __nccwpck_require__(133)
+const Symbols = __nccwpck_require__(188)
+const { InvalidArgumentError } = __nccwpck_require__(461)
 
 /**
  * MockPool provides an API that extends the Pool to influence the mockDispatches.
@@ -62978,7 +63009,7 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_ts_http_runtime = __nccwpck_require__(86);
+var import_ts_http_runtime = __nccwpck_require__(88);
 const RestError = import_ts_http_runtime.RestError;
 function isRestError(e) {
   return (0, import_ts_http_runtime.isRestError)(e);
@@ -62995,16 +63026,16 @@ function isRestError(e) {
 "use strict";
 
 
-const { finished, PassThrough } = __nccwpck_require__(127)
+const { finished, PassThrough } = __nccwpck_require__(128)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(460)
+} = __nccwpck_require__(461)
 const util = __nccwpck_require__(66)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(184)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(182)
 const { AsyncResource } = __nccwpck_require__(403)
-const { addSignal, removeSignal } = __nccwpck_require__(100)
+const { addSignal, removeSignal } = __nccwpck_require__(102)
 
 class StreamHandler extends AsyncResource {
   constructor (opts, factory, callback) {
@@ -63231,9 +63262,9 @@ module.exports = stream
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(413));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(173));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing BlockBlob operations. */
 class BlockBlobImpl {
@@ -63652,7 +63683,7 @@ function decompressResponsePolicy() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GenericPollOperation = void 0;
 const operation_js_1 = __nccwpck_require__(49);
-const logger_js_1 = __nccwpck_require__(186);
+const logger_js_1 = __nccwpck_require__(184);
 const createStateProxy = () => ({
     initState: (config) => ({ config, isStarted: true }),
     setCanceled: (state) => (state.isCancelled = true),
@@ -64193,8 +64224,8 @@ exports.BufferScheduler = BufferScheduler;
 "use strict";
 
 
-const { Blob, File: NativeFile } = __nccwpck_require__(116)
-const { types } = __nccwpck_require__(120)
+const { Blob, File: NativeFile } = __nccwpck_require__(117)
+const { types } = __nccwpck_require__(121)
 const { kState } = __nccwpck_require__(13)
 const { isBlobLike } = __nccwpck_require__(487)
 const { webidl } = __nccwpck_require__(430)
@@ -64545,21 +64576,21 @@ module.exports = { File, FileLike, isFileLike }
 "use strict";
 
 
-const diagnosticsChannel = __nccwpck_require__(138)
+const diagnosticsChannel = __nccwpck_require__(139)
 const { uid, states } = __nccwpck_require__(438)
 const {
   kReadyState,
   kSentClose,
   kByteParser,
   kReceivedClose
-} = __nccwpck_require__(95)
+} = __nccwpck_require__(97)
 const { fireEvent, failWebsocketConnection } = __nccwpck_require__(54)
 const { CloseEvent } = __nccwpck_require__(241)
-const { makeRequest } = __nccwpck_require__(81)
+const { makeRequest } = __nccwpck_require__(83)
 const { fetching } = __nccwpck_require__(424)
 const { Headers } = __nccwpck_require__(486)
 const { getGlobalDispatcher } = __nccwpck_require__(356)
-const { kHeadersList } = __nccwpck_require__(190)
+const { kHeadersList } = __nccwpck_require__(188)
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -64569,7 +64600,7 @@ channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(279)
+  crypto = __nccwpck_require__(280)
 } catch {
 
 }
@@ -64880,7 +64911,7 @@ __export(restError_exports, {
 });
 module.exports = __toCommonJS(restError_exports);
 var import_restError = __nccwpck_require__(418);
-var import_httpHeaders = __nccwpck_require__(457);
+var import_httpHeaders = __nccwpck_require__(458);
 function createRestError(messageOrResponse, response) {
   const resp = typeof messageOrResponse === "string" ? response : messageOrResponse;
   const internalError = resp.body?.error ?? resp.body;
@@ -64917,8 +64948,8 @@ function statusCodeToNumber(statusCode) {
 
 
 const DispatcherBase = __nccwpck_require__(59)
-const FixedQueue = __nccwpck_require__(191)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(190)
+const FixedQueue = __nccwpck_require__(189)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(188)
 const PoolStats = __nccwpck_require__(20)
 
 const kClients = Symbol('clients')
@@ -65181,7 +65212,7 @@ exports.TracingContextImpl = TracingContextImpl;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const BuffersStream_js_1 = __nccwpck_require__(364);
 const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(255));
 /**
@@ -65322,9 +65353,9 @@ function createDefaultHttpClient() {
 
 
 const { AsyncResource } = __nccwpck_require__(403)
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(460)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(461)
 const util = __nccwpck_require__(66)
-const { addSignal, removeSignal } = __nccwpck_require__(100)
+const { addSignal, removeSignal } = __nccwpck_require__(102)
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -65613,7 +65644,7 @@ module.exports = require("node:util");
 // We include a version number for the Dispatcher API. In case of breaking changes,
 // this version number must be increased to avoid conflicts.
 const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
-const { InvalidArgumentError } = __nccwpck_require__(460)
+const { InvalidArgumentError } = __nccwpck_require__(461)
 const Agent = __nccwpck_require__(5)
 
 if (getGlobalDispatcher() === undefined) {
@@ -65650,7 +65681,7 @@ module.exports = {
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(190)
+const { kClients } = __nccwpck_require__(188)
 const Agent = __nccwpck_require__(5)
 const {
   kAgent,
@@ -65663,10 +65694,10 @@ const {
   kOptions,
   kFactory
 } = __nccwpck_require__(443)
-const MockClient = __nccwpck_require__(194)
+const MockClient = __nccwpck_require__(193)
 const MockPool = __nccwpck_require__(331)
 const { matchValue, buildMockOptions } = __nccwpck_require__(7)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(460)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(461)
 const Dispatcher = __nccwpck_require__(450)
 const Pluralizer = __nccwpck_require__(245)
 const PendingInterceptorsFormatter = __nccwpck_require__(225)
@@ -66012,7 +66043,7 @@ function bearerAuthenticationPolicy(options) {
 const {
   BalancedPoolMissingUpstreamError,
   InvalidArgumentError
-} = __nccwpck_require__(460)
+} = __nccwpck_require__(461)
 const {
   PoolBase,
   kClients,
@@ -66022,7 +66053,7 @@ const {
   kGetDispatcher
 } = __nccwpck_require__(349)
 const Pool = __nccwpck_require__(322)
-const { kUrl, kInterceptors } = __nccwpck_require__(190)
+const { kUrl, kInterceptors } = __nccwpck_require__(188)
 const { parseOrigin } = __nccwpck_require__(66)
 const kFactory = Symbol('factory')
 
@@ -66602,7 +66633,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(280);
+var import_userAgent = __nccwpck_require__(281);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -66630,9 +66661,9 @@ function userAgentPolicy(options = {}) {
 
 
 const util = __nccwpck_require__(66)
-const { kBodyUsed } = __nccwpck_require__(190)
+const { kBodyUsed } = __nccwpck_require__(188)
 const assert = __nccwpck_require__(495)
-const { InvalidArgumentError } = __nccwpck_require__(460)
+const { InvalidArgumentError } = __nccwpck_require__(461)
 const EE = __nccwpck_require__(442)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
@@ -67135,8 +67166,8 @@ exports.CacheScope = new CacheScope$Type();
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredential = void 0;
-const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(90);
-const Credential_js_1 = __nccwpck_require__(92);
+const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(92);
+const Credential_js_1 = __nccwpck_require__(94);
 /**
  * AnonymousCredential provides a credentialPolicyCreator member used to create
  * AnonymousCredentialPolicy objects. AnonymousCredentialPolicy is used with
@@ -67168,7 +67199,7 @@ exports.AnonymousCredential = AnonymousCredential;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 let cachedHttpClient;
 function getCachedDefaultHttpClient() {
     if (!cachedHttpClient) {
@@ -67238,9 +67269,9 @@ function getPathStringFromParameter(parameter) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobServiceClient = void 0;
 const core_auth_1 = __nccwpck_require__(484);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(12);
-const Pipeline_js_1 = __nccwpck_require__(178);
+const Pipeline_js_1 = __nccwpck_require__(176);
 const ContainerClient_js_1 = __nccwpck_require__(61);
 const utils_common_js_1 = __nccwpck_require__(151);
 const storage_common_1 = __nccwpck_require__(267);
@@ -67958,7 +67989,7 @@ const BlobBatch_js_1 = __nccwpck_require__(319);
 const tracing_js_1 = __nccwpck_require__(29);
 const storage_common_1 = __nccwpck_require__(267);
 const StorageContextClient_js_1 = __nccwpck_require__(258);
-const Pipeline_js_1 = __nccwpck_require__(178);
+const Pipeline_js_1 = __nccwpck_require__(176);
 const utils_common_js_1 = __nccwpck_require__(151);
 /**
  * A BlobBatchClient allows you to make batched requests to the Azure Storage Blob service.
@@ -68134,7 +68165,7 @@ exports.BlobBatchClient = BlobBatchClient;
 
 const Decoder = __nccwpck_require__(40)
 const decodeText = __nccwpck_require__(266)
-const getLimit = __nccwpck_require__(455)
+const getLimit = __nccwpck_require__(456)
 
 const RE_CHARSET = /^charset$/i
 
@@ -68355,7 +68386,7 @@ exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
 const tracingContext_js_1 = __nccwpck_require__(350);
-const state_js_1 = __nccwpck_require__(93);
+const state_js_1 = __nccwpck_require__(95);
 function createDefaultTracingSpan() {
     return {
         end: () => {
@@ -68486,7 +68517,7 @@ exports.readSnapshotFile = readSnapshotFile;
 const fs = __importStar(__nccwpck_require__(240));
 const path = __importStar(__nccwpck_require__(479));
 const node_crypto_1 = __nccwpck_require__(265);
-const normalize_source_mtime_js_1 = __nccwpck_require__(76);
+const normalize_source_mtime_js_1 = __nccwpck_require__(77);
 exports.SNAPSHOT_FILENAME = "setup-soldr-source-mtimes.json";
 async function hashFile(absolute) {
     // sha256 prefix (first 32 hex = 128 bits). Streaming so we don't load
@@ -68664,7 +68695,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
 const binary_format_contract_1 = __nccwpck_require__(318);
 const reflection_info_1 = __nccwpck_require__(426);
-const reflection_long_convert_1 = __nccwpck_require__(155);
+const reflection_long_convert_1 = __nccwpck_require__(154);
 const reflection_scalar_default_1 = __nccwpck_require__(435);
 /**
  * Reads proto3 messages in binary format using reflection information.
@@ -69162,8 +69193,8 @@ __export(response_exports, {
   toPipelineResponse: () => toPipelineResponse
 });
 module.exports = __toCommonJS(response_exports);
-var import_core_rest_pipeline = __nccwpck_require__(98);
-var import_util = __nccwpck_require__(106);
+var import_core_rest_pipeline = __nccwpck_require__(100);
+var import_util = __nccwpck_require__(108);
 const originalResponse = /* @__PURE__ */ Symbol("Original FullOperationResponse");
 function toCompatResponse(response, options) {
   let request = (0, import_util.toWebResourceLike)(response.request);
@@ -69284,7 +69315,7 @@ exports.getOptions = getOptions;
 
 /* istanbul ignore file: only for Node 12 */
 
-const { kConnected, kSize } = __nccwpck_require__(190)
+const { kConnected, kSize } = __nccwpck_require__(188)
 
 class CompatWeakRef {
   constructor (value) {
@@ -69472,7 +69503,7 @@ const Dicer = __nccwpck_require__(11)
 
 const MultipartParser = __nccwpck_require__(0)
 const UrlencodedParser = __nccwpck_require__(381)
-const parseParams = __nccwpck_require__(187)
+const parseParams = __nccwpck_require__(185)
 
 function Busboy (opts) {
   if (!(this instanceof Busboy)) { return new Busboy(opts) }
@@ -69622,7 +69653,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDetails = exports.isLinux = exports.isMacOS = exports.isWindows = exports.arch = exports.platform = void 0;
-const os_1 = __importDefault(__nccwpck_require__(89));
+const os_1 = __importDefault(__nccwpck_require__(91));
 const exec = __importStar(__nccwpck_require__(16));
 const getWindowsInfo = () => __awaiter(void 0, void 0, void 0, function* () {
     const { stdout: version } = yield exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Version"', undefined, {
@@ -69800,7 +69831,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReader = void 0;
 // TODO: Do a review of non-interfaces
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
-const AvroConstants_js_1 = __nccwpck_require__(221);
+const AvroConstants_js_1 = __nccwpck_require__(220);
 const AvroParser_js_1 = __nccwpck_require__(289);
 const utils_common_js_1 = __nccwpck_require__(370);
 class AvroReader {
@@ -69926,7 +69957,7 @@ exports.CacheService = exports.GetCacheEntryDownloadURLResponse = exports.GetCac
 // @generated by protobuf-ts 2.9.1 with parameter long_type_string,client_none,generate_dependencies
 // @generated from protobuf file "results/api/v1/cache.proto" (package "github.actions.results.api.v1", syntax proto3)
 // tslint:disable
-const runtime_rpc_1 = __nccwpck_require__(170);
+const runtime_rpc_1 = __nccwpck_require__(168);
 const runtime_1 = __nccwpck_require__(17);
 const runtime_2 = __nccwpck_require__(17);
 const runtime_3 = __nccwpck_require__(17);
@@ -70331,7 +70362,7 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(124)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(125)
 const { isCTLExcludingHtab } = __nccwpck_require__(386)
 const { collectASequenceOfCodePointsFast } = __nccwpck_require__(23)
 const assert = __nccwpck_require__(495)
@@ -70728,7 +70759,7 @@ exports.BlobDownloadResponse = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core_util_1 = __nccwpck_require__(12);
-const RetriableReadableStream_js_1 = __nccwpck_require__(464);
+const RetriableReadableStream_js_1 = __nccwpck_require__(465);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -71370,11 +71401,11 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DefaultGlobber = void 0;
 const core = __importStar(__nccwpck_require__(432));
-const fs = __importStar(__nccwpck_require__(500));
+const fs = __importStar(__nccwpck_require__(501));
 const globOptionsHelper = __importStar(__nccwpck_require__(389));
 const path = __importStar(__nccwpck_require__(239));
 const patternHelper = __importStar(__nccwpck_require__(41));
-const internal_match_kind_1 = __nccwpck_require__(497);
+const internal_match_kind_1 = __nccwpck_require__(498);
 const internal_pattern_1 = __nccwpck_require__(474);
 const internal_search_state_1 = __nccwpck_require__(4);
 const IS_WINDOWS = process.platform === 'win32';
@@ -71668,10 +71699,10 @@ function getOperationRequestInfo(request) {
 "use strict";
 
 
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(460)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(461)
 const { AsyncResource } = __nccwpck_require__(403)
 const util = __nccwpck_require__(66)
-const { addSignal, removeSignal } = __nccwpck_require__(100)
+const { addSignal, removeSignal } = __nccwpck_require__(102)
 const assert = __nccwpck_require__(495)
 
 class UpgradeHandler extends AsyncResource {
@@ -71780,8 +71811,8 @@ module.exports = upgrade
 
 "use strict";
 
-const os = __nccwpck_require__(89);
-const tty = __nccwpck_require__(177);
+const os = __nccwpck_require__(91);
+const tty = __nccwpck_require__(175);
 const hasFlag = __nccwpck_require__(347);
 
 const {env} = process;
@@ -72165,18 +72196,18 @@ var serviceClient_js_1 = __nccwpck_require__(301);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
 var pipeline_js_1 = __nccwpck_require__(273);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
-var interfaces_js_1 = __nccwpck_require__(96);
+var interfaces_js_1 = __nccwpck_require__(98);
 Object.defineProperty(exports, "XML_ATTRKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_ATTRKEY; } }));
 Object.defineProperty(exports, "XML_CHARKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_CHARKEY; } }));
-var deserializationPolicy_js_1 = __nccwpck_require__(83);
+var deserializationPolicy_js_1 = __nccwpck_require__(85);
 Object.defineProperty(exports, "deserializationPolicy", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicy; } }));
 Object.defineProperty(exports, "deserializationPolicyName", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicyName; } }));
-var serializationPolicy_js_1 = __nccwpck_require__(461);
+var serializationPolicy_js_1 = __nccwpck_require__(462);
 Object.defineProperty(exports, "serializationPolicy", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicy; } }));
 Object.defineProperty(exports, "serializationPolicyName", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicyName; } }));
-var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(109);
+var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(110);
 Object.defineProperty(exports, "authorizeRequestOnClaimChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnClaimChallenge_js_1.authorizeRequestOnClaimChallenge; } }));
-var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(168);
+var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(166);
 Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnTenantChallenge_js_1.authorizeRequestOnTenantChallenge; } }));
 //# sourceMappingURL=index.js.map
 
@@ -72223,7 +72254,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTar = exports.extractTar = exports.listTar = void 0;
 const exec_1 = __nccwpck_require__(16);
 const io = __importStar(__nccwpck_require__(283));
-const fs_1 = __nccwpck_require__(500);
+const fs_1 = __nccwpck_require__(501);
 const path = __importStar(__nccwpck_require__(239));
 const utils = __importStar(__nccwpck_require__(73));
 const constants_1 = __nccwpck_require__(43);
@@ -72502,10 +72533,10 @@ var import_node_https = __toESM(__nccwpck_require__(367));
 var import_node_zlib = __toESM(__nccwpck_require__(489));
 var import_node_stream = __nccwpck_require__(404);
 var import_AbortError = __nccwpck_require__(9);
-var import_httpHeaders = __nccwpck_require__(457);
+var import_httpHeaders = __nccwpck_require__(458);
 var import_restError = __nccwpck_require__(418);
 var import_log = __nccwpck_require__(148);
-var import_sanitizer = __nccwpck_require__(118);
+var import_sanitizer = __nccwpck_require__(119);
 const DEFAULT_TLS_SETTINGS = {};
 function isReadableStream(body) {
   return body && typeof body.pipe === "function";
@@ -72929,9 +72960,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const crypto = __importStar(__nccwpck_require__(279));
-const fs = __importStar(__nccwpck_require__(500));
-const os = __importStar(__nccwpck_require__(89));
+const crypto = __importStar(__nccwpck_require__(280));
+const fs = __importStar(__nccwpck_require__(501));
+const os = __importStar(__nccwpck_require__(91));
 const utils_1 = __nccwpck_require__(476);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -72993,7 +73024,7 @@ __export(restError_exports, {
 module.exports = __toCommonJS(restError_exports);
 var import_error = __nccwpck_require__(150);
 var import_inspect = __nccwpck_require__(1);
-var import_sanitizer = __nccwpck_require__(118);
+var import_sanitizer = __nccwpck_require__(119);
 const errorSanitizer = new import_sanitizer.Sanitizer();
 class RestError extends Error {
   /**
@@ -73134,7 +73165,7 @@ function wrapAbortSignalLike(abortSignalLike) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const coreHttpCompat = tslib_1.__importStar(__nccwpck_require__(69));
 const index_js_1 = __nccwpck_require__(268);
 class StorageClient extends coreHttpCompat.ExtendedServiceClient {
@@ -73202,13 +73233,13 @@ exports.StorageClient = StorageClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = exports.StorageSharedKeyCredentialPolicy = exports.StorageSharedKeyCredential = exports.StorageRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = exports.Credential = exports.CredentialPolicy = exports.BaseRequestPolicy = exports.AnonymousCredentialPolicy = exports.AnonymousCredential = exports.StorageOAuthScopes = exports.newPipeline = exports.isPipelineLike = exports.Pipeline = exports.getBlobServiceAccountAudience = exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTier = exports.generateBlobSASQueryParameters = exports.generateAccountSASQueryParameters = void 0;
-const tslib_1 = __nccwpck_require__(210);
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const tslib_1 = __nccwpck_require__(209);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
 tslib_1.__exportStar(__nccwpck_require__(379), exports);
-tslib_1.__exportStar(__nccwpck_require__(180), exports);
+tslib_1.__exportStar(__nccwpck_require__(178), exports);
 tslib_1.__exportStar(__nccwpck_require__(61), exports);
-tslib_1.__exportStar(__nccwpck_require__(199), exports);
+tslib_1.__exportStar(__nccwpck_require__(198), exports);
 tslib_1.__exportStar(__nccwpck_require__(55), exports);
 tslib_1.__exportStar(__nccwpck_require__(2), exports);
 tslib_1.__exportStar(__nccwpck_require__(359), exports);
@@ -73216,7 +73247,7 @@ var AccountSASSignatureValues_js_1 = __nccwpck_require__(277);
 Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
 tslib_1.__exportStar(__nccwpck_require__(319), exports);
 tslib_1.__exportStar(__nccwpck_require__(380), exports);
-tslib_1.__exportStar(__nccwpck_require__(169), exports);
+tslib_1.__exportStar(__nccwpck_require__(167), exports);
 tslib_1.__exportStar(__nccwpck_require__(475), exports);
 var BlobSASSignatureValues_js_1 = __nccwpck_require__(65);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
@@ -73226,7 +73257,7 @@ Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: functi
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
 Object.defineProperty(exports, "getBlobServiceAccountAudience", ({ enumerable: true, get: function () { return models_js_1.getBlobServiceAccountAudience; } }));
-var Pipeline_js_1 = __nccwpck_require__(178);
+var Pipeline_js_1 = __nccwpck_require__(176);
 Object.defineProperty(exports, "Pipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.Pipeline; } }));
 Object.defineProperty(exports, "isPipelineLike", ({ enumerable: true, get: function () { return Pipeline_js_1.isPipelineLike; } }));
 Object.defineProperty(exports, "newPipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.newPipeline; } }));
@@ -73246,7 +73277,7 @@ Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get:
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
 tslib_1.__exportStar(__nccwpck_require__(494), exports);
 tslib_1.__exportStar(__nccwpck_require__(309), exports);
-var log_js_1 = __nccwpck_require__(103);
+var log_js_1 = __nccwpck_require__(105);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
 
@@ -73564,9 +73595,9 @@ __export(sendRequest_exports, {
 });
 module.exports = __toCommonJS(sendRequest_exports);
 var import_restError = __nccwpck_require__(418);
-var import_httpHeaders = __nccwpck_require__(457);
-var import_pipelineRequest = __nccwpck_require__(112);
-var import_clientHelpers = __nccwpck_require__(463);
+var import_httpHeaders = __nccwpck_require__(458);
+var import_pipelineRequest = __nccwpck_require__(113);
+var import_clientHelpers = __nccwpck_require__(464);
 var import_typeGuards = __nccwpck_require__(469);
 var import_multipart = __nccwpck_require__(260);
 async function sendRequest(method, url, pipeline, options = {}, customHttpClient) {
@@ -73737,7 +73768,7 @@ const {
   makeResponse
 } = __nccwpck_require__(39)
 const { Headers } = __nccwpck_require__(486)
-const { Request, makeRequest } = __nccwpck_require__(81)
+const { Request, makeRequest } = __nccwpck_require__(83)
 const zlib = __nccwpck_require__(387)
 const {
   bytesMatch,
@@ -73780,9 +73811,9 @@ const {
   subresourceSet,
   DOMException
 } = __nccwpck_require__(28)
-const { kHeadersList } = __nccwpck_require__(190)
+const { kHeadersList } = __nccwpck_require__(188)
 const EE = __nccwpck_require__(442)
-const { Readable, pipeline } = __nccwpck_require__(127)
+const { Readable, pipeline } = __nccwpck_require__(128)
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(66)
 const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(23)
 const { TransformStream } = __nccwpck_require__(248)
@@ -74530,7 +74561,7 @@ function schemeFetch (fetchParams) {
     }
     case 'blob:': {
       if (!resolveObjectURL) {
-        resolveObjectURL = (__nccwpck_require__(116).resolveObjectURL)
+        resolveObjectURL = (__nccwpck_require__(117).resolveObjectURL)
       }
 
       // 1. Let blobURLEntry be request’s current URL’s blob URL entry.
@@ -76154,7 +76185,7 @@ exports.lowerCamelCase = lowerCamelCase;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
 const StorageContextClient_js_1 = __nccwpck_require__(258);
-const Pipeline_js_1 = __nccwpck_require__(178);
+const Pipeline_js_1 = __nccwpck_require__(176);
 const utils_common_js_1 = __nccwpck_require__(151);
 /**
  * A StorageClient represents a based URL class for {@link BlobServiceClient}, {@link ContainerClient}
@@ -76288,7 +76319,7 @@ function parseHeaderValueAsNumber(response, headerName) {
 "use strict";
 
 
-const { types } = __nccwpck_require__(120)
+const { types } = __nccwpck_require__(121)
 const { hasOwn, toUSVString } = __nccwpck_require__(487)
 
 /** @type {import('../../types/webidl').Webidl} */
@@ -76943,8 +76974,8 @@ module.exports = {
  * Module dependencies.
  */
 
-const tty = __nccwpck_require__(177);
-const util = __nccwpck_require__(120);
+const tty = __nccwpck_require__(175);
+const util = __nccwpck_require__(121);
 
 /**
  * This is the Node.js implementation of `debug()`.
@@ -77178,7 +77209,7 @@ function init(debug) {
 	}
 }
 
-module.exports = __nccwpck_require__(139)(exports);
+module.exports = __nccwpck_require__(140)(exports);
 
 const {formatters} = module.exports;
 
@@ -77245,12 +77276,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.platform = exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = exports.markdownSummary = exports.summary = exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(502);
+const command_1 = __nccwpck_require__(503);
 const file_command_1 = __nccwpck_require__(417);
 const utils_1 = __nccwpck_require__(476);
-const os = __importStar(__nccwpck_require__(89));
+const os = __importStar(__nccwpck_require__(91));
 const path = __importStar(__nccwpck_require__(239));
-const oidc_utils_1 = __nccwpck_require__(130);
+const oidc_utils_1 = __nccwpck_require__(131);
 /**
  * The code to exit an action
  */
@@ -77668,8 +77699,8 @@ function repeatedMsgEq(type, a, b) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
 const reflection_info_1 = __nccwpck_require__(426);
-const reflection_long_convert_1 = __nccwpck_require__(155);
-const pb_long_1 = __nccwpck_require__(114);
+const reflection_long_convert_1 = __nccwpck_require__(154);
+const pb_long_1 = __nccwpck_require__(115);
 /**
  * Creates the default value for a scalar type.
  */
@@ -77872,7 +77903,7 @@ __export(debug_exports, {
   default: () => debug_default
 });
 module.exports = __toCommonJS(debug_exports);
-var import_log = __nccwpck_require__(459);
+var import_log = __nccwpck_require__(460);
 const debugEnvVariable = typeof process !== "undefined" && process.env && process.env.DEBUG || void 0;
 let enabledString;
 let enabledNamespaces = [];
@@ -78297,7 +78328,7 @@ function localstorage() {
 	}
 }
 
-module.exports = __nccwpck_require__(139)(exports);
+module.exports = __nccwpck_require__(140)(exports);
 
 const {formatters} = module.exports;
 
@@ -78713,7 +78744,7 @@ exports.attachCredential = attachCredential;
 exports.httpAuthorizationToString = httpAuthorizationToString;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(98);
+const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(12);
 const constants_js_1 = __nccwpck_require__(34);
 /**
@@ -79396,7 +79427,7 @@ module.exports = Dispatcher
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceType = void 0;
-const reflection_info_1 = __nccwpck_require__(496);
+const reflection_info_1 = __nccwpck_require__(497);
 class ServiceType {
     constructor(typeName, methods, options) {
         this.typeName = typeName;
@@ -79419,9 +79450,9 @@ exports.ServiceType = ServiceType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(209);
 const base64 = tslib_1.__importStar(__nccwpck_require__(411));
-const interfaces_js_1 = __nccwpck_require__(96);
+const interfaces_js_1 = __nccwpck_require__(98);
 const utils_js_1 = __nccwpck_require__(299);
 class SerializerImpl {
     modelMappers;
@@ -80363,12 +80394,12 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 "use strict";
 
 
-const { Writable } = __nccwpck_require__(127)
-const diagnosticsChannel = __nccwpck_require__(138)
+const { Writable } = __nccwpck_require__(128)
+const diagnosticsChannel = __nccwpck_require__(139)
 const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(438)
-const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(95)
+const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(97)
 const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(54)
-const { WebsocketFrameSend } = __nccwpck_require__(182)
+const { WebsocketFrameSend } = __nccwpck_require__(180)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -80710,6 +80741,334 @@ module.exports = {
 /***/ }),
 
 /***/ 455:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Cook cache layer — long-lived deps tarball keyed by Cargo.lock content.
+//
+// Per CLAUDE.md "Cache-lifetime axis" + the cook simulation findings:
+// the cook cache is short-lived/large (churns on every Cargo.lock change,
+// 100s of MB to multi-GB). It must NOT include SHA in the key (causes
+// catastrophic eviction churn). Content-addressable keying gives parent-
+// to-branch sharing automatically: same Cargo.lock = same key, regardless
+// of branch or commit.
+//
+// Save path: snapshot `target/` immediately after cook completes, before
+// the user's `cargo build` adds project artifacts. We tar+zstd-19 with
+// `--long=27` because compiled rust deps have heavy cross-crate
+// redundancy that benefits from the 128 MB zstd window.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.hashCookFlags = hashCookFlags;
+exports.buildCookCacheKey = buildCookCacheKey;
+exports.decideCookGate = decideCookGate;
+exports.runCook = runCook;
+exports.restoreCookCache = restoreCookCache;
+exports.saveCookCache = saveCookCache;
+exports.parseCookFlags = parseCookFlags;
+exports.canonicalizeCookFlags = canonicalizeCookFlags;
+const node_crypto_1 = __nccwpck_require__(265);
+const fs = __importStar(__nccwpck_require__(240));
+const fsp = __importStar(__nccwpck_require__(107));
+const path = __importStar(__nccwpck_require__(479));
+const exec = __importStar(__nccwpck_require__(16));
+const cache = __importStar(__nccwpck_require__(207));
+const cache_compress_js_1 = __nccwpck_require__(496);
+const COOK_KEY_PREFIX = "cook";
+/**
+ * Compute the canonical flag fingerprint. Sorts and lowercases so flag
+ * order doesn't perturb the key, and so `--release` vs `--RELEASE`
+ * collapse. Only flags that affect cook output structure should be
+ * here; cosmetic flags must be filtered upstream.
+ */
+function hashCookFlags(flags) {
+    const sorted = [...flags.map((s) => s.trim()).filter((s) => s.length > 0)].sort();
+    if (sorted.length === 0)
+        return "none";
+    const h = (0, node_crypto_1.createHash)("sha256");
+    for (const s of sorted) {
+        h.update(s);
+        h.update("\0");
+    }
+    return h.digest("hex").slice(0, 8);
+}
+function buildCookCacheKey(parts) {
+    const release = parts.rustcRelease.trim() || "unresolved";
+    return [
+        COOK_KEY_PREFIX,
+        parts.runnerOs,
+        parts.runnerArch,
+        parts.libc,
+        `rustc${release}`,
+        `f${parts.flagsHash}`,
+        `l${parts.lockHash}`,
+        `soldr${parts.soldrVersion}`,
+    ].join("-");
+}
+/**
+ * Decide whether to run cook based on the runtime environment. Returns a
+ * reason string for diagnostic logging in both branches.
+ */
+function decideCookGate(opts) {
+    const mode = opts.prebuildDeps.trim().toLowerCase();
+    if (mode === "" || mode === "none" || mode === "off" || mode === "false") {
+        return { enabled: false, reason: `prebuild-deps=${opts.prebuildDeps || "(empty)"} - cook disabled` };
+    }
+    if (mode !== "cargo-chef") {
+        return {
+            enabled: false,
+            reason: `prebuild-deps=${opts.prebuildDeps} - unknown strategy, only "cargo-chef" supported`,
+        };
+    }
+    if (!opts.cacheUmbrella) {
+        return { enabled: false, reason: "cache: false - cook produces no value without caching" };
+    }
+    if (!opts.lockfilePath) {
+        return { enabled: false, reason: "no Cargo.lock found - cook needs a lockfile to derive recipe" };
+    }
+    if (!fs.existsSync(opts.lockfilePath)) {
+        return { enabled: false, reason: `Cargo.lock path ${opts.lockfilePath} does not exist` };
+    }
+    return { enabled: true, reason: "cook enabled" };
+}
+/**
+ * Run `soldr cook` in the project directory. Cargo-chef itself emits
+ * the recipe and runs the cook compile. We tolerate failure: cook is
+ * an optimization, not a correctness primitive, so any non-zero exit
+ * is logged and the action proceeds. The user's normal `cargo build`
+ * step will work fine without a cooked target.
+ */
+async function runCook(opts) {
+    const { soldrBinary, projectRoot, flags, log } = opts;
+    log(`cook: running '${soldrBinary} cook ${flags.join(" ")}' in ${projectRoot}`);
+    const t0 = Date.now();
+    let exitCode = 0;
+    try {
+        exitCode = await exec.exec(soldrBinary, ["cook", ...flags], {
+            cwd: projectRoot,
+            ignoreReturnCode: true,
+        });
+    }
+    catch (err) {
+        log(`cook: exec threw: ${err instanceof Error ? err.message : String(err)}`);
+        exitCode = 1;
+    }
+    const ranSeconds = (Date.now() - t0) / 1000;
+    if (exitCode !== 0) {
+        log(`cook: failed with exit ${exitCode} after ${ranSeconds.toFixed(1)}s; continuing without cooked deps`);
+    }
+    else {
+        log(`cook: completed in ${ranSeconds.toFixed(1)}s`);
+    }
+    return { exitCode, ranSeconds };
+}
+/**
+ * Attempt to restore a cooked target directory from the actions cache.
+ * Single exact key — no fallback ladder; cook is content-addressable so
+ * a fallback would either be redundant or wrong.
+ */
+async function restoreCookCache(opts) {
+    const { exactKey, archivePath, targetDir, longWindow, log } = opts;
+    await fsp.mkdir(path.dirname(archivePath), { recursive: true });
+    await fsp.rm(archivePath, { force: true });
+    let matched;
+    try {
+        matched = await cache.restoreCache([archivePath], exactKey);
+    }
+    catch (err) {
+        log(`cook-cache: restore failed: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "", archiveBytes: 0 };
+    }
+    if (!matched) {
+        log(`cook-cache: no entry for key ${exactKey}`);
+        return { hit: false, matchedKey: "", archiveBytes: 0 };
+    }
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fsp.stat(archivePath)).size;
+    }
+    catch {
+        return { hit: false, matchedKey: matched, archiveBytes: 0 };
+    }
+    const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+    if (magic !== "zstd" && magic !== "gzip") {
+        log(`cook-cache: restored archive has unknown codec, treating as miss`);
+        return { hit: false, matchedKey: matched, archiveBytes };
+    }
+    await fsp.mkdir(targetDir, { recursive: true });
+    try {
+        await (0, cache_compress_js_1.decompressCache)({
+            archivePath,
+            targetDir,
+            longWindow,
+            log,
+            debug: opts.debug,
+        });
+    }
+    catch (err) {
+        log(`cook-cache: decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: matched, archiveBytes };
+    }
+    log(`cook-cache: restored matched=${matched} archive=${archiveBytes}B target=${targetDir}`);
+    return { hit: true, matchedKey: matched, archiveBytes };
+}
+/**
+ * Tar+zstd the post-cook target directory and upload via actions cache.
+ * Caller passes the same `longWindow` as the restore side so the archive
+ * is readable on subsequent runs.
+ */
+async function saveCookCache(opts) {
+    const { targetDir, exactKey, level, longWindow, debug, log } = opts;
+    if (!fs.existsSync(targetDir)) {
+        return { status: "skipped-missing-target" };
+    }
+    // Bail if the directory is effectively empty — cook should have produced
+    // *something*; an empty target dir indicates cook failed silently or the
+    // gate let us through when it shouldn't have.
+    let entryCount = 0;
+    try {
+        entryCount = (await fsp.readdir(targetDir)).length;
+    }
+    catch { /* */ }
+    if (entryCount === 0) {
+        return { status: "skipped-empty" };
+    }
+    let archivePath = null;
+    let archiveBytes;
+    let inflatedBytes;
+    let fileCount;
+    try {
+        const compress = await (0, cache_compress_js_1.compressCache)({
+            cacheDir: targetDir,
+            codec: "zstd",
+            level,
+            longWindow,
+            debug,
+            log,
+        });
+        archivePath = compress.archivePath;
+        archiveBytes = compress.archiveBytes;
+        if (compress.inflatedBytes !== null)
+            inflatedBytes = compress.inflatedBytes;
+        if (compress.fileCount !== null)
+            fileCount = compress.fileCount;
+    }
+    catch (err) {
+        return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+    }
+    if (!archivePath) {
+        return { status: "failed", error: "compressCache returned null archive (zstd unavailable?)" };
+    }
+    try {
+        const id = await cache.saveCache([archivePath], exactKey);
+        if (id <= 0) {
+            // @actions/cache returns -1 when reserveCache fails — typically
+            // because the key already exists (parallel job got there first)
+            // or the cache budget is exhausted. Not an error: future runs
+            // will hit the entry the other job saved.
+            log(`cook-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
+                `job already saved key=${exactKey} or repo cache budget is exhausted`);
+            return {
+                status: "skipped-race",
+                cacheId: id,
+                archiveBytes,
+                inflatedBytes,
+                fileCount,
+                archivePath,
+            };
+        }
+        log(`cook-cache: saved id=${id} key=${exactKey} archive=${archivePath}`);
+        return {
+            status: "saved",
+            cacheId: id,
+            archiveBytes,
+            inflatedBytes,
+            fileCount,
+            archivePath,
+        };
+    }
+    catch (err) {
+        return {
+            status: "failed",
+            error: err instanceof Error ? err.message : String(err),
+            archivePath,
+        };
+    }
+}
+/** Tokenize a free-form flags string into a flags array. Whitespace-split. */
+function parseCookFlags(raw) {
+    return raw
+        .trim()
+        .split(/\s+/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+}
+/**
+ * From a flags array, extract only the tokens that materially affect cook
+ * output structure for hashing. Excludes verbosity / colour flags.
+ *
+ * Conservative: keep anything that isn't on a known-cosmetic list. This
+ * over-keys (extra misses on cosmetic-only changes) rather than under-keys
+ * (serving stale cooked artifacts under a key that doesn't reflect them).
+ */
+function canonicalizeCookFlags(flags) {
+    const COSMETIC = new Set([
+        "--verbose", "-v", "-vv", "--quiet", "-q",
+        "--color=auto", "--color=always", "--color=never",
+        "--no-default-features", // affects output; KEEP — moved out below
+    ]);
+    COSMETIC.delete("--no-default-features"); // safety net for the comment above
+    const out = [];
+    for (let i = 0; i < flags.length; i++) {
+        const f = flags[i];
+        if (COSMETIC.has(f))
+            continue;
+        if (f === "--color" || f === "--message-format") {
+            i += 1; // skip the value
+            continue;
+        }
+        out.push(f);
+    }
+    return out;
+}
+
+
+/***/ }),
+
+/***/ 456:
 /***/ ((module) => {
 
 "use strict";
@@ -80733,7 +81092,7 @@ module.exports = function getLimit (limits, name, defaultLimit) {
 
 /***/ }),
 
-/***/ 456:
+/***/ 457:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -80784,7 +81143,7 @@ exports.assertFloat32 = assertFloat32;
 
 /***/ }),
 
-/***/ 457:
+/***/ 458:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -80897,11 +81256,11 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 458:
+/***/ 459:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var concatMap = __nccwpck_require__(333);
-var balanced = __nccwpck_require__(128);
+var balanced = __nccwpck_require__(129);
 
 module.exports = expandTop;
 
@@ -81107,7 +81466,7 @@ function expand(str, max, isTop) {
 
 /***/ }),
 
-/***/ 459:
+/***/ 460:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -81155,7 +81514,7 @@ function log(message, ...args) {
 
 /***/ }),
 
-/***/ 460:
+/***/ 461:
 /***/ ((module) => {
 
 "use strict";
@@ -81393,7 +81752,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 461:
+/***/ 462:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -81405,7 +81764,7 @@ exports.serializationPolicyName = void 0;
 exports.serializationPolicy = serializationPolicy;
 exports.serializeHeaders = serializeHeaders;
 exports.serializeRequestBody = serializeRequestBody;
-const interfaces_js_1 = __nccwpck_require__(96);
+const interfaces_js_1 = __nccwpck_require__(98);
 const operationHelpers_js_1 = __nccwpck_require__(406);
 const serializer_js_1 = __nccwpck_require__(452);
 const interfaceHelpers_js_1 = __nccwpck_require__(378);
@@ -81557,7 +81916,7 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 /***/ }),
 
-/***/ 462:
+/***/ 463:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -81569,7 +81928,7 @@ var http = __nccwpck_require__(315);
 var https = __nccwpck_require__(67);
 var events = __nccwpck_require__(442);
 var assert = __nccwpck_require__(495);
-var util = __nccwpck_require__(120);
+var util = __nccwpck_require__(121);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -81829,7 +82188,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 463:
+/***/ 464:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -81857,9 +82216,9 @@ __export(clientHelpers_exports, {
 module.exports = __toCommonJS(clientHelpers_exports);
 var import_defaultHttpClient = __nccwpck_require__(352);
 var import_createPipelineFromOptions = __nccwpck_require__(302);
-var import_apiVersionPolicy = __nccwpck_require__(219);
-var import_credentials = __nccwpck_require__(183);
-var import_apiKeyAuthenticationPolicy = __nccwpck_require__(84);
+var import_apiVersionPolicy = __nccwpck_require__(218);
+var import_credentials = __nccwpck_require__(181);
+var import_apiKeyAuthenticationPolicy = __nccwpck_require__(86);
 var import_basicAuthenticationPolicy = __nccwpck_require__(149);
 var import_bearerAuthenticationPolicy = __nccwpck_require__(360);
 var import_oauth2AuthenticationPolicy = __nccwpck_require__(323);
@@ -81902,7 +82261,7 @@ function getCachedDefaultHttpsClient() {
 
 /***/ }),
 
-/***/ 464:
+/***/ 465:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82037,317 +82396,6 @@ class RetriableReadableStream extends node_stream_1.Readable {
 }
 exports.RetriableReadableStream = RetriableReadableStream;
 //# sourceMappingURL=RetriableReadableStream.js.map
-
-/***/ }),
-
-/***/ 465:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Tar+zstd cache compression helpers. Owned by Agent 2.
-//
-// Used by src/main.ts (restore: auto-detect .tar.zst, decompress in place)
-// and src/post.ts (save: tar+zstd the cache dir).
-//
-// Acceptance criterion #1 + #2 of zackees/setup-soldr#70: post-job tar+zstd
-// at level configured by target-cache-compress-level, restore auto-detects
-// zstd vs gzip magic bytes for back-compat.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.walkDirSize = walkDirSize;
-exports.detectCompressMagic = detectCompressMagic;
-exports.decompressCache = decompressCache;
-exports.compressCache = compressCache;
-const fs = __importStar(__nccwpck_require__(105));
-const path = __importStar(__nccwpck_require__(479));
-const core = __importStar(__nccwpck_require__(432));
-const exec = __importStar(__nccwpck_require__(16));
-const io = __importStar(__nccwpck_require__(283));
-/**
- * Recursively walk a directory and sum file sizes.
- */
-async function walkDirSize(dir) {
-    let bytes = 0;
-    let files = 0;
-    async function walk(d) {
-        let entries;
-        try {
-            entries = await fs.readdir(d, { withFileTypes: true });
-        }
-        catch {
-            return;
-        }
-        for (const entry of entries) {
-            const full = path.join(d, entry.name);
-            if (entry.isDirectory()) {
-                await walk(full);
-            }
-            else if (entry.isFile()) {
-                try {
-                    bytes += (await fs.stat(full)).size;
-                    files++;
-                }
-                catch {
-                    // skip inaccessible files
-                }
-            }
-        }
-    }
-    await walk(dir);
-    return { bytes, files };
-}
-function fmtBytesDebug(n) {
-    if (n < 1024)
-        return `${n}B`;
-    if (n < 1024 * 1024)
-        return `${(n / 1024).toFixed(1)}KB`;
-    if (n < 1024 * 1024 * 1024)
-        return `${(n / 1024 / 1024).toFixed(1)}MB`;
-    return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
-}
-/**
- * Read the first 4 bytes of a file and identify the compression codec.
- *   zstd:  0x28 B5 2F FD
- *   gzip:  0x1F 8B
- */
-async function detectCompressMagic(filePath) {
-    let handle = null;
-    try {
-        handle = await fs.open(filePath, "r");
-        const buf = Buffer.alloc(4);
-        const { bytesRead } = await handle.read(buf, 0, 4, 0);
-        if (bytesRead >= 4 && buf[0] === 0x28 && buf[1] === 0xb5 && buf[2] === 0x2f && buf[3] === 0xfd) {
-            return "zstd";
-        }
-        if (bytesRead >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
-            return "gzip";
-        }
-        return "unknown";
-    }
-    catch {
-        return "unknown";
-    }
-    finally {
-        if (handle)
-            await handle.close().catch(() => undefined);
-    }
-}
-async function ensureDir(dir) {
-    await fs.mkdir(dir, { recursive: true });
-}
-async function pathExists(p) {
-    try {
-        await fs.access(p);
-        return true;
-    }
-    catch {
-        return false;
-    }
-}
-/**
- * Decompress <cache-dir>.tar.zst (or .tar.gz) into <cache-dir>.
- *
- *   zstd: `zstd -d <archive>` piped into `tar -xf - -C <extractRoot>`.
- *   gzip: `tar -xzf <archive> -C <extractRoot>`.
- *
- * `extractRoot` is `dirname(targetDir)` because compressCache writes
- * archives via `tar -cf - -C <parent> <basename>` — the archive's
- * top-level directory IS `<basename>`. If we extract into <targetDir>
- * directly, that <basename> gets nested twice and the contents end up
- * at <targetDir>/<basename>/... where zccache and cargo can't find them.
- * That double-nesting is the root cause of the long-standing zccache
- * "0 hits despite restored artifacts" symptom.
- *
- * Returns compressed/inflated byte counts and file count (the count is
- * taken from <targetDir> after extraction, so consumers see exactly
- * what landed in the cache dir).
- * When debug=true, logs diagnostics via the supplied log fn.
- */
-async function decompressCache(opts) {
-    const { archivePath, targetDir, debug = false, log = () => undefined, longWindow } = opts;
-    // Ensure both <targetDir> exists (zccache may have already populated it)
-    // and the extract root (which is the parent) is writable.
-    await ensureDir(targetDir);
-    const extractRoot = path.dirname(targetDir);
-    await ensureDir(extractRoot);
-    let archiveBytes = 0;
-    try {
-        archiveBytes = (await fs.stat(archivePath)).size;
-    }
-    catch { /* archive may not exist */ }
-    const magic = await detectCompressMagic(archivePath);
-    if (debug) {
-        log(`[debug] decompress ${path.basename(archivePath)}: magic=${magic} archive=${fmtBytesDebug(archiveBytes)}`);
-    }
-    if (magic === "gzip") {
-        if (debug)
-            log(`[debug] decompress cmd: tar -xzf ${archivePath} -C ${extractRoot}`);
-        await exec.exec("tar", ["-xzf", archivePath, "-C", extractRoot]);
-    }
-    else if (magic === "zstd") {
-        const zstdPath = await io.which("zstd", false);
-        const longFlag = typeof longWindow === "number" ? [`--long=${longWindow}`] : [];
-        if (!zstdPath) {
-            if (debug)
-                log(`[debug] decompress cmd (fallback): tar --use-compress-program "zstd -d${longFlag.length ? ` --long=${longWindow}` : ""}" -xf ${archivePath} -C ${extractRoot}`);
-            // Fall back: route the decompression through tar's --use-compress-program
-            // so we can pass through --long when the archive needs it. tar --zstd
-            // doesn't accept extra zstd flags directly.
-            const program = longFlag.length ? `zstd -d --long=${longWindow}` : "zstd -d";
-            await exec.exec("tar", ["--use-compress-program", program, "-xf", archivePath, "-C", extractRoot]);
-        }
-        else {
-            if (debug)
-                log(`[debug] decompress cmd: zstd -d ${longFlag.join(" ")} -c ${archivePath} | tar -xf - -C ${extractRoot}`);
-            await runPipe([zstdPath, ["-d", ...longFlag, "-c", archivePath]], ["tar", ["-xf", "-", "-C", extractRoot]]);
-        }
-    }
-    else {
-        throw new Error(`decompressCache: unrecognized archive magic for ${archivePath}`);
-    }
-    const { bytes: inflatedBytes, files: fileCount } = await walkDirSize(targetDir);
-    if (debug) {
-        const ratio = archiveBytes > 0 && inflatedBytes > 0 ? (archiveBytes / inflatedBytes).toFixed(2) : "n/a";
-        log(`[debug] decompress result: inflated=${fmtBytesDebug(inflatedBytes)} files=${fileCount} ratio=${ratio}`);
-    }
-    return { archiveBytes, inflatedBytes, fileCount };
-}
-/**
- * tar -cf - <cache-dir-basename> | zstd -T0 -<level> > <cache-dir>.tar.zst
- *
- * When codec=="none" or zstd is not installed, returns archivePath=null and
- * leaves the caller to use the default actions/cache compression.
- * When debug=true, walks the source dir for byte/file counts and logs ratios.
- */
-async function compressCache(opts) {
-    const { cacheDir, codec, level, debug = false, log = () => undefined, longWindow, ultra } = opts;
-    const nullResult = { archivePath: null, archiveBytes: 0, inflatedBytes: null, fileCount: null };
-    if (codec === "none")
-        return nullResult;
-    const zstdPath = await io.which("zstd", false);
-    if (!zstdPath) {
-        core.warning("setup-soldr: zstd binary not found on PATH; falling back to actions/cache default codec");
-        return nullResult;
-    }
-    if (!(await pathExists(cacheDir))) {
-        core.warning(`setup-soldr: cache dir ${cacheDir} does not exist, skipping compression`);
-        return nullResult;
-    }
-    let inflatedBytes = null;
-    let fileCount = null;
-    if (debug) {
-        const walked = await walkDirSize(cacheDir);
-        inflatedBytes = walked.bytes;
-        fileCount = walked.files;
-        log(`[debug] compress ${path.basename(cacheDir)}: input=${fmtBytesDebug(inflatedBytes)} files=${fileCount}`);
-    }
-    const parent = path.dirname(cacheDir);
-    const basename = path.basename(cacheDir);
-    const archivePath = `${cacheDir}.tar.zst`;
-    // Best-effort cleanup of any previous archive.
-    await fs.rm(archivePath, { force: true }).catch(() => undefined);
-    const levelNumeric = parseLevel(level);
-    const levelFlag = `-${levelNumeric}`;
-    const longFlag = typeof longWindow === "number" ? [`--long=${longWindow}`] : [];
-    const ultraFlag = ultra || levelNumeric >= 20 ? ["--ultra"] : [];
-    if (debug)
-        log(`[debug] compress cmd: tar -cf - -C ${parent} ${basename} | zstd -T0 ${levelFlag}${longFlag.length ? ` --long=${longWindow}` : ""}${ultraFlag.length ? " --ultra" : ""} -o ${archivePath}`);
-    await runPipe(["tar", ["-cf", "-", "-C", parent, basename]], [zstdPath, ["-T0", levelFlag, ...longFlag, ...ultraFlag, "-o", archivePath]]);
-    let archiveBytes = 0;
-    try {
-        archiveBytes = (await fs.stat(archivePath)).size;
-    }
-    catch { /* archive may not exist */ }
-    if (debug && inflatedBytes !== null && inflatedBytes > 0) {
-        log(`[debug] compress result: archive=${fmtBytesDebug(archiveBytes)} ratio=${(archiveBytes / inflatedBytes).toFixed(2)}`);
-    }
-    return { archivePath, archiveBytes, inflatedBytes, fileCount };
-}
-function parseLevel(value) {
-    const trimmed = (value ?? "").toString().trim();
-    if (!trimmed)
-        return 3;
-    const parsed = Number(trimmed);
-    if (Number.isNaN(parsed) || !Number.isFinite(parsed))
-        return 3;
-    const clamped = Math.max(1, Math.min(22, Math.floor(parsed)));
-    return clamped;
-}
-/**
- * Run two processes piped together: producer.stdout -> consumer.stdin.
- * Bubbles non-zero exit codes from either side.
- */
-async function runPipe(producer, consumer) {
-    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 192, 23));
-    const [pCmd, pArgs] = producer;
-    const [cCmd, cArgs] = consumer;
-    await new Promise((resolve, reject) => {
-        const prod = spawn(pCmd, pArgs, { stdio: ["ignore", "pipe", "inherit"] });
-        const cons = spawn(cCmd, cArgs, { stdio: ["pipe", "inherit", "inherit"] });
-        prod.on("error", (err) => reject(err));
-        cons.on("error", (err) => reject(err));
-        if (prod.stdout && cons.stdin) {
-            prod.stdout.pipe(cons.stdin);
-        }
-        let prodExit = null;
-        let consExit = null;
-        const maybeDone = () => {
-            if (prodExit !== null && consExit !== null) {
-                if (prodExit !== 0) {
-                    reject(new Error(`${pCmd} exited with code ${prodExit}`));
-                }
-                else if (consExit !== 0) {
-                    reject(new Error(`${cCmd} exited with code ${consExit}`));
-                }
-                else {
-                    resolve();
-                }
-            }
-        };
-        prod.on("close", (code) => {
-            prodExit = code ?? 0;
-            maybeDone();
-        });
-        cons.on("close", (code) => {
-            consExit = code ?? 0;
-            maybeDone();
-        });
-    });
-}
-
 
 /***/ }),
 
@@ -82719,13 +82767,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
-const os = __importStar(__nccwpck_require__(89));
+const os = __importStar(__nccwpck_require__(91));
 const path = __importStar(__nccwpck_require__(239));
-const pathHelper = __importStar(__nccwpck_require__(215));
+const pathHelper = __importStar(__nccwpck_require__(214));
 const assert_1 = __importDefault(__nccwpck_require__(495));
-const minimatch_1 = __nccwpck_require__(121);
-const internal_match_kind_1 = __nccwpck_require__(497);
-const internal_path_1 = __nccwpck_require__(117);
+const minimatch_1 = __nccwpck_require__(122);
+const internal_match_kind_1 = __nccwpck_require__(498);
+const internal_path_1 = __nccwpck_require__(118);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, isImplicitPattern = false, segments, homedir) {
@@ -83279,15 +83327,15 @@ module.exports = require("timers");
 "use strict";
 
 
-const Readable = __nccwpck_require__(125)
+const Readable = __nccwpck_require__(126)
 const {
   InvalidArgumentError,
   RequestAbortedError
-} = __nccwpck_require__(460)
+} = __nccwpck_require__(461)
 const util = __nccwpck_require__(66)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(184)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(182)
 const { AsyncResource } = __nccwpck_require__(403)
-const { addSignal, removeSignal } = __nccwpck_require__(100)
+const { addSignal, removeSignal } = __nccwpck_require__(102)
 
 class RequestHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -83477,10 +83525,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TestTransport = void 0;
-const rpc_error_1 = __nccwpck_require__(171);
+const rpc_error_1 = __nccwpck_require__(169);
 const runtime_1 = __nccwpck_require__(17);
 const rpc_output_stream_1 = __nccwpck_require__(294);
-const rpc_options_1 = __nccwpck_require__(281);
+const rpc_options_1 = __nccwpck_require__(282);
 const unary_call_1 = __nccwpck_require__(53);
 const server_streaming_call_1 = __nccwpck_require__(425);
 const client_streaming_call_1 = __nccwpck_require__(332);
@@ -83838,7 +83886,7 @@ if (typeof process === 'undefined' || process.type === 'renderer' || process.bro
 
 
 
-const { kHeadersList, kConstruct } = __nccwpck_require__(190)
+const { kHeadersList, kConstruct } = __nccwpck_require__(188)
 const { kGuard } = __nccwpck_require__(13)
 const { kEnumerableProperty } = __nccwpck_require__(66)
 const {
@@ -83846,7 +83894,7 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(487)
-const util = __nccwpck_require__(120)
+const util = __nccwpck_require__(121)
 const { webidl } = __nccwpck_require__(430)
 const assert = __nccwpck_require__(495)
 
@@ -84438,11 +84486,11 @@ module.exports = {
 
 
 const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(28)
-const { getGlobalOrigin } = __nccwpck_require__(136)
+const { getGlobalOrigin } = __nccwpck_require__(137)
 const { performance } = __nccwpck_require__(307)
 const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(66)
 const assert = __nccwpck_require__(495)
-const { isUint8Array } = __nccwpck_require__(193)
+const { isUint8Array } = __nccwpck_require__(192)
 
 let supportedHashes = []
 
@@ -84451,7 +84499,7 @@ let supportedHashes = []
 let crypto
 
 try {
-  crypto = __nccwpck_require__(279)
+  crypto = __nccwpck_require__(280)
   const possibleRelevantHashes = ['sha256', 'sha384', 'sha512']
   supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
 /* c8 ignore next 3 */
@@ -85670,7 +85718,7 @@ module.exports = require("node:zlib");
 /***/ 490:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(462);
+module.exports = __nccwpck_require__(463);
 
 
 /***/ }),
@@ -86367,6 +86415,332 @@ module.exports = require("assert");
 /***/ }),
 
 /***/ 496:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Tar+zstd cache compression helpers. Owned by Agent 2.
+//
+// Used by src/main.ts (restore: auto-detect .tar.zst, decompress in place)
+// and src/post.ts (save: tar+zstd the cache dir).
+//
+// Acceptance criterion #1 + #2 of zackees/setup-soldr#70: post-job tar+zstd
+// at level configured by target-cache-compress-level, restore auto-detects
+// zstd vs gzip magic bytes for back-compat.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.walkDirSize = walkDirSize;
+exports.detectCompressMagic = detectCompressMagic;
+exports.decompressCache = decompressCache;
+exports.compressCache = compressCache;
+const fs = __importStar(__nccwpck_require__(107));
+const path = __importStar(__nccwpck_require__(479));
+const core = __importStar(__nccwpck_require__(432));
+const exec = __importStar(__nccwpck_require__(16));
+const io = __importStar(__nccwpck_require__(283));
+/**
+ * Recursively walk a directory and sum file sizes.
+ */
+async function walkDirSize(dir) {
+    let bytes = 0;
+    let files = 0;
+    async function walk(d) {
+        let entries;
+        try {
+            entries = await fs.readdir(d, { withFileTypes: true });
+        }
+        catch {
+            return;
+        }
+        for (const entry of entries) {
+            const full = path.join(d, entry.name);
+            if (entry.isDirectory()) {
+                await walk(full);
+            }
+            else if (entry.isFile()) {
+                try {
+                    bytes += (await fs.stat(full)).size;
+                    files++;
+                }
+                catch {
+                    // skip inaccessible files
+                }
+            }
+        }
+    }
+    await walk(dir);
+    return { bytes, files };
+}
+function fmtBytesDebug(n) {
+    if (n < 1024)
+        return `${n}B`;
+    if (n < 1024 * 1024)
+        return `${(n / 1024).toFixed(1)}KB`;
+    if (n < 1024 * 1024 * 1024)
+        return `${(n / 1024 / 1024).toFixed(1)}MB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
+}
+/**
+ * Read the first 4 bytes of a file and identify the compression codec.
+ *   zstd:  0x28 B5 2F FD
+ *   gzip:  0x1F 8B
+ */
+async function detectCompressMagic(filePath) {
+    let handle = null;
+    try {
+        handle = await fs.open(filePath, "r");
+        const buf = Buffer.alloc(4);
+        const { bytesRead } = await handle.read(buf, 0, 4, 0);
+        if (bytesRead >= 4 && buf[0] === 0x28 && buf[1] === 0xb5 && buf[2] === 0x2f && buf[3] === 0xfd) {
+            return "zstd";
+        }
+        if (bytesRead >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
+            return "gzip";
+        }
+        return "unknown";
+    }
+    catch {
+        return "unknown";
+    }
+    finally {
+        if (handle)
+            await handle.close().catch(() => undefined);
+    }
+}
+async function ensureDir(dir) {
+    await fs.mkdir(dir, { recursive: true });
+}
+async function pathExists(p) {
+    try {
+        await fs.access(p);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+/**
+ * Decompress <cache-dir>.tar.zst (or .tar.gz) into <cache-dir>.
+ *
+ *   zstd: `zstd -d <archive>` piped into `tar -xf - -C <extractRoot>`.
+ *   gzip: `tar -xzf <archive> -C <extractRoot>`.
+ *
+ * `extractRoot` is `dirname(targetDir)` because compressCache writes
+ * archives via `tar -cf - -C <parent> <basename>` — the archive's
+ * top-level directory IS `<basename>`. If we extract into <targetDir>
+ * directly, that <basename> gets nested twice and the contents end up
+ * at <targetDir>/<basename>/... where zccache and cargo can't find them.
+ * That double-nesting is the root cause of the long-standing zccache
+ * "0 hits despite restored artifacts" symptom.
+ *
+ * Returns compressed/inflated byte counts and file count (the count is
+ * taken from <targetDir> after extraction, so consumers see exactly
+ * what landed in the cache dir).
+ * When debug=true, logs diagnostics via the supplied log fn.
+ */
+async function decompressCache(opts) {
+    const { archivePath, targetDir, debug = false, log = () => undefined, longWindow } = opts;
+    // Ensure both <targetDir> exists (zccache may have already populated it)
+    // and the extract root (which is the parent) is writable.
+    await ensureDir(targetDir);
+    const extractRoot = path.dirname(targetDir);
+    await ensureDir(extractRoot);
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fs.stat(archivePath)).size;
+    }
+    catch { /* archive may not exist */ }
+    const magic = await detectCompressMagic(archivePath);
+    if (debug) {
+        log(`[debug] decompress ${path.basename(archivePath)}: magic=${magic} archive=${fmtBytesDebug(archiveBytes)}`);
+    }
+    if (magic === "gzip") {
+        if (debug)
+            log(`[debug] decompress cmd: tar -xzf ${archivePath} -C ${extractRoot}`);
+        await exec.exec("tar", ["-xzf", archivePath, "-C", extractRoot]);
+    }
+    else if (magic === "zstd") {
+        const zstdPath = await io.which("zstd", false);
+        const longFlag = typeof longWindow === "number" ? [`--long=${longWindow}`] : [];
+        if (!zstdPath) {
+            if (debug)
+                log(`[debug] decompress cmd (fallback): tar --use-compress-program "zstd -d${longFlag.length ? ` --long=${longWindow}` : ""}" -xf ${archivePath} -C ${extractRoot}`);
+            // Fall back: route the decompression through tar's --use-compress-program
+            // so we can pass through --long when the archive needs it. tar --zstd
+            // doesn't accept extra zstd flags directly.
+            const program = longFlag.length ? `zstd -d --long=${longWindow}` : "zstd -d";
+            await exec.exec("tar", ["--use-compress-program", program, "-xf", archivePath, "-C", extractRoot]);
+        }
+        else {
+            if (debug)
+                log(`[debug] decompress cmd: zstd -d ${longFlag.join(" ")} -c ${archivePath} | tar -xf - -C ${extractRoot}`);
+            await runPipe([zstdPath, ["-d", ...longFlag, "-c", archivePath]], ["tar", ["-xf", "-", "-C", extractRoot]]);
+        }
+    }
+    else {
+        throw new Error(`decompressCache: unrecognized archive magic for ${archivePath}`);
+    }
+    const { bytes: inflatedBytes, files: fileCount } = await walkDirSize(targetDir);
+    if (debug) {
+        const ratio = archiveBytes > 0 && inflatedBytes > 0 ? (archiveBytes / inflatedBytes).toFixed(2) : "n/a";
+        log(`[debug] decompress result: inflated=${fmtBytesDebug(inflatedBytes)} files=${fileCount} ratio=${ratio}`);
+    }
+    return { archiveBytes, inflatedBytes, fileCount };
+}
+/**
+ * tar -cf - <cache-dir-basename> | zstd -T0 -<level> > <cache-dir>.tar.zst
+ *
+ * When codec=="none" or zstd is not installed, returns archivePath=null and
+ * leaves the caller to use the default actions/cache compression.
+ * When debug=true, walks the source dir for byte/file counts and logs ratios.
+ */
+async function compressCache(opts) {
+    const { cacheDir, codec, level, debug = false, log = () => undefined, longWindow, ultra, extraBasenames = [], } = opts;
+    const nullResult = { archivePath: null, archiveBytes: 0, inflatedBytes: null, fileCount: null };
+    if (codec === "none")
+        return nullResult;
+    const zstdPath = await io.which("zstd", false);
+    if (!zstdPath) {
+        core.warning("setup-soldr: zstd binary not found on PATH; falling back to actions/cache default codec");
+        return nullResult;
+    }
+    if (!(await pathExists(cacheDir))) {
+        core.warning(`setup-soldr: cache dir ${cacheDir} does not exist, skipping compression`);
+        return nullResult;
+    }
+    let inflatedBytes = null;
+    let fileCount = null;
+    if (debug) {
+        const walked = await walkDirSize(cacheDir);
+        inflatedBytes = walked.bytes;
+        fileCount = walked.files;
+        log(`[debug] compress ${path.basename(cacheDir)}: input=${fmtBytesDebug(inflatedBytes)} files=${fileCount}`);
+    }
+    const parent = path.dirname(cacheDir);
+    const basename = path.basename(cacheDir);
+    // Filter sibling basenames to ones that actually exist under the parent —
+    // tar errors on missing inputs, and cargo-registry's `.global-cache` /
+    // `git/` may legitimately be absent on a cold checkout.
+    const presentExtras = [];
+    for (const extra of extraBasenames) {
+        if (!extra || extra === basename)
+            continue;
+        if (await pathExists(path.join(parent, extra))) {
+            presentExtras.push(extra);
+        }
+        else if (debug) {
+            log(`[debug] compress: skipping missing sibling basename '${extra}' under ${parent}`);
+        }
+    }
+    const archivePath = `${cacheDir}.tar.zst`;
+    // Best-effort cleanup of any previous archive.
+    await fs.rm(archivePath, { force: true }).catch(() => undefined);
+    const levelNumeric = parseLevel(level);
+    const levelFlag = `-${levelNumeric}`;
+    const longFlag = typeof longWindow === "number" ? [`--long=${longWindow}`] : [];
+    const ultraFlag = ultra || levelNumeric >= 20 ? ["--ultra"] : [];
+    const tarInputs = [basename, ...presentExtras];
+    if (debug)
+        log(`[debug] compress cmd: tar -cf - -C ${parent} ${tarInputs.join(" ")} | zstd -T0 ${levelFlag}${longFlag.length ? ` --long=${longWindow}` : ""}${ultraFlag.length ? " --ultra" : ""} -o ${archivePath}`);
+    await runPipe(["tar", ["-cf", "-", "-C", parent, ...tarInputs]], [zstdPath, ["-T0", levelFlag, ...longFlag, ...ultraFlag, "-o", archivePath]]);
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fs.stat(archivePath)).size;
+    }
+    catch { /* archive may not exist */ }
+    if (debug && inflatedBytes !== null && inflatedBytes > 0) {
+        log(`[debug] compress result: archive=${fmtBytesDebug(archiveBytes)} ratio=${(archiveBytes / inflatedBytes).toFixed(2)}`);
+    }
+    return { archivePath, archiveBytes, inflatedBytes, fileCount };
+}
+function parseLevel(value) {
+    const trimmed = (value ?? "").toString().trim();
+    if (!trimmed)
+        return 3;
+    const parsed = Number(trimmed);
+    if (Number.isNaN(parsed) || !Number.isFinite(parsed))
+        return 3;
+    const clamped = Math.max(1, Math.min(22, Math.floor(parsed)));
+    return clamped;
+}
+/**
+ * Run two processes piped together: producer.stdout -> consumer.stdin.
+ * Bubbles non-zero exit codes from either side.
+ */
+async function runPipe(producer, consumer) {
+    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 190, 23));
+    const [pCmd, pArgs] = producer;
+    const [cCmd, cArgs] = consumer;
+    await new Promise((resolve, reject) => {
+        const prod = spawn(pCmd, pArgs, { stdio: ["ignore", "pipe", "inherit"] });
+        const cons = spawn(cCmd, cArgs, { stdio: ["pipe", "inherit", "inherit"] });
+        prod.on("error", (err) => reject(err));
+        cons.on("error", (err) => reject(err));
+        if (prod.stdout && cons.stdin) {
+            prod.stdout.pipe(cons.stdin);
+        }
+        let prodExit = null;
+        let consExit = null;
+        const maybeDone = () => {
+            if (prodExit !== null && consExit !== null) {
+                if (prodExit !== 0) {
+                    reject(new Error(`${pCmd} exited with code ${prodExit}`));
+                }
+                else if (consExit !== 0) {
+                    reject(new Error(`${cCmd} exited with code ${consExit}`));
+                }
+                else {
+                    resolve();
+                }
+            }
+        };
+        prod.on("close", (code) => {
+            prodExit = code ?? 0;
+            maybeDone();
+        });
+        cons.on("close", (code) => {
+            consExit = code ?? 0;
+            maybeDone();
+        });
+    });
+}
+
+
+/***/ }),
+
+/***/ 497:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -86431,7 +86805,7 @@ exports.readServiceOption = readServiceOption;
 
 /***/ }),
 
-/***/ 497:
+/***/ 498:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -86456,7 +86830,7 @@ var MatchKind;
 
 /***/ }),
 
-/***/ 498:
+/***/ 499:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -86648,7 +87022,7 @@ async function shutdownCacheDaemons(opts) {
 
 /***/ }),
 
-/***/ 499:
+/***/ 500:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -86659,16 +87033,16 @@ const message_type_contract_1 = __nccwpck_require__(382);
 const reflection_info_1 = __nccwpck_require__(426);
 const reflection_type_check_1 = __nccwpck_require__(278);
 const reflection_json_reader_1 = __nccwpck_require__(327);
-const reflection_json_writer_1 = __nccwpck_require__(87);
+const reflection_json_writer_1 = __nccwpck_require__(89);
 const reflection_binary_reader_1 = __nccwpck_require__(385);
-const reflection_binary_writer_1 = __nccwpck_require__(181);
-const reflection_create_1 = __nccwpck_require__(200);
-const reflection_merge_partial_1 = __nccwpck_require__(133);
+const reflection_binary_writer_1 = __nccwpck_require__(179);
+const reflection_create_1 = __nccwpck_require__(199);
+const reflection_merge_partial_1 = __nccwpck_require__(134);
 const json_typings_1 = __nccwpck_require__(373);
 const json_format_contract_1 = __nccwpck_require__(233);
 const reflection_equals_1 = __nccwpck_require__(434);
 const binary_writer_1 = __nccwpck_require__(242);
-const binary_reader_1 = __nccwpck_require__(131);
+const binary_reader_1 = __nccwpck_require__(132);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
 const messageTypeDescriptor = baseDescriptors[message_type_contract_1.MESSAGE_TYPE] = {};
 /**
@@ -86833,7 +87207,7 @@ exports.MessageType = MessageType;
 
 /***/ }),
 
-/***/ 500:
+/***/ 501:
 /***/ ((module) => {
 
 "use strict";
@@ -86841,7 +87215,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 501:
+/***/ 502:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -86923,7 +87297,7 @@ exports.stackDuplexStreamingInterceptors = stackDuplexStreamingInterceptors;
 
 /***/ }),
 
-/***/ 502:
+/***/ 503:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -86953,7 +87327,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(89));
+const os = __importStar(__nccwpck_require__(91));
 const utils_1 = __nccwpck_require__(476);
 /**
  * Commands
@@ -87026,357 +87400,6 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 503:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Read + summarize zccache's per-rustc-invocation JSONL journal so
-// `dumpDiagnostics` can emit a `[compile_journal]` section telling
-// the reader (or future-me) *what* was cached and *why* every miss
-// missed. Without this, "warm reports hits=0 misses=206" is true but
-// useless — we can't tell whether the cache lookups all returned
-// "no cache file with this key" (genuinely-new fingerprint) or "the
-// cached entry's recorded inputs don't match my current inputs"
-// (content/path/env drift between cold and warm). The journal records
-// the per-invocation `outcome` and `miss_reason`; soldr's
-// `cache report --json` already returns `zccache analyze --json`'s
-// rollups under `report.rollups`. We just have to parse them.
-//
-// Pure-functional: no `core.*` here, no side effects beyond reading
-// the journal file. Easier to unit-test that way.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.readJournal = readJournal;
-exports.summarize = summarize;
-exports.formatJournalSection = formatJournalSection;
-exports.formatRollupsSection = formatRollupsSection;
-const fs = __importStar(__nccwpck_require__(240));
-const diagnostics_js_1 = __nccwpck_require__(108);
-const SLOWEST_TOP_N = 20;
-/**
- * Read a `last-session.jsonl` file. Returns `null` if it doesn't exist
- * (the common "no build happened" case); throws nothing for malformed
- * lines — they're silently skipped so a single garbled record doesn't
- * blank the whole dump.
- */
-function readJournal(path) {
-    let raw;
-    try {
-        raw = fs.readFileSync(path, "utf8");
-    }
-    catch (err) {
-        if (err.code === "ENOENT")
-            return null;
-        throw err;
-    }
-    const out = [];
-    for (const line of raw.split(/\r?\n/)) {
-        if (line.trim() === "")
-            continue;
-        try {
-            const obj = JSON.parse(line);
-            if (obj && typeof obj === "object")
-                out.push(obj);
-        }
-        catch {
-            // Skip malformed lines.
-        }
-    }
-    return out;
-}
-/**
- * Pure summary. Stable across runs given the same input order so the
- * dump diffs cleanly across CI runs.
- */
-function summarize(records) {
-    const outcomes = {};
-    const miss_reasons = {};
-    const per_extension = {};
-    const misses = [];
-    for (const r of records) {
-        const outcome = r.outcome ?? "unknown";
-        outcomes[outcome] = (outcomes[outcome] ?? 0) + 1;
-        if (outcome === "miss") {
-            const reason = r.miss_reason ?? "unknown";
-            miss_reasons[reason] = (miss_reasons[reason] ?? 0) + 1;
-            misses.push(r);
-        }
-        const ext = r.output_ext ?? "?";
-        if (!per_extension[ext])
-            per_extension[ext] = { hit: 0, miss: 0 };
-        if (outcome === "hit" || outcome === "link_hit")
-            per_extension[ext].hit += 1;
-        else if (outcome === "miss" || outcome === "link_miss")
-            per_extension[ext].miss += 1;
-    }
-    // Sort misses by latency descending and take top N.
-    const slowest_misses = [...misses]
-        .sort((a, b) => (b.latency_ns ?? 0) - (a.latency_ns ?? 0))
-        .slice(0, SLOWEST_TOP_N)
-        .map((r) => ({
-        crate: r.crate_name ?? "?",
-        reason: r.miss_reason ?? "?",
-        ext: r.output_ext ?? "?",
-        latency_ms: Math.round((r.latency_ns ?? 0) / 1_000_000),
-        diff: r.miss_diff ?? null,
-    }));
-    // One sample per distinct miss_reason (covers the long-tail rarer
-    // reasons even when ContentChanged dominates the histogram).
-    const seenReasons = new Set();
-    const sample_records = [];
-    for (const r of misses) {
-        const reason = r.miss_reason ?? "unknown";
-        if (seenReasons.has(reason))
-            continue;
-        seenReasons.add(reason);
-        sample_records.push(r);
-        if (sample_records.length >= 5)
-            break;
-    }
-    // Also include one hit sample if we have any, so cold/warm diffs are
-    // diffable in both directions.
-    const firstHit = records.find((r) => r.outcome === "hit" || r.outcome === "link_hit");
-    if (firstHit && sample_records.length < 6)
-        sample_records.push(firstHit);
-    return {
-        total: records.length,
-        outcomes,
-        miss_reasons,
-        per_extension,
-        slowest_misses,
-        sample_records,
-    };
-}
-// ---------- formatters ----------
-function pad(left, right, label, value) {
-    return `${label.padEnd(left)}${String(value).padStart(right)}`;
-}
-/**
- * Normalise zccache's `env` field into a plain `{key: value}` map.
- * The wire format is array-of-pairs (`Array<[string, string]>`) in
- * current zccache builds; older / future builds may use a plain
- * object. We tolerate both — and crucially, when given the array
- * form we DO NOT use array indices as keys (the previous bug:
- * indices like "0", "1" don't match the redaction regex so secrets
- * leaked verbatim).
- */
-function normaliseEnv(env) {
-    if (!env)
-        return {};
-    if (Array.isArray(env)) {
-        const out = {};
-        for (const pair of env) {
-            if (Array.isArray(pair) && pair.length >= 2 && typeof pair[0] === "string") {
-                out[pair[0]] = String(pair[1] ?? "");
-            }
-        }
-        return out;
-    }
-    // Plain object form. Defend against the legacy index-keyed shape that
-    // sneaks in if some intermediate code stringifies an array via
-    // `Object.fromEntries(arr.entries())` — detect that and recover.
-    const entries = Object.entries(env);
-    const looksLikeIndexedArray = entries.length > 0 &&
-        entries.every(([k, v]) => /^\d+$/.test(k) &&
-            Array.isArray(v) &&
-            v.length >= 2 &&
-            typeof v[0] === "string");
-    if (looksLikeIndexedArray) {
-        const out = {};
-        for (const [, v] of entries) {
-            const pair = v;
-            out[pair[0]] = String(pair[1] ?? "");
-        }
-        return out;
-    }
-    return env;
-}
-function redactEnv(env) {
-    const norm = normaliseEnv(env);
-    const out = {};
-    for (const [k, v] of Object.entries(norm))
-        out[k] = (0, diagnostics_js_1.redactValue)(k, v);
-    return out;
-}
-function envIsNonEmpty(env) {
-    if (!env)
-        return false;
-    if (Array.isArray(env))
-        return env.length > 0;
-    return Object.keys(env).length > 0;
-}
-function formatRecord(r) {
-    // Hand-shape JSON to keep one record-per-line readable: top-level keys
-    // on one line, then args/env/miss_diff (if present) on their own.
-    const summary = {
-        outcome: r.outcome,
-        miss_reason: r.miss_reason,
-        crate_name: r.crate_name,
-        crate_type: r.crate_type,
-        output_ext: r.output_ext,
-        latency_ms: r.latency_ns !== undefined ? Math.round(r.latency_ns / 1_000_000) : undefined,
-        cwd: r.cwd,
-    };
-    const parts = [];
-    parts.push(`    summary: ${JSON.stringify(summary)}`);
-    if (r.args && r.args.length > 0) {
-        parts.push(`    args: ${JSON.stringify(r.args)}`);
-    }
-    if (envIsNonEmpty(r.env)) {
-        parts.push(`    env (redacted): ${JSON.stringify(redactEnv(r.env))}`);
-    }
-    if (r.miss_diff && Object.keys(r.miss_diff).length > 0) {
-        parts.push(`    miss_diff: ${JSON.stringify(r.miss_diff)}`);
-    }
-    if (r.self_profile_ns) {
-        parts.push(`    self_profile_ns: ${JSON.stringify(r.self_profile_ns)}`);
-    }
-    return parts.join("\n");
-}
-/**
- * Format a `[compile_journal]` section's body lines (without the
- * surrounding header/footer — those are added by `dumpDiagnostics`).
- */
-function formatJournalSection(summary) {
-    const lines = [];
-    lines.push(`[compile_journal]`);
-    lines.push(`  total_records=${summary.total}`);
-    lines.push(`  outcomes:`);
-    const outcomeEntries = Object.entries(summary.outcomes).sort((a, b) => b[1] - a[1]);
-    if (outcomeEntries.length === 0)
-        lines.push(`    (none)`);
-    for (const [k, v] of outcomeEntries)
-        lines.push(`    ${pad(16, 8, k, v)}`);
-    lines.push(`  miss_reasons (zccache fingerprint divergence; the answer to "why warm missed"):`);
-    const missEntries = Object.entries(summary.miss_reasons).sort((a, b) => b[1] - a[1]);
-    if (missEntries.length === 0)
-        lines.push(`    (none)`);
-    for (const [k, v] of missEntries)
-        lines.push(`    ${pad(28, 8, k, v)}`);
-    lines.push(`  per_output_ext (hit/miss split per artifact kind):`);
-    const extEntries = Object.entries(summary.per_extension).sort((a, b) => a[0] < b[0] ? -1 : 1);
-    if (extEntries.length === 0)
-        lines.push(`    (none)`);
-    for (const [ext, c] of extEntries) {
-        lines.push(`    ${ext.padEnd(10)}hit=${String(c.hit).padStart(5)}  miss=${String(c.miss).padStart(5)}`);
-    }
-    lines.push(`  slowest_misses (top ${summary.slowest_misses.length} by wall-clock):`);
-    if (summary.slowest_misses.length === 0)
-        lines.push(`    (none)`);
-    for (const m of summary.slowest_misses) {
-        lines.push(`    ${String(m.latency_ms + "ms").padStart(7)}  ${m.reason.padEnd(20)}  ${m.ext.padEnd(8)}  ${m.crate}`);
-        if (m.diff && typeof m.diff === "object" && Object.keys(m.diff).length > 0) {
-            lines.push(`        diff: ${JSON.stringify(m.diff)}`);
-        }
-    }
-    lines.push(`  sample_records (one verbatim per distinct outcome, env redacted):`);
-    if (summary.sample_records.length === 0)
-        lines.push(`    (none)`);
-    for (let i = 0; i < summary.sample_records.length; i += 1) {
-        lines.push(`  --- record ${i + 1} ---`);
-        lines.push(formatRecord(summary.sample_records[i]));
-    }
-    return lines;
-}
-/**
- * Format the `rollups` field returned by `soldr cache report --json`
- * (i.e. `zccache analyze --json` output). Tolerates missing /
- * malformed fields — older soldr versions or error paths just yield
- * an empty section.
- */
-function formatRollupsSection(report) {
-    const lines = [];
-    lines.push(`[compile_rollups (zccache analyze --json)]`);
-    if (!report || typeof report !== "object") {
-        lines.push(`  (no report payload)`);
-        return lines;
-    }
-    const rollups = report.rollups;
-    if (!rollups || typeof rollups !== "object") {
-        lines.push(`  (no rollups field)`);
-        return lines;
-    }
-    const r = rollups;
-    // by_extension: { ext: { hits, misses, total_ns } }
-    const byExt = r.by_extension;
-    lines.push(`  by_extension:`);
-    if (!byExt || Object.keys(byExt).length === 0)
-        lines.push(`    (none)`);
-    else {
-        for (const [ext, v] of Object.entries(byExt)) {
-            const hits = v?.hits ?? 0;
-            const misses = v?.misses ?? 0;
-            const totalMs = Math.round((v?.total_ns ?? 0) / 1_000_000);
-            const denom = hits + misses;
-            const rate = denom > 0 ? ((hits / denom) * 100).toFixed(1) : "n/a";
-            lines.push(`    ${ext.padEnd(10)}hits=${String(hits).padStart(5)}  misses=${String(misses).padStart(5)}  rate=${rate.padStart(5)}%  total=${totalMs}ms`);
-        }
-    }
-    // slowest_entries: [{outcome, crate_name, latency_ns}, ...]
-    const slowest = r.slowest_entries;
-    lines.push(`  slowest_entries (analyze top-N):`);
-    if (!slowest || slowest.length === 0)
-        lines.push(`    (none)`);
-    else {
-        for (const e of slowest.slice(0, 20)) {
-            const latencyMs = Math.round(Number(e.latency_ns ?? 0) / 1_000_000);
-            const outcome = String(e.outcome ?? "?");
-            const crate = String(e.crate_name ?? "?");
-            lines.push(`    ${String(latencyMs + "ms").padStart(7)}  ${outcome.padEnd(10)}  ${crate}`);
-        }
-    }
-    // miss_crate_counts: { crate: N }
-    const missByCrate = r.miss_crate_counts;
-    lines.push(`  miss_crate_counts (top 20):`);
-    if (!missByCrate || Object.keys(missByCrate).length === 0)
-        lines.push(`    (none)`);
-    else {
-        const sorted = Object.entries(missByCrate)
-            .sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))
-            .slice(0, 20);
-        for (const [crate, count] of sorted) {
-            lines.push(`    ${String(count).padStart(5)}  ${crate}`);
-        }
-    }
-    return lines;
-}
-
-
-/***/ }),
-
 /***/ 504:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -87387,7 +87410,7 @@ function formatRollupsSection(report) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBeginCopyFromUrlPoller = void 0;
 const core_util_1 = __nccwpck_require__(12);
-const core_lro_1 = __nccwpck_require__(218);
+const core_lro_1 = __nccwpck_require__(217);
 /**
  * This is the poller returned by {@link BlobClient.beginCopyFromURL}.
  * This can not be instantiated directly outside of this package.
@@ -87622,7 +87645,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(142);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(191);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/src/lib/cache-compress.ts
+++ b/src/lib/cache-compress.ts
@@ -210,8 +210,29 @@ export async function compressCache(opts: {
    * ultra anywhere; included for completeness.
    */
   ultra?: boolean;
+  /**
+   * Optional sibling basenames (relative to `dirname(cacheDir)`) to bundle
+   * into the same archive. Used by the cargo-registry cache layer to ship
+   * `~/.cargo/registry`, `~/.cargo/.global-cache`, and `~/.cargo/git` in a
+   * single tarball without touching the public archive path / cache key
+   * shape — see setup-soldr#102. Missing basenames are silently skipped so
+   * a fresh checkout (no `git/` deps cloned yet) doesn't fail the save.
+   * Archive layout matches today's: each basename becomes a top-level entry
+   * under the shared parent, so `tar -xf - -C <parent>` restores all of
+   * them with no decompressCache changes required.
+   */
+  extraBasenames?: string[];
 }): Promise<CompressResult> {
-  const { cacheDir, codec, level, debug = false, log = (): void => undefined, longWindow, ultra } = opts;
+  const {
+    cacheDir,
+    codec,
+    level,
+    debug = false,
+    log = (): void => undefined,
+    longWindow,
+    ultra,
+    extraBasenames = [],
+  } = opts;
   const nullResult: CompressResult = { archivePath: null, archiveBytes: 0, inflatedBytes: null, fileCount: null };
 
   if (codec === "none") return nullResult;
@@ -240,6 +261,18 @@ export async function compressCache(opts: {
 
   const parent = path.dirname(cacheDir);
   const basename = path.basename(cacheDir);
+  // Filter sibling basenames to ones that actually exist under the parent —
+  // tar errors on missing inputs, and cargo-registry's `.global-cache` /
+  // `git/` may legitimately be absent on a cold checkout.
+  const presentExtras: string[] = [];
+  for (const extra of extraBasenames) {
+    if (!extra || extra === basename) continue;
+    if (await pathExists(path.join(parent, extra))) {
+      presentExtras.push(extra);
+    } else if (debug) {
+      log(`[debug] compress: skipping missing sibling basename '${extra}' under ${parent}`);
+    }
+  }
   const archivePath = `${cacheDir}.tar.zst`;
   // Best-effort cleanup of any previous archive.
   await fs.rm(archivePath, { force: true }).catch(() => undefined);
@@ -249,9 +282,10 @@ export async function compressCache(opts: {
   const longFlag = typeof longWindow === "number" ? [`--long=${longWindow}`] : [];
   const ultraFlag = ultra || levelNumeric >= 20 ? ["--ultra"] : [];
 
-  if (debug) log(`[debug] compress cmd: tar -cf - -C ${parent} ${basename} | zstd -T0 ${levelFlag}${longFlag.length ? ` --long=${longWindow}` : ""}${ultraFlag.length ? " --ultra" : ""} -o ${archivePath}`);
+  const tarInputs = [basename, ...presentExtras];
+  if (debug) log(`[debug] compress cmd: tar -cf - -C ${parent} ${tarInputs.join(" ")} | zstd -T0 ${levelFlag}${longFlag.length ? ` --long=${longWindow}` : ""}${ultraFlag.length ? " --ultra" : ""} -o ${archivePath}`);
   await runPipe(
-    ["tar", ["-cf", "-", "-C", parent, basename]],
+    ["tar", ["-cf", "-", "-C", parent, ...tarInputs]],
     [zstdPath, ["-T0", levelFlag, ...longFlag, ...ultraFlag, "-o", archivePath]],
   );
 

--- a/src/lib/cache-keys.ts
+++ b/src/lib/cache-keys.ts
@@ -429,12 +429,20 @@ export function setupCachePaths(
   rustupHome: string,
 ): string {
   const paths: string[] = [binDir, soldrBinCachePath];
+  // setup-soldr#102: always cache `~/.rustup/update-hashes/<channel>-<host>`.
+  // These are ~64-byte manifest hashes that let `rustup update` short-circuit
+  // without a dist-server roundtrip. The dir is tiny (KB range) and the
+  // latency win is large, so we include it even on the `system` rustup layout
+  // where the toolchains/ tree itself is shared with the runner image and
+  // deliberately excluded. (Toolchains/settings.toml stay gated on
+  // rustupHome being inside setupCachePath — those payloads are large and
+  // only owned by the managed rustup layout.)
+  paths.push(path.join(rustupHome, "update-hashes"));
   if (!isPathInside(setupCachePath, rustupHome)) {
     return paths.join("\n");
   }
   paths.push(path.join(rustupHome, "settings.toml"));
   paths.push(path.join(rustupHome, "toolchains"));
-  paths.push(path.join(rustupHome, "update-hashes"));
   return paths.join("\n");
 }
 

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -97,6 +97,9 @@ function cachePlanLines(result: ResolveResult): string[] {
   lines.push(`    key=${result.cargoRegistryCache.key}`);
   lines.push(`    restore_prefix=${result.cargoRegistryCache.restorePrefix}`);
   lines.push(`    path=${result.cargoRegistryCache.path}`);
+  // setup-soldr#102: sibling basenames bundled into the same archive.
+  const extras = result.cargoRegistryCache.extraBasenames;
+  lines.push(`    extra_basenames=${extras.length > 0 ? extras.join(",") : "(none)"}`);
   return lines;
 }
 

--- a/src/lib/resolve-setup.ts
+++ b/src/lib/resolve-setup.ts
@@ -481,6 +481,21 @@ export async function resolveSetup(
   // ---- cargo registry cache ----
   const cargoRegistryCacheRequested = isTruthy(inputs.cargoRegistryCache.trim() || "true");
   const cargoRegistryCachePath = path.join(cargoHome, "registry");
+  // setup-soldr#102: bundle additional `$CARGO_HOME` siblings into the same
+  // cargo-registry archive so we close the cache-retention gaps without
+  // introducing a new top-level cache layer or changing the cache key shape.
+  //   - `.global-cache` — cargo's RFC-3413 GC sqlite database. Without it the
+  //     per-job `cargo gc` sees fresh access times and conservatively keeps
+  //     everything. Shared read-only dep between setup-soldr (persists) and
+  //     soldr (reads via zackees/soldr#323). One-line leverage win.
+  //   - `git`           — `$CARGO_HOME/git/{db,checkouts}/`. `db/` holds the
+  //     bare mirrors of git-source crate deps and `checkouts/` holds the
+  //     per-commit working trees derived from `db/`; both are required for
+  //     cargo to build from a restored `db/`. Caching the parent `git/` dir
+  //     covers both subtrees and any future siblings cargo introduces.
+  // Siblings that don't exist on disk at save time (e.g. workspaces with no
+  // git-source deps) are silently skipped by compressCache — see #102.
+  const cargoRegistryCacheExtras = [".global-cache", "git"];
   const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-v1-${runnerOs}-${runnerArch}`;
   const cargoRegistryCacheRestorePrefix = `${cargoRegistryCachePrefix}-${cargoLockHash}-`;
   let cargoRegistryCacheKey = `${cargoRegistryCacheRestorePrefix}${digest}-${githubSha}`;
@@ -703,6 +718,7 @@ export async function resolveSetup(
     key: cargoRegistryCacheKey,
     restorePrefix: cargoRegistryCacheRestorePrefix,
     path: cargoRegistryCachePath,
+    extraBasenames: cargoRegistryCacheExtras,
   };
 
   // Avoid unused warnings on alias helper.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -136,12 +136,28 @@ export interface TargetCachePlan {
 
 /**
  * Cargo-registry cache plan (payload C of issue #70).
+ *
+ * `path` is the primary cache dir (`$CARGO_HOME/registry`) and the host
+ * of the tarball — the archive is written as `${path}.tar.zst` so the
+ * existing on-disk shape, restore key, and cache key are unchanged.
+ *
+ * `extraBasenames` are sibling directories under `dirname(path)` that
+ * ride inside the same archive without a new actions/cache layer or a
+ * cache-key change — see setup-soldr#102. Today these are:
+ *   - `.global-cache` — cargo's RFC-3413 GC database; without it every
+ *     job's `cargo gc` sees fresh access times and conservatively keeps
+ *     everything. setup-soldr persists it, soldr reads it (zackees/soldr#323).
+ *   - `git`           — `$CARGO_HOME/git/{db,checkouts}/`, the bare git
+ *     mirrors plus checked-out source trees for git-source crate deps.
+ * Missing siblings are silently skipped on save so a cold checkout (no
+ * `git/` deps cloned yet) still produces a valid archive.
  */
 export interface CargoRegistryCachePlan {
   enabled: boolean;
   key: string;
   restorePrefix: string;
   path: string;
+  extraBasenames: string[];
 }
 
 /**

--- a/src/post.ts
+++ b/src/post.ts
@@ -195,8 +195,14 @@ async function saveOne(opts: {
   label: string;
   debug: boolean;
   log: (msg: string) => void;
+  /**
+   * Optional sibling basenames bundled into the same archive as `cacheDir`.
+   * Used by the cargo-registry layer to ship `.global-cache` and `git/` next
+   * to `registry/` without a new cache layer — setup-soldr#102.
+   */
+  extraBasenames?: string[];
 }): Promise<CacheSaveResult & { archiveBytes: number | null }> {
-  const { cacheDir, codec, level, key, matchedKey, label, debug, log } = opts;
+  const { cacheDir, codec, level, key, matchedKey, label, debug, log, extraBasenames } = opts;
   const withBytes = (r: CacheSaveResult): CacheSaveResult & { archiveBytes: number | null } =>
     Object.assign(r, { archiveBytes: null });
   if (!dirExists(cacheDir)) {
@@ -210,7 +216,7 @@ async function saveOne(opts: {
   let archiveBytes: number | null = null;
   let archivePath: string | null = null;
   try {
-    const result = await compressCache({ cacheDir, codec, level, debug, log });
+    const result = await compressCache({ cacheDir, codec, level, debug, log, extraBasenames });
     archivePath = result.archivePath;
     archiveBytes = result.archiveBytes || null;
   } catch (err) {
@@ -893,7 +899,11 @@ export async function run(): Promise<void> {
     }
   }
 
-  // Cargo registry cache (only when enabled)
+  // Cargo registry cache (only when enabled).
+  // setup-soldr#102: bundle `.global-cache` (cargo's RFC-3413 GC db) and the
+  // `git/` directory (bare mirrors + checkouts for git-source crate deps)
+  // into the same archive alongside `registry/`. Cache key + archive path
+  // are unchanged — the extras simply ride inside the existing tarball.
   let cargoRegistrySave = Object.assign(disabledSave(), { archiveBytes: null as number | null });
   if (result.cargoRegistryCache.enabled) {
     const regSaveStart = Date.now();
@@ -906,6 +916,7 @@ export async function run(): Promise<void> {
       label: "cargo-registry-cache",
       debug: debugMode,
       log: debugLog,
+      extraBasenames: result.cargoRegistryCache.extraBasenames,
     });
     if (cargoRegistrySave.status === "saved") {
       postCollector.record({


### PR DESCRIPTION
## Summary

- **`cargoRegistryCache`** now bundles `~/.cargo/.global-cache` (cargo's RFC-3413 GC sqlite db — without it every job's `cargo gc` sees fresh access times and conservatively keeps everything) and `~/.cargo/git/` (bare mirrors + checkouts for git-source crate deps) inside the existing `~/.cargo/registry.tar.zst` archive. Implemented via a new `extraBasenames: string[]` field on `CargoRegistryCachePlan` and an optional `extraBasenames` param on `compressCache`. Missing siblings (e.g. workspaces without git deps on a cold checkout) are silently skipped so the save still succeeds.
- **`setupCache`** now always includes `~/.rustup/update-hashes/` in its path list — previously only included on the managed-rustup layout. The dir is ~64 B per channel and lets `rustup update` short-circuit the dist-server roundtrip; on the `system` rustup layout where `toolchains/` + `settings.toml` stay excluded (owned by the runner image), we still capture the latency win without the toolchain payload.
- **No cache key shape changes** — these are pure path-list additions under the same actions/cache key. Verified by two new regression tests asserting both the cargo-registry and setup-cache key shapes are unchanged. The `.global-cache` / `git` names do not appear in the cache key.

Per the issue: `.global-cache` is documented as a shared read-only dep between setup-soldr (persists) and soldr (reads, via zackees/soldr#323). The explicit "do not cache" list (`.package-cache`, `.package-cache-mutate`, `credentials.toml`) is documented in `action.yml` so the basename-allowlist approach can't accidentally pick them up.

Partially addresses #102 (PRs 1-3 of 5 from the issue rollout); leaves PR 4 (verify index `.cache/`) and PR 5 (`state.redb`) as follow-ups.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 325 pass / 5 skipped (6 new tests added)
  - `cargo-registry-cache extraBasenames bundles .global-cache + git`
  - `cargo-registry-cache extras are siblings of path (under $CARGO_HOME)`
  - `cargo-registry-cache key is unchanged by extraBasenames` (no key shape change)
  - `setup-cache always includes rustup update-hashes path`
  - `setup-cache layout key is unchanged by always-on update-hashes` (no key shape change)
  - `setupCachePaths still caches update-hashes when rustupHome is the system layout`
- [x] `npm run build` — `dist/main.js` + `dist/post.js` rebuilt and committed
- [ ] Smoke test on a real CI job once merged — cold save of cargo-registry archive should include the `.global-cache/` and `git/` siblings; subsequent runs should restore them. Look for `cargo gc` "kept N, removed M" output reflecting cross-run access times rather than always-fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)