### PR TITLE
feat(workflow): reusable rust-ci.yml template (#120)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,258 @@
+# Reusable Rust CI workflow for repos that consume setup-soldr.
+#
+# Pattern: warm-then-fan-out. The `warm` job runs setup-soldr and a
+# `soldr cargo build --workspace --all-targets`, populating the
+# build/target/registry caches. Per-tool jobs (`fmt`, `lint`, `clippy`,
+# `test`, `dylint`) then each re-run setup-soldr (same SHA -> same
+# cache key, so the restore is a hot hit) and execute their respective
+# `soldr cargo ...` invocation. Per-tool jobs are individually toggleable
+# via boolean inputs.
+#
+# Usage:
+#
+#   jobs:
+#     ci:
+#       uses: zackees/setup-soldr/.github/workflows/rust-ci.yml@v0
+#       with:
+#         os: ubuntu-latest
+#
+# See README.md "Reusable Rust CI workflow" for the full input table
+# and cross-compile matrix example.
+
+name: rust-ci (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: Runner label (e.g. ubuntu-latest, macos-latest, windows-latest).
+        type: string
+        required: false
+        default: ubuntu-latest
+      target:
+        description: >
+          Rust target triple. Empty (default) builds for the host. A non-empty
+          value triggers `rustup target add <target>` plus `--target <target>`
+          on every cargo invocation.
+        type: string
+        required: false
+        default: ""
+      toolchain:
+        description: >
+          Forwarded to setup-soldr's `toolchain` input. Empty (default) means
+          setup-soldr resolves the toolchain from `rust-toolchain.toml` and
+          falls back to stable.
+        type: string
+        required: false
+        default: ""
+      features:
+        description: Forwarded as `--features <value>` on the warm build.
+        type: string
+        required: false
+        default: ""
+      cargo-args:
+        description: Free-form extra args appended to the warm `soldr cargo build` invocation.
+        type: string
+        required: false
+        default: ""
+      cache:
+        description: Forwarded to setup-soldr's `cache` umbrella input.
+        type: boolean
+        required: false
+        default: true
+      lint:
+        description: When true, runs `cargo check --workspace --all-targets`.
+        type: boolean
+        required: false
+        default: true
+      fmt:
+        description: When true, runs `cargo fmt --all -- --check`.
+        type: boolean
+        required: false
+        default: true
+      clippy:
+        description: When true, runs `cargo clippy --workspace --all-targets -- -D warnings`.
+        type: boolean
+        required: false
+        default: true
+      test:
+        description: When true, runs `cargo test --workspace`.
+        type: boolean
+        required: false
+        default: true
+      dylint:
+        description: >
+          When true, installs `cargo-dylint` + `dylint-link` and runs
+          `cargo dylint --all --workspace`. Opt-in because dylint requires
+          consumer-provided `dylint.toml` + driver crates.
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  warm:
+    name: warm (build)
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain: ${{ inputs.toolchain }}
+          cache: ${{ inputs.cache }}
+
+      - name: Add cross-compile target
+        if: inputs.target != ''
+        shell: bash
+        run: rustup target add "${{ inputs.target }}"
+
+      - name: Warm build (workspace, all-targets)
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(--workspace --all-targets)
+          if [ -n "${{ inputs.target }}" ]; then
+            args+=(--target "${{ inputs.target }}")
+          fi
+          if [ -n "${{ inputs.features }}" ]; then
+            args+=(--features "${{ inputs.features }}")
+          fi
+          # shellcheck disable=SC2206 # intentional word-split on cargo-args
+          extra=(${{ inputs.cargo-args }})
+          soldr cargo build "${args[@]}" "${extra[@]}"
+
+  fmt:
+    name: fmt
+    needs: warm
+    if: ${{ inputs.fmt }}
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain: ${{ inputs.toolchain }}
+          cache: ${{ inputs.cache }}
+
+      - name: cargo fmt --check
+        shell: bash
+        run: soldr cargo fmt --all -- --check
+
+  lint:
+    name: lint (cargo check)
+    needs: warm
+    if: ${{ inputs.lint }}
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain: ${{ inputs.toolchain }}
+          cache: ${{ inputs.cache }}
+
+      - name: Add cross-compile target
+        if: inputs.target != ''
+        shell: bash
+        run: rustup target add "${{ inputs.target }}"
+
+      - name: cargo check
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(--workspace --all-targets)
+          if [ -n "${{ inputs.target }}" ]; then
+            args+=(--target "${{ inputs.target }}")
+          fi
+          soldr cargo check "${args[@]}"
+
+  clippy:
+    name: clippy
+    needs: warm
+    if: ${{ inputs.clippy }}
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain: ${{ inputs.toolchain }}
+          cache: ${{ inputs.cache }}
+
+      - name: Add cross-compile target
+        if: inputs.target != ''
+        shell: bash
+        run: rustup target add "${{ inputs.target }}"
+
+      - name: cargo clippy
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(--workspace --all-targets)
+          if [ -n "${{ inputs.target }}" ]; then
+            args+=(--target "${{ inputs.target }}")
+          fi
+          soldr cargo clippy "${args[@]}" -- -D warnings
+
+  test:
+    name: test
+    needs: warm
+    if: ${{ inputs.test }}
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain: ${{ inputs.toolchain }}
+          cache: ${{ inputs.cache }}
+
+      - name: Add cross-compile target
+        if: inputs.target != ''
+        shell: bash
+        run: rustup target add "${{ inputs.target }}"
+
+      - name: cargo test
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(--workspace)
+          if [ -n "${{ inputs.target }}" ]; then
+            args+=(--target "${{ inputs.target }}")
+          fi
+          soldr cargo test "${args[@]}"
+
+  dylint:
+    name: dylint
+    needs: warm
+    if: ${{ inputs.dylint }}
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain: ${{ inputs.toolchain }}
+          cache: ${{ inputs.cache }}
+
+      - name: Install cargo-dylint and dylint-link
+        shell: bash
+        run: |
+          set -euo pipefail
+          soldr cargo install cargo-dylint dylint-link --locked
+
+      - name: cargo dylint
+        shell: bash
+        run: soldr cargo dylint --all --workspace

--- a/README.md
+++ b/README.md
@@ -71,6 +71,72 @@ jobs:
       - run: soldr cargo test --locked
 ```
 
+### Reusable Rust CI workflow
+
+For repos that just want the standard Rust quality gates
+(`build`, `fmt`, `lint`, `clippy`, `test`, optional `dylint`) wired up on
+top of `setup-soldr` without hand-rolling them, this repo ships a
+reusable workflow at `.github/workflows/rust-ci.yml`. It uses a
+warm-then-fan-out pattern: a single `warm` job runs `setup-soldr` plus
+`soldr cargo build --workspace --all-targets` to populate the caches,
+then each per-tool job re-runs `setup-soldr` (same SHA = same cache
+key, so it hits the freshly-saved cache) and runs its own `soldr
+cargo …` invocation. Per-tool jobs are independently toggleable.
+
+Publishing / artifact / release work is intentionally out of scope —
+release flows vary too much across repos to template.
+
+#### Inputs
+
+| Name | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `os` | string | `ubuntu-latest` | Runner label. |
+| `target` | string | `""` (host) | Rust target triple. Non-empty triggers `rustup target add` + `--target` on every cargo invocation. |
+| `toolchain` | string | `""` | Forwarded to `setup-soldr`. Empty = `rust-toolchain.toml` or `stable`. |
+| `features` | string | `""` | Forwarded as `--features` to the warm build. |
+| `cargo-args` | string | `""` | Free-form extra args appended to the warm build. |
+| `cache` | boolean | `true` | Forwarded to `setup-soldr`'s umbrella cache switch. |
+| `lint` | boolean | `true` | `cargo check --workspace --all-targets`. |
+| `fmt` | boolean | `true` | `cargo fmt --all -- --check`. |
+| `clippy` | boolean | `true` | `cargo clippy --workspace --all-targets -- -D warnings`. |
+| `test` | boolean | `true` | `cargo test --workspace`. |
+| `dylint` | boolean | `false` | `cargo dylint --all --workspace` (installs `cargo-dylint` + `dylint-link` first). Opt-in: needs a consumer-provided `dylint.toml`. |
+
+#### Simple consumer
+
+```yaml
+jobs:
+  ci:
+    uses: zackees/setup-soldr/.github/workflows/rust-ci.yml@v0
+    with:
+      os: ubuntu-latest
+      dylint: false
+```
+
+#### Cross-compile matrix
+
+```yaml
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-latest,  target: aarch64-unknown-linux-musl }
+          - { os: macos-latest,   target: aarch64-apple-darwin }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc }
+    uses: zackees/setup-soldr/.github/workflows/rust-ci.yml@v0
+    with:
+      os:     ${{ matrix.os }}
+      target: ${{ matrix.target }}
+      test:   ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+```
+
+Cross-compiled binaries usually can't run on the host, so the matrix
+example gates `test:` on the native cell. The template never tries to
+auto-detect runnability — the consumer chooses.
+
 ## Multi-platform builds (cross-target tutorial)
 
 The single-platform examples above all build for the runner's own host


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/rust-ci.yml`, a `workflow_call`-style reusable workflow that wires the standard Rust quality gates (`build`, `fmt`, `lint`, `clippy`, `test`, optional `dylint`) on top of `zackees/setup-soldr@v0` using a warm-then-fan-out pattern.
- All 11 inputs from issue #120 declared with the spec'd types/defaults; per-tool jobs gated on their matching boolean (`fmt`/`lint`/`clippy`/`test` default `true`, `dylint` default `false`).
- `target` is empty-safe: when non-empty, every job runs `rustup target add <target>` and appends `--target <target>` to its cargo invocation; when empty, both are skipped. `features` and `cargo-args` are appended to the warm build only.
- README gains a "Reusable Rust CI workflow" subsection with the input table and both the simple + cross-compile matrix consumer snippets from the issue.

Per-issue scope: publishing / artifact / release work is intentionally out of scope.

Closes #120.

## Consumer usage

```yaml
jobs:
  ci:
    uses: zackees/setup-soldr/.github/workflows/rust-ci.yml@v0
    with:
      os: ubuntu-latest
      dylint: false
```

## Test plan

- [x] `npm test` — 320 pass, 5 skipped, 0 fail.
- [x] YAML parses (Python `yaml.safe_load`), 6 jobs present (`warm`, `fmt`, `lint`, `clippy`, `test`, `dylint`), 11 inputs declared exactly as in the spec.
- [ ] Consumer smoke run from a downstream Rust repo (out of scope for this PR; the in-repo smoke wiring was skipped per the task brief because setup-soldr itself isn't a Rust project, so calling the template against this repo wouldn't be a meaningful test).