### PR TITLE
chore(version): bump soldr 0.7.33 -> 0.7.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.33`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.34`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -393,7 +393,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.33`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.34`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -457,7 +457,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.33`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.34`.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - Toolchain-file `components` and `targets` are installed during setup so later `cargo`/`soldr cargo` steps do not trigger rustup lazy installs.
 - The action keeps using the runner's existing `CARGO_HOME` unless `CARGO_HOME` is already set by the workflow. When `RUSTUP_HOME` is not explicitly set, setup-soldr prefers the runner's existing rustup home if it already satisfies the requested toolchain/components/targets; otherwise it falls back to a managed `RUSTUP_HOME` under the action cache root and rehydrates that state on later warm runs.

--- a/__tests__/diagnostics.test.ts
+++ b/__tests__/diagnostics.test.ts
@@ -21,7 +21,7 @@ function captureLogger(): { logger: Logger; lines: string[] } {
 function fixtureRawInputs(): RawInputs {
   return {
     enable: "true",
-    version: "0.7.33",
+    version: "0.7.34",
     repo: "zackees/soldr",
     ref: "",
     cache: "true",
@@ -114,7 +114,7 @@ test("dumpDiagnostics includes parsed RawInputs", () => {
   const body = lines.join("\n");
   assert.match(body, /\[raw_inputs/);
   assert.match(body, /cacheKeySuffix="zccache-demo"/);
-  assert.match(body, /version="0\.7\.33"/);
+  assert.match(body, /version="0\.7\.34"/);
 });
 
 test("dumpDiagnostics redacts token-shaped env values", () => {

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.33.
+    description: Soldr version or tag to install. Defaults to 0.7.34.
     required: false
-    default: "0.7.33"
+    default: "0.7.34"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary

Bumps the default `soldr` version from 0.7.33 → 0.7.34.

soldr 0.7.34 ([zackees/soldr#511](https://github.com/zackees/soldr/pull/511), released 2026-05-24) ships **fix(linker)**: `SOLDR_LINKER=fast` / `=rust-lld` no longer inject `-fuse-ld=lld` into Apple clang. Apple's clang rejects that flag because stock macOS toolchains do not ship the `ld64.lld` shim it would resolve to, which was breaking cc-rs build scripts (and therefore maturin-style workflows) on macOS runners that routed through setup-soldr with `linker: fast`. Linux/Windows behavior unchanged. (Closes [zackees/soldr#509](https://github.com/zackees/soldr/issues/509).)

For setup-soldr users this means `linker: fast` can now be used on macOS without the platform-default workaround that downstreams (e.g. `zackees/clud`) were carrying.

## Test plan
- [x] `action.yml`: `default: "0.7.34"`
- [x] `README.md`: docs updated to 0.7.34
- [x] `__tests__/diagnostics.test.ts`: version fixture + regex updated
- [x] `npm test`: 325/325 passing (0 fail / 5 skip)
- [x] No dist rebuild needed (action.yml defaults are read at runtime, not bundled)
