### PR TITLE
feat(observability): multi-step session aggregation (#98 PR4 of 4)

### DIFF
--- a/__tests__/compile-cache-stats.test.ts
+++ b/__tests__/compile-cache-stats.test.ts
@@ -27,7 +27,10 @@ process.env["SETUP_SOLDR_TEST_IMPORT"] = "1";
 
 interface PostModule {
   buildFinalCacheSummary: (result: any, state: any, saves: any, passthrough?: boolean) => any;
-  formatFinalCacheSummaryMarkdown: (summary: any, mode?: "none" | "summarize" | "detailed") => string;
+  formatFinalCacheSummaryMarkdown: (
+    summary: any,
+    mode?: "none" | "summarize" | "detailed" | "insights",
+  ) => string;
 }
 
 function mkTmp(prefix: string): string {
@@ -610,4 +613,459 @@ test("insights: normalizeCompileCacheStats accepts 'insights' as a distinct valu
   assert.equal(mod.normalizeCompileCacheStats("none"), "none");
   // Unknown values still fall back to "summarize" (preserves old behavior).
   assert.equal(mod.normalizeCompileCacheStats("garbage"), "summarize");
+});
+
+// ---------------------------------------------------------------------------
+// PR4 — Multi-step session aggregation across all sessions in a CI job.
+//
+// Today each `soldr cargo <verb>` invocation in a CI job writes its own
+// `logs/last-session-stats.json`, and each new invocation overwrites the
+// prior one. setup-soldr v0.9.7 + soldr#379 added `--archive-logs <dir>`
+// so the per-session logs land under `<cache-dir>/logs/archive/<session-id>/`
+// before the next invocation overwrites the "last" file. PR4 walks that
+// archive dir in the post-step and rolls up every session's stats into a
+// single job-wide aggregate.
+//
+// All tests below were written FIRST (TDD) — they were RED against the
+// PR3 codebase before any aggregator/renderer/wiring landed. They turn
+// GREEN once PR4's `aggregateSessions`, `collectArchivedSessionStats`,
+// `renderMultiSessionRollup`, and `setMultiSessionOutputs` ship.
+// ---------------------------------------------------------------------------
+
+interface AggregatorModule {
+  aggregateSessions: (statsFiles: Array<Record<string, unknown>>) => {
+    sessionCount: number;
+    totalHits: number;
+    totalMisses: number;
+    totalCompilations: number;
+    overallHitRate: number | null;
+    totalTimeSavedMs: number;
+    totalBytesRead: number;
+    totalBytesWritten: number;
+    sessions: Array<{
+      sessionId: string;
+      hits: number;
+      misses: number;
+      hitRate: number | null;
+      timeSavedMs: number;
+    }>;
+  };
+  collectArchivedSessionStats: (archiveDir: string) => Array<Record<string, unknown>>;
+  renderMultiSessionRollup: (rollup: ReturnType<AggregatorModule["aggregateSessions"]>) => string;
+}
+
+/**
+ * Three synthetic per-session stats payloads — these are what each
+ * `last-session-stats.json` looks like after soldr writes it under
+ * `<cache-dir>/logs/archive/<session-id>/`. The schema follows
+ * zackees/soldr#320 (the same one consumed by the single-session renderer).
+ */
+function multiSessionFixtures(): Array<Record<string, unknown>> {
+  return [
+    {
+      status: "ok",
+      session_id: "sess-cargo-build",
+      compilations: 100,
+      hits: 80,
+      misses: 20,
+      hit_rate: 0.8,
+      time_saved_ms: 30000,
+      bytes_read: 100_000_000,
+      bytes_written: 20_000_000,
+    },
+    {
+      status: "ok",
+      session_id: "sess-cargo-test",
+      compilations: 50,
+      hits: 30,
+      misses: 20,
+      hit_rate: 0.6,
+      time_saved_ms: 15000,
+      bytes_read: 50_000_000,
+      bytes_written: 10_000_000,
+    },
+    {
+      status: "ok",
+      session_id: "sess-cargo-clippy",
+      compilations: 60,
+      hits: 55,
+      misses: 5,
+      hit_rate: 55 / 60,
+      time_saved_ms: 22500,
+      bytes_read: 60_000_000,
+      bytes_written: 2_000_000,
+    },
+  ];
+}
+
+test("PR4 aggregateSessions: sums hits, misses, compilations across all sessions", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const rollup = mod.aggregateSessions(multiSessionFixtures());
+  assert.equal(rollup.sessionCount, 3);
+  // 80 + 30 + 55 = 165
+  assert.equal(rollup.totalHits, 165);
+  // 20 + 20 + 5 = 45
+  assert.equal(rollup.totalMisses, 45);
+  // 100 + 50 + 60 = 210
+  assert.equal(rollup.totalCompilations, 210);
+});
+
+test("PR4 aggregateSessions: overallHitRate is hits / compilations (weighted across sessions)", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const rollup = mod.aggregateSessions(multiSessionFixtures());
+  // Overall = 165 / 210 ≈ 0.7857 (NOT the unweighted mean of per-session rates)
+  assert.ok(rollup.overallHitRate !== null);
+  assert.ok(Math.abs((rollup.overallHitRate as number) - 165 / 210) < 1e-9);
+});
+
+test("PR4 aggregateSessions: sums time-saved and byte counters", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const rollup = mod.aggregateSessions(multiSessionFixtures());
+  // 30000 + 15000 + 22500 = 67500
+  assert.equal(rollup.totalTimeSavedMs, 67500);
+  // 100M + 50M + 60M = 210M
+  assert.equal(rollup.totalBytesRead, 210_000_000);
+  // 20M + 10M + 2M = 32M
+  assert.equal(rollup.totalBytesWritten, 32_000_000);
+});
+
+test("PR4 aggregateSessions: produces per-session breakdown preserving session_id", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const rollup = mod.aggregateSessions(multiSessionFixtures());
+  assert.equal(rollup.sessions.length, 3);
+  const ids = rollup.sessions.map((s) => s.sessionId).sort();
+  assert.deepEqual(ids, ["sess-cargo-build", "sess-cargo-clippy", "sess-cargo-test"]);
+  const build = rollup.sessions.find((s) => s.sessionId === "sess-cargo-build")!;
+  assert.equal(build.hits, 80);
+  assert.equal(build.misses, 20);
+  assert.ok(Math.abs((build.hitRate as number) - 0.8) < 1e-9);
+  assert.equal(build.timeSavedMs, 30000);
+});
+
+test("PR4 aggregateSessions: empty input → sessionCount=0, nulls and zeros, no throw", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const rollup = mod.aggregateSessions([]);
+  assert.equal(rollup.sessionCount, 0);
+  assert.equal(rollup.totalHits, 0);
+  assert.equal(rollup.totalMisses, 0);
+  assert.equal(rollup.totalCompilations, 0);
+  // No compilations → hit_rate is null (not NaN, not 0).
+  assert.equal(rollup.overallHitRate, null);
+  assert.equal(rollup.totalTimeSavedMs, 0);
+  assert.equal(rollup.totalBytesRead, 0);
+  assert.equal(rollup.totalBytesWritten, 0);
+  assert.deepEqual(rollup.sessions, []);
+});
+
+test("PR4 aggregateSessions: tolerates missing optional fields (time_saved_ms, bytes_*)", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const rollup = mod.aggregateSessions([
+    { status: "ok", session_id: "minimal-1", hits: 10, misses: 0, compilations: 10, hit_rate: 1.0 },
+    { status: "ok", session_id: "minimal-2", hits: 5, misses: 5, compilations: 10 },
+  ]);
+  assert.equal(rollup.sessionCount, 2);
+  assert.equal(rollup.totalHits, 15);
+  assert.equal(rollup.totalMisses, 5);
+  assert.equal(rollup.totalCompilations, 20);
+  assert.equal(rollup.totalTimeSavedMs, 0);
+  assert.equal(rollup.totalBytesRead, 0);
+  assert.equal(rollup.totalBytesWritten, 0);
+  // Second session has no hit_rate field → null in the per-session row,
+  // but the aggregate hit rate is still well-defined.
+  const second = rollup.sessions.find((s) => s.sessionId === "minimal-2")!;
+  assert.equal(second.hitRate, null);
+  assert.ok(Math.abs((rollup.overallHitRate as number) - 0.75) < 1e-9);
+});
+
+test("PR4 aggregateSessions: skips entries with status != ok (e.g. 'missing', 'invalid')", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const rollup = mod.aggregateSessions([
+    { status: "ok", session_id: "good", hits: 10, misses: 0, compilations: 10 },
+    { status: "missing", session_id: "bad-1" },
+    { status: "invalid", session_id: "bad-2", error: "bad json" },
+    { status: "ok", session_id: "good2", hits: 5, misses: 5, compilations: 10 },
+  ]);
+  // Only the two "ok" entries are aggregated.
+  assert.equal(rollup.sessionCount, 2);
+  assert.equal(rollup.totalHits, 15);
+  assert.equal(rollup.totalCompilations, 20);
+  assert.equal(rollup.sessions.length, 2);
+});
+
+test("PR4 collectArchivedSessionStats: walks <archive-dir>/<session-id>/last-session-stats.json", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const root = mkTmp("pr4-collect-");
+  const archive = path.join(root, "logs", "archive");
+  fs.mkdirSync(archive, { recursive: true });
+  try {
+    // Plant three sessions under archive/<session-id>/last-session-stats.json.
+    for (const fixture of multiSessionFixtures()) {
+      const sid = fixture["session_id"] as string;
+      const sessionDir = path.join(archive, sid);
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sessionDir, "last-session-stats.json"),
+        JSON.stringify(fixture),
+        "utf8",
+      );
+    }
+    const found = mod.collectArchivedSessionStats(archive);
+    assert.equal(found.length, 3, "expected three archived session stats");
+    const hits = found.map((s) => s["hits"]).sort();
+    assert.deepEqual(hits, [30, 55, 80]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("PR4 collectArchivedSessionStats: missing archive dir → empty array (no throw)", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const root = mkTmp("pr4-noarchive-");
+  try {
+    const found = mod.collectArchivedSessionStats(path.join(root, "does", "not", "exist"));
+    assert.deepEqual(found, []);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("PR4 collectArchivedSessionStats: skips invalid JSON without throwing", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const root = mkTmp("pr4-badjson-");
+  const archive = path.join(root, "logs", "archive");
+  fs.mkdirSync(path.join(archive, "good"), { recursive: true });
+  fs.mkdirSync(path.join(archive, "bad"), { recursive: true });
+  fs.mkdirSync(path.join(archive, "non-object"), { recursive: true });
+  try {
+    fs.writeFileSync(
+      path.join(archive, "good", "last-session-stats.json"),
+      JSON.stringify({ status: "ok", session_id: "good", hits: 1, misses: 0, compilations: 1 }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(archive, "bad", "last-session-stats.json"),
+      "{not valid json",
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(archive, "non-object", "last-session-stats.json"),
+      "[1, 2, 3]",
+      "utf8",
+    );
+    const found = mod.collectArchivedSessionStats(archive);
+    // Only the well-formed one survives.
+    assert.equal(found.length, 1);
+    assert.equal(found[0]!["session_id"], "good");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("PR4 renderMultiSessionRollup: includes <details> block, title with session count, aggregate table", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const rollup = mod.aggregateSessions(multiSessionFixtures());
+  const md = mod.renderMultiSessionRollup(rollup);
+  // The roll-up is wrapped in a collapsed <details> so it doesn't dominate
+  // the step summary on long jobs.
+  assert.match(md, /<details>/);
+  assert.match(md, /<\/details>/);
+  // Title carries the session count so users see "Multi-step roll-up (3 sessions)".
+  assert.match(md, /Multi-step roll-up \(3 sessions\)/);
+  // Aggregate scalars table — hits/misses/compilations/hit-rate land at the top.
+  assert.match(md, /\| Sessions \| 3 \|/);
+  assert.match(md, /\| Total hits \| 165 \|/);
+  assert.match(md, /\| Total misses \| 45 \|/);
+  assert.match(md, /\| Total compilations \| 210 \|/);
+  assert.match(md, /\| Overall hit rate \| 78\.6% \|/);
+  // Total time saved and bytes appear too (67500 ms = 67.5s).
+  assert.match(md, /67\.5\s*s/);
+});
+
+test("PR4 renderMultiSessionRollup: includes per-session table beneath the aggregate", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const rollup = mod.aggregateSessions(multiSessionFixtures());
+  const md = mod.renderMultiSessionRollup(rollup);
+  // Per-session table header. Columns: Session, Hits, Misses, Hit rate, Time saved.
+  assert.match(md, /\| Session \| Hits \| Misses \| Hit rate \| Time saved \|/);
+  assert.match(md, /sess-cargo-build/);
+  assert.match(md, /sess-cargo-test/);
+  assert.match(md, /sess-cargo-clippy/);
+  // Per-session percentages (80.0%, 60.0%, ~91.7%).
+  assert.match(md, /80\.0%/);
+  assert.match(md, /60\.0%/);
+});
+
+test("PR4 renderMultiSessionRollup: returns empty string when sessionCount <= 1 (single-session path stays unchanged)", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const empty = mod.renderMultiSessionRollup(mod.aggregateSessions([]));
+  assert.equal(empty, "");
+  const single = mod.renderMultiSessionRollup(
+    mod.aggregateSessions([
+      { status: "ok", session_id: "only", hits: 1, misses: 1, compilations: 2, hit_rate: 0.5 },
+    ]),
+  );
+  // Single session: still empty — the existing single-session renderer
+  // already covers this case and a multi-step block would be redundant.
+  assert.equal(single, "");
+});
+
+test("PR4 renderMultiSessionRollup: handles null overallHitRate gracefully (n/a)", async () => {
+  const mod = (await import("../src/lib/compile-cache-stats.js")) as unknown as AggregatorModule;
+  const rollup = mod.aggregateSessions([
+    // Two sessions with zero compilations each → overall hit rate is null.
+    { status: "ok", session_id: "empty-1", hits: 0, misses: 0, compilations: 0 },
+    { status: "ok", session_id: "empty-2", hits: 0, misses: 0, compilations: 0 },
+  ]);
+  const md = mod.renderMultiSessionRollup(rollup);
+  // Aggregate hit rate renders as n/a when no compilations happened.
+  assert.match(md, /\| Overall hit rate \| n\/a \|/);
+});
+
+test("PR4 formatFinalCacheSummaryMarkdown: multi-session rollup appears in summary when archive has N>1 sessions", async () => {
+  const mod = (await import("../src/post.js")) as PostModule;
+  const root = mkTmp("pr4-fmt-multi-");
+  const buildCachePath = path.join(root, "cache", "zccache");
+  const archive = path.join(buildCachePath, "logs", "archive");
+  fs.mkdirSync(archive, { recursive: true });
+  try {
+    // Plant three sessions on disk where post-step will discover them.
+    for (const fixture of multiSessionFixtures()) {
+      const sid = fixture["session_id"] as string;
+      const sessionDir = path.join(archive, sid);
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sessionDir, "last-session-stats.json"),
+        JSON.stringify(fixture),
+        "utf8",
+      );
+    }
+    const result = fakeResult(buildCachePath);
+    const summary = mod.buildFinalCacheSummary(result, emptyRestoreState(), disabledSaves());
+    // The single-session report still renders (PR1 path); PR4 just adds a
+    // roll-up block on top when archive holds >1 sessions.
+    summary.compile_cache_report = {
+      status: "ok",
+      report: fixtureReport(),
+    };
+    const md = mod.formatFinalCacheSummaryMarkdown(summary, "summarize");
+    assert.match(md, /Multi-step roll-up \(3 sessions\)/);
+    assert.match(md, /\| Sessions \| 3 \|/);
+    assert.match(md, /sess-cargo-build/);
+    // Single-session path must still work — both surfaces coexist.
+    assert.match(md, /### Compile cache \(zccache\)/);
+    assert.match(md, /\| Hit rate \| 86\.4% \|/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("PR4 formatFinalCacheSummaryMarkdown: NO multi-session block when archive is empty (single-session unchanged)", async () => {
+  const mod = (await import("../src/post.js")) as PostModule;
+  const root = mkTmp("pr4-fmt-single-");
+  try {
+    const result = fakeResult(path.join(root, "cache", "zccache"));
+    const summary = mod.buildFinalCacheSummary(result, emptyRestoreState(), disabledSaves());
+    summary.compile_cache_report = {
+      status: "ok",
+      report: fixtureReport(),
+    };
+    const md = mod.formatFinalCacheSummaryMarkdown(summary, "summarize");
+    // No archive → no roll-up. Existing single-session table still renders.
+    assert.doesNotMatch(md, /Multi-step roll-up/);
+    assert.match(md, /### Compile cache \(zccache\)/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("PR4 formatFinalCacheSummaryMarkdown: multi-session works in detailed and insights modes too", async () => {
+  const mod = (await import("../src/post.js")) as PostModule;
+  const root = mkTmp("pr4-fmt-allmodes-");
+  const buildCachePath = path.join(root, "cache", "zccache");
+  const archive = path.join(buildCachePath, "logs", "archive");
+  fs.mkdirSync(archive, { recursive: true });
+  try {
+    for (const fixture of multiSessionFixtures()) {
+      const sid = fixture["session_id"] as string;
+      const sessionDir = path.join(archive, sid);
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sessionDir, "last-session-stats.json"),
+        JSON.stringify(fixture),
+        "utf8",
+      );
+    }
+    const result = fakeResult(buildCachePath);
+    const summary = mod.buildFinalCacheSummary(result, emptyRestoreState(), disabledSaves());
+    summary.compile_cache_report = {
+      status: "ok",
+      report: fixtureReport(),
+    };
+    for (const mode of ["summarize", "detailed", "insights"] as const) {
+      const md = mod.formatFinalCacheSummaryMarkdown(summary, mode as any);
+      assert.match(md, /Multi-step roll-up \(3 sessions\)/, `mode=${mode} should render multi-step block`);
+    }
+    // But "none" mode suppresses everything compile-cache related,
+    // including the multi-step block.
+    const mdNone = mod.formatFinalCacheSummaryMarkdown(summary, "none");
+    assert.doesNotMatch(mdNone, /Multi-step roll-up/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("PR4 scalar outputs: compile-cache-sessions-total and compile-cache-overall-hit-rate emitted when N>1 sessions", async () => {
+  const mod = (await import("../src/post.js")) as PostModule & {
+    setMultiSessionOutputs?: (
+      rollup: { sessionCount: number; overallHitRate: number | null },
+    ) => void;
+  };
+  const root = mkTmp("pr4-outputs-");
+  const ghOutputPath = path.join(root, "github-output.txt");
+  const previousOutput = process.env["GITHUB_OUTPUT"];
+  process.env["GITHUB_OUTPUT"] = ghOutputPath;
+  try {
+    fs.writeFileSync(ghOutputPath, "", "utf8");
+    assert.ok(
+      typeof mod.setMultiSessionOutputs === "function",
+      "post.ts must export setMultiSessionOutputs for PR4",
+    );
+    mod.setMultiSessionOutputs!({ sessionCount: 3, overallHitRate: 165 / 210 });
+    const ghOutContent = fs.readFileSync(ghOutputPath, "utf8");
+    // @actions/core appends `name<<HEREDOC\nvalue\nHEREDOC\n` per output.
+    assert.match(ghOutContent, /compile-cache-sessions-total/);
+    assert.match(ghOutContent, /\b3\b/);
+    assert.match(ghOutContent, /compile-cache-overall-hit-rate/);
+  } finally {
+    if (previousOutput === undefined) delete process.env["GITHUB_OUTPUT"];
+    else process.env["GITHUB_OUTPUT"] = previousOutput;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("PR4 setMultiSessionOutputs: skips emission when sessionCount <= 1 (no false signal)", async () => {
+  const mod = (await import("../src/post.js")) as PostModule & {
+    setMultiSessionOutputs?: (
+      rollup: { sessionCount: number; overallHitRate: number | null },
+    ) => void;
+  };
+  const root = mkTmp("pr4-outputs-single-");
+  const ghOutputPath = path.join(root, "github-output.txt");
+  const previousOutput = process.env["GITHUB_OUTPUT"];
+  process.env["GITHUB_OUTPUT"] = ghOutputPath;
+  try {
+    fs.writeFileSync(ghOutputPath, "", "utf8");
+    assert.ok(typeof mod.setMultiSessionOutputs === "function");
+    mod.setMultiSessionOutputs!({ sessionCount: 1, overallHitRate: 0.5 });
+    mod.setMultiSessionOutputs!({ sessionCount: 0, overallHitRate: null });
+    const ghOutContent = fs.readFileSync(ghOutputPath, "utf8");
+    // With <= 1 sessions there is no "multi-step" — outputs stay empty so
+    // downstream workflows can use `if: steps.x.outputs.compile-cache-sessions-total`
+    // as a feature gate.
+    assert.equal(ghOutContent, "");
+  } finally {
+    if (previousOutput === undefined) delete process.env["GITHUB_OUTPUT"];
+    else process.env["GITHUB_OUTPUT"] = previousOutput;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/action.yml
+++ b/action.yml
@@ -541,6 +541,21 @@ outputs:
     description: >
       Full soldr cache report JSON payload (one-shot consumer hook).
       Set whenever soldr cache report succeeds (status "ok").
+  compile-cache-sessions-total:
+    description: >
+      Total number of cargo invocations whose per-session stats were
+      archived under `<build-cache>/logs/archive/` during the job. Only
+      set when more than one session was observed (multi-step jobs); the
+      empty value lets downstream steps gate on
+      `${{ steps.setup.outputs.compile-cache-sessions-total }}`.
+      Added in setup-soldr#98 PR4.
+  compile-cache-overall-hit-rate:
+    description: >
+      Compile-cache hit rate (0.0–1.0) computed across every per-invocation
+      session archived during the job (weighted by compilations, NOT the
+      unweighted mean of per-session rates). Only set alongside
+      compile-cache-sessions-total when more than one session was observed.
+      Added in setup-soldr#98 PR4.
 runs:
   using: node20
   main: dist/main.js

--- a/dist/post.js
+++ b/dist/post.js
@@ -14,15 +14,15 @@
 //  * support limits.fieldNameSize
 //     -- this will require modifications to utils.parseParams
 
-const { Readable } = __nccwpck_require__(408)
-const { inherits } = __nccwpck_require__(359)
+const { Readable } = __nccwpck_require__(407)
+const { inherits } = __nccwpck_require__(358)
 
 const Dicer = __nccwpck_require__(11)
 
-const parseParams = __nccwpck_require__(188)
-const decodeText = __nccwpck_require__(270)
-const basename = __nccwpck_require__(454)
-const getLimit = __nccwpck_require__(461)
+const parseParams = __nccwpck_require__(187)
+const decodeText = __nccwpck_require__(269)
+const basename = __nccwpck_require__(453)
+const getLimit = __nccwpck_require__(460)
 
 const RE_BOUNDARY = /^boundary$/i
 const RE_FIELD = /^form-data$/i
@@ -340,7 +340,7 @@ __export(inspect_exports, {
   custom: () => custom
 });
 module.exports = __toCommonJS(inspect_exports);
-var import_node_util = __nccwpck_require__(359);
+var import_node_util = __nccwpck_require__(358);
 const custom = import_node_util.inspect.custom;
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -469,17 +469,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = exports.downloadCacheHttpClient = exports.DownloadProgress = void 0;
-const core = __importStar(__nccwpck_require__(437));
-const http_client_1 = __nccwpck_require__(278);
-const storage_blob_1 = __nccwpck_require__(426);
-const buffer = __importStar(__nccwpck_require__(118));
+const core = __importStar(__nccwpck_require__(436));
+const http_client_1 = __nccwpck_require__(277);
+const storage_blob_1 = __nccwpck_require__(425);
+const buffer = __importStar(__nccwpck_require__(119));
 const fs = __importStar(__nccwpck_require__(507));
 const stream = __importStar(__nccwpck_require__(130));
-const util = __importStar(__nccwpck_require__(122));
+const util = __importStar(__nccwpck_require__(123));
 const utils = __importStar(__nccwpck_require__(73));
 const constants_1 = __nccwpck_require__(43);
-const requestUtils_1 = __nccwpck_require__(256);
-const abort_controller_1 = __nccwpck_require__(221);
+const requestUtils_1 = __nccwpck_require__(255);
+const abort_controller_1 = __nccwpck_require__(220);
 /**
  * Pipes the body of a HTTP response to a stream
  *
@@ -839,14 +839,14 @@ exports.SearchState = SearchState;
 "use strict";
 
 
-const { InvalidArgumentError } = __nccwpck_require__(466)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(191)
+const { InvalidArgumentError } = __nccwpck_require__(465)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(190)
 const DispatcherBase = __nccwpck_require__(59)
-const Pool = __nccwpck_require__(327)
+const Pool = __nccwpck_require__(326)
 const Client = __nccwpck_require__(87)
 const util = __nccwpck_require__(66)
-const createRedirectInterceptor = __nccwpck_require__(249)
-const { WeakRef, FinalizationRegistry } = __nccwpck_require__(394)()
+const createRedirectInterceptor = __nccwpck_require__(248)
+const { WeakRef, FinalizationRegistry } = __nccwpck_require__(393)()
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -1071,21 +1071,21 @@ function isNamedKeyCredential(credential) {
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(225)
+const { MockNotMatchedError } = __nccwpck_require__(224)
 const {
   kDispatches,
   kMockAgent,
   kOriginalDispatch,
   kOrigin,
   kGetNetConnect
-} = __nccwpck_require__(448)
+} = __nccwpck_require__(447)
 const { buildURL, nop } = __nccwpck_require__(66)
-const { STATUS_CODES } = __nccwpck_require__(320)
+const { STATUS_CODES } = __nccwpck_require__(319)
 const {
   types: {
     isPromise
   }
-} = __nccwpck_require__(122)
+} = __nccwpck_require__(123)
 
 function matchValue (match, value) {
   if (typeof match === 'string') {
@@ -1518,15 +1518,15 @@ class AbortError extends Error {
 const { kConstruct } = __nccwpck_require__(155)
 const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(78)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(66)
-const { kHeadersList } = __nccwpck_require__(191)
-const { webidl } = __nccwpck_require__(435)
+const { kHeadersList } = __nccwpck_require__(190)
+const { webidl } = __nccwpck_require__(434)
 const { Response, cloneResponse } = __nccwpck_require__(39)
 const { Request } = __nccwpck_require__(83)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(13)
-const { fetching } = __nccwpck_require__(429)
-const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(493)
+const { fetching } = __nccwpck_require__(428)
+const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(492)
 const assert = __nccwpck_require__(501)
-const { getGlobalDispatcher } = __nccwpck_require__(360)
+const { getGlobalDispatcher } = __nccwpck_require__(359)
 
 /**
  * @see https://w3c.github.io/ServiceWorker/#dfn-cache-batch-operation
@@ -2361,13 +2361,13 @@ module.exports = {
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(408).Writable)
-const inherits = (__nccwpck_require__(359).inherits)
+const WritableStream = (__nccwpck_require__(407).Writable)
+const inherits = (__nccwpck_require__(358).inherits)
 
-const StreamSearch = __nccwpck_require__(113)
+const StreamSearch = __nccwpck_require__(114)
 
 const PartStream = __nccwpck_require__(63)
-const HeaderParser = __nccwpck_require__(106)
+const HeaderParser = __nccwpck_require__(107)
 
 const DASH = 45
 const B_ONEDASH = Buffer.from('-')
@@ -2594,17 +2594,17 @@ exports.isObject = isObject;
 exports.randomUUID = randomUUID;
 exports.uint8ArrayToString = uint8ArrayToString;
 exports.stringToUint8Array = stringToUint8Array;
-const tslib_1 = __nccwpck_require__(211);
+const tslib_1 = __nccwpck_require__(210);
 const tspRuntime = tslib_1.__importStar(__nccwpck_require__(145));
-var aborterUtils_js_1 = __nccwpck_require__(99);
+var aborterUtils_js_1 = __nccwpck_require__(100);
 Object.defineProperty(exports, "cancelablePromiseRace", ({ enumerable: true, get: function () { return aborterUtils_js_1.cancelablePromiseRace; } }));
-var createAbortablePromise_js_1 = __nccwpck_require__(254);
+var createAbortablePromise_js_1 = __nccwpck_require__(253);
 Object.defineProperty(exports, "createAbortablePromise", ({ enumerable: true, get: function () { return createAbortablePromise_js_1.createAbortablePromise; } }));
-var delay_js_1 = __nccwpck_require__(112);
+var delay_js_1 = __nccwpck_require__(113);
 Object.defineProperty(exports, "delay", ({ enumerable: true, get: function () { return delay_js_1.delay; } }));
-var error_js_1 = __nccwpck_require__(208);
+var error_js_1 = __nccwpck_require__(207);
 Object.defineProperty(exports, "getErrorMessage", ({ enumerable: true, get: function () { return error_js_1.getErrorMessage; } }));
-var typeGuards_js_1 = __nccwpck_require__(109);
+var typeGuards_js_1 = __nccwpck_require__(110);
 Object.defineProperty(exports, "isDefined", ({ enumerable: true, get: function () { return typeGuards_js_1.isDefined; } }));
 Object.defineProperty(exports, "isObjectWithProperties", ({ enumerable: true, get: function () { return typeGuards_js_1.isObjectWithProperties; } }));
 Object.defineProperty(exports, "objectHasProperty", ({ enumerable: true, get: function () { return typeGuards_js_1.objectHasProperty; } }));
@@ -2777,10 +2777,10 @@ __export(retryPolicy_exports, {
   retryPolicy: () => retryPolicy
 });
 module.exports = __toCommonJS(retryPolicy_exports);
-var import_helpers = __nccwpck_require__(434);
-var import_restError = __nccwpck_require__(423);
+var import_helpers = __nccwpck_require__(433);
+var import_restError = __nccwpck_require__(422);
 var import_AbortError = __nccwpck_require__(9);
-var import_logger = __nccwpck_require__(240);
+var import_logger = __nccwpck_require__(239);
 var import_constants = __nccwpck_require__(46);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("ts-http-runtime retryPolicy");
 const retryPolicyName = "retryPolicy";
@@ -2938,7 +2938,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
 const string_decoder_1 = __nccwpck_require__(148);
-const tr = __importStar(__nccwpck_require__(124));
+const tr = __importStar(__nccwpck_require__(125));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -3022,18 +3022,18 @@ exports.getExecOutput = getExecOutput;
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Convenience JSON typings and corresponding type guards
-var json_typings_1 = __nccwpck_require__(377);
+var json_typings_1 = __nccwpck_require__(376);
 Object.defineProperty(exports, "typeofJsonValue", ({ enumerable: true, get: function () { return json_typings_1.typeofJsonValue; } }));
 Object.defineProperty(exports, "isJsonObject", ({ enumerable: true, get: function () { return json_typings_1.isJsonObject; } }));
 // Base 64 encoding
-var base64_1 = __nccwpck_require__(294);
+var base64_1 = __nccwpck_require__(293);
 Object.defineProperty(exports, "base64decode", ({ enumerable: true, get: function () { return base64_1.base64decode; } }));
 Object.defineProperty(exports, "base64encode", ({ enumerable: true, get: function () { return base64_1.base64encode; } }));
 // UTF8 encoding
-var protobufjs_utf8_1 = __nccwpck_require__(334);
+var protobufjs_utf8_1 = __nccwpck_require__(333);
 Object.defineProperty(exports, "utf8read", ({ enumerable: true, get: function () { return protobufjs_utf8_1.utf8read; } }));
 // Binary format contracts, options for reading and writing, for example
-var binary_format_contract_1 = __nccwpck_require__(323);
+var binary_format_contract_1 = __nccwpck_require__(322);
 Object.defineProperty(exports, "WireType", ({ enumerable: true, get: function () { return binary_format_contract_1.WireType; } }));
 Object.defineProperty(exports, "mergeBinaryOptions", ({ enumerable: true, get: function () { return binary_format_contract_1.mergeBinaryOptions; } }));
 Object.defineProperty(exports, "UnknownFieldHandler", ({ enumerable: true, get: function () { return binary_format_contract_1.UnknownFieldHandler; } }));
@@ -3042,26 +3042,26 @@ var binary_reader_1 = __nccwpck_require__(134);
 Object.defineProperty(exports, "BinaryReader", ({ enumerable: true, get: function () { return binary_reader_1.BinaryReader; } }));
 Object.defineProperty(exports, "binaryReadOptions", ({ enumerable: true, get: function () { return binary_reader_1.binaryReadOptions; } }));
 // Standard IBinaryWriter implementation
-var binary_writer_1 = __nccwpck_require__(245);
+var binary_writer_1 = __nccwpck_require__(244);
 Object.defineProperty(exports, "BinaryWriter", ({ enumerable: true, get: function () { return binary_writer_1.BinaryWriter; } }));
 Object.defineProperty(exports, "binaryWriteOptions", ({ enumerable: true, get: function () { return binary_writer_1.binaryWriteOptions; } }));
 // Int64 and UInt64 implementations required for the binary format
-var pb_long_1 = __nccwpck_require__(116);
+var pb_long_1 = __nccwpck_require__(117);
 Object.defineProperty(exports, "PbLong", ({ enumerable: true, get: function () { return pb_long_1.PbLong; } }));
 Object.defineProperty(exports, "PbULong", ({ enumerable: true, get: function () { return pb_long_1.PbULong; } }));
 // JSON format contracts, options for reading and writing, for example
-var json_format_contract_1 = __nccwpck_require__(235);
+var json_format_contract_1 = __nccwpck_require__(234);
 Object.defineProperty(exports, "jsonReadOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonReadOptions; } }));
 Object.defineProperty(exports, "jsonWriteOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonWriteOptions; } }));
 Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: function () { return json_format_contract_1.mergeJsonOptions; } }));
 // Message type contract
-var message_type_contract_1 = __nccwpck_require__(386);
+var message_type_contract_1 = __nccwpck_require__(385);
 Object.defineProperty(exports, "MESSAGE_TYPE", ({ enumerable: true, get: function () { return message_type_contract_1.MESSAGE_TYPE; } }));
 // Message type implementation via reflection
 var message_type_1 = __nccwpck_require__(506);
 Object.defineProperty(exports, "MessageType", ({ enumerable: true, get: function () { return message_type_1.MessageType; } }));
 // Reflection info, generated by the plugin, exposed to the user, used by reflection ops
-var reflection_info_1 = __nccwpck_require__(431);
+var reflection_info_1 = __nccwpck_require__(430);
 Object.defineProperty(exports, "ScalarType", ({ enumerable: true, get: function () { return reflection_info_1.ScalarType; } }));
 Object.defineProperty(exports, "LongType", ({ enumerable: true, get: function () { return reflection_info_1.LongType; } }));
 Object.defineProperty(exports, "RepeatType", ({ enumerable: true, get: function () { return reflection_info_1.RepeatType; } }));
@@ -3070,44 +3070,44 @@ Object.defineProperty(exports, "readFieldOptions", ({ enumerable: true, get: fun
 Object.defineProperty(exports, "readFieldOption", ({ enumerable: true, get: function () { return reflection_info_1.readFieldOption; } }));
 Object.defineProperty(exports, "readMessageOption", ({ enumerable: true, get: function () { return reflection_info_1.readMessageOption; } }));
 // Message operations via reflection
-var reflection_type_check_1 = __nccwpck_require__(282);
+var reflection_type_check_1 = __nccwpck_require__(281);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
-var reflection_create_1 = __nccwpck_require__(201);
+var reflection_create_1 = __nccwpck_require__(200);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
-var reflection_scalar_default_1 = __nccwpck_require__(440);
+var reflection_scalar_default_1 = __nccwpck_require__(439);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
 var reflection_merge_partial_1 = __nccwpck_require__(136);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
-var reflection_equals_1 = __nccwpck_require__(439);
+var reflection_equals_1 = __nccwpck_require__(438);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
-var reflection_binary_reader_1 = __nccwpck_require__(389);
+var reflection_binary_reader_1 = __nccwpck_require__(388);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
-var reflection_binary_writer_1 = __nccwpck_require__(182);
+var reflection_binary_writer_1 = __nccwpck_require__(181);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
-var reflection_json_reader_1 = __nccwpck_require__(332);
+var reflection_json_reader_1 = __nccwpck_require__(331);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
 var reflection_json_writer_1 = __nccwpck_require__(89);
 Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get: function () { return reflection_json_writer_1.ReflectionJsonWriter; } }));
 var reflection_contains_message_type_1 = __nccwpck_require__(48);
 Object.defineProperty(exports, "containsMessageType", ({ enumerable: true, get: function () { return reflection_contains_message_type_1.containsMessageType; } }));
 // Oneof helpers
-var oneof_1 = __nccwpck_require__(186);
+var oneof_1 = __nccwpck_require__(185);
 Object.defineProperty(exports, "isOneofGroup", ({ enumerable: true, get: function () { return oneof_1.isOneofGroup; } }));
 Object.defineProperty(exports, "setOneofValue", ({ enumerable: true, get: function () { return oneof_1.setOneofValue; } }));
 Object.defineProperty(exports, "getOneofValue", ({ enumerable: true, get: function () { return oneof_1.getOneofValue; } }));
 Object.defineProperty(exports, "clearOneofValue", ({ enumerable: true, get: function () { return oneof_1.clearOneofValue; } }));
 Object.defineProperty(exports, "getSelectedOneofValue", ({ enumerable: true, get: function () { return oneof_1.getSelectedOneofValue; } }));
 // Enum object type guard and reflection util, may be interesting to the user.
-var enum_object_1 = __nccwpck_require__(267);
+var enum_object_1 = __nccwpck_require__(266);
 Object.defineProperty(exports, "listEnumValues", ({ enumerable: true, get: function () { return enum_object_1.listEnumValues; } }));
 Object.defineProperty(exports, "listEnumNames", ({ enumerable: true, get: function () { return enum_object_1.listEnumNames; } }));
 Object.defineProperty(exports, "listEnumNumbers", ({ enumerable: true, get: function () { return enum_object_1.listEnumNumbers; } }));
 Object.defineProperty(exports, "isEnumObject", ({ enumerable: true, get: function () { return enum_object_1.isEnumObject; } }));
 // lowerCamelCase() is exported for plugin, rpc-runtime and other rpc packages
-var lower_camel_case_1 = __nccwpck_require__(432);
+var lower_camel_case_1 = __nccwpck_require__(431);
 Object.defineProperty(exports, "lowerCamelCase", ({ enumerable: true, get: function () { return lower_camel_case_1.lowerCamelCase; } }));
 // assertion functions are exported for plugin, may also be useful to user
-var assert_1 = __nccwpck_require__(462);
+var assert_1 = __nccwpck_require__(461);
 Object.defineProperty(exports, "assert", ({ enumerable: true, get: function () { return assert_1.assert; } }));
 Object.defineProperty(exports, "assertNever", ({ enumerable: true, get: function () { return assert_1.assertNever; } }));
 Object.defineProperty(exports, "assertInt32", ({ enumerable: true, get: function () { return assert_1.assertInt32; } }));
@@ -3190,7 +3190,7 @@ const XML_CHARKEY = "_";
 /***/ 20:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(191)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(190)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -3254,7 +3254,7 @@ __export(throttlingRetryPolicy_exports, {
   throttlingRetryPolicyName: () => throttlingRetryPolicyName
 });
 module.exports = __toCommonJS(throttlingRetryPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const throttlingRetryPolicyName = import_policies.throttlingRetryPolicyName;
 function throttlingRetryPolicy(options = {}) {
   return (0, import_policies.throttlingRetryPolicy)(options);
@@ -3271,7 +3271,7 @@ function throttlingRetryPolicy(options = {}) {
 "use strict";
 
 
-const Busboy = __nccwpck_require__(396)
+const Busboy = __nccwpck_require__(395)
 const util = __nccwpck_require__(66)
 const {
   ReadableStreamFrom,
@@ -3280,22 +3280,22 @@ const {
   readableStreamClose,
   createDeferredPromise,
   fullyReadBody
-} = __nccwpck_require__(493)
-const { FormData } = __nccwpck_require__(203)
+} = __nccwpck_require__(492)
+const { FormData } = __nccwpck_require__(202)
 const { kState } = __nccwpck_require__(13)
-const { webidl } = __nccwpck_require__(435)
+const { webidl } = __nccwpck_require__(434)
 const { DOMException, structuredClone } = __nccwpck_require__(28)
-const { Blob, File: NativeFile } = __nccwpck_require__(118)
-const { kBodyUsed } = __nccwpck_require__(191)
+const { Blob, File: NativeFile } = __nccwpck_require__(119)
+const { kBodyUsed } = __nccwpck_require__(190)
 const assert = __nccwpck_require__(501)
 const { isErrored } = __nccwpck_require__(66)
-const { isUint8Array, isArrayBuffer } = __nccwpck_require__(194)
-const { File: UndiciFile } = __nccwpck_require__(349)
+const { isUint8Array, isArrayBuffer } = __nccwpck_require__(193)
+const { File: UndiciFile } = __nccwpck_require__(348)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(23)
 
 let random
 try {
-  const crypto = __nccwpck_require__(269)
+  const crypto = __nccwpck_require__(268)
   random = (max) => crypto.randomInt(0, max)
 } catch {
   random = (max) => Math.floor(Math.random(max))
@@ -3311,7 +3311,7 @@ const textDecoder = new TextDecoder()
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 function extractBody (object, keepalive = false) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(251).ReadableStream)
+    ReadableStream = (__nccwpck_require__(250).ReadableStream)
   }
 
   // 1. Let stream be null.
@@ -3532,7 +3532,7 @@ function extractBody (object, keepalive = false) {
 function safelyExtractBody (object, keepalive = false) {
   if (!ReadableStream) {
     // istanbul ignore next
-    ReadableStream = (__nccwpck_require__(251).ReadableStream)
+    ReadableStream = (__nccwpck_require__(250).ReadableStream)
   }
 
   // To safely extract a body and a `Content-Type` value from
@@ -3890,8 +3890,8 @@ module.exports = {
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(501)
-const { atob } = __nccwpck_require__(118)
-const { isomorphicDecode } = __nccwpck_require__(493)
+const { atob } = __nccwpck_require__(119)
+const { isomorphicDecode } = __nccwpck_require__(492)
 
 const encoder = new TextEncoder()
 
@@ -4534,9 +4534,9 @@ module.exports = {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(211);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(418));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
+const tslib_1 = __nccwpck_require__(210);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(417));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing AppendBlob operations. */
 class AppendBlobImpl {
@@ -4869,7 +4869,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(378);
+var import_exponentialRetryStrategy = __nccwpck_require__(377);
 var import_retryPolicy = __nccwpck_require__(14);
 var import_constants = __nccwpck_require__(46);
 const systemErrorRetryPolicyName = "systemErrorRetryPolicy";
@@ -4943,7 +4943,7 @@ function rangeResponseFromModel(response) {
 "use strict";
 
 
-const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(309)
+const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(308)
 
 const corsSafeListedMethods = ['GET', 'HEAD', 'POST']
 const corsSafeListedMethodsSet = new Set(corsSafeListedMethods)
@@ -5230,18 +5230,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.reserveCache = exports.downloadCache = exports.getCacheEntry = void 0;
-const core = __importStar(__nccwpck_require__(437));
-const http_client_1 = __nccwpck_require__(278);
+const core = __importStar(__nccwpck_require__(436));
+const http_client_1 = __nccwpck_require__(277);
 const auth_1 = __nccwpck_require__(25);
 const fs = __importStar(__nccwpck_require__(507));
 const url_1 = __nccwpck_require__(84);
 const utils = __importStar(__nccwpck_require__(73));
 const uploadUtils_1 = __nccwpck_require__(158);
 const downloadUtils_1 = __nccwpck_require__(3);
-const options_1 = __nccwpck_require__(260);
-const requestUtils_1 = __nccwpck_require__(256);
+const options_1 = __nccwpck_require__(259);
+const requestUtils_1 = __nccwpck_require__(255);
 const config_1 = __nccwpck_require__(35);
-const user_agent_1 = __nccwpck_require__(347);
+const user_agent_1 = __nccwpck_require__(346);
 function getCacheApiUrl(resource) {
     const baseUrl = (0, config_1.getCacheServiceURL)();
     if (!baseUrl) {
@@ -5480,7 +5480,7 @@ __export(throttlingRetryStrategy_exports, {
   throttlingRetryStrategy: () => throttlingRetryStrategy
 });
 module.exports = __toCommonJS(throttlingRetryStrategy_exports);
-var import_helpers = __nccwpck_require__(434);
+var import_helpers = __nccwpck_require__(433);
 const RetryAfterHeader = "Retry-After";
 const AllRetryAfterHeaders = ["retry-after-ms", "x-ms-retry-after-ms", RetryAfterHeader];
 function getRetryAfterInMs(response) {
@@ -5696,7 +5696,7 @@ __export(proxyPolicy_exports, {
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
 var import_https_proxy_agent = __nccwpck_require__(132);
-var import_http_proxy_agent = __nccwpck_require__(217);
+var import_http_proxy_agent = __nccwpck_require__(216);
 var import_log = __nccwpck_require__(150);
 const HTTPS_PROXY = "HTTPS_PROXY";
 const HTTP_PROXY = "HTTP_PROXY";
@@ -5870,7 +5870,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 "use strict";
 
 
-const { Headers, HeadersList, fill } = __nccwpck_require__(492)
+const { Headers, HeadersList, fill } = __nccwpck_require__(491)
 const { extractBody, cloneBody, mixinBody } = __nccwpck_require__(22)
 const util = __nccwpck_require__(66)
 const { kEnumerableProperty } = util
@@ -5882,22 +5882,22 @@ const {
   serializeJavascriptValueToJSONString,
   isErrorLike,
   isomorphicEncode
-} = __nccwpck_require__(493)
+} = __nccwpck_require__(492)
 const {
   redirectStatusSet,
   nullBodyStatus,
   DOMException
 } = __nccwpck_require__(28)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(13)
-const { webidl } = __nccwpck_require__(435)
-const { FormData } = __nccwpck_require__(203)
+const { webidl } = __nccwpck_require__(434)
+const { FormData } = __nccwpck_require__(202)
 const { getGlobalOrigin } = __nccwpck_require__(139)
 const { URLSerializer } = __nccwpck_require__(23)
-const { kHeadersList, kConstruct } = __nccwpck_require__(191)
+const { kHeadersList, kConstruct } = __nccwpck_require__(190)
 const assert = __nccwpck_require__(501)
-const { types } = __nccwpck_require__(122)
+const { types } = __nccwpck_require__(123)
 
-const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(251).ReadableStream)
+const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(250).ReadableStream)
 const textEncoder = new TextEncoder('utf-8')
 
 // https://fetch.spec.whatwg.org/#response-class
@@ -6531,7 +6531,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
-const pathHelper = __importStar(__nccwpck_require__(216));
+const pathHelper = __importStar(__nccwpck_require__(215));
 const internal_match_kind_1 = __nccwpck_require__(504);
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -6770,9 +6770,9 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(211);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(418));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
+const tslib_1 = __nccwpck_require__(210);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(417));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing Blob operations. */
 class BlobImpl {
@@ -7845,7 +7845,7 @@ exports.StorageBrowserPolicy = void 0;
 const RequestPolicy_js_1 = __nccwpck_require__(44);
 const core_util_1 = __nccwpck_require__(12);
 const constants_js_1 = __nccwpck_require__(34);
-const utils_common_js_1 = __nccwpck_require__(451);
+const utils_common_js_1 = __nccwpck_require__(450);
 /**
  * StorageBrowserPolicy will handle differences between Node.js and browser runtime, including:
  *
@@ -7898,7 +7898,7 @@ exports.StorageBrowserPolicy = StorageBrowserPolicy;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.containsMessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(386);
+const message_type_contract_1 = __nccwpck_require__(385);
 /**
  * Check if the provided object is a proto message.
  *
@@ -7923,7 +7923,7 @@ exports.containsMessageType = containsMessageType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollHttpOperation = exports.isOperationError = exports.getResourceLocation = exports.getOperationStatus = exports.getOperationLocation = exports.initHttpOperation = exports.getStatusFromInitialResponse = exports.getErrorFromResponse = exports.parseRetryAfter = exports.inferLroMode = void 0;
 const operation_js_1 = __nccwpck_require__(140);
-const logger_js_1 = __nccwpck_require__(187);
+const logger_js_1 = __nccwpck_require__(186);
 function getOperationLocationPollingUrl(inputs) {
     const { azureAsyncOperation, operationLocation } = inputs;
     return operationLocation !== null && operationLocation !== void 0 ? operationLocation : azureAsyncOperation;
@@ -8321,14 +8321,14 @@ const {
   kResult,
   kAborted,
   kLastProgressEventFired
-} = __nccwpck_require__(438)
-const { ProgressEvent } = __nccwpck_require__(421)
-const { getEncoding } = __nccwpck_require__(96)
+} = __nccwpck_require__(437)
+const { ProgressEvent } = __nccwpck_require__(420)
+const { getEncoding } = __nccwpck_require__(97)
 const { DOMException } = __nccwpck_require__(28)
 const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(23)
-const { types } = __nccwpck_require__(122)
+const { types } = __nccwpck_require__(123)
 const { StringDecoder } = __nccwpck_require__(148)
-const { btoa } = __nccwpck_require__(118)
+const { btoa } = __nccwpck_require__(119)
 
 /** @type {PropertyDescriptor} */
 const staticPropertyDescriptors = {
@@ -8735,7 +8735,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const defaultRetryPolicyName = import_policies.defaultRetryPolicyName;
 function defaultRetryPolicy(options = {}) {
   return (0, import_policies.defaultRetryPolicy)(options);
@@ -8809,9 +8809,9 @@ exports.UnaryCall = UnaryCall;
 "use strict";
 
 
-const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(97)
-const { states, opcodes } = __nccwpck_require__(443)
-const { MessageEvent, ErrorEvent } = __nccwpck_require__(244)
+const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(98)
+const { states, opcodes } = __nccwpck_require__(442)
+const { MessageEvent, ErrorEvent } = __nccwpck_require__(243)
 
 /* globals Blob */
 
@@ -9292,15 +9292,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.internalCacheTwirpClient = void 0;
-const core_1 = __nccwpck_require__(437);
-const user_agent_1 = __nccwpck_require__(347);
-const errors_1 = __nccwpck_require__(296);
+const core_1 = __nccwpck_require__(436);
+const user_agent_1 = __nccwpck_require__(346);
+const errors_1 = __nccwpck_require__(295);
 const config_1 = __nccwpck_require__(35);
 const cacheUtils_1 = __nccwpck_require__(73);
 const auth_1 = __nccwpck_require__(25);
-const http_client_1 = __nccwpck_require__(278);
-const cache_twirp_client_1 = __nccwpck_require__(415);
-const util_1 = __nccwpck_require__(288);
+const http_client_1 = __nccwpck_require__(277);
+const cache_twirp_client_1 = __nccwpck_require__(414);
+const util_1 = __nccwpck_require__(287);
 /**
  * This class is a wrapper around the CacheServiceClientJSON class generated by Twirp.
  *
@@ -9451,13 +9451,13 @@ exports.internalCacheTwirpClient = internalCacheTwirpClient;
 "use strict";
 
 
-const Dispatcher = __nccwpck_require__(455)
+const Dispatcher = __nccwpck_require__(454)
 const {
   ClientDestroyedError,
   ClientClosedError,
   InvalidArgumentError
-} = __nccwpck_require__(466)
-const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(191)
+} = __nccwpck_require__(465)
+const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(190)
 
 const kDestroyed = Symbol('destroyed')
 const kClosed = Symbol('closed')
@@ -9672,8 +9672,8 @@ __export(requestPolicyFactoryPolicy_exports, {
   requestPolicyFactoryPolicyName: () => requestPolicyFactoryPolicyName
 });
 module.exports = __toCommonJS(requestPolicyFactoryPolicy_exports);
-var import_util = __nccwpck_require__(108);
-var import_response = __nccwpck_require__(392);
+var import_util = __nccwpck_require__(109);
+var import_response = __nccwpck_require__(391);
 var HttpPipelineLogLevel = /* @__PURE__ */ ((HttpPipelineLogLevel2) => {
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["ERROR"] = 1] = "ERROR";
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["INFO"] = 3] = "INFO";
@@ -9723,18 +9723,18 @@ function createRequestPolicyFactoryPolicy(factories) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(100);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
 const core_util_1 = __nccwpck_require__(12);
-const core_auth_1 = __nccwpck_require__(490);
-const storage_common_1 = __nccwpck_require__(271);
-const Pipeline_js_1 = __nccwpck_require__(179);
-const StorageClient_js_1 = __nccwpck_require__(433);
+const core_auth_1 = __nccwpck_require__(489);
+const storage_common_1 = __nccwpck_require__(270);
+const Pipeline_js_1 = __nccwpck_require__(178);
+const StorageClient_js_1 = __nccwpck_require__(432);
 const tracing_js_1 = __nccwpck_require__(29);
 const utils_common_js_1 = __nccwpck_require__(153);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(65);
-const BlobLeaseClient_js_1 = __nccwpck_require__(200);
-const Clients_js_1 = __nccwpck_require__(181);
-const BlobBatchClient_js_1 = __nccwpck_require__(384);
+const BlobLeaseClient_js_1 = __nccwpck_require__(199);
+const Clients_js_1 = __nccwpck_require__(180);
+const BlobBatchClient_js_1 = __nccwpck_require__(383);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
  */
@@ -11036,7 +11036,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.action3 = exports.action2 = exports.leaseId1 = exports.action1 = exports.proposedLeaseId = exports.duration = exports.action = exports.comp10 = exports.sourceLeaseId = exports.sourceContainerName = exports.comp9 = exports.deletedContainerVersion = exports.deletedContainerName = exports.comp8 = exports.containerAcl = exports.comp7 = exports.comp6 = exports.ifUnmodifiedSince = exports.ifModifiedSince = exports.leaseId = exports.preventEncryptionScopeOverride = exports.defaultEncryptionScope = exports.access = exports.metadata = exports.restype2 = exports.where = exports.comp5 = exports.multipartContentType = exports.contentLength = exports.comp4 = exports.body = exports.restype1 = exports.comp3 = exports.keyInfo = exports.include = exports.maxPageSize = exports.marker = exports.prefix = exports.comp2 = exports.comp1 = exports.accept1 = exports.requestId = exports.version = exports.timeoutInSeconds = exports.comp = exports.restype = exports.url = exports.accept = exports.blobServiceProperties = exports.contentType = void 0;
 exports.copySourceTags = exports.copySourceAuthorization = exports.sourceContentMD5 = exports.xMsRequiresSync = exports.legalHold1 = exports.sealBlob = exports.blobTagsString = exports.copySource = exports.sourceIfTags = exports.sourceIfNoneMatch = exports.sourceIfMatch = exports.sourceIfUnmodifiedSince = exports.sourceIfModifiedSince = exports.rehydratePriority = exports.tier = exports.comp14 = exports.encryptionScope = exports.legalHold = exports.comp13 = exports.immutabilityPolicyMode = exports.immutabilityPolicyExpiry = exports.comp12 = exports.blobContentDisposition = exports.blobContentLanguage = exports.blobContentEncoding = exports.blobContentMD5 = exports.blobContentType = exports.blobCacheControl = exports.expiresOn = exports.expiryOptions = exports.comp11 = exports.blobDeleteType = exports.deleteSnapshots = exports.ifTags = exports.ifNoneMatch = exports.ifMatch = exports.encryptionAlgorithm = exports.encryptionKeySha256 = exports.encryptionKey = exports.rangeGetContentCRC64 = exports.rangeGetContentMD5 = exports.range = exports.versionId = exports.snapshot = exports.delimiter = exports.startFrom = exports.include1 = exports.proposedLeaseId1 = exports.action4 = exports.breakPeriod = void 0;
 exports.listType = exports.comp25 = exports.blocks = exports.blockId = exports.comp24 = exports.copySourceBlobProperties = exports.blobType2 = exports.comp23 = exports.sourceRange1 = exports.appendPosition = exports.maxSize = exports.comp22 = exports.blobType1 = exports.comp21 = exports.sequenceNumberAction = exports.prevSnapshotUrl = exports.prevsnapshot = exports.comp20 = exports.range1 = exports.sourceContentCrc64 = exports.sourceRange = exports.sourceUrl = exports.pageWrite1 = exports.ifSequenceNumberEqualTo = exports.ifSequenceNumberLessThan = exports.ifSequenceNumberLessThanOrEqualTo = exports.pageWrite = exports.comp19 = exports.accept2 = exports.body1 = exports.contentType1 = exports.blobSequenceNumber = exports.blobContentLength = exports.blobType = exports.transactionalContentCrc64 = exports.transactionalContentMD5 = exports.tags = exports.ifNoneMatch1 = exports.ifMatch1 = exports.ifUnmodifiedSince1 = exports.ifModifiedSince1 = exports.comp18 = exports.comp17 = exports.queryRequest = exports.tier1 = exports.comp16 = exports.copyId = exports.copyActionAbortConstant = exports.comp15 = exports.fileRequestIntent = void 0;
-const mappers_js_1 = __nccwpck_require__(176);
+const mappers_js_1 = __nccwpck_require__(175);
 exports.contentType = {
     parameterPath: ["options", "contentType"],
     mapper: {
@@ -12712,8 +12712,8 @@ exports.listType = {
 "use strict";
 
 
-const inherits = (__nccwpck_require__(359).inherits)
-const ReadableStream = (__nccwpck_require__(408).Readable)
+const inherits = (__nccwpck_require__(358).inherits)
+const ReadableStream = (__nccwpck_require__(407).Readable)
 
 function PartStream (opts) {
   ReadableStream.call(this, opts)
@@ -12745,14 +12745,14 @@ exports.generateBlobSASQueryParameters = generateBlobSASQueryParameters;
 exports.generateBlobSASQueryParametersInternal = generateBlobSASQueryParametersInternal;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const BlobSASPermissions_js_1 = __nccwpck_require__(480);
-const ContainerSASPermissions_js_1 = __nccwpck_require__(273);
-const storage_common_1 = __nccwpck_require__(271);
-const SasIPRange_js_1 = __nccwpck_require__(345);
+const BlobSASPermissions_js_1 = __nccwpck_require__(479);
+const ContainerSASPermissions_js_1 = __nccwpck_require__(272);
+const storage_common_1 = __nccwpck_require__(270);
+const SasIPRange_js_1 = __nccwpck_require__(344);
 const SASQueryParameters_js_1 = __nccwpck_require__(500);
 const constants_js_1 = __nccwpck_require__(147);
 const utils_common_js_1 = __nccwpck_require__(153);
-const storage_common_2 = __nccwpck_require__(271);
+const storage_common_2 = __nccwpck_require__(270);
 function generateBlobSASQueryParameters(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName) {
     return generateBlobSASQueryParametersInternal(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName).sasQueryParameters;
 }
@@ -13419,13 +13419,13 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 
 
 const assert = __nccwpck_require__(501)
-const { kDestroyed, kBodyUsed } = __nccwpck_require__(191)
-const { IncomingMessage } = __nccwpck_require__(320)
+const { kDestroyed, kBodyUsed } = __nccwpck_require__(190)
+const { IncomingMessage } = __nccwpck_require__(319)
 const stream = __nccwpck_require__(130)
-const net = __nccwpck_require__(486)
-const { InvalidArgumentError } = __nccwpck_require__(466)
-const { Blob } = __nccwpck_require__(118)
-const nodeUtil = __nccwpck_require__(122)
+const net = __nccwpck_require__(485)
+const { InvalidArgumentError } = __nccwpck_require__(465)
+const { Blob } = __nccwpck_require__(119)
+const nodeUtil = __nccwpck_require__(123)
 const { stringify } = __nccwpck_require__(129)
 const { headerNameLowerCasedRecord } = __nccwpck_require__(70)
 
@@ -13796,7 +13796,7 @@ async function * convertIterableToBuffer (iterable) {
 let ReadableStream
 function ReadableStreamFrom (iterable) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(251).ReadableStream)
+    ReadableStream = (__nccwpck_require__(250).ReadableStream)
   }
 
   if (ReadableStream.from) {
@@ -13976,8 +13976,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(180);
-var import_policies = __nccwpck_require__(279);
+var import_log = __nccwpck_require__(179);
+var import_policies = __nccwpck_require__(278);
 const logPolicyName = import_policies.logPolicyName;
 function logPolicy(options = {}) {
   return (0, import_policies.logPolicy)({
@@ -14023,12 +14023,12 @@ __export(src_exports, {
   toHttpHeadersLike: () => import_util.toHttpHeadersLike
 });
 module.exports = __toCommonJS(src_exports);
-var import_extendedClient = __nccwpck_require__(210);
-var import_response = __nccwpck_require__(392);
+var import_extendedClient = __nccwpck_require__(209);
+var import_response = __nccwpck_require__(391);
 var import_requestPolicyFactoryPolicy = __nccwpck_require__(60);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_httpClientAdapter = __nccwpck_require__(206);
-var import_util = __nccwpck_require__(108);
+var import_httpClientAdapter = __nccwpck_require__(205);
+var import_util = __nccwpck_require__(109);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -14202,9 +14202,9 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StatsCollector = void 0;
-const fs = __importStar(__nccwpck_require__(107));
-const path = __importStar(__nccwpck_require__(485));
-const core = __importStar(__nccwpck_require__(437));
+const fs = __importStar(__nccwpck_require__(108));
+const path = __importStar(__nccwpck_require__(484));
+const core = __importStar(__nccwpck_require__(436));
 function fmtBytes(n) {
     if (n === null)
         return "-";
@@ -14818,15 +14818,15 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
-const core = __importStar(__nccwpck_require__(437));
+const core = __importStar(__nccwpck_require__(436));
 const exec = __importStar(__nccwpck_require__(16));
-const glob = __importStar(__nccwpck_require__(166));
-const io = __importStar(__nccwpck_require__(287));
-const crypto = __importStar(__nccwpck_require__(284));
+const glob = __importStar(__nccwpck_require__(165));
+const io = __importStar(__nccwpck_require__(286));
+const crypto = __importStar(__nccwpck_require__(283));
 const fs = __importStar(__nccwpck_require__(507));
-const path = __importStar(__nccwpck_require__(242));
-const semver = __importStar(__nccwpck_require__(175));
-const util = __importStar(__nccwpck_require__(122));
+const path = __importStar(__nccwpck_require__(241));
+const semver = __importStar(__nccwpck_require__(174));
+const util = __importStar(__nccwpck_require__(123));
 const constants_1 = __nccwpck_require__(43);
 const versionSalt = '1.0';
 // From https://github.com/actions/toolkit/blob/main/packages/tool-cache/src/tool-cache.ts#L23
@@ -15013,10 +15013,10 @@ module.exports = 'AGFzbQEAAAABMAhgAX8Bf2ADf39/AX9gBH9/f38Bf2AAAGADf39/AGABfwBgAn
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageSharedKeyCredentialPolicyName = void 0;
 exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
-const node_crypto_1 = __nccwpck_require__(269);
+const node_crypto_1 = __nccwpck_require__(268);
 const constants_js_1 = __nccwpck_require__(34);
-const utils_common_js_1 = __nccwpck_require__(451);
-const SharedKeyComparator_js_1 = __nccwpck_require__(173);
+const utils_common_js_1 = __nccwpck_require__(450);
+const SharedKeyComparator_js_1 = __nccwpck_require__(172);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
  */
@@ -15210,10 +15210,10 @@ exports.buildMiniCacheKey = buildMiniCacheKey;
 exports.restoreMiniCache = restoreMiniCache;
 exports.saveMiniCache = saveMiniCache;
 exports.isEligibleForMiniCache = isEligibleForMiniCache;
-const fs = __importStar(__nccwpck_require__(243));
-const fsp = __importStar(__nccwpck_require__(107));
-const path = __importStar(__nccwpck_require__(485));
-const cache = __importStar(__nccwpck_require__(209));
+const fs = __importStar(__nccwpck_require__(242));
+const fsp = __importStar(__nccwpck_require__(108));
+const path = __importStar(__nccwpck_require__(484));
+const cache = __importStar(__nccwpck_require__(208));
 const cache_compress_js_1 = __nccwpck_require__(502);
 const MINI_KEY_PREFIX = "soldr-mini";
 /**
@@ -15439,10 +15439,10 @@ exports.isGitRepo = isGitRepo;
 exports.listTrackedFiles = listTrackedFiles;
 exports.normalizeWorkspace = normalizeWorkspace;
 exports.normalizeSourceMtime = normalizeSourceMtime;
-const fs = __importStar(__nccwpck_require__(243));
-const path = __importStar(__nccwpck_require__(485));
+const fs = __importStar(__nccwpck_require__(242));
+const path = __importStar(__nccwpck_require__(484));
 const exec = __importStar(__nccwpck_require__(16));
-const log_utils_js_1 = __nccwpck_require__(339);
+const log_utils_js_1 = __nccwpck_require__(338);
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 // Globs evaluated against the repo-relative POSIX path of each tracked file.
 const INCLUDE_GLOBS = [
@@ -15682,7 +15682,7 @@ exports._internal = {
 
 const assert = __nccwpck_require__(501)
 const { URLSerializer } = __nccwpck_require__(23)
-const { isValidHeaderName } = __nccwpck_require__(493)
+const { isValidHeaderName } = __nccwpck_require__(492)
 
 /**
  * @see https://url.spec.whatwg.org/#concept-url-equals
@@ -15788,8 +15788,8 @@ exports.readJournal = readJournal;
 exports.summarize = summarize;
 exports.formatJournalSection = formatJournalSection;
 exports.formatRollupsSection = formatRollupsSection;
-const fs = __importStar(__nccwpck_require__(243));
-const diagnostics_js_1 = __nccwpck_require__(226);
+const fs = __importStar(__nccwpck_require__(242));
+const diagnostics_js_1 = __nccwpck_require__(225);
 const SLOWEST_TOP_N = 20;
 /**
  * Read a `last-session.jsonl` file. Returns `null` if it doesn't exist
@@ -16092,12 +16092,12 @@ function formatRollupsSection(report) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageRetryPolicy = void 0;
 exports.NewRetryPolicyFactory = NewRetryPolicyFactory;
-const abort_controller_1 = __nccwpck_require__(472);
+const abort_controller_1 = __nccwpck_require__(471);
 const RequestPolicy_js_1 = __nccwpck_require__(44);
 const constants_js_1 = __nccwpck_require__(34);
-const utils_common_js_1 = __nccwpck_require__(451);
+const utils_common_js_1 = __nccwpck_require__(450);
 const log_js_1 = __nccwpck_require__(15);
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(397);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(396);
 /**
  * A factory method used to generated a RetryPolicy factory.
  *
@@ -16322,9 +16322,9 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = exports.useInstrumenter = void 0;
-var instrumenter_js_1 = __nccwpck_require__(387);
+var instrumenter_js_1 = __nccwpck_require__(386);
 Object.defineProperty(exports, "useInstrumenter", ({ enumerable: true, get: function () { return instrumenter_js_1.useInstrumenter; } }));
-var tracingClient_js_1 = __nccwpck_require__(335);
+var tracingClient_js_1 = __nccwpck_require__(334);
 Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: function () { return tracingClient_js_1.createTracingClient; } }));
 //# sourceMappingURL=index.js.map
 
@@ -16351,8 +16351,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 
 const { extractBody, mixinBody, cloneBody } = __nccwpck_require__(22)
-const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(492)
-const { FinalizationRegistry } = __nccwpck_require__(394)()
+const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(491)
+const { FinalizationRegistry } = __nccwpck_require__(393)()
 const util = __nccwpck_require__(66)
 const {
   isValidHTTPToken,
@@ -16360,7 +16360,7 @@ const {
   normalizeMethod,
   makePolicyContainer,
   normalizeMethodRecord
-} = __nccwpck_require__(493)
+} = __nccwpck_require__(492)
 const {
   forbiddenMethodsSet,
   corsSafeListedMethodsSet,
@@ -16373,12 +16373,12 @@ const {
 } = __nccwpck_require__(28)
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(13)
-const { webidl } = __nccwpck_require__(435)
+const { webidl } = __nccwpck_require__(434)
 const { getGlobalOrigin } = __nccwpck_require__(139)
 const { URLSerializer } = __nccwpck_require__(23)
-const { kHeadersList, kConstruct } = __nccwpck_require__(191)
+const { kHeadersList, kConstruct } = __nccwpck_require__(190)
 const assert = __nccwpck_require__(501)
-const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(447)
+const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(446)
 
 let TransformStream = globalThis.TransformStream
 
@@ -16865,7 +16865,7 @@ class Request {
 
       // 2. Set finalBody to the result of creating a proxy for inputBody.
       if (!TransformStream) {
-        TransformStream = (__nccwpck_require__(251).TransformStream)
+        TransformStream = (__nccwpck_require__(250).TransformStream)
       }
 
       // https://streams.spec.whatwg.org/#readablestream-create-a-proxy
@@ -17314,10 +17314,10 @@ module.exports = require("url");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.deserializationPolicyName = void 0;
 exports.deserializationPolicy = deserializationPolicy;
-const interfaces_js_1 = __nccwpck_require__(98);
-const core_rest_pipeline_1 = __nccwpck_require__(100);
-const serializer_js_1 = __nccwpck_require__(457);
-const operationHelpers_js_1 = __nccwpck_require__(410);
+const interfaces_js_1 = __nccwpck_require__(99);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
+const serializer_js_1 = __nccwpck_require__(456);
+const operationHelpers_js_1 = __nccwpck_require__(409);
 const defaultJsonContentTypes = ["application/json", "text/json"];
 const defaultXmlContentTypes = ["application/xml", "application/atom+xml"];
 /**
@@ -17571,7 +17571,7 @@ __export(apiKeyAuthenticationPolicy_exports, {
   apiKeyAuthenticationPolicyName: () => apiKeyAuthenticationPolicyName
 });
 module.exports = __toCommonJS(apiKeyAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(413);
+var import_checkInsecureConnection = __nccwpck_require__(412);
 const apiKeyAuthenticationPolicyName = "apiKeyAuthenticationPolicy";
 function apiKeyAuthenticationPolicy(options) {
   return {
@@ -17608,12 +17608,12 @@ function apiKeyAuthenticationPolicy(options) {
 /* global WebAssembly */
 
 const assert = __nccwpck_require__(501)
-const net = __nccwpck_require__(486)
-const http = __nccwpck_require__(320)
+const net = __nccwpck_require__(485)
+const http = __nccwpck_require__(319)
 const { pipeline } = __nccwpck_require__(130)
 const util = __nccwpck_require__(66)
-const timers = __nccwpck_require__(319)
-const Request = __nccwpck_require__(291)
+const timers = __nccwpck_require__(318)
+const Request = __nccwpck_require__(290)
 const DispatcherBase = __nccwpck_require__(59)
 const {
   RequestContentLengthMismatchError,
@@ -17628,8 +17628,8 @@ const {
   HTTPParserError,
   ResponseExceededMaxSizeError,
   ClientDestroyedError
-} = __nccwpck_require__(466)
-const buildConnector = __nccwpck_require__(261)
+} = __nccwpck_require__(465)
+const buildConnector = __nccwpck_require__(260)
 const {
   kUrl,
   kReset,
@@ -17681,7 +17681,7 @@ const {
   kHTTP2BuildRequest,
   kHTTP2CopyHeaders,
   kHTTP1BuildRequest
-} = __nccwpck_require__(191)
+} = __nccwpck_require__(190)
 
 /** @type {import('http2')} */
 let http2
@@ -18087,8 +18087,8 @@ function onHTTP2GoAway (code) {
   resume(client)
 }
 
-const constants = __nccwpck_require__(427)
-const createRedirectInterceptor = __nccwpck_require__(249)
+const constants = __nccwpck_require__(426)
+const createRedirectInterceptor = __nccwpck_require__(248)
 const EMPTY_BUF = Buffer.alloc(0)
 
 async function lazyllhttp () {
@@ -19929,16 +19929,16 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 var import_AbortError = __nccwpck_require__(9);
-var import_logger = __nccwpck_require__(240);
-var import_httpHeaders = __nccwpck_require__(463);
-var import_pipelineRequest = __nccwpck_require__(114);
+var import_logger = __nccwpck_require__(239);
+var import_httpHeaders = __nccwpck_require__(462);
+var import_pipelineRequest = __nccwpck_require__(115);
 var import_pipeline = __nccwpck_require__(499);
-var import_restError = __nccwpck_require__(423);
-var import_bytesEncoding = __nccwpck_require__(280);
-var import_defaultHttpClient = __nccwpck_require__(356);
-var import_getClient = __nccwpck_require__(205);
-var import_operationOptionHelpers = __nccwpck_require__(367);
-var import_restError2 = __nccwpck_require__(352);
+var import_restError = __nccwpck_require__(422);
+var import_bytesEncoding = __nccwpck_require__(279);
+var import_defaultHttpClient = __nccwpck_require__(355);
+var import_getClient = __nccwpck_require__(204);
+var import_operationOptionHelpers = __nccwpck_require__(366);
+var import_restError2 = __nccwpck_require__(351);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -19953,10 +19953,10 @@ var import_restError2 = __nccwpck_require__(352);
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
-const base64_1 = __nccwpck_require__(294);
-const pb_long_1 = __nccwpck_require__(116);
-const reflection_info_1 = __nccwpck_require__(431);
-const assert_1 = __nccwpck_require__(462);
+const base64_1 = __nccwpck_require__(293);
+const pb_long_1 = __nccwpck_require__(117);
+const reflection_info_1 = __nccwpck_require__(430);
+const assert_1 = __nccwpck_require__(461);
 /**
  * Writes proto3 messages in canonical JSON format using reflection
  * information.
@@ -20195,7 +20195,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Batch = void 0;
 // In browser, during webpack or browserify bundling, this module will be replaced by 'events'
 // https://github.com/Gozala/events
-const events_1 = __nccwpck_require__(447);
+const events_1 = __nccwpck_require__(446);
 /**
  * States for Batch.
  */
@@ -20342,7 +20342,7 @@ module.exports = require("os");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredentialPolicy = void 0;
-const CredentialPolicy_js_1 = __nccwpck_require__(300);
+const CredentialPolicy_js_1 = __nccwpck_require__(299);
 /**
  * AnonymousCredentialPolicy is used with HTTP(S) requests that read public resources
  * or for use with Shared Access Signatures (SAS).
@@ -20381,8 +20381,8 @@ const {
   kResult,
   kEvents,
   kAborted
-} = __nccwpck_require__(438)
-const { webidl } = __nccwpck_require__(435)
+} = __nccwpck_require__(437)
+const { webidl } = __nccwpck_require__(434)
 const { kEnumerableProperty } = __nccwpck_require__(66)
 
 class FileReader extends EventTarget {
@@ -20717,6 +20717,1267 @@ module.exports = {
 /***/ }),
 
 /***/ 94:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr post-job entry point. Owned by Agent 2.
+//
+// Runs in the post-job phase via action.yml's `post: dist/post.js`. This is
+// the architectural fix for zackees/setup-soldr#70 — it lets us tar+zstd
+// the build-cache (and optionally cargo-registry) directories BEFORE
+// @actions/cache's post-save uploads them, so the wire format is zstd on
+// every platform (including Windows-x64 where actions/cache@v5 still
+// falls back to gzip).
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.resolveJournalPrintRaw = resolveJournalPrintRaw;
+exports.buildFinalCacheSummary = buildFinalCacheSummary;
+exports.formatFinalCacheSummaryMarkdown = formatFinalCacheSummaryMarkdown;
+exports.setMultiSessionOutputs = setMultiSessionOutputs;
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(242));
+const path = __importStar(__nccwpck_require__(484));
+const node_child_process_1 = __nccwpck_require__(192);
+const core = __importStar(__nccwpck_require__(436));
+const cache = __importStar(__nccwpck_require__(208));
+const cache_compress_js_1 = __nccwpck_require__(502);
+const solo_toolchain_cache_js_1 = __nccwpck_require__(282);
+const cook_cache_js_1 = __nccwpck_require__(459);
+const soldr_mini_cache_js_1 = __nccwpck_require__(76);
+const log_utils_js_1 = __nccwpck_require__(338);
+const shutdown_cache_js_1 = __nccwpck_require__(505);
+const stats_collector_js_1 = __nccwpck_require__(71);
+const compile_cache_stats_js_1 = __nccwpck_require__(498);
+const diagnostics_js_1 = __nccwpck_require__(225);
+const raw_inputs_js_1 = __nccwpck_require__(483);
+const source_mtime_snapshot_js_1 = __nccwpck_require__(387);
+function dirExists(p) {
+    try {
+        return fs.statSync(p).isDirectory();
+    }
+    catch {
+        return false;
+    }
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+function stateBool(name, fallback = false) {
+    const value = core.getState(name).trim().toLowerCase();
+    if (value === "true")
+        return true;
+    if (value === "false")
+        return false;
+    return fallback;
+}
+/**
+ * Decide whether the post-phase diagnostic dump includes the verbatim
+ * per-rustc-invocation JSONL stream. The raw stream is large (thousands
+ * of records / 20-30 MB on the demo warm build) and dominates Post Setup
+ * Soldr wall-clock when emitted. Default: mirror debug mode (preserves
+ * pre-existing behavior for workflows that already opted into debug).
+ * Explicit values "true"/"false"/"on"/"off"/"yes"/"no"/"1"/"0" override.
+ */
+function resolveJournalPrintRaw(rawValue, debugMode) {
+    const v = (rawValue ?? "").trim().toLowerCase();
+    if (v === "")
+        return debugMode;
+    if (v === "true" || v === "1" || v === "yes" || v === "on")
+        return true;
+    if (v === "false" || v === "0" || v === "no" || v === "off")
+        return false;
+    return debugMode;
+}
+function readRestoreState() {
+    return {
+        setupCacheEnabled: stateBool("setupCacheEnabled"),
+        setupCacheExactHit: stateBool("setupCacheExactHit"),
+        setupCacheMatchedKey: core.getState("setupCacheMatchedKey"),
+        targetCacheEnabled: stateBool("targetCacheEnabled"),
+        targetCacheExactHit: stateBool("targetCacheExactHit"),
+        targetCacheMatchedKey: core.getState("targetCacheMatchedKey"),
+        buildCacheEnabled: stateBool("buildCacheEnabled"),
+        buildCacheExactHit: stateBool("buildCacheExactHit"),
+        buildCacheMatchedKey: core.getState("buildCacheMatchedKey"),
+        cargoRegistryCacheEnabled: stateBool("cargoRegistryCacheEnabled"),
+        cargoRegistryCacheExactHit: stateBool("cargoRegistryCacheExactHit"),
+        cargoRegistryCacheMatchedKey: core.getState("cargoRegistryCacheMatchedKey"),
+    };
+}
+function disabledSave() {
+    return { status: "disabled" };
+}
+// setup-cache is intentionally restore-only. Its restore is kept so the
+// action's `cache-hit` output (wired from setupCacheExactHit in main.ts)
+// retains its public contract for downstream workflows, but the save path
+// is permanently inert: the soldr binary moved to soldr-mini-cache (#142)
+// and the rustup toolchain state moved to solo-toolchain-cache (#139),
+// both of which are content-addressable and coarser-keyed. Wiring a save
+// here would re-introduce a duplicate path and defeat those layers' LRU
+// access pattern. See setup-soldr#151 for the full decision rationale.
+function notManagedSave() {
+    return { status: "not-managed-in-post" };
+}
+function restoreStatus(enabled, exactHit, matchedKey) {
+    if (!enabled)
+        return "disabled";
+    if (exactHit)
+        return "exact-hit";
+    if (matchedKey.trim())
+        return "restore-key-hit";
+    return "miss";
+}
+async function saveOne(opts) {
+    const { cacheDir, codec, level, key, matchedKey, label, debug, log, extraBasenames } = opts;
+    const withBytes = (r) => Object.assign(r, { archiveBytes: null });
+    if (!dirExists(cacheDir)) {
+        log(`${label}: cache dir ${cacheDir} does not exist, skipping save`);
+        return withBytes({ status: "missing-dir-skip", cache_dir: cacheDir });
+    }
+    if (matchedKey === key) {
+        log(`${label}: exact cache hit on ${key}, skipping save`);
+        return withBytes({ status: "exact-hit-skip", cache_dir: cacheDir });
+    }
+    let archiveBytes = null;
+    let archivePath = null;
+    try {
+        const result = await (0, cache_compress_js_1.compressCache)({ cacheDir, codec, level, debug, log, extraBasenames });
+        archivePath = result.archivePath;
+        archiveBytes = result.archiveBytes || null;
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log(`${label}: compression failed: ${message}`);
+        return withBytes({ status: "failed", cache_dir: cacheDir, error: message });
+    }
+    const pathsToSave = archivePath ? [archivePath] : [cacheDir];
+    try {
+        const id = await cache.saveCache(pathsToSave, key);
+        log(`${label}: saved cache id=${id} key=${key} via ${archivePath ? "tar.zst" : "default"}`);
+        return {
+            status: "saved",
+            cache_dir: cacheDir,
+            archive_path: archivePath ?? undefined,
+            saved_paths: pathsToSave,
+            cache_id: id,
+            archiveBytes,
+        };
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log(`${label}: save failed: ${message}`);
+        return {
+            status: "failed",
+            cache_dir: cacheDir,
+            archive_path: archivePath ?? undefined,
+            saved_paths: pathsToSave,
+            error: message,
+            archiveBytes,
+        };
+    }
+}
+function cacheLayerSummary(opts) {
+    const matchedKey = opts.matchedKey.trim();
+    return {
+        enabled: opts.enabled,
+        key: opts.key,
+        matched_key: matchedKey,
+        exact_hit: opts.enabled ? opts.exactHit : false,
+        restore_status: restoreStatus(opts.enabled, opts.exactHit, matchedKey),
+        save: opts.save,
+    };
+}
+function readSoldrCacheReport(soldrBinary, passthrough) {
+    if (passthrough) {
+        // Short-circuit when the main step installed a passthrough stub
+        // (enable=false). Skips spawning a .cmd on Windows (where
+        // child_process.spawnSync can't launch shell scripts directly) and
+        // documents the passthrough state in the post-step summary.
+        return {
+            status: "ok",
+            soldr_version: "passthrough",
+            report: {
+                notes: ["setup-soldr enable=false: soldr passthrough stub"],
+                last_session: null,
+                rollups: null,
+            },
+        };
+    }
+    if (!soldrBinary || !fileExists(soldrBinary)) {
+        return {
+            status: "missing-binary",
+            error: soldrBinary === undefined
+                ? "SOLDR_BINARY env var not set"
+                : `soldr binary at ${soldrBinary} does not exist`,
+        };
+    }
+    // Use spawnSync so the post step has no async dependencies. The
+    // report subcommand is fast (sub-100ms) — never worth pulling in
+    // @actions/exec just for one shell-out.
+    const child = (0, node_child_process_1.spawnSync)(soldrBinary, ["cache", "report", "--json"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+    });
+    if (child.error) {
+        return {
+            status: "error",
+            error: `failed to spawn soldr: ${child.error.message}`,
+        };
+    }
+    const stdout = (child.stdout || "").trim();
+    const stderr = (child.stderr || "").trim();
+    if (child.status !== 0) {
+        const combined = `${stderr}\n${stdout}`;
+        if (/unrecognized subcommand|invalid value for|unknown sub[- ]?command/i.test(combined) &&
+            /\breport\b/.test(combined)) {
+            return {
+                status: "unsupported",
+                error: stderr || stdout || `soldr exited ${child.status}`,
+            };
+        }
+        return {
+            status: "error",
+            error: stderr || stdout || `soldr exited ${child.status}`,
+        };
+    }
+    let report;
+    try {
+        const parsed = JSON.parse(stdout);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            return {
+                status: "error",
+                error: "soldr cache report --json returned a non-object payload",
+            };
+        }
+        report = parsed;
+    }
+    catch (err) {
+        return {
+            status: "error",
+            error: `failed to parse soldr cache report JSON: ${err instanceof Error ? err.message : String(err)}`,
+        };
+    }
+    const soldrVersion = typeof report["soldr_version"] === "string" ? report["soldr_version"] : undefined;
+    const zccacheVersion = typeof report["managed_zccache_version"] === "string"
+        ? report["managed_zccache_version"]
+        : undefined;
+    return {
+        status: "ok",
+        soldr_version: soldrVersion,
+        managed_zccache_version: zccacheVersion,
+        report,
+    };
+}
+function readZccacheSessionSummary(buildCachePath) {
+    const statsPath = path.join(buildCachePath, "logs", "last-session-stats.json");
+    if (!fileExists(statsPath)) {
+        return { stats_path: statsPath, present: false, status: "missing" };
+    }
+    try {
+        const parsed = JSON.parse(fs.readFileSync(statsPath, "utf8"));
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            return {
+                stats_path: statsPath,
+                present: true,
+                status: "invalid",
+                error: "stats JSON was not an object",
+            };
+        }
+        const stats = parsed;
+        const status = typeof stats["status"] === "string" ? stats["status"] : "unknown";
+        return { stats_path: statsPath, present: true, status, stats };
+    }
+    catch (err) {
+        return {
+            stats_path: statsPath,
+            present: true,
+            status: "invalid",
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+}
+function buildFinalCacheSummary(result, state, saves, passthrough = false) {
+    return {
+        schema_version: 1,
+        setup_cache: cacheLayerSummary({
+            enabled: state.setupCacheEnabled,
+            key: result.setupCache.key,
+            exactHit: state.setupCacheExactHit,
+            matchedKey: state.setupCacheMatchedKey,
+            save: notManagedSave(),
+        }),
+        target_cache: cacheLayerSummary({
+            enabled: state.targetCacheEnabled,
+            key: result.targetCache.key,
+            exactHit: state.targetCacheExactHit,
+            matchedKey: state.targetCacheMatchedKey,
+            save: saves.targetCache,
+        }),
+        build_cache: cacheLayerSummary({
+            enabled: state.buildCacheEnabled,
+            key: result.buildCache.key,
+            exactHit: state.buildCacheExactHit,
+            matchedKey: state.buildCacheMatchedKey,
+            save: saves.buildCache,
+        }),
+        cargo_registry_cache: cacheLayerSummary({
+            enabled: state.cargoRegistryCacheEnabled,
+            key: result.cargoRegistryCache.key,
+            exactHit: state.cargoRegistryCacheExactHit,
+            matchedKey: state.cargoRegistryCacheMatchedKey,
+            save: saves.cargoRegistryCache,
+        }),
+        zccache_session: readZccacheSessionSummary(result.buildCache.path),
+        compile_cache_report: readSoldrCacheReport(process.env["SOLDR_BINARY"]?.trim(), passthrough),
+        // PR4 — walk the per-session archive that soldr#379's
+        // `cache shutdown --archive-logs` populates between cargo invocations
+        // and roll the per-session stats up into a single job-wide aggregate.
+        // Empty archive (no archival happened, or only one session ran) leaves
+        // `sessionCount=0`, which makes the renderer / outputs no-op.
+        multi_session_rollup: (0, compile_cache_stats_js_1.aggregateSessions)((0, compile_cache_stats_js_1.collectArchivedSessionStats)(path.join(result.buildCache.path, "logs", "archive"))),
+    };
+}
+function numberStat(stats, key) {
+    const value = stats?.[key];
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+function zccacheOneLine(summary) {
+    if (!summary.present)
+        return `missing (${summary.stats_path})`;
+    if (summary.status !== "ok") {
+        return summary.error ? `${summary.status} (${summary.error})` : summary.status;
+    }
+    const hits = numberStat(summary.stats, "hits") ?? 0;
+    const misses = numberStat(summary.stats, "misses") ?? 0;
+    const compilations = numberStat(summary.stats, "compilations") ?? hits + misses;
+    const nonCacheable = numberStat(summary.stats, "non_cacheable") ?? 0;
+    const errors = numberStat(summary.stats, "errors") ?? 0;
+    const hitRate = numberStat(summary.stats, "hit_rate");
+    const hitRateText = hitRate === undefined ? "n/a" : `${(hitRate * 100).toFixed(1)}%`;
+    return `hits=${hits} misses=${misses} compilations=${compilations} non_cacheable=${nonCacheable} errors=${errors} hit_rate=${hitRateText}`;
+}
+function restoreText(layer) {
+    if (!layer.enabled)
+        return "disabled";
+    if (layer.restore_status === "exact-hit")
+        return "exact hit";
+    if (layer.restore_status === "restore-key-hit")
+        return "restore-key hit";
+    return "miss";
+}
+function saveText(save) {
+    switch (save.status) {
+        case "saved":
+            return save.cache_id === undefined ? "saved" : `saved id=${save.cache_id}`;
+        case "exact-hit-skip":
+            return "skipped exact hit";
+        case "missing-dir-skip":
+            return "skipped missing dir";
+        case "failed":
+            return save.error ? `failed: ${save.error}` : "failed";
+        case "disabled":
+            return "disabled";
+        case "not-managed-in-post":
+            return "not managed in post";
+    }
+}
+function markdownCell(value) {
+    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+function tableRow(label, layer) {
+    return [
+        label,
+        restoreText(layer),
+        layer.key,
+        layer.matched_key || "",
+        saveText(layer.save),
+    ]
+        .map(markdownCell)
+        .join(" | ");
+}
+function fmtBytes(n) {
+    if (n >= 1_073_741_824)
+        return `${(n / 1_073_741_824).toFixed(1)} GB`;
+    if (n >= 1_048_576)
+        return `${(n / 1_048_576).toFixed(1)} MB`;
+    if (n >= 1_024)
+        return `${(n / 1_024).toFixed(1)} KB`;
+    return `${n} B`;
+}
+function setCompileCacheOutputs(report, mode) {
+    core.setOutput("compile-cache-session-status", report.status);
+    if (report.status !== "ok" || !report.report)
+        return;
+    core.setOutput("compile-cache-summary-json", JSON.stringify(report.report));
+    const lastSession = report.report["last_session"];
+    if (lastSession) {
+        const hits = numberStat(lastSession, "hits") ?? 0;
+        const misses = numberStat(lastSession, "misses") ?? 0;
+        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
+        const hitRate = numberStat(lastSession, "hit_rate");
+        const timeSavedMs = numberStat(lastSession, "time_saved_ms");
+        const bytesRead = numberStat(lastSession, "bytes_read");
+        const bytesWritten = numberStat(lastSession, "bytes_written");
+        core.setOutput("compile-cache-hits", String(hits));
+        core.setOutput("compile-cache-misses", String(misses));
+        core.setOutput("compile-cache-compilations", String(compilations));
+        if (hitRate !== undefined)
+            core.setOutput("compile-cache-hit-rate", String(hitRate));
+        if (timeSavedMs !== undefined)
+            core.setOutput("compile-cache-time-saved-ms", String(timeSavedMs));
+        if (bytesRead !== undefined)
+            core.setOutput("compile-cache-bytes-read", String(bytesRead));
+        if (bytesWritten !== undefined)
+            core.setOutput("compile-cache-bytes-written", String(bytesWritten));
+    }
+    if (mode === "detailed") {
+        const rollups = report.report["rollups"];
+        if (rollups)
+            core.setOutput("compile-cache-rollups-json", JSON.stringify(rollups));
+    }
+}
+function compileCacheReportSection(report, mode) {
+    if (mode === "none")
+        return [];
+    // Insights mode is a superset of summarize — render the per-session table
+    // first so workflows don't lose the baseline metrics, then append the
+    // diagnoses block underneath. The detailed roll-up tables stay
+    // detailed-only (they're already noisy enough on their own).
+    const summaryMode = mode === "insights" ? "summarize" : mode;
+    const lines = ["", "### Compile cache (zccache)", ""];
+    if (report.status !== "ok" || !report.report) {
+        lines.push(`| Status | ${markdownCell(report.status)} |`);
+        if (report.error)
+            lines.push(`| Detail | ${markdownCell(report.error)} |`);
+        return lines;
+    }
+    const body = report.report;
+    const lastSession = body["last_session"] ?? null;
+    const rollups = body["rollups"] ?? null;
+    if (lastSession) {
+        const hits = numberStat(lastSession, "hits") ?? 0;
+        const misses = numberStat(lastSession, "misses") ?? 0;
+        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
+        const rate = numberStat(lastSession, "hit_rate");
+        const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
+        const saved = numberStat(lastSession, "time_saved_ms");
+        const bytesRead = numberStat(lastSession, "bytes_read");
+        const bytesWritten = numberStat(lastSession, "bytes_written");
+        lines.push("| Metric | Value |", "| --- | --- |");
+        lines.push(`| Compilations | ${compilations} |`);
+        lines.push(`| Hits | ${hits} |`);
+        lines.push(`| Misses | ${misses} |`);
+        lines.push(`| Hit rate | ${rateText} |`);
+        if (saved !== undefined)
+            lines.push(`| Time saved (est.) | ${(saved / 1000).toFixed(1)}s |`);
+        if (bytesRead !== undefined)
+            lines.push(`| Bytes read | ${fmtBytes(bytesRead)} |`);
+        if (bytesWritten !== undefined)
+            lines.push(`| Bytes written | ${fmtBytes(bytesWritten)} |`);
+        if (report.soldr_version)
+            lines.push(`| soldr | ${markdownCell(report.soldr_version)} |`);
+        if (report.managed_zccache_version)
+            lines.push(`| zccache | ${markdownCell(report.managed_zccache_version)} |`);
+    }
+    else {
+        lines.push("_(no last\\_session yet — run a cache-enabled build first)_");
+    }
+    if (mode === "detailed" && rollups) {
+        const byExt = rollups["by_extension"];
+        if (byExt && typeof byExt === "object" && !Array.isArray(byExt)) {
+            const rows = Object.entries(byExt);
+            if (rows.length > 0) {
+                lines.push("", "#### By output extension", "");
+                lines.push("| Extension | Hits | Misses | Total ms |", "| --- | --- | --- | --- |");
+                for (const [ext, bucket] of rows) {
+                    const b = bucket ?? {};
+                    const h = numberStat(b, "hits") ?? 0;
+                    const m = numberStat(b, "misses") ?? 0;
+                    const t = numberStat(b, "total_ms") ?? 0;
+                    lines.push(`| ${markdownCell(ext)} | ${h} | ${m} | ${t} |`);
+                }
+            }
+        }
+        const byTool = rollups["by_tool_total_ms"];
+        if (byTool && typeof byTool === "object" && !Array.isArray(byTool)) {
+            const rows = Object.entries(byTool)
+                .map(([tool, ms]) => [tool, typeof ms === "number" ? ms : 0])
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 10);
+            if (rows.length > 0) {
+                lines.push("", "#### By tool (wall-clock)", "");
+                lines.push("| Tool | ms |", "| --- | --- |");
+                for (const [tool, ms] of rows) {
+                    lines.push(`| ${markdownCell(tool)} | ${ms} |`);
+                }
+            }
+        }
+    }
+    // PR3 — insights mode appends per-diagnosis <details> blocks below the
+    // per-session table. Each diagnosis renders its evidence (miss reasons
+    // table + slowest misses list + wasted_ms) plus a blockquoted
+    // suggested_fix line. Annotations are not emitted from this pure
+    // renderer — the run() loop separately forwards them to core.warning /
+    // core.notice so they show up pinned in the PR Files view.
+    if (mode === "insights") {
+        const insights = (0, compile_cache_stats_js_1.renderInsights)(body);
+        if (insights.markdown.length > 0) {
+            lines.push("", "### Compile cache insights", "");
+            lines.push(insights.markdown);
+        }
+    }
+    const notes = body["notes"];
+    if (Array.isArray(notes) && notes.length > 0) {
+        lines.push("", "<details><summary>Notes from soldr</summary>", "");
+        for (const note of notes) {
+            if (typeof note === "string")
+                lines.push(`- ${markdownCell(note)}`);
+        }
+        lines.push("", "</details>");
+    }
+    // Silence the "unused variable" warning — summaryMode is reserved for a
+    // future split where insights includes/excludes the detailed-rollup
+    // tables. Today the rollup gate is still keyed on `mode`.
+    void summaryMode;
+    return lines;
+}
+function formatFinalCacheSummaryMarkdown(summary, compileCacheStats = "summarize") {
+    // PR4 — multi-step roll-up. Renders only when >1 sessions were
+    // archived AND the user didn't opt out via compile-cache-stats=none.
+    // The block sits between the layer table and the per-session compile
+    // cache section so the high-level "what happened across the whole job"
+    // signal lands first, with the per-invocation breakdown beneath.
+    const multiStepBlock = compileCacheStats !== "none"
+        ? (0, compile_cache_stats_js_1.renderMultiSessionRollup)(summary.multi_session_rollup)
+        : "";
+    const multiStepLines = multiStepBlock.length > 0 ? ["", multiStepBlock] : [];
+    const lines = [
+        "## setup-soldr final cache summary",
+        "",
+        "| Layer | Restore | Primary key | Matched key | Save |",
+        "| --- | --- | --- | --- | --- |",
+        `| ${tableRow("setup cache", summary.setup_cache)} |`,
+        `| ${tableRow("target cache", summary.target_cache)} |`,
+        `| ${tableRow("build cache", summary.build_cache)} |`,
+        `| ${tableRow("cargo registry cache", summary.cargo_registry_cache)} |`,
+        ...multiStepLines,
+        "",
+        "### zccache session",
+        "",
+        `- Stats: ${zccacheOneLine(summary.zccache_session)}`,
+        `- Stats file: ${summary.zccache_session.stats_path}`,
+        ...compileCacheReportSection(summary.compile_cache_report, compileCacheStats),
+        "",
+        "<details><summary>Final cache summary JSON</summary>",
+        "",
+        "```json",
+        JSON.stringify(summary, null, 2),
+        "```",
+        "",
+        "</details>",
+        "",
+    ];
+    return `${lines.join("\n")}\n`;
+}
+/**
+ * PR4 — emit the multi-step roll-up's scalar outputs. Skipped when
+ * `sessionCount <= 1` so single-session jobs don't surface a misleading
+ * roll-up to downstream workflow steps. Exported so the post-step `run()`
+ * function and the contract tests can drive it the same way.
+ */
+function setMultiSessionOutputs(rollup) {
+    if (rollup.sessionCount <= 1)
+        return;
+    core.setOutput("compile-cache-sessions-total", String(rollup.sessionCount));
+    if (rollup.overallHitRate !== null && Number.isFinite(rollup.overallHitRate)) {
+        core.setOutput("compile-cache-overall-hit-rate", String(rollup.overallHitRate));
+    }
+}
+function logFinalCacheSummary(summary, log) {
+    log(`final cache summary: setup=${restoreText(summary.setup_cache)} target=${restoreText(summary.target_cache)} ` +
+        `build=${restoreText(summary.build_cache)}/${saveText(summary.build_cache.save)} ` +
+        `cargo-registry=${restoreText(summary.cargo_registry_cache)}/${saveText(summary.cargo_registry_cache.save)}`);
+    log(`final zccache session stats: ${zccacheOneLine(summary.zccache_session)}`);
+    log(`compile cache report: ${compileCacheReportOneLine(summary.compile_cache_report)}`);
+}
+function compileCacheReportOneLine(report) {
+    if (report.status !== "ok" || !report.report) {
+        return report.error ? `${report.status} (${report.error})` : report.status;
+    }
+    const lastSession = report.report["last_session"];
+    if (!lastSession) {
+        return `ok (no last_session yet, soldr ${report.soldr_version ?? "?"})`;
+    }
+    const hits = numberStat(lastSession, "hits") ?? 0;
+    const misses = numberStat(lastSession, "misses") ?? 0;
+    const rate = numberStat(lastSession, "hit_rate");
+    const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
+    return `ok hits=${hits} misses=${misses} hit_rate=${rateText} soldr=${report.soldr_version ?? "?"}`;
+}
+function writeCompileCacheReportFile(report, runnerTemp, log) {
+    if (!runnerTemp)
+        return undefined;
+    const outPath = path.join(runnerTemp, "setup-soldr-compile-cache-report.json");
+    try {
+        fs.writeFileSync(outPath, JSON.stringify(report, null, 2), "utf8");
+        return outPath;
+    }
+    catch (err) {
+        log(`post: failed to write compile-cache-report.json: ${err instanceof Error ? err.message : String(err)}`);
+        return undefined;
+    }
+}
+function writeStepSummary(markdown, log) {
+    const summaryPath = process.env["GITHUB_STEP_SUMMARY"]?.trim();
+    if (!summaryPath)
+        return;
+    try {
+        fs.appendFileSync(summaryPath, markdown, "utf8");
+    }
+    catch (err) {
+        log(`post: failed to write GitHub step summary: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+/**
+ * PR3 — Emit insights-mode side effects:
+ *   - Forward each `renderInsights` annotation line to core.warning /
+ *     core.notice so it shows up pinned in the PR Files-Changed view.
+ *   - Best-effort: ask soldr to write a chrome-trace JSON (a developer
+ *     debugger trace file consumable by chrome://tracing or Perfetto)
+ *     and upload it as a workflow artifact. Silently skipped when soldr
+ *     doesn't support the `--chrome-trace` flag — keeps the action green
+ *     on older soldr versions that don't have the subcommand yet.
+ */
+async function emitInsightsAnnotationsAndTrace(opts) {
+    const { report, soldrBinary, runnerTemp, log } = opts;
+    if (report.status === "ok" && report.report) {
+        try {
+            const out = (0, compile_cache_stats_js_1.renderInsights)(report.report);
+            for (const line of out.annotations) {
+                // Echo to stdout exactly as GitHub Actions expects — the runner
+                // ingests `::warning::` / `::notice::` workflow-command lines
+                // from stdout regardless of which library wrote them. Avoid the
+                // @actions/core helpers because they re-encode the message and
+                // we want the file= pin we computed in renderInsights to land
+                // verbatim.
+                process.stdout.write(`${line}\n`);
+            }
+            log(`compile-cache-stats: emitted ${out.annotations.length} insights annotations`);
+        }
+        catch (err) {
+            log(`compile-cache-stats: failed to emit insights annotations: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    // Chrome-trace upload. Skipped when no SOLDR_BINARY is on disk, or
+    // when soldr's `cache report --chrome-trace <path>` exits with an
+    // "unknown subcommand"/"unrecognized flag" error (i.e. the user is on
+    // a soldr build that predates the trace flag).
+    if (!soldrBinary || !fileExists(soldrBinary) || !runnerTemp)
+        return;
+    const runId = process.env["GITHUB_RUN_ID"]?.trim() || "local";
+    const tracePath = path.join(runnerTemp, `setup-soldr-trace-${runId}.json`);
+    let traced = false;
+    try {
+        const child = (0, node_child_process_1.spawnSync)(soldrBinary, ["cache", "report", "--chrome-trace", tracePath], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+            windowsHide: true,
+        });
+        if (child.error) {
+            log(`compile-cache-stats: chrome-trace spawn failed: ${child.error.message}`);
+            return;
+        }
+        if (child.status !== 0) {
+            const combined = `${child.stderr || ""}\n${child.stdout || ""}`;
+            if (/unrecognized|unknown|invalid/i.test(combined) && /chrome[-_ ]?trace/i.test(combined)) {
+                log("compile-cache-stats: chrome-trace flag not supported by this soldr — skipping upload");
+                return;
+            }
+            log(`compile-cache-stats: chrome-trace generation failed (exit ${child.status})`);
+            return;
+        }
+        traced = fileExists(tracePath);
+    }
+    catch (err) {
+        log(`compile-cache-stats: chrome-trace generation threw: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+    }
+    if (!traced) {
+        log(`compile-cache-stats: chrome-trace file not present at ${tracePath} — skipping upload`);
+        return;
+    }
+    try {
+        // Lazy require so the action stays loadable even when
+        // @actions/artifact's runtime requirements aren't met (e.g. running
+        // outside of a GitHub-hosted runner, which is the case for every
+        // unit test in this repo). Any failure is logged-not-thrown.
+        const artifact = await __nccwpck_require__.e(/* import() */ 846).then(__nccwpck_require__.t.bind(__nccwpck_require__, 76846, 23));
+        const client = new artifact.DefaultArtifactClient();
+        const artifactName = `setup-soldr-trace-${runId}.json`;
+        await client.uploadArtifact(artifactName, [tracePath], path.dirname(tracePath));
+        log(`compile-cache-stats: uploaded chrome-trace artifact ${artifactName}`);
+    }
+    catch (err) {
+        log(`compile-cache-stats: chrome-trace artifact upload failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+async function run() {
+    const logger = (0, log_utils_js_1.createLogger)(process.env);
+    const log = (msg) => logger.log(msg);
+    const state = core.getState("resolveResult");
+    if (!state) {
+        log("post: no resolve state available, exiting");
+        return;
+    }
+    let result;
+    try {
+        result = JSON.parse(state);
+    }
+    catch (err) {
+        log(`post: failed to parse resolve state: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+    }
+    const buildCacheMatched = core.getState("buildCacheMatchedKey");
+    const registryMatched = core.getState("cargoRegistryCacheMatchedKey");
+    const passthrough = stateBool("setupSoldrPassthrough");
+    const restoreState = readRestoreState();
+    const statsMode = (core.getState("statsMode") || "summarize");
+    const compileCacheStats = (core.getState("compileCacheStats") || "summarize");
+    const runnerTemp = core.getState("runnerTemp") || "";
+    const debugMode = result.debugMode ?? false;
+    const debugLog = debugMode ? log : () => undefined;
+    const postCollector = new stats_collector_js_1.StatsCollector();
+    // Always stop long-running cache daemons before packing the build
+    // cache so file locks release and the tarball reflects a quiescent
+    // on-disk view. Best-effort; failures are logged, not raised.
+    //
+    // Wire `--archive-logs <build-cache>/logs/archive` through so soldr
+    // (post-#379) stashes the just-ended session's logs into a
+    // per-session subdirectory inside the build-cache. Setup-soldr's
+    // existing tar.zst flow already picks up the entire build-cache
+    // subtree, so the archived logs ride the cache cycle for free and
+    // survive across runs (see issue #126).
+    const logsArchiveDir = restoreState.buildCacheEnabled
+        ? path.join(result.buildCache.path, "logs", "archive")
+        : undefined;
+    await (0, shutdown_cache_js_1.shutdownCacheDaemons)({
+        soldrPath: process.env["SOLDR_BINARY"]?.trim() || undefined,
+        logsArchiveDir,
+        log,
+    });
+    // Source-mtime snapshot (preserve-source-mtimes opt-in). Walk tracked
+    // sources, capture each (mtime, size, content-hash), and drop the JSON
+    // INSIDE the build-cache directory so it gets bundled into the same
+    // tar.zst the build-cache save will upload. main.ts replays the
+    // mtimes on warm after the build-cache decompresses, gated on each
+    // file's content matching what we snapshotted here.
+    const preserveSourceMtimes = core.getState("preserveSourceMtimes") === "true";
+    if (preserveSourceMtimes && restoreState.buildCacheEnabled) {
+        const t0 = Date.now();
+        // The "project root" — where the Cargo workspace being built actually
+        // lives — is the parent of the resolved target-dir, NOT result.workspace
+        // (which is GITHUB_WORKSPACE — usually the outer checkout containing
+        // the action itself plus one or more sub-repos). For the demo,
+        // result.workspace=/home/runner/work/setup-soldr/setup-soldr but the
+        // zccache project being built is at .../setup-soldr/zccache.
+        const projectRoot = path.dirname(result.targetCache.targetPath);
+        try {
+            const r = await (0, source_mtime_snapshot_js_1.snapshotSourceMtimes)({ workspace: projectRoot, log });
+            const out = path.join(result.buildCache.path, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
+            try {
+                fs.mkdirSync(path.dirname(out), { recursive: true });
+                (0, source_mtime_snapshot_js_1.writeSnapshotFile)(r.snapshot, out);
+                log(`source-mtime-snapshot: wrote ${out} scanned=${r.scanned} hashed=${r.hashed} skipped=${r.skipped} elapsed_ms=${Date.now() - t0}`);
+            }
+            catch (err) {
+                log(`source-mtime-snapshot: failed to write ${out}: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+        catch (err) {
+            log(`source-mtime-snapshot: scan failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    // Build cache
+    const buildSaveStart = Date.now();
+    const buildSave = restoreState.buildCacheEnabled
+        ? await saveOne({
+            cacheDir: result.buildCache.path,
+            codec: result.targetCacheCompress,
+            level: result.targetCacheCompressLevel,
+            key: result.buildCache.key,
+            matchedKey: buildCacheMatched,
+            label: "build-cache",
+            debug: debugMode,
+            log: debugLog,
+        })
+        : Object.assign(disabledSave(), { archiveBytes: null });
+    if (buildSave.status === "saved") {
+        postCollector.record({
+            label: "build-cache", operation: "save", hit: false,
+            key: result.buildCache.key, matchedKey: buildCacheMatched, restoreKeys: [],
+            archiveBytes: buildSave.archiveBytes, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - buildSaveStart, timestamp: new Date().toISOString(),
+        });
+    }
+    // Target cache. Previously slotted as `notManagedSave()` in the
+    // finalSummary — i.e. restored in main.ts but never saved here. That
+    // meant every commit cold-rebuilt `target/` (or the rust-plan bundle)
+    // because no entry was ever written for the restore-key prefix to
+    // fall back to. This block fixes the gap.
+    //
+    // Behavior:
+    // - Skip when target-cache layer is disabled (`target-cache: false`
+    //   or umbrella `cache: false`).
+    // - Skip on exact-hit (re-saving the same content under the same key
+    //   wastes time and triggers @actions/cache's "reservation already
+    //   exists" path).
+    // - Use `cache.saveCache` directly with the multi-path array (one
+    //   path in `thin`/`once` modes, two in `full`). @actions/cache will
+    //   tar+compress with its default codec — we don't route through
+    //   compressCache because target-cache may legitimately carry
+    //   multiple roots and compressCache is single-dir-shaped.
+    // - Paths array must match the one passed to restoreCache in main.ts
+    //   (the @actions/cache "version" hash depends on it — same gotcha
+    //   that bit cook-cache in #141).
+    let targetCacheSave = Object.assign(disabledSave(), { archiveBytes: null });
+    if (restoreState.targetCacheEnabled) {
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        const targetKey = result.targetCache.key;
+        const targetMatched = restoreState.targetCacheMatchedKey;
+        if (targetPaths.length === 0) {
+            log("target-cache: no paths configured, skipping save");
+            targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: "(no paths)" }, { archiveBytes: null });
+        }
+        else if (restoreState.targetCacheExactHit) {
+            log(`target-cache: exact cache hit on ${targetKey}, skipping save`);
+            targetCacheSave = Object.assign({ status: "exact-hit-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
+        }
+        else {
+            const existingPaths = targetPaths.filter((p) => fs.existsSync(p));
+            if (existingPaths.length === 0) {
+                log(`target-cache: none of the configured paths exist on disk (${targetPaths.join(", ")}), skipping save`);
+                targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
+            }
+            else {
+                const targetSaveStart = Date.now();
+                try {
+                    const id = await cache.saveCache(existingPaths, targetKey);
+                    if (id <= 0) {
+                        log(`target-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
+                            `job already saved key=${targetKey}`);
+                        targetCacheSave = Object.assign({
+                            status: "failed",
+                            cache_dir: existingPaths.join(","),
+                            saved_paths: existingPaths,
+                            error: `saveCache returned id=${id} (reserve failed; race or quota)`,
+                        }, { archiveBytes: null });
+                    }
+                    else {
+                        log(`target-cache: saved cache id=${id} key=${targetKey} paths=${existingPaths.join(",")}`);
+                        targetCacheSave = Object.assign({
+                            status: "saved",
+                            cache_dir: existingPaths.join(","),
+                            saved_paths: existingPaths,
+                            cache_id: id,
+                        }, { archiveBytes: null });
+                        postCollector.record({
+                            label: "target-cache",
+                            operation: "save",
+                            hit: false,
+                            key: targetKey,
+                            matchedKey: targetMatched,
+                            restoreKeys: [],
+                            archiveBytes: null,
+                            inflatedBytes: null,
+                            fileCount: null,
+                            durationMs: Date.now() - targetSaveStart,
+                            timestamp: new Date().toISOString(),
+                        });
+                    }
+                }
+                catch (err) {
+                    const message = err instanceof Error ? err.message : String(err);
+                    log(`target-cache: save failed: ${message}`);
+                    targetCacheSave = Object.assign({
+                        status: "failed",
+                        cache_dir: existingPaths.join(","),
+                        saved_paths: existingPaths,
+                        error: message,
+                    }, { archiveBytes: null });
+                }
+            }
+        }
+    }
+    // Cargo registry cache (only when enabled).
+    // setup-soldr#102: bundle `.global-cache` (cargo's RFC-3413 GC db) and the
+    // `git/` directory (bare mirrors + checkouts for git-source crate deps)
+    // into the same archive alongside `registry/`. Cache key + archive path
+    // are unchanged — the extras simply ride inside the existing tarball.
+    let cargoRegistrySave = Object.assign(disabledSave(), { archiveBytes: null });
+    if (result.cargoRegistryCache.enabled) {
+        const regSaveStart = Date.now();
+        cargoRegistrySave = await saveOne({
+            cacheDir: result.cargoRegistryCache.path,
+            codec: result.targetCacheCompress,
+            level: result.targetCacheCompressLevel,
+            key: result.cargoRegistryCache.key,
+            matchedKey: registryMatched,
+            label: "cargo-registry-cache",
+            debug: debugMode,
+            log: debugLog,
+            extraBasenames: result.cargoRegistryCache.extraBasenames,
+        });
+        if (cargoRegistrySave.status === "saved") {
+            postCollector.record({
+                label: "cargo-registry", operation: "save", hit: false,
+                key: result.cargoRegistryCache.key, matchedKey: registryMatched, restoreKeys: [],
+                archiveBytes: cargoRegistrySave.archiveBytes, inflatedBytes: null, fileCount: null,
+                durationMs: Date.now() - regSaveStart, timestamp: new Date().toISOString(),
+            });
+        }
+    }
+    // Solo toolchain cache save. Opt-in via the `solo-toolchain-cache`
+    // input. Skip the save when the install delta is empty (the common
+    // case on hosted runners that already provide the requested
+    // toolchain) — per CLAUDE.md "Default-stable workflows should
+    // produce zero cache writes."
+    const soloEnabled = core.getState("soloToolchainEnabled") === "true";
+    if (soloEnabled) {
+        const soloExactKey = core.getState("soloToolchainExactKey");
+        const soloMatchedKey = core.getState("soloToolchainMatchedKey");
+        const soloExactHit = core.getState("soloToolchainExactHit") === "true";
+        const soloIncrementalEmpty = core.getState("soloToolchainIncrementalEmpty") === "true";
+        const soloSaveDiffPath = core.getState("soloToolchainSaveDiffPath");
+        const soloLevel = core.getState("soloToolchainLevel") || "19";
+        log(`solo-toolchain-cache: post-step exactKey=${soloExactKey} matched=${soloMatchedKey} ` +
+            `exactHit=${soloExactHit} incrementalEmpty=${soloIncrementalEmpty} saveDiffPath=${soloSaveDiffPath}`);
+        if (soloExactHit && soloIncrementalEmpty) {
+            log("solo-toolchain-cache: exact hit and no install delta — skipping save");
+        }
+        else if (!soloSaveDiffPath || !fs.existsSync(soloSaveDiffPath)) {
+            log("solo-toolchain-cache: no save-diff manifest available, skipping save");
+        }
+        else {
+            try {
+                const manifest = JSON.parse(fs.readFileSync(soloSaveDiffPath, "utf8"));
+                const added = Array.isArray(manifest.added) ? manifest.added : [];
+                if (added.length === 0) {
+                    log("solo-toolchain-cache: empty save-diff manifest, skipping save");
+                }
+                else {
+                    const soloRootMap = {
+                        "rustup-toolchains": path.join(result.rustupHome, "toolchains"),
+                        "cargo-bin": path.join(result.cargoHome, "bin"),
+                    };
+                    const stagingDir = path.join(runnerTemp, "setup-soldr-solo-stage-save");
+                    const soloSaveStart = Date.now();
+                    const staged = await (0, solo_toolchain_cache_js_1.stageDiffForSave)({ added, removed: [], changed: [] }, soloRootMap, stagingDir);
+                    log(`solo-toolchain-cache: staged ${staged.stagedFiles} files (missing=${staged.missingFiles})`);
+                    const saveResult = await (0, solo_toolchain_cache_js_1.saveSoloCache)({
+                        stagingDir,
+                        key: soloExactKey,
+                        level: soloLevel,
+                        debug: debugMode,
+                        log,
+                    });
+                    if (saveResult.status === "saved") {
+                        postCollector.record({
+                            label: "solo-toolchain-cache",
+                            operation: "save",
+                            hit: false,
+                            key: soloExactKey,
+                            matchedKey: soloMatchedKey,
+                            restoreKeys: [],
+                            archiveBytes: saveResult.archiveBytes ?? null,
+                            inflatedBytes: saveResult.inflatedBytes ?? null,
+                            fileCount: saveResult.fileCount ?? null,
+                            durationMs: Date.now() - soloSaveStart,
+                            timestamp: new Date().toISOString(),
+                        });
+                    }
+                    else {
+                        log(`solo-toolchain-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
+                    }
+                }
+            }
+            catch (err) {
+                log(`solo-toolchain-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    }
+    // Cook cache save. Default-on layer; skipped when cook didn't run
+    // (cache hit, gate disabled, or run failed). zstd-19 + --long=27 per
+    // CLAUDE.md "Compression" + the cook simulation findings.
+    const cookEnabled = core.getState("cookEnabled") === "true";
+    if (cookEnabled) {
+        const cookHit = core.getState("cookHit") === "true";
+        const cookRan = core.getState("cookRan") === "true";
+        const cookExactKey = core.getState("cookExactKey");
+        const cookTargetDir = core.getState("cookTargetDir");
+        const cookLongWindow = parseInt(core.getState("cookLongWindow") || "27", 10);
+        const cookLevel = core.getState("cookCompressLevel") || "19";
+        log(`cook-cache: post-step key=${cookExactKey} hit=${cookHit} ran=${cookRan} target=${cookTargetDir}`);
+        if (cookHit) {
+            log("cook-cache: exact hit - skipping save");
+        }
+        else if (!cookRan) {
+            log("cook-cache: cook did not run successfully - skipping save");
+        }
+        else if (!cookTargetDir || !fs.existsSync(cookTargetDir)) {
+            log(`cook-cache: target dir ${cookTargetDir} missing - skipping save`);
+        }
+        else {
+            const cookSaveStart = Date.now();
+            try {
+                const saveResult = await (0, cook_cache_js_1.saveCookCache)({
+                    targetDir: cookTargetDir,
+                    exactKey: cookExactKey,
+                    level: cookLevel,
+                    longWindow: cookLongWindow,
+                    debug: debugMode,
+                    log,
+                });
+                if (saveResult.status === "saved") {
+                    postCollector.record({
+                        label: "cook-cache",
+                        operation: "save",
+                        hit: false,
+                        key: cookExactKey,
+                        matchedKey: "",
+                        restoreKeys: [],
+                        archiveBytes: saveResult.archiveBytes ?? null,
+                        inflatedBytes: saveResult.inflatedBytes ?? null,
+                        fileCount: saveResult.fileCount ?? null,
+                        durationMs: Date.now() - cookSaveStart,
+                        timestamp: new Date().toISOString(),
+                    });
+                }
+                else {
+                    log(`cook-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
+                }
+            }
+            catch (err) {
+                log(`cook-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    }
+    // Soldr-mini-cache save. Default-on; skipped when restore already hit
+    // (binary is byte-identical, no point re-saving), when disabled, or
+    // when running in passthrough mode.
+    const soldrMiniEnabled = core.getState("soldrMiniEnabled") === "true";
+    if (soldrMiniEnabled && !passthrough) {
+        const miniHit = core.getState("soldrMiniHit") === "true";
+        const miniExactKey = core.getState("soldrMiniExactKey");
+        const miniInstallDir = core.getState("soldrMiniInstallDir");
+        const miniArchive = core.getState("soldrMiniArchive");
+        log(`soldr-mini-cache: post-step key=${miniExactKey} hit=${miniHit} installDir=${miniInstallDir}`);
+        if (miniHit) {
+            log("soldr-mini-cache: exact hit — skipping save");
+        }
+        else if (!miniExactKey) {
+            log("soldr-mini-cache: no key (ineligible at main-time) — skipping save");
+        }
+        else if (!miniInstallDir || !fs.existsSync(miniInstallDir)) {
+            log(`soldr-mini-cache: install dir ${miniInstallDir} missing — skipping save`);
+        }
+        else {
+            const miniSaveStart = Date.now();
+            try {
+                const saveResult = await (0, soldr_mini_cache_js_1.saveMiniCache)({
+                    installDir: miniInstallDir,
+                    archivePath: miniArchive,
+                    exactKey: miniExactKey,
+                    level: "19",
+                    longWindow: 27,
+                    debug: debugMode,
+                    log,
+                });
+                if (saveResult.status === "saved") {
+                    postCollector.record({
+                        label: "soldr-mini-cache",
+                        operation: "save",
+                        hit: false,
+                        key: miniExactKey,
+                        matchedKey: "",
+                        restoreKeys: [],
+                        archiveBytes: saveResult.archiveBytes ?? null,
+                        inflatedBytes: saveResult.inflatedBytes ?? null,
+                        fileCount: saveResult.fileCount ?? null,
+                        durationMs: Date.now() - miniSaveStart,
+                        timestamp: new Date().toISOString(),
+                    });
+                }
+                else {
+                    log(`soldr-mini-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
+                }
+            }
+            catch (err) {
+                log(`soldr-mini-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    }
+    const finalSummary = buildFinalCacheSummary(result, restoreState, {
+        buildCache: buildSave,
+        cargoRegistryCache: cargoRegistrySave,
+        targetCache: targetCacheSave,
+    }, passthrough);
+    logFinalCacheSummary(finalSummary, log);
+    if (compileCacheStats !== "none") {
+        setCompileCacheOutputs(finalSummary.compile_cache_report, compileCacheStats);
+        // PR4 — surface the two job-wide scalar outputs alongside the
+        // existing per-session outputs. The setter no-ops when the archive
+        // walker didn't find >1 sessions, so single-session jobs see no
+        // change in behavior.
+        setMultiSessionOutputs(finalSummary.multi_session_rollup);
+    }
+    writeStepSummary(formatFinalCacheSummaryMarkdown(finalSummary, compileCacheStats), log);
+    // PR3 — insights mode side-effects: emit GH annotations + optional
+    // chrome-trace artifact upload. These run only when the user explicitly
+    // opted into `insights`; the markdown insights block already landed in
+    // the step summary above via formatFinalCacheSummaryMarkdown.
+    if (compileCacheStats === "insights") {
+        await emitInsightsAnnotationsAndTrace({
+            report: finalSummary.compile_cache_report,
+            soldrBinary: process.env["SOLDR_BINARY"]?.trim(),
+            runnerTemp,
+            log,
+        });
+    }
+    const reportPath = writeCompileCacheReportFile(finalSummary.compile_cache_report, runnerTemp, log);
+    if (reportPath) {
+        log(`compile-cache-report.json written to ${reportPath}`);
+    }
+    // Note: setup-soldr-cache-keys.txt is written in main.ts (right after
+    // resolveSetup) so workflow steps that run between main and post —
+    // notably actions/upload-artifact — can read it. Re-write it here
+    // anyway as a safety net in case main.ts crashed before writing.
+    if (runnerTemp) {
+        writeCacheKeysManifestFromSummary(finalSummary, runnerTemp, log);
+    }
+    // Append save ops to detailed session log if requested
+    if (statsMode === "detailed" && runnerTemp) {
+        try {
+            await postCollector.appendSavesToSessionLog(runnerTemp);
+        }
+        catch (err) {
+            log(`post: stats log append failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    // Optional verbose diagnostic dump. Gated on `logging: true` which
+    // main.ts persists into action state.
+    const loggingState = core.getState("logging");
+    if ((0, diagnostics_js_1.loggingEnabled)(loggingState)) {
+        const rawInputs = (0, raw_inputs_js_1.readRawInputs)(process.env);
+        // zccache writes its per-rustc-invocation JSONL journal under the
+        // build-cache directory (which == ZCCACHE_CACHE_DIR per
+        // resolve-setup.ts's env exports). When `logging: true` is on we
+        // surface its contents so the reader can answer "warm reported 0
+        // hits — why did each lookup miss" without another build.
+        const journalPath = path.join(result.buildCache.path, "logs", "last-session.jsonl");
+        // Forward the verbatim `report` field from `soldr cache report --json`
+        // so dumpDiagnostics can format its `rollups` (per-extension /
+        // per-crate / slowest_entries) breakdown.
+        const cacheReport = finalSummary.compile_cache_report.report;
+        // Capture a process snapshot only when debug mode is on — `ps` /
+        // `tasklist` are cheap but the output is large and only useful when
+        // you're investigating cache-state weirdness (e.g. orphan daemons).
+        const processSnapshot = debugMode ? (0, diagnostics_js_1.captureProcessSnapshot)() ?? undefined : undefined;
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "post",
+            env: process.env,
+            rawInputs,
+            result,
+            cacheOutcomes: postCollector.snapshot(),
+            finalSummary: finalSummary,
+            journalPath,
+            // Raw JSONL stream — one record per rustc invocation, often
+            // thousands of lines / 20-30 MB of stdout per warm build. Default
+            // gate is `debug:true` (backwards compat with #134 era), but a
+            // workflow can explicitly opt out via `journal-print-raw: false`
+            // when it already uploads the JSONL as an artifact and doesn't
+            // want to pay the post-step log-writer cost (~30-50 s on the
+            // hosted ubuntu demo).
+            journalPrintRaw: resolveJournalPrintRaw(rawInputs.journalPrintRaw, debugMode),
+            cacheReport,
+            processSnapshot,
+            logger,
+            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
+        });
+    }
+}
+function writeCacheKeysManifestFromSummary(summary, runnerTemp, log) {
+    const keys = [
+        summary.setup_cache.key,
+        summary.build_cache.key,
+        summary.target_cache.key,
+        summary.cargo_registry_cache.key,
+    ].filter((k) => Boolean(k));
+    if (keys.length === 0)
+        return;
+    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
+    try {
+        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
+        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
+    }
+    catch (err) {
+        log(`post: failed to write cache-keys manifest: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+// See main.ts for the rationale behind the test-import escape hatch.
+if (typeof process !== "undefined" &&
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    run().catch((err) => {
+        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        core.warning(`setup-soldr post-job step failed: ${message}`);
+    });
+}
+
+
+/***/ }),
+
+/***/ 95:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20745,7 +22006,7 @@ exports.Credential = Credential;
 
 /***/ }),
 
-/***/ 95:
+/***/ 96:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -20766,7 +22027,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 96:
+/***/ 97:
 /***/ ((module) => {
 
 "use strict";
@@ -21064,7 +22325,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 97:
+/***/ 98:
 /***/ ((module) => {
 
 "use strict";
@@ -21084,7 +22345,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 98:
+/***/ 99:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21105,7 +22366,7 @@ exports.XML_CHARKEY = "_";
 
 /***/ }),
 
-/***/ 99:
+/***/ 100:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21135,7 +22396,7 @@ async function cancelablePromiseRace(abortablePromiseBuilders, options) {
 
 /***/ }),
 
-/***/ 100:
+/***/ 101:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -21205,39 +22466,39 @@ __export(src_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(src_exports);
-var import_pipeline = __nccwpck_require__(239);
-var import_createPipelineFromOptions = __nccwpck_require__(274);
-var import_defaultHttpClient = __nccwpck_require__(229);
-var import_httpHeaders = __nccwpck_require__(236);
+var import_pipeline = __nccwpck_require__(238);
+var import_createPipelineFromOptions = __nccwpck_require__(273);
+var import_defaultHttpClient = __nccwpck_require__(228);
+var import_httpHeaders = __nccwpck_require__(235);
 var import_pipelineRequest = __nccwpck_require__(18);
-var import_restError = __nccwpck_require__(340);
-var import_decompressResponsePolicy = __nccwpck_require__(232);
-var import_exponentialRetryPolicy = __nccwpck_require__(375);
+var import_restError = __nccwpck_require__(339);
+var import_decompressResponsePolicy = __nccwpck_require__(231);
+var import_exponentialRetryPolicy = __nccwpck_require__(374);
 var import_setClientRequestIdPolicy = __nccwpck_require__(149);
 var import_logPolicy = __nccwpck_require__(68);
-var import_multipartPolicy = __nccwpck_require__(266);
-var import_proxyPolicy = __nccwpck_require__(450);
-var import_redirectPolicy = __nccwpck_require__(330);
-var import_systemErrorRetryPolicy = __nccwpck_require__(213);
+var import_multipartPolicy = __nccwpck_require__(265);
+var import_proxyPolicy = __nccwpck_require__(449);
+var import_redirectPolicy = __nccwpck_require__(329);
+var import_systemErrorRetryPolicy = __nccwpck_require__(212);
 var import_throttlingRetryPolicy = __nccwpck_require__(21);
-var import_retryPolicy = __nccwpck_require__(207);
-var import_tracingPolicy = __nccwpck_require__(326);
+var import_retryPolicy = __nccwpck_require__(206);
+var import_tracingPolicy = __nccwpck_require__(325);
 var import_defaultRetryPolicy = __nccwpck_require__(52);
-var import_userAgentPolicy = __nccwpck_require__(372);
-var import_tlsPolicy = __nccwpck_require__(362);
-var import_formDataPolicy = __nccwpck_require__(263);
-var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(212);
-var import_ndJsonPolicy = __nccwpck_require__(233);
-var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(189);
-var import_agentPolicy = __nccwpck_require__(224);
-var import_file = __nccwpck_require__(318);
+var import_userAgentPolicy = __nccwpck_require__(371);
+var import_tlsPolicy = __nccwpck_require__(361);
+var import_formDataPolicy = __nccwpck_require__(262);
+var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(211);
+var import_ndJsonPolicy = __nccwpck_require__(232);
+var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(188);
+var import_agentPolicy = __nccwpck_require__(223);
+var import_file = __nccwpck_require__(317);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 
 
 /***/ }),
 
-/***/ 101:
+/***/ 102:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -21264,7 +22525,7 @@ __export(logPolicy_exports, {
 });
 module.exports = __toCommonJS(logPolicy_exports);
 var import_log = __nccwpck_require__(150);
-var import_sanitizer = __nccwpck_require__(120);
+var import_sanitizer = __nccwpck_require__(121);
 const logPolicyName = "logPolicy";
 function logPolicy(options = {}) {
   const logger = options.logger ?? import_log.logger.info;
@@ -21293,11 +22554,11 @@ function logPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 102:
+/***/ 103:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const { addAbortListener } = __nccwpck_require__(66)
-const { RequestAbortedError } = __nccwpck_require__(466)
+const { RequestAbortedError } = __nccwpck_require__(465)
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')
@@ -21354,7 +22615,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 103:
+/***/ 104:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -21385,7 +22646,7 @@ function rangeToString(iRange) {
 
 /***/ }),
 
-/***/ 104:
+/***/ 105:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21400,10 +22661,10 @@ const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(466)
+} = __nccwpck_require__(465)
 const util = __nccwpck_require__(66)
-const { AsyncResource } = __nccwpck_require__(407)
-const { addSignal, removeSignal } = __nccwpck_require__(102)
+const { AsyncResource } = __nccwpck_require__(406)
+const { addSignal, removeSignal } = __nccwpck_require__(103)
 const assert = __nccwpck_require__(501)
 
 const kResume = Symbol('resume')
@@ -21642,7 +22903,7 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 105:
+/***/ 106:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21660,17 +22921,17 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 
 /***/ }),
 
-/***/ 106:
+/***/ 107:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const EventEmitter = (__nccwpck_require__(143).EventEmitter)
-const inherits = (__nccwpck_require__(359).inherits)
-const getLimit = __nccwpck_require__(461)
+const inherits = (__nccwpck_require__(358).inherits)
+const getLimit = __nccwpck_require__(460)
 
-const StreamSearch = __nccwpck_require__(113)
+const StreamSearch = __nccwpck_require__(114)
 
 const B_DCRLF = Buffer.from('\r\n\r\n')
 const RE_CRLF = /\r\n/g
@@ -21768,7 +23029,7 @@ module.exports = HeaderParser
 
 /***/ }),
 
-/***/ 107:
+/***/ 108:
 /***/ ((module) => {
 
 "use strict";
@@ -21776,7 +23037,7 @@ module.exports = require("node:fs/promises");
 
 /***/ }),
 
-/***/ 108:
+/***/ 109:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -21804,7 +23065,7 @@ __export(util_exports, {
   toWebResourceLike: () => toWebResourceLike
 });
 module.exports = __toCommonJS(util_exports);
-var import_core_rest_pipeline = __nccwpck_require__(100);
+var import_core_rest_pipeline = __nccwpck_require__(101);
 const originalRequestSymbol = /* @__PURE__ */ Symbol("Original PipelineRequest");
 const originalClientRequestSymbol = /* @__PURE__ */ Symbol.for("@azure/core-client original request");
 function toPipelineRequest(webResource, options = {}) {
@@ -22046,7 +23307,7 @@ class HttpHeaders {
 
 /***/ }),
 
-/***/ 109:
+/***/ 110:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22092,7 +23353,7 @@ function objectHasProperty(thing, property) {
 
 /***/ }),
 
-/***/ 110:
+/***/ 111:
 /***/ ((module) => {
 
 "use strict";
@@ -22100,7 +23361,7 @@ module.exports = require("constants");
 
 /***/ }),
 
-/***/ 111:
+/***/ 112:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22110,8 +23371,8 @@ module.exports = require("constants");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseCAEChallenge = parseCAEChallenge;
 exports.authorizeRequestOnClaimChallenge = authorizeRequestOnClaimChallenge;
-const log_js_1 = __nccwpck_require__(458);
-const base64_js_1 = __nccwpck_require__(416);
+const log_js_1 = __nccwpck_require__(457);
+const base64_js_1 = __nccwpck_require__(415);
 /**
  * Converts: `Bearer a="b", c="d", Bearer d="e", f="g"`.
  * Into: `[ { a: 'b', c: 'd' }, { d: 'e', f: 'g' } ]`.
@@ -22183,7 +23444,7 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 
 /***/ }),
 
-/***/ 112:
+/***/ 113:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22193,7 +23454,7 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.delay = delay;
 exports.calculateRetryDelay = calculateRetryDelay;
-const createAbortablePromise_js_1 = __nccwpck_require__(254);
+const createAbortablePromise_js_1 = __nccwpck_require__(253);
 const util_1 = __nccwpck_require__(145);
 const StandardAbortMessage = "The delay was aborted.";
 /**
@@ -22233,7 +23494,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 113:
+/***/ 114:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22266,7 +23527,7 @@ function calculateRetryDelay(retryAttempt, config) {
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
 const EventEmitter = (__nccwpck_require__(143).EventEmitter)
-const inherits = (__nccwpck_require__(359).inherits)
+const inherits = (__nccwpck_require__(358).inherits)
 
 function SBMH (needle) {
   if (typeof needle === 'string') {
@@ -22469,7 +23730,7 @@ module.exports = SBMH
 
 /***/ }),
 
-/***/ 114:
+/***/ 115:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -22494,8 +23755,8 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_httpHeaders = __nccwpck_require__(463);
-var import_uuidUtils = __nccwpck_require__(376);
+var import_httpHeaders = __nccwpck_require__(462);
+var import_uuidUtils = __nccwpck_require__(375);
 class PipelineRequestImpl {
   url;
   method;
@@ -22548,7 +23809,7 @@ function createPipelineRequest(options) {
 
 /***/ }),
 
-/***/ 115:
+/***/ 116:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -22584,8 +23845,8 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(366));
-var import_node_process = __toESM(__nccwpck_require__(230));
+var import_node_os = __toESM(__nccwpck_require__(365));
+var import_node_process = __toESM(__nccwpck_require__(229));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -22608,14 +23869,14 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 116:
+/***/ 117:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PbLong = exports.PbULong = exports.detectBi = void 0;
-const goog_varint_1 = __nccwpck_require__(199);
+const goog_varint_1 = __nccwpck_require__(198);
 let BI;
 function detectBi() {
     const dv = new DataView(new ArrayBuffer(8));
@@ -22854,7 +24115,7 @@ PbLong.ZERO = new PbLong(0, 0);
 
 /***/ }),
 
-/***/ 117:
+/***/ 118:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22871,7 +24132,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 118:
+/***/ 119:
 /***/ ((module) => {
 
 "use strict";
@@ -22879,7 +24140,7 @@ module.exports = require("buffer");
 
 /***/ }),
 
-/***/ 119:
+/***/ 120:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -22908,8 +24169,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
-const path = __importStar(__nccwpck_require__(242));
-const pathHelper = __importStar(__nccwpck_require__(216));
+const path = __importStar(__nccwpck_require__(241));
+const pathHelper = __importStar(__nccwpck_require__(215));
 const assert_1 = __importDefault(__nccwpck_require__(501));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -22999,7 +24260,7 @@ exports.Path = Path;
 
 /***/ }),
 
-/***/ 120:
+/***/ 121:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -23173,7 +24434,7 @@ class Sanitizer {
 
 /***/ }),
 
-/***/ 121:
+/***/ 122:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -23190,7 +24451,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 122:
+/***/ 123:
 /***/ ((module) => {
 
 "use strict";
@@ -23198,19 +24459,19 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 123:
+/***/ 124:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
-var path = (function () { try { return __nccwpck_require__(242) } catch (e) {}}()) || {
+var path = (function () { try { return __nccwpck_require__(241) } catch (e) {}}()) || {
   sep: '/'
 }
 minimatch.sep = path.sep
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __nccwpck_require__(464)
+var expand = __nccwpck_require__(463)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -24210,7 +25471,7 @@ function regExpEscape (s) {
 
 /***/ }),
 
-/***/ 124:
+/***/ 125:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -24246,12 +25507,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
 const os = __importStar(__nccwpck_require__(91));
-const events = __importStar(__nccwpck_require__(447));
-const child = __importStar(__nccwpck_require__(163));
-const path = __importStar(__nccwpck_require__(242));
-const io = __importStar(__nccwpck_require__(287));
-const ioUtil = __importStar(__nccwpck_require__(218));
-const timers_1 = __nccwpck_require__(487);
+const events = __importStar(__nccwpck_require__(446));
+const child = __importStar(__nccwpck_require__(162));
+const path = __importStar(__nccwpck_require__(241));
+const io = __importStar(__nccwpck_require__(286));
+const ioUtil = __importStar(__nccwpck_require__(217));
+const timers_1 = __nccwpck_require__(486);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -24835,7 +26096,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 125:
+/***/ 126:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24845,9 +26106,9 @@ class ExecState extends events.EventEmitter {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredentialPolicy = void 0;
 const constants_js_1 = __nccwpck_require__(34);
-const utils_common_js_1 = __nccwpck_require__(451);
-const CredentialPolicy_js_1 = __nccwpck_require__(300);
-const SharedKeyComparator_js_1 = __nccwpck_require__(173);
+const utils_common_js_1 = __nccwpck_require__(450);
+const CredentialPolicy_js_1 = __nccwpck_require__(299);
+const SharedKeyComparator_js_1 = __nccwpck_require__(172);
 /**
  * StorageSharedKeyCredentialPolicy is a policy used to sign HTTP request with a shared key.
  */
@@ -24991,7 +26252,7 @@ exports.StorageSharedKeyCredentialPolicy = StorageSharedKeyCredentialPolicy;
 
 /***/ }),
 
-/***/ 126:
+/***/ 127:
 /***/ ((module) => {
 
 "use strict";
@@ -25011,1231 +26272,6 @@ module.exports = {
 
 /***/ }),
 
-/***/ 127:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// setup-soldr post-job entry point. Owned by Agent 2.
-//
-// Runs in the post-job phase via action.yml's `post: dist/post.js`. This is
-// the architectural fix for zackees/setup-soldr#70 — it lets us tar+zstd
-// the build-cache (and optionally cargo-registry) directories BEFORE
-// @actions/cache's post-save uploads them, so the wire format is zstd on
-// every platform (including Windows-x64 where actions/cache@v5 still
-// falls back to gzip).
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.resolveJournalPrintRaw = resolveJournalPrintRaw;
-exports.buildFinalCacheSummary = buildFinalCacheSummary;
-exports.formatFinalCacheSummaryMarkdown = formatFinalCacheSummaryMarkdown;
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(243));
-const path = __importStar(__nccwpck_require__(485));
-const node_child_process_1 = __nccwpck_require__(193);
-const core = __importStar(__nccwpck_require__(437));
-const cache = __importStar(__nccwpck_require__(209));
-const cache_compress_js_1 = __nccwpck_require__(502);
-const solo_toolchain_cache_js_1 = __nccwpck_require__(283);
-const cook_cache_js_1 = __nccwpck_require__(460);
-const soldr_mini_cache_js_1 = __nccwpck_require__(76);
-const log_utils_js_1 = __nccwpck_require__(339);
-const shutdown_cache_js_1 = __nccwpck_require__(505);
-const stats_collector_js_1 = __nccwpck_require__(71);
-const compile_cache_stats_js_1 = __nccwpck_require__(159);
-const diagnostics_js_1 = __nccwpck_require__(226);
-const raw_inputs_js_1 = __nccwpck_require__(484);
-const source_mtime_snapshot_js_1 = __nccwpck_require__(388);
-function dirExists(p) {
-    try {
-        return fs.statSync(p).isDirectory();
-    }
-    catch {
-        return false;
-    }
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
-    }
-}
-function stateBool(name, fallback = false) {
-    const value = core.getState(name).trim().toLowerCase();
-    if (value === "true")
-        return true;
-    if (value === "false")
-        return false;
-    return fallback;
-}
-/**
- * Decide whether the post-phase diagnostic dump includes the verbatim
- * per-rustc-invocation JSONL stream. The raw stream is large (thousands
- * of records / 20-30 MB on the demo warm build) and dominates Post Setup
- * Soldr wall-clock when emitted. Default: mirror debug mode (preserves
- * pre-existing behavior for workflows that already opted into debug).
- * Explicit values "true"/"false"/"on"/"off"/"yes"/"no"/"1"/"0" override.
- */
-function resolveJournalPrintRaw(rawValue, debugMode) {
-    const v = (rawValue ?? "").trim().toLowerCase();
-    if (v === "")
-        return debugMode;
-    if (v === "true" || v === "1" || v === "yes" || v === "on")
-        return true;
-    if (v === "false" || v === "0" || v === "no" || v === "off")
-        return false;
-    return debugMode;
-}
-function readRestoreState() {
-    return {
-        setupCacheEnabled: stateBool("setupCacheEnabled"),
-        setupCacheExactHit: stateBool("setupCacheExactHit"),
-        setupCacheMatchedKey: core.getState("setupCacheMatchedKey"),
-        targetCacheEnabled: stateBool("targetCacheEnabled"),
-        targetCacheExactHit: stateBool("targetCacheExactHit"),
-        targetCacheMatchedKey: core.getState("targetCacheMatchedKey"),
-        buildCacheEnabled: stateBool("buildCacheEnabled"),
-        buildCacheExactHit: stateBool("buildCacheExactHit"),
-        buildCacheMatchedKey: core.getState("buildCacheMatchedKey"),
-        cargoRegistryCacheEnabled: stateBool("cargoRegistryCacheEnabled"),
-        cargoRegistryCacheExactHit: stateBool("cargoRegistryCacheExactHit"),
-        cargoRegistryCacheMatchedKey: core.getState("cargoRegistryCacheMatchedKey"),
-    };
-}
-function disabledSave() {
-    return { status: "disabled" };
-}
-// setup-cache is intentionally restore-only. Its restore is kept so the
-// action's `cache-hit` output (wired from setupCacheExactHit in main.ts)
-// retains its public contract for downstream workflows, but the save path
-// is permanently inert: the soldr binary moved to soldr-mini-cache (#142)
-// and the rustup toolchain state moved to solo-toolchain-cache (#139),
-// both of which are content-addressable and coarser-keyed. Wiring a save
-// here would re-introduce a duplicate path and defeat those layers' LRU
-// access pattern. See setup-soldr#151 for the full decision rationale.
-function notManagedSave() {
-    return { status: "not-managed-in-post" };
-}
-function restoreStatus(enabled, exactHit, matchedKey) {
-    if (!enabled)
-        return "disabled";
-    if (exactHit)
-        return "exact-hit";
-    if (matchedKey.trim())
-        return "restore-key-hit";
-    return "miss";
-}
-async function saveOne(opts) {
-    const { cacheDir, codec, level, key, matchedKey, label, debug, log, extraBasenames } = opts;
-    const withBytes = (r) => Object.assign(r, { archiveBytes: null });
-    if (!dirExists(cacheDir)) {
-        log(`${label}: cache dir ${cacheDir} does not exist, skipping save`);
-        return withBytes({ status: "missing-dir-skip", cache_dir: cacheDir });
-    }
-    if (matchedKey === key) {
-        log(`${label}: exact cache hit on ${key}, skipping save`);
-        return withBytes({ status: "exact-hit-skip", cache_dir: cacheDir });
-    }
-    let archiveBytes = null;
-    let archivePath = null;
-    try {
-        const result = await (0, cache_compress_js_1.compressCache)({ cacheDir, codec, level, debug, log, extraBasenames });
-        archivePath = result.archivePath;
-        archiveBytes = result.archiveBytes || null;
-    }
-    catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        log(`${label}: compression failed: ${message}`);
-        return withBytes({ status: "failed", cache_dir: cacheDir, error: message });
-    }
-    const pathsToSave = archivePath ? [archivePath] : [cacheDir];
-    try {
-        const id = await cache.saveCache(pathsToSave, key);
-        log(`${label}: saved cache id=${id} key=${key} via ${archivePath ? "tar.zst" : "default"}`);
-        return {
-            status: "saved",
-            cache_dir: cacheDir,
-            archive_path: archivePath ?? undefined,
-            saved_paths: pathsToSave,
-            cache_id: id,
-            archiveBytes,
-        };
-    }
-    catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        log(`${label}: save failed: ${message}`);
-        return {
-            status: "failed",
-            cache_dir: cacheDir,
-            archive_path: archivePath ?? undefined,
-            saved_paths: pathsToSave,
-            error: message,
-            archiveBytes,
-        };
-    }
-}
-function cacheLayerSummary(opts) {
-    const matchedKey = opts.matchedKey.trim();
-    return {
-        enabled: opts.enabled,
-        key: opts.key,
-        matched_key: matchedKey,
-        exact_hit: opts.enabled ? opts.exactHit : false,
-        restore_status: restoreStatus(opts.enabled, opts.exactHit, matchedKey),
-        save: opts.save,
-    };
-}
-function readSoldrCacheReport(soldrBinary, passthrough) {
-    if (passthrough) {
-        // Short-circuit when the main step installed a passthrough stub
-        // (enable=false). Skips spawning a .cmd on Windows (where
-        // child_process.spawnSync can't launch shell scripts directly) and
-        // documents the passthrough state in the post-step summary.
-        return {
-            status: "ok",
-            soldr_version: "passthrough",
-            report: {
-                notes: ["setup-soldr enable=false: soldr passthrough stub"],
-                last_session: null,
-                rollups: null,
-            },
-        };
-    }
-    if (!soldrBinary || !fileExists(soldrBinary)) {
-        return {
-            status: "missing-binary",
-            error: soldrBinary === undefined
-                ? "SOLDR_BINARY env var not set"
-                : `soldr binary at ${soldrBinary} does not exist`,
-        };
-    }
-    // Use spawnSync so the post step has no async dependencies. The
-    // report subcommand is fast (sub-100ms) — never worth pulling in
-    // @actions/exec just for one shell-out.
-    const child = (0, node_child_process_1.spawnSync)(soldrBinary, ["cache", "report", "--json"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-        windowsHide: true,
-    });
-    if (child.error) {
-        return {
-            status: "error",
-            error: `failed to spawn soldr: ${child.error.message}`,
-        };
-    }
-    const stdout = (child.stdout || "").trim();
-    const stderr = (child.stderr || "").trim();
-    if (child.status !== 0) {
-        const combined = `${stderr}\n${stdout}`;
-        if (/unrecognized subcommand|invalid value for|unknown sub[- ]?command/i.test(combined) &&
-            /\breport\b/.test(combined)) {
-            return {
-                status: "unsupported",
-                error: stderr || stdout || `soldr exited ${child.status}`,
-            };
-        }
-        return {
-            status: "error",
-            error: stderr || stdout || `soldr exited ${child.status}`,
-        };
-    }
-    let report;
-    try {
-        const parsed = JSON.parse(stdout);
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-            return {
-                status: "error",
-                error: "soldr cache report --json returned a non-object payload",
-            };
-        }
-        report = parsed;
-    }
-    catch (err) {
-        return {
-            status: "error",
-            error: `failed to parse soldr cache report JSON: ${err instanceof Error ? err.message : String(err)}`,
-        };
-    }
-    const soldrVersion = typeof report["soldr_version"] === "string" ? report["soldr_version"] : undefined;
-    const zccacheVersion = typeof report["managed_zccache_version"] === "string"
-        ? report["managed_zccache_version"]
-        : undefined;
-    return {
-        status: "ok",
-        soldr_version: soldrVersion,
-        managed_zccache_version: zccacheVersion,
-        report,
-    };
-}
-function readZccacheSessionSummary(buildCachePath) {
-    const statsPath = path.join(buildCachePath, "logs", "last-session-stats.json");
-    if (!fileExists(statsPath)) {
-        return { stats_path: statsPath, present: false, status: "missing" };
-    }
-    try {
-        const parsed = JSON.parse(fs.readFileSync(statsPath, "utf8"));
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-            return {
-                stats_path: statsPath,
-                present: true,
-                status: "invalid",
-                error: "stats JSON was not an object",
-            };
-        }
-        const stats = parsed;
-        const status = typeof stats["status"] === "string" ? stats["status"] : "unknown";
-        return { stats_path: statsPath, present: true, status, stats };
-    }
-    catch (err) {
-        return {
-            stats_path: statsPath,
-            present: true,
-            status: "invalid",
-            error: err instanceof Error ? err.message : String(err),
-        };
-    }
-}
-function buildFinalCacheSummary(result, state, saves, passthrough = false) {
-    return {
-        schema_version: 1,
-        setup_cache: cacheLayerSummary({
-            enabled: state.setupCacheEnabled,
-            key: result.setupCache.key,
-            exactHit: state.setupCacheExactHit,
-            matchedKey: state.setupCacheMatchedKey,
-            save: notManagedSave(),
-        }),
-        target_cache: cacheLayerSummary({
-            enabled: state.targetCacheEnabled,
-            key: result.targetCache.key,
-            exactHit: state.targetCacheExactHit,
-            matchedKey: state.targetCacheMatchedKey,
-            save: saves.targetCache,
-        }),
-        build_cache: cacheLayerSummary({
-            enabled: state.buildCacheEnabled,
-            key: result.buildCache.key,
-            exactHit: state.buildCacheExactHit,
-            matchedKey: state.buildCacheMatchedKey,
-            save: saves.buildCache,
-        }),
-        cargo_registry_cache: cacheLayerSummary({
-            enabled: state.cargoRegistryCacheEnabled,
-            key: result.cargoRegistryCache.key,
-            exactHit: state.cargoRegistryCacheExactHit,
-            matchedKey: state.cargoRegistryCacheMatchedKey,
-            save: saves.cargoRegistryCache,
-        }),
-        zccache_session: readZccacheSessionSummary(result.buildCache.path),
-        compile_cache_report: readSoldrCacheReport(process.env["SOLDR_BINARY"]?.trim(), passthrough),
-    };
-}
-function numberStat(stats, key) {
-    const value = stats?.[key];
-    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-function zccacheOneLine(summary) {
-    if (!summary.present)
-        return `missing (${summary.stats_path})`;
-    if (summary.status !== "ok") {
-        return summary.error ? `${summary.status} (${summary.error})` : summary.status;
-    }
-    const hits = numberStat(summary.stats, "hits") ?? 0;
-    const misses = numberStat(summary.stats, "misses") ?? 0;
-    const compilations = numberStat(summary.stats, "compilations") ?? hits + misses;
-    const nonCacheable = numberStat(summary.stats, "non_cacheable") ?? 0;
-    const errors = numberStat(summary.stats, "errors") ?? 0;
-    const hitRate = numberStat(summary.stats, "hit_rate");
-    const hitRateText = hitRate === undefined ? "n/a" : `${(hitRate * 100).toFixed(1)}%`;
-    return `hits=${hits} misses=${misses} compilations=${compilations} non_cacheable=${nonCacheable} errors=${errors} hit_rate=${hitRateText}`;
-}
-function restoreText(layer) {
-    if (!layer.enabled)
-        return "disabled";
-    if (layer.restore_status === "exact-hit")
-        return "exact hit";
-    if (layer.restore_status === "restore-key-hit")
-        return "restore-key hit";
-    return "miss";
-}
-function saveText(save) {
-    switch (save.status) {
-        case "saved":
-            return save.cache_id === undefined ? "saved" : `saved id=${save.cache_id}`;
-        case "exact-hit-skip":
-            return "skipped exact hit";
-        case "missing-dir-skip":
-            return "skipped missing dir";
-        case "failed":
-            return save.error ? `failed: ${save.error}` : "failed";
-        case "disabled":
-            return "disabled";
-        case "not-managed-in-post":
-            return "not managed in post";
-    }
-}
-function markdownCell(value) {
-    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
-}
-function tableRow(label, layer) {
-    return [
-        label,
-        restoreText(layer),
-        layer.key,
-        layer.matched_key || "",
-        saveText(layer.save),
-    ]
-        .map(markdownCell)
-        .join(" | ");
-}
-function fmtBytes(n) {
-    if (n >= 1_073_741_824)
-        return `${(n / 1_073_741_824).toFixed(1)} GB`;
-    if (n >= 1_048_576)
-        return `${(n / 1_048_576).toFixed(1)} MB`;
-    if (n >= 1_024)
-        return `${(n / 1_024).toFixed(1)} KB`;
-    return `${n} B`;
-}
-function setCompileCacheOutputs(report, mode) {
-    core.setOutput("compile-cache-session-status", report.status);
-    if (report.status !== "ok" || !report.report)
-        return;
-    core.setOutput("compile-cache-summary-json", JSON.stringify(report.report));
-    const lastSession = report.report["last_session"];
-    if (lastSession) {
-        const hits = numberStat(lastSession, "hits") ?? 0;
-        const misses = numberStat(lastSession, "misses") ?? 0;
-        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
-        const hitRate = numberStat(lastSession, "hit_rate");
-        const timeSavedMs = numberStat(lastSession, "time_saved_ms");
-        const bytesRead = numberStat(lastSession, "bytes_read");
-        const bytesWritten = numberStat(lastSession, "bytes_written");
-        core.setOutput("compile-cache-hits", String(hits));
-        core.setOutput("compile-cache-misses", String(misses));
-        core.setOutput("compile-cache-compilations", String(compilations));
-        if (hitRate !== undefined)
-            core.setOutput("compile-cache-hit-rate", String(hitRate));
-        if (timeSavedMs !== undefined)
-            core.setOutput("compile-cache-time-saved-ms", String(timeSavedMs));
-        if (bytesRead !== undefined)
-            core.setOutput("compile-cache-bytes-read", String(bytesRead));
-        if (bytesWritten !== undefined)
-            core.setOutput("compile-cache-bytes-written", String(bytesWritten));
-    }
-    if (mode === "detailed") {
-        const rollups = report.report["rollups"];
-        if (rollups)
-            core.setOutput("compile-cache-rollups-json", JSON.stringify(rollups));
-    }
-}
-function compileCacheReportSection(report, mode) {
-    if (mode === "none")
-        return [];
-    // Insights mode is a superset of summarize — render the per-session table
-    // first so workflows don't lose the baseline metrics, then append the
-    // diagnoses block underneath. The detailed roll-up tables stay
-    // detailed-only (they're already noisy enough on their own).
-    const summaryMode = mode === "insights" ? "summarize" : mode;
-    const lines = ["", "### Compile cache (zccache)", ""];
-    if (report.status !== "ok" || !report.report) {
-        lines.push(`| Status | ${markdownCell(report.status)} |`);
-        if (report.error)
-            lines.push(`| Detail | ${markdownCell(report.error)} |`);
-        return lines;
-    }
-    const body = report.report;
-    const lastSession = body["last_session"] ?? null;
-    const rollups = body["rollups"] ?? null;
-    if (lastSession) {
-        const hits = numberStat(lastSession, "hits") ?? 0;
-        const misses = numberStat(lastSession, "misses") ?? 0;
-        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
-        const rate = numberStat(lastSession, "hit_rate");
-        const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
-        const saved = numberStat(lastSession, "time_saved_ms");
-        const bytesRead = numberStat(lastSession, "bytes_read");
-        const bytesWritten = numberStat(lastSession, "bytes_written");
-        lines.push("| Metric | Value |", "| --- | --- |");
-        lines.push(`| Compilations | ${compilations} |`);
-        lines.push(`| Hits | ${hits} |`);
-        lines.push(`| Misses | ${misses} |`);
-        lines.push(`| Hit rate | ${rateText} |`);
-        if (saved !== undefined)
-            lines.push(`| Time saved (est.) | ${(saved / 1000).toFixed(1)}s |`);
-        if (bytesRead !== undefined)
-            lines.push(`| Bytes read | ${fmtBytes(bytesRead)} |`);
-        if (bytesWritten !== undefined)
-            lines.push(`| Bytes written | ${fmtBytes(bytesWritten)} |`);
-        if (report.soldr_version)
-            lines.push(`| soldr | ${markdownCell(report.soldr_version)} |`);
-        if (report.managed_zccache_version)
-            lines.push(`| zccache | ${markdownCell(report.managed_zccache_version)} |`);
-    }
-    else {
-        lines.push("_(no last\\_session yet — run a cache-enabled build first)_");
-    }
-    if (mode === "detailed" && rollups) {
-        const byExt = rollups["by_extension"];
-        if (byExt && typeof byExt === "object" && !Array.isArray(byExt)) {
-            const rows = Object.entries(byExt);
-            if (rows.length > 0) {
-                lines.push("", "#### By output extension", "");
-                lines.push("| Extension | Hits | Misses | Total ms |", "| --- | --- | --- | --- |");
-                for (const [ext, bucket] of rows) {
-                    const b = bucket ?? {};
-                    const h = numberStat(b, "hits") ?? 0;
-                    const m = numberStat(b, "misses") ?? 0;
-                    const t = numberStat(b, "total_ms") ?? 0;
-                    lines.push(`| ${markdownCell(ext)} | ${h} | ${m} | ${t} |`);
-                }
-            }
-        }
-        const byTool = rollups["by_tool_total_ms"];
-        if (byTool && typeof byTool === "object" && !Array.isArray(byTool)) {
-            const rows = Object.entries(byTool)
-                .map(([tool, ms]) => [tool, typeof ms === "number" ? ms : 0])
-                .sort((a, b) => b[1] - a[1])
-                .slice(0, 10);
-            if (rows.length > 0) {
-                lines.push("", "#### By tool (wall-clock)", "");
-                lines.push("| Tool | ms |", "| --- | --- |");
-                for (const [tool, ms] of rows) {
-                    lines.push(`| ${markdownCell(tool)} | ${ms} |`);
-                }
-            }
-        }
-    }
-    // PR3 — insights mode appends per-diagnosis <details> blocks below the
-    // per-session table. Each diagnosis renders its evidence (miss reasons
-    // table + slowest misses list + wasted_ms) plus a blockquoted
-    // suggested_fix line. Annotations are not emitted from this pure
-    // renderer — the run() loop separately forwards them to core.warning /
-    // core.notice so they show up pinned in the PR Files view.
-    if (mode === "insights") {
-        const insights = (0, compile_cache_stats_js_1.renderInsights)(body);
-        if (insights.markdown.length > 0) {
-            lines.push("", "### Compile cache insights", "");
-            lines.push(insights.markdown);
-        }
-    }
-    const notes = body["notes"];
-    if (Array.isArray(notes) && notes.length > 0) {
-        lines.push("", "<details><summary>Notes from soldr</summary>", "");
-        for (const note of notes) {
-            if (typeof note === "string")
-                lines.push(`- ${markdownCell(note)}`);
-        }
-        lines.push("", "</details>");
-    }
-    // Silence the "unused variable" warning — summaryMode is reserved for a
-    // future split where insights includes/excludes the detailed-rollup
-    // tables. Today the rollup gate is still keyed on `mode`.
-    void summaryMode;
-    return lines;
-}
-function formatFinalCacheSummaryMarkdown(summary, compileCacheStats = "summarize") {
-    const lines = [
-        "## setup-soldr final cache summary",
-        "",
-        "| Layer | Restore | Primary key | Matched key | Save |",
-        "| --- | --- | --- | --- | --- |",
-        `| ${tableRow("setup cache", summary.setup_cache)} |`,
-        `| ${tableRow("target cache", summary.target_cache)} |`,
-        `| ${tableRow("build cache", summary.build_cache)} |`,
-        `| ${tableRow("cargo registry cache", summary.cargo_registry_cache)} |`,
-        "",
-        "### zccache session",
-        "",
-        `- Stats: ${zccacheOneLine(summary.zccache_session)}`,
-        `- Stats file: ${summary.zccache_session.stats_path}`,
-        ...compileCacheReportSection(summary.compile_cache_report, compileCacheStats),
-        "",
-        "<details><summary>Final cache summary JSON</summary>",
-        "",
-        "```json",
-        JSON.stringify(summary, null, 2),
-        "```",
-        "",
-        "</details>",
-        "",
-    ];
-    return `${lines.join("\n")}\n`;
-}
-function logFinalCacheSummary(summary, log) {
-    log(`final cache summary: setup=${restoreText(summary.setup_cache)} target=${restoreText(summary.target_cache)} ` +
-        `build=${restoreText(summary.build_cache)}/${saveText(summary.build_cache.save)} ` +
-        `cargo-registry=${restoreText(summary.cargo_registry_cache)}/${saveText(summary.cargo_registry_cache.save)}`);
-    log(`final zccache session stats: ${zccacheOneLine(summary.zccache_session)}`);
-    log(`compile cache report: ${compileCacheReportOneLine(summary.compile_cache_report)}`);
-}
-function compileCacheReportOneLine(report) {
-    if (report.status !== "ok" || !report.report) {
-        return report.error ? `${report.status} (${report.error})` : report.status;
-    }
-    const lastSession = report.report["last_session"];
-    if (!lastSession) {
-        return `ok (no last_session yet, soldr ${report.soldr_version ?? "?"})`;
-    }
-    const hits = numberStat(lastSession, "hits") ?? 0;
-    const misses = numberStat(lastSession, "misses") ?? 0;
-    const rate = numberStat(lastSession, "hit_rate");
-    const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
-    return `ok hits=${hits} misses=${misses} hit_rate=${rateText} soldr=${report.soldr_version ?? "?"}`;
-}
-function writeCompileCacheReportFile(report, runnerTemp, log) {
-    if (!runnerTemp)
-        return undefined;
-    const outPath = path.join(runnerTemp, "setup-soldr-compile-cache-report.json");
-    try {
-        fs.writeFileSync(outPath, JSON.stringify(report, null, 2), "utf8");
-        return outPath;
-    }
-    catch (err) {
-        log(`post: failed to write compile-cache-report.json: ${err instanceof Error ? err.message : String(err)}`);
-        return undefined;
-    }
-}
-function writeStepSummary(markdown, log) {
-    const summaryPath = process.env["GITHUB_STEP_SUMMARY"]?.trim();
-    if (!summaryPath)
-        return;
-    try {
-        fs.appendFileSync(summaryPath, markdown, "utf8");
-    }
-    catch (err) {
-        log(`post: failed to write GitHub step summary: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-/**
- * PR3 — Emit insights-mode side effects:
- *   - Forward each `renderInsights` annotation line to core.warning /
- *     core.notice so it shows up pinned in the PR Files-Changed view.
- *   - Best-effort: ask soldr to write a chrome-trace JSON (a developer
- *     debugger trace file consumable by chrome://tracing or Perfetto)
- *     and upload it as a workflow artifact. Silently skipped when soldr
- *     doesn't support the `--chrome-trace` flag — keeps the action green
- *     on older soldr versions that don't have the subcommand yet.
- */
-async function emitInsightsAnnotationsAndTrace(opts) {
-    const { report, soldrBinary, runnerTemp, log } = opts;
-    if (report.status === "ok" && report.report) {
-        try {
-            const out = (0, compile_cache_stats_js_1.renderInsights)(report.report);
-            for (const line of out.annotations) {
-                // Echo to stdout exactly as GitHub Actions expects — the runner
-                // ingests `::warning::` / `::notice::` workflow-command lines
-                // from stdout regardless of which library wrote them. Avoid the
-                // @actions/core helpers because they re-encode the message and
-                // we want the file= pin we computed in renderInsights to land
-                // verbatim.
-                process.stdout.write(`${line}\n`);
-            }
-            log(`compile-cache-stats: emitted ${out.annotations.length} insights annotations`);
-        }
-        catch (err) {
-            log(`compile-cache-stats: failed to emit insights annotations: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    // Chrome-trace upload. Skipped when no SOLDR_BINARY is on disk, or
-    // when soldr's `cache report --chrome-trace <path>` exits with an
-    // "unknown subcommand"/"unrecognized flag" error (i.e. the user is on
-    // a soldr build that predates the trace flag).
-    if (!soldrBinary || !fileExists(soldrBinary) || !runnerTemp)
-        return;
-    const runId = process.env["GITHUB_RUN_ID"]?.trim() || "local";
-    const tracePath = path.join(runnerTemp, `setup-soldr-trace-${runId}.json`);
-    let traced = false;
-    try {
-        const child = (0, node_child_process_1.spawnSync)(soldrBinary, ["cache", "report", "--chrome-trace", tracePath], {
-            encoding: "utf8",
-            stdio: ["ignore", "pipe", "pipe"],
-            windowsHide: true,
-        });
-        if (child.error) {
-            log(`compile-cache-stats: chrome-trace spawn failed: ${child.error.message}`);
-            return;
-        }
-        if (child.status !== 0) {
-            const combined = `${child.stderr || ""}\n${child.stdout || ""}`;
-            if (/unrecognized|unknown|invalid/i.test(combined) && /chrome[-_ ]?trace/i.test(combined)) {
-                log("compile-cache-stats: chrome-trace flag not supported by this soldr — skipping upload");
-                return;
-            }
-            log(`compile-cache-stats: chrome-trace generation failed (exit ${child.status})`);
-            return;
-        }
-        traced = fileExists(tracePath);
-    }
-    catch (err) {
-        log(`compile-cache-stats: chrome-trace generation threw: ${err instanceof Error ? err.message : String(err)}`);
-        return;
-    }
-    if (!traced) {
-        log(`compile-cache-stats: chrome-trace file not present at ${tracePath} — skipping upload`);
-        return;
-    }
-    try {
-        // Lazy require so the action stays loadable even when
-        // @actions/artifact's runtime requirements aren't met (e.g. running
-        // outside of a GitHub-hosted runner, which is the case for every
-        // unit test in this repo). Any failure is logged-not-thrown.
-        const artifact = await __nccwpck_require__.e(/* import() */ 846).then(__nccwpck_require__.t.bind(__nccwpck_require__, 76846, 23));
-        const client = new artifact.DefaultArtifactClient();
-        const artifactName = `setup-soldr-trace-${runId}.json`;
-        await client.uploadArtifact(artifactName, [tracePath], path.dirname(tracePath));
-        log(`compile-cache-stats: uploaded chrome-trace artifact ${artifactName}`);
-    }
-    catch (err) {
-        log(`compile-cache-stats: chrome-trace artifact upload failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-async function run() {
-    const logger = (0, log_utils_js_1.createLogger)(process.env);
-    const log = (msg) => logger.log(msg);
-    const state = core.getState("resolveResult");
-    if (!state) {
-        log("post: no resolve state available, exiting");
-        return;
-    }
-    let result;
-    try {
-        result = JSON.parse(state);
-    }
-    catch (err) {
-        log(`post: failed to parse resolve state: ${err instanceof Error ? err.message : String(err)}`);
-        return;
-    }
-    const buildCacheMatched = core.getState("buildCacheMatchedKey");
-    const registryMatched = core.getState("cargoRegistryCacheMatchedKey");
-    const passthrough = stateBool("setupSoldrPassthrough");
-    const restoreState = readRestoreState();
-    const statsMode = (core.getState("statsMode") || "summarize");
-    const compileCacheStats = (core.getState("compileCacheStats") || "summarize");
-    const runnerTemp = core.getState("runnerTemp") || "";
-    const debugMode = result.debugMode ?? false;
-    const debugLog = debugMode ? log : () => undefined;
-    const postCollector = new stats_collector_js_1.StatsCollector();
-    // Always stop long-running cache daemons before packing the build
-    // cache so file locks release and the tarball reflects a quiescent
-    // on-disk view. Best-effort; failures are logged, not raised.
-    //
-    // Wire `--archive-logs <build-cache>/logs/archive` through so soldr
-    // (post-#379) stashes the just-ended session's logs into a
-    // per-session subdirectory inside the build-cache. Setup-soldr's
-    // existing tar.zst flow already picks up the entire build-cache
-    // subtree, so the archived logs ride the cache cycle for free and
-    // survive across runs (see issue #126).
-    const logsArchiveDir = restoreState.buildCacheEnabled
-        ? path.join(result.buildCache.path, "logs", "archive")
-        : undefined;
-    await (0, shutdown_cache_js_1.shutdownCacheDaemons)({
-        soldrPath: process.env["SOLDR_BINARY"]?.trim() || undefined,
-        logsArchiveDir,
-        log,
-    });
-    // Source-mtime snapshot (preserve-source-mtimes opt-in). Walk tracked
-    // sources, capture each (mtime, size, content-hash), and drop the JSON
-    // INSIDE the build-cache directory so it gets bundled into the same
-    // tar.zst the build-cache save will upload. main.ts replays the
-    // mtimes on warm after the build-cache decompresses, gated on each
-    // file's content matching what we snapshotted here.
-    const preserveSourceMtimes = core.getState("preserveSourceMtimes") === "true";
-    if (preserveSourceMtimes && restoreState.buildCacheEnabled) {
-        const t0 = Date.now();
-        // The "project root" — where the Cargo workspace being built actually
-        // lives — is the parent of the resolved target-dir, NOT result.workspace
-        // (which is GITHUB_WORKSPACE — usually the outer checkout containing
-        // the action itself plus one or more sub-repos). For the demo,
-        // result.workspace=/home/runner/work/setup-soldr/setup-soldr but the
-        // zccache project being built is at .../setup-soldr/zccache.
-        const projectRoot = path.dirname(result.targetCache.targetPath);
-        try {
-            const r = await (0, source_mtime_snapshot_js_1.snapshotSourceMtimes)({ workspace: projectRoot, log });
-            const out = path.join(result.buildCache.path, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
-            try {
-                fs.mkdirSync(path.dirname(out), { recursive: true });
-                (0, source_mtime_snapshot_js_1.writeSnapshotFile)(r.snapshot, out);
-                log(`source-mtime-snapshot: wrote ${out} scanned=${r.scanned} hashed=${r.hashed} skipped=${r.skipped} elapsed_ms=${Date.now() - t0}`);
-            }
-            catch (err) {
-                log(`source-mtime-snapshot: failed to write ${out}: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-        catch (err) {
-            log(`source-mtime-snapshot: scan failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    // Build cache
-    const buildSaveStart = Date.now();
-    const buildSave = restoreState.buildCacheEnabled
-        ? await saveOne({
-            cacheDir: result.buildCache.path,
-            codec: result.targetCacheCompress,
-            level: result.targetCacheCompressLevel,
-            key: result.buildCache.key,
-            matchedKey: buildCacheMatched,
-            label: "build-cache",
-            debug: debugMode,
-            log: debugLog,
-        })
-        : Object.assign(disabledSave(), { archiveBytes: null });
-    if (buildSave.status === "saved") {
-        postCollector.record({
-            label: "build-cache", operation: "save", hit: false,
-            key: result.buildCache.key, matchedKey: buildCacheMatched, restoreKeys: [],
-            archiveBytes: buildSave.archiveBytes, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - buildSaveStart, timestamp: new Date().toISOString(),
-        });
-    }
-    // Target cache. Previously slotted as `notManagedSave()` in the
-    // finalSummary — i.e. restored in main.ts but never saved here. That
-    // meant every commit cold-rebuilt `target/` (or the rust-plan bundle)
-    // because no entry was ever written for the restore-key prefix to
-    // fall back to. This block fixes the gap.
-    //
-    // Behavior:
-    // - Skip when target-cache layer is disabled (`target-cache: false`
-    //   or umbrella `cache: false`).
-    // - Skip on exact-hit (re-saving the same content under the same key
-    //   wastes time and triggers @actions/cache's "reservation already
-    //   exists" path).
-    // - Use `cache.saveCache` directly with the multi-path array (one
-    //   path in `thin`/`once` modes, two in `full`). @actions/cache will
-    //   tar+compress with its default codec — we don't route through
-    //   compressCache because target-cache may legitimately carry
-    //   multiple roots and compressCache is single-dir-shaped.
-    // - Paths array must match the one passed to restoreCache in main.ts
-    //   (the @actions/cache "version" hash depends on it — same gotcha
-    //   that bit cook-cache in #141).
-    let targetCacheSave = Object.assign(disabledSave(), { archiveBytes: null });
-    if (restoreState.targetCacheEnabled) {
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        const targetKey = result.targetCache.key;
-        const targetMatched = restoreState.targetCacheMatchedKey;
-        if (targetPaths.length === 0) {
-            log("target-cache: no paths configured, skipping save");
-            targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: "(no paths)" }, { archiveBytes: null });
-        }
-        else if (restoreState.targetCacheExactHit) {
-            log(`target-cache: exact cache hit on ${targetKey}, skipping save`);
-            targetCacheSave = Object.assign({ status: "exact-hit-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
-        }
-        else {
-            const existingPaths = targetPaths.filter((p) => fs.existsSync(p));
-            if (existingPaths.length === 0) {
-                log(`target-cache: none of the configured paths exist on disk (${targetPaths.join(", ")}), skipping save`);
-                targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
-            }
-            else {
-                const targetSaveStart = Date.now();
-                try {
-                    const id = await cache.saveCache(existingPaths, targetKey);
-                    if (id <= 0) {
-                        log(`target-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
-                            `job already saved key=${targetKey}`);
-                        targetCacheSave = Object.assign({
-                            status: "failed",
-                            cache_dir: existingPaths.join(","),
-                            saved_paths: existingPaths,
-                            error: `saveCache returned id=${id} (reserve failed; race or quota)`,
-                        }, { archiveBytes: null });
-                    }
-                    else {
-                        log(`target-cache: saved cache id=${id} key=${targetKey} paths=${existingPaths.join(",")}`);
-                        targetCacheSave = Object.assign({
-                            status: "saved",
-                            cache_dir: existingPaths.join(","),
-                            saved_paths: existingPaths,
-                            cache_id: id,
-                        }, { archiveBytes: null });
-                        postCollector.record({
-                            label: "target-cache",
-                            operation: "save",
-                            hit: false,
-                            key: targetKey,
-                            matchedKey: targetMatched,
-                            restoreKeys: [],
-                            archiveBytes: null,
-                            inflatedBytes: null,
-                            fileCount: null,
-                            durationMs: Date.now() - targetSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                }
-                catch (err) {
-                    const message = err instanceof Error ? err.message : String(err);
-                    log(`target-cache: save failed: ${message}`);
-                    targetCacheSave = Object.assign({
-                        status: "failed",
-                        cache_dir: existingPaths.join(","),
-                        saved_paths: existingPaths,
-                        error: message,
-                    }, { archiveBytes: null });
-                }
-            }
-        }
-    }
-    // Cargo registry cache (only when enabled).
-    // setup-soldr#102: bundle `.global-cache` (cargo's RFC-3413 GC db) and the
-    // `git/` directory (bare mirrors + checkouts for git-source crate deps)
-    // into the same archive alongside `registry/`. Cache key + archive path
-    // are unchanged — the extras simply ride inside the existing tarball.
-    let cargoRegistrySave = Object.assign(disabledSave(), { archiveBytes: null });
-    if (result.cargoRegistryCache.enabled) {
-        const regSaveStart = Date.now();
-        cargoRegistrySave = await saveOne({
-            cacheDir: result.cargoRegistryCache.path,
-            codec: result.targetCacheCompress,
-            level: result.targetCacheCompressLevel,
-            key: result.cargoRegistryCache.key,
-            matchedKey: registryMatched,
-            label: "cargo-registry-cache",
-            debug: debugMode,
-            log: debugLog,
-            extraBasenames: result.cargoRegistryCache.extraBasenames,
-        });
-        if (cargoRegistrySave.status === "saved") {
-            postCollector.record({
-                label: "cargo-registry", operation: "save", hit: false,
-                key: result.cargoRegistryCache.key, matchedKey: registryMatched, restoreKeys: [],
-                archiveBytes: cargoRegistrySave.archiveBytes, inflatedBytes: null, fileCount: null,
-                durationMs: Date.now() - regSaveStart, timestamp: new Date().toISOString(),
-            });
-        }
-    }
-    // Solo toolchain cache save. Opt-in via the `solo-toolchain-cache`
-    // input. Skip the save when the install delta is empty (the common
-    // case on hosted runners that already provide the requested
-    // toolchain) — per CLAUDE.md "Default-stable workflows should
-    // produce zero cache writes."
-    const soloEnabled = core.getState("soloToolchainEnabled") === "true";
-    if (soloEnabled) {
-        const soloExactKey = core.getState("soloToolchainExactKey");
-        const soloMatchedKey = core.getState("soloToolchainMatchedKey");
-        const soloExactHit = core.getState("soloToolchainExactHit") === "true";
-        const soloIncrementalEmpty = core.getState("soloToolchainIncrementalEmpty") === "true";
-        const soloSaveDiffPath = core.getState("soloToolchainSaveDiffPath");
-        const soloLevel = core.getState("soloToolchainLevel") || "19";
-        log(`solo-toolchain-cache: post-step exactKey=${soloExactKey} matched=${soloMatchedKey} ` +
-            `exactHit=${soloExactHit} incrementalEmpty=${soloIncrementalEmpty} saveDiffPath=${soloSaveDiffPath}`);
-        if (soloExactHit && soloIncrementalEmpty) {
-            log("solo-toolchain-cache: exact hit and no install delta — skipping save");
-        }
-        else if (!soloSaveDiffPath || !fs.existsSync(soloSaveDiffPath)) {
-            log("solo-toolchain-cache: no save-diff manifest available, skipping save");
-        }
-        else {
-            try {
-                const manifest = JSON.parse(fs.readFileSync(soloSaveDiffPath, "utf8"));
-                const added = Array.isArray(manifest.added) ? manifest.added : [];
-                if (added.length === 0) {
-                    log("solo-toolchain-cache: empty save-diff manifest, skipping save");
-                }
-                else {
-                    const soloRootMap = {
-                        "rustup-toolchains": path.join(result.rustupHome, "toolchains"),
-                        "cargo-bin": path.join(result.cargoHome, "bin"),
-                    };
-                    const stagingDir = path.join(runnerTemp, "setup-soldr-solo-stage-save");
-                    const soloSaveStart = Date.now();
-                    const staged = await (0, solo_toolchain_cache_js_1.stageDiffForSave)({ added, removed: [], changed: [] }, soloRootMap, stagingDir);
-                    log(`solo-toolchain-cache: staged ${staged.stagedFiles} files (missing=${staged.missingFiles})`);
-                    const saveResult = await (0, solo_toolchain_cache_js_1.saveSoloCache)({
-                        stagingDir,
-                        key: soloExactKey,
-                        level: soloLevel,
-                        debug: debugMode,
-                        log,
-                    });
-                    if (saveResult.status === "saved") {
-                        postCollector.record({
-                            label: "solo-toolchain-cache",
-                            operation: "save",
-                            hit: false,
-                            key: soloExactKey,
-                            matchedKey: soloMatchedKey,
-                            restoreKeys: [],
-                            archiveBytes: saveResult.archiveBytes ?? null,
-                            inflatedBytes: saveResult.inflatedBytes ?? null,
-                            fileCount: saveResult.fileCount ?? null,
-                            durationMs: Date.now() - soloSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                    else {
-                        log(`solo-toolchain-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
-                    }
-                }
-            }
-            catch (err) {
-                log(`solo-toolchain-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    }
-    // Cook cache save. Default-on layer; skipped when cook didn't run
-    // (cache hit, gate disabled, or run failed). zstd-19 + --long=27 per
-    // CLAUDE.md "Compression" + the cook simulation findings.
-    const cookEnabled = core.getState("cookEnabled") === "true";
-    if (cookEnabled) {
-        const cookHit = core.getState("cookHit") === "true";
-        const cookRan = core.getState("cookRan") === "true";
-        const cookExactKey = core.getState("cookExactKey");
-        const cookTargetDir = core.getState("cookTargetDir");
-        const cookLongWindow = parseInt(core.getState("cookLongWindow") || "27", 10);
-        const cookLevel = core.getState("cookCompressLevel") || "19";
-        log(`cook-cache: post-step key=${cookExactKey} hit=${cookHit} ran=${cookRan} target=${cookTargetDir}`);
-        if (cookHit) {
-            log("cook-cache: exact hit - skipping save");
-        }
-        else if (!cookRan) {
-            log("cook-cache: cook did not run successfully - skipping save");
-        }
-        else if (!cookTargetDir || !fs.existsSync(cookTargetDir)) {
-            log(`cook-cache: target dir ${cookTargetDir} missing - skipping save`);
-        }
-        else {
-            const cookSaveStart = Date.now();
-            try {
-                const saveResult = await (0, cook_cache_js_1.saveCookCache)({
-                    targetDir: cookTargetDir,
-                    exactKey: cookExactKey,
-                    level: cookLevel,
-                    longWindow: cookLongWindow,
-                    debug: debugMode,
-                    log,
-                });
-                if (saveResult.status === "saved") {
-                    postCollector.record({
-                        label: "cook-cache",
-                        operation: "save",
-                        hit: false,
-                        key: cookExactKey,
-                        matchedKey: "",
-                        restoreKeys: [],
-                        archiveBytes: saveResult.archiveBytes ?? null,
-                        inflatedBytes: saveResult.inflatedBytes ?? null,
-                        fileCount: saveResult.fileCount ?? null,
-                        durationMs: Date.now() - cookSaveStart,
-                        timestamp: new Date().toISOString(),
-                    });
-                }
-                else {
-                    log(`cook-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
-                }
-            }
-            catch (err) {
-                log(`cook-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    }
-    // Soldr-mini-cache save. Default-on; skipped when restore already hit
-    // (binary is byte-identical, no point re-saving), when disabled, or
-    // when running in passthrough mode.
-    const soldrMiniEnabled = core.getState("soldrMiniEnabled") === "true";
-    if (soldrMiniEnabled && !passthrough) {
-        const miniHit = core.getState("soldrMiniHit") === "true";
-        const miniExactKey = core.getState("soldrMiniExactKey");
-        const miniInstallDir = core.getState("soldrMiniInstallDir");
-        const miniArchive = core.getState("soldrMiniArchive");
-        log(`soldr-mini-cache: post-step key=${miniExactKey} hit=${miniHit} installDir=${miniInstallDir}`);
-        if (miniHit) {
-            log("soldr-mini-cache: exact hit — skipping save");
-        }
-        else if (!miniExactKey) {
-            log("soldr-mini-cache: no key (ineligible at main-time) — skipping save");
-        }
-        else if (!miniInstallDir || !fs.existsSync(miniInstallDir)) {
-            log(`soldr-mini-cache: install dir ${miniInstallDir} missing — skipping save`);
-        }
-        else {
-            const miniSaveStart = Date.now();
-            try {
-                const saveResult = await (0, soldr_mini_cache_js_1.saveMiniCache)({
-                    installDir: miniInstallDir,
-                    archivePath: miniArchive,
-                    exactKey: miniExactKey,
-                    level: "19",
-                    longWindow: 27,
-                    debug: debugMode,
-                    log,
-                });
-                if (saveResult.status === "saved") {
-                    postCollector.record({
-                        label: "soldr-mini-cache",
-                        operation: "save",
-                        hit: false,
-                        key: miniExactKey,
-                        matchedKey: "",
-                        restoreKeys: [],
-                        archiveBytes: saveResult.archiveBytes ?? null,
-                        inflatedBytes: saveResult.inflatedBytes ?? null,
-                        fileCount: saveResult.fileCount ?? null,
-                        durationMs: Date.now() - miniSaveStart,
-                        timestamp: new Date().toISOString(),
-                    });
-                }
-                else {
-                    log(`soldr-mini-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
-                }
-            }
-            catch (err) {
-                log(`soldr-mini-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    }
-    const finalSummary = buildFinalCacheSummary(result, restoreState, {
-        buildCache: buildSave,
-        cargoRegistryCache: cargoRegistrySave,
-        targetCache: targetCacheSave,
-    }, passthrough);
-    logFinalCacheSummary(finalSummary, log);
-    if (compileCacheStats !== "none") {
-        setCompileCacheOutputs(finalSummary.compile_cache_report, compileCacheStats);
-    }
-    writeStepSummary(formatFinalCacheSummaryMarkdown(finalSummary, compileCacheStats), log);
-    // PR3 — insights mode side-effects: emit GH annotations + optional
-    // chrome-trace artifact upload. These run only when the user explicitly
-    // opted into `insights`; the markdown insights block already landed in
-    // the step summary above via formatFinalCacheSummaryMarkdown.
-    if (compileCacheStats === "insights") {
-        await emitInsightsAnnotationsAndTrace({
-            report: finalSummary.compile_cache_report,
-            soldrBinary: process.env["SOLDR_BINARY"]?.trim(),
-            runnerTemp,
-            log,
-        });
-    }
-    const reportPath = writeCompileCacheReportFile(finalSummary.compile_cache_report, runnerTemp, log);
-    if (reportPath) {
-        log(`compile-cache-report.json written to ${reportPath}`);
-    }
-    // Note: setup-soldr-cache-keys.txt is written in main.ts (right after
-    // resolveSetup) so workflow steps that run between main and post —
-    // notably actions/upload-artifact — can read it. Re-write it here
-    // anyway as a safety net in case main.ts crashed before writing.
-    if (runnerTemp) {
-        writeCacheKeysManifestFromSummary(finalSummary, runnerTemp, log);
-    }
-    // Append save ops to detailed session log if requested
-    if (statsMode === "detailed" && runnerTemp) {
-        try {
-            await postCollector.appendSavesToSessionLog(runnerTemp);
-        }
-        catch (err) {
-            log(`post: stats log append failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    // Optional verbose diagnostic dump. Gated on `logging: true` which
-    // main.ts persists into action state.
-    const loggingState = core.getState("logging");
-    if ((0, diagnostics_js_1.loggingEnabled)(loggingState)) {
-        const rawInputs = (0, raw_inputs_js_1.readRawInputs)(process.env);
-        // zccache writes its per-rustc-invocation JSONL journal under the
-        // build-cache directory (which == ZCCACHE_CACHE_DIR per
-        // resolve-setup.ts's env exports). When `logging: true` is on we
-        // surface its contents so the reader can answer "warm reported 0
-        // hits — why did each lookup miss" without another build.
-        const journalPath = path.join(result.buildCache.path, "logs", "last-session.jsonl");
-        // Forward the verbatim `report` field from `soldr cache report --json`
-        // so dumpDiagnostics can format its `rollups` (per-extension /
-        // per-crate / slowest_entries) breakdown.
-        const cacheReport = finalSummary.compile_cache_report.report;
-        // Capture a process snapshot only when debug mode is on — `ps` /
-        // `tasklist` are cheap but the output is large and only useful when
-        // you're investigating cache-state weirdness (e.g. orphan daemons).
-        const processSnapshot = debugMode ? (0, diagnostics_js_1.captureProcessSnapshot)() ?? undefined : undefined;
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "post",
-            env: process.env,
-            rawInputs,
-            result,
-            cacheOutcomes: postCollector.snapshot(),
-            finalSummary: finalSummary,
-            journalPath,
-            // Raw JSONL stream — one record per rustc invocation, often
-            // thousands of lines / 20-30 MB of stdout per warm build. Default
-            // gate is `debug:true` (backwards compat with #134 era), but a
-            // workflow can explicitly opt out via `journal-print-raw: false`
-            // when it already uploads the JSONL as an artifact and doesn't
-            // want to pay the post-step log-writer cost (~30-50 s on the
-            // hosted ubuntu demo).
-            journalPrintRaw: resolveJournalPrintRaw(rawInputs.journalPrintRaw, debugMode),
-            cacheReport,
-            processSnapshot,
-            logger,
-            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
-        });
-    }
-}
-function writeCacheKeysManifestFromSummary(summary, runnerTemp, log) {
-    const keys = [
-        summary.setup_cache.key,
-        summary.build_cache.key,
-        summary.target_cache.key,
-        summary.cargo_registry_cache.key,
-    ].filter((k) => Boolean(k));
-    if (keys.length === 0)
-        return;
-    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
-    try {
-        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
-        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
-    }
-    catch (err) {
-        log(`post: failed to write cache-keys manifest: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-// See main.ts for the rationale behind the test-import escape hatch.
-if (typeof process !== "undefined" &&
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.warning(`setup-soldr post-job step failed: ${message}`);
-    });
-}
-
-
-/***/ }),
-
 /***/ 128:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -26246,7 +26282,7 @@ if (typeof process !== "undefined" &&
 
 const assert = __nccwpck_require__(501)
 const { Readable } = __nccwpck_require__(130)
-const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(466)
+const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(465)
 const util = __nccwpck_require__(66)
 const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(66)
 
@@ -26528,7 +26564,7 @@ function consumeEnd (consume) {
       resolve(dst.buffer)
     } else if (type === 'blob') {
       if (!Blob) {
-        Blob = (__nccwpck_require__(118).Blob)
+        Blob = (__nccwpck_require__(119).Blob)
       }
       resolve(new Blob(body, { type: stream[kContentType] }))
     }
@@ -26685,13 +26721,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpsProxyAgent = void 0;
-const net = __importStar(__nccwpck_require__(486));
-const tls = __importStar(__nccwpck_require__(482));
+const net = __importStar(__nccwpck_require__(485));
+const tls = __importStar(__nccwpck_require__(481));
 const assert_1 = __importDefault(__nccwpck_require__(501));
-const debug_1 = __importDefault(__nccwpck_require__(491));
-const agent_base_1 = __nccwpck_require__(234);
+const debug_1 = __importDefault(__nccwpck_require__(490));
+const agent_base_1 = __nccwpck_require__(233);
 const url_1 = __nccwpck_require__(84);
-const parse_proxy_response_1 = __nccwpck_require__(399);
+const parse_proxy_response_1 = __nccwpck_require__(398);
 const debug = (0, debug_1.default)('https-proxy-agent');
 const setServernameFromNonIpHost = (options) => {
     if (options.servername === undefined &&
@@ -26855,9 +26891,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(278);
+const http_client_1 = __nccwpck_require__(277);
 const auth_1 = __nccwpck_require__(25);
-const core_1 = __nccwpck_require__(437);
+const core_1 = __nccwpck_require__(436);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -26930,9 +26966,9 @@ exports.OidcClient = OidcClient;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
-const binary_format_contract_1 = __nccwpck_require__(323);
-const pb_long_1 = __nccwpck_require__(116);
-const goog_varint_1 = __nccwpck_require__(199);
+const binary_format_contract_1 = __nccwpck_require__(322);
+const pb_long_1 = __nccwpck_require__(117);
+const goog_varint_1 = __nccwpck_require__(198);
 const defaultsRead = {
     readUnknownField: true,
     readerFactory: bytes => new BinaryReader(bytes),
@@ -27128,8 +27164,8 @@ const {
   kDefaultTrailers,
   kContentLength,
   kMockDispatch
-} = __nccwpck_require__(448)
-const { InvalidArgumentError } = __nccwpck_require__(466)
+} = __nccwpck_require__(447)
+const { InvalidArgumentError } = __nccwpck_require__(465)
 const { buildURL } = __nccwpck_require__(66)
 
 /**
@@ -27452,7 +27488,7 @@ __export(xml_exports, {
   stringifyXML: () => stringifyXML
 });
 module.exports = __toCommonJS(xml_exports);
-var import_fast_xml_parser = __nccwpck_require__(312);
+var import_fast_xml_parser = __nccwpck_require__(311);
 var import_xml_common = __nccwpck_require__(19);
 function getCommonOptions(options) {
   return {
@@ -27525,11 +27561,11 @@ async function parseXML(str, opts = {}) {
 "use strict";
 
 
-module.exports.request = __nccwpck_require__(488)
-module.exports.stream = __nccwpck_require__(341)
-module.exports.pipeline = __nccwpck_require__(104)
-module.exports.upgrade = __nccwpck_require__(411)
-module.exports.connect = __nccwpck_require__(357)
+module.exports.request = __nccwpck_require__(487)
+module.exports.stream = __nccwpck_require__(340)
+module.exports.pipeline = __nccwpck_require__(105)
+module.exports.upgrade = __nccwpck_require__(410)
+module.exports.connect = __nccwpck_require__(356)
 
 
 /***/ }),
@@ -27591,7 +27627,7 @@ module.exports = {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollOperation = exports.initOperation = exports.deserializeState = void 0;
-const logger_js_1 = __nccwpck_require__(187);
+const logger_js_1 = __nccwpck_require__(186);
 const constants_js_1 = __nccwpck_require__(57);
 /**
  * Deserializes the state
@@ -27785,7 +27821,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(358);
+	createDebug.humanize = __nccwpck_require__(357);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -28152,15 +28188,15 @@ __export(internal_exports, {
   uint8ArrayToString: () => import_bytesEncoding.uint8ArrayToString
 });
 module.exports = __toCommonJS(internal_exports);
-var import_delay = __nccwpck_require__(452);
-var import_random = __nccwpck_require__(483);
+var import_delay = __nccwpck_require__(451);
+var import_random = __nccwpck_require__(482);
 var import_object = __nccwpck_require__(144);
 var import_error = __nccwpck_require__(152);
-var import_sha256 = __nccwpck_require__(196);
-var import_uuidUtils = __nccwpck_require__(376);
-var import_checkEnvironment = __nccwpck_require__(417);
-var import_bytesEncoding = __nccwpck_require__(280);
-var import_sanitizer = __nccwpck_require__(120);
+var import_sha256 = __nccwpck_require__(195);
+var import_uuidUtils = __nccwpck_require__(375);
+var import_checkEnvironment = __nccwpck_require__(416);
+var import_bytesEncoding = __nccwpck_require__(279);
+var import_sanitizer = __nccwpck_require__(121);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -28193,7 +28229,7 @@ __export(internal_exports, {
   createLoggerContext: () => import_logger.createLoggerContext
 });
 module.exports = __toCommonJS(internal_exports);
-var import_logger = __nccwpck_require__(240);
+var import_logger = __nccwpck_require__(239);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -28514,7 +28550,7 @@ __export(log_exports, {
   logger: () => logger
 });
 module.exports = __toCommonJS(log_exports);
-var import_logger = __nccwpck_require__(240);
+var import_logger = __nccwpck_require__(239);
 const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -28549,8 +28585,8 @@ __export(basicAuthenticationPolicy_exports, {
   basicAuthenticationPolicyName: () => basicAuthenticationPolicyName
 });
 module.exports = __toCommonJS(basicAuthenticationPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(280);
-var import_checkInsecureConnection = __nccwpck_require__(413);
+var import_bytesEncoding = __nccwpck_require__(279);
+var import_checkInsecureConnection = __nccwpck_require__(412);
 const basicAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function basicAuthenticationPolicy(options) {
   return {
@@ -28665,7 +28701,7 @@ exports.ConvertInternalResponseOfListBlobHierarchy = ConvertInternalResponseOfLi
 exports.ExtractPageRangeInfoItems = ExtractPageRangeInfoItems;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(100);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
 const core_util_1 = __nccwpck_require__(12);
 const constants_js_1 = __nccwpck_require__(147);
 /**
@@ -29472,7 +29508,7 @@ exports.StorageBrowserPolicyFactory = StorageBrowserPolicyFactory;
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(191).kConstruct)
+  kConstruct: (__nccwpck_require__(190).kConstruct)
 }
 
 
@@ -29485,7 +29521,7 @@ module.exports = {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionLongConvert = void 0;
-const reflection_info_1 = __nccwpck_require__(431);
+const reflection_info_1 = __nccwpck_require__(430);
 /**
  * Utility method to convert a PbLong or PbUlong to a JavaScript
  * representation during runtime.
@@ -29583,9 +29619,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.uploadCacheArchiveSDK = exports.UploadProgress = void 0;
-const core = __importStar(__nccwpck_require__(437));
-const storage_blob_1 = __nccwpck_require__(426);
-const errors_1 = __nccwpck_require__(296);
+const core = __importStar(__nccwpck_require__(436));
+const storage_blob_1 = __nccwpck_require__(425);
+const errors_1 = __nccwpck_require__(295);
 /**
  * Class for tracking the upload state and displaying stats.
  */
@@ -29719,198 +29755,6 @@ exports.uploadCacheArchiveSDK = uploadCacheArchiveSDK;
 /***/ }),
 
 /***/ 159:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-// setup-soldr#98 PR3 — insights-mode renderer + GitHub annotation builder.
-//
-// Consumes the `diagnoses[]` array shipped by `soldr cache report --json`
-// (schema defined in zackees/soldr#321) and produces:
-//
-//   - A Markdown block (per-diagnosis <details> with severity emoji,
-//     headline, evidence tables, and a suggested_fix blockquote) suitable
-//     for appending to $GITHUB_STEP_SUMMARY.
-//   - A list of GitHub workflow-command annotations
-//     (::warning::/::notice:: with optional file= pins) ready to be
-//     forwarded to core.warning / core.notice in the post-step runner.
-//
-// The renderer is pure — no I/O, no @actions/* imports — so it stays
-// trivially unit-testable. The post-step wires its output into the
-// step-summary append + the @actions/core annotation surface.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.renderInsights = renderInsights;
-/** Markdown table cell escaping — keeps the table grid intact. */
-function cell(value) {
-    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
-}
-/**
- * Severity → leading emoji. Maps "high" to a red circle (loudest signal in
- * a step summary), "medium" to yellow, "low" to green. Unknown severities
- * fall back to the medium glyph so the renderer never throws on a typo
- * from a future soldr release.
- */
-function severityEmoji(severity) {
-    switch ((severity ?? "").toLowerCase()) {
-        case "high":
-            return "🔴";
-        case "medium":
-            return "🟡";
-        case "low":
-            return "🟢";
-        default:
-            return "🟡";
-    }
-}
-/**
- * Severity → GitHub workflow-command verb. "high" gets `::warning::` so it
- * surfaces in the PR Files-Changed view; "medium"/"low" get `::notice::`
- * (less intrusive — annotation-tray only). Unknown severities default to
- * notice, the more conservative choice.
- */
-function severityCommand(severity) {
-    return (severity ?? "").toLowerCase() === "high" ? "warning" : "notice";
-}
-/** Human-readable ms → seconds when ≥ 1s, otherwise verbatim ms. */
-function fmtMs(ms) {
-    if (!Number.isFinite(ms) || ms < 0)
-        return `${ms} ms`;
-    if (ms >= 1000)
-        return `${(ms / 1000).toFixed(1)}s`;
-    return `${ms} ms`;
-}
-/**
- * Strip newlines from a string before splicing it into a GitHub workflow
- * command. The `::warning ::<msg>` syntax breaks if `<msg>` contains a
- * literal `\n` (the runner stops parsing at the line break). URL-encoded
- * `%0A` is the documented escape; the actions/core library uses the same
- * transform internally.
- */
-function escapeAnnotationMessage(msg) {
-    return msg.replace(/\r?\n/g, "%0A").replace(/\r/g, "%0D");
-}
-/**
- * Pull the first miss-reason entry that has a file path. Used to pin the
- * workflow annotation to a specific source file when one is available.
- * Falls back to undefined when no entry carries a file (e.g. all misses
- * are flag-driven).
- */
-function pickFile(evidence) {
-    const top = evidence?.miss_reasons_top;
-    if (!Array.isArray(top))
-        return undefined;
-    for (const entry of top) {
-        if (entry && typeof entry.file === "string" && entry.file.length > 0) {
-            return entry.file;
-        }
-    }
-    return undefined;
-}
-function renderMissReasonsTable(rows) {
-    if (rows.length === 0)
-        return [];
-    const out = [];
-    out.push("| Category | File/Flag | Misses |");
-    out.push("| --- | --- | --- |");
-    for (const row of rows) {
-        const category = typeof row.category === "string" ? row.category : "";
-        const fileOrFlag = typeof row.file === "string" && row.file.length > 0
-            ? row.file
-            : typeof row.flag === "string"
-                ? row.flag
-                : "";
-        const misses = typeof row.misses === "number" && Number.isFinite(row.misses)
-            ? String(row.misses)
-            : "";
-        out.push(`| ${cell(category)} | ${cell(fileOrFlag)} | ${misses} |`);
-    }
-    return out;
-}
-function renderSlowestMissesList(rows) {
-    if (rows.length === 0)
-        return [];
-    const out = ["", "**Slowest misses:**", ""];
-    for (const row of rows) {
-        const crateName = typeof row.crate === "string" ? row.crate : "(unknown)";
-        const ms = typeof row.ms === "number" ? row.ms : 0;
-        const reason = typeof row.miss_reason === "string" ? row.miss_reason : "";
-        const reasonText = reason ? ` — ${reason}` : "";
-        out.push(`- ${crateName}: ${fmtMs(ms)} (${ms} ms)${reasonText}`);
-    }
-    return out;
-}
-function renderOneDiagnosis(diag) {
-    const emoji = severityEmoji(diag.severity);
-    const headline = typeof diag.headline === "string" ? diag.headline : "(no headline)";
-    const lines = [];
-    lines.push("<details>");
-    lines.push(`<summary>${emoji} ${headline}</summary>`);
-    lines.push("");
-    const evidence = diag.evidence;
-    const missRows = Array.isArray(evidence?.miss_reasons_top)
-        ? evidence.miss_reasons_top
-        : [];
-    if (missRows.length > 0) {
-        lines.push("**Top miss reasons:**", "");
-        lines.push(...renderMissReasonsTable(missRows));
-    }
-    const slowest = Array.isArray(evidence?.slowest_misses)
-        ? evidence.slowest_misses
-        : [];
-    if (slowest.length > 0) {
-        lines.push(...renderSlowestMissesList(slowest));
-    }
-    if (evidence && typeof evidence.wasted_ms === "number" && Number.isFinite(evidence.wasted_ms)) {
-        lines.push("", `**Wasted compile time:** ${fmtMs(evidence.wasted_ms)}`);
-    }
-    if (typeof diag.suggested_fix === "string" && diag.suggested_fix.length > 0) {
-        lines.push("");
-        // Render the suggested fix as a Markdown blockquote so it stands
-        // out from the evidence body — the user's eye goes straight to the
-        // "what do I do about this" line.
-        lines.push(`> ${diag.suggested_fix}`);
-    }
-    lines.push("");
-    lines.push("</details>");
-    return lines;
-}
-function buildAnnotation(diag) {
-    const verb = severityCommand(diag.severity);
-    const file = pickFile(diag.evidence);
-    const headline = typeof diag.headline === "string" ? diag.headline : "(no headline)";
-    const message = escapeAnnotationMessage(headline);
-    if (file) {
-        return `::${verb} file=${file},line=1::${message}`;
-    }
-    return `::${verb}::${message}`;
-}
-/**
- * Render the insights surface from a parsed `soldr cache report --json`
- * payload. Tolerant of every optional field — a payload from an older
- * soldr (no `diagnoses` array) returns an empty result without throwing.
- */
-function renderInsights(payload) {
-    const raw = payload?.["diagnoses"];
-    if (!Array.isArray(raw) || raw.length === 0) {
-        return { markdown: "", annotations: [] };
-    }
-    const diagnoses = raw;
-    const markdownChunks = [];
-    const annotations = [];
-    for (const diag of diagnoses) {
-        markdownChunks.push(...renderOneDiagnosis(diag));
-        annotations.push(buildAnnotation(diag));
-    }
-    return {
-        markdown: markdownChunks.join("\n"),
-        annotations,
-    };
-}
-
-
-/***/ }),
-
-/***/ 160:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29940,7 +29784,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.req = exports.json = exports.toBuffer = void 0;
-const http = __importStar(__nccwpck_require__(320));
+const http = __importStar(__nccwpck_require__(319));
 const https = __importStar(__nccwpck_require__(67));
 async function toBuffer(stream) {
     let length = 0;
@@ -29983,7 +29827,7 @@ exports.req = req;
 
 /***/ }),
 
-/***/ 161:
+/***/ 160:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30121,36 +29965,36 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 
 /***/ }),
 
-/***/ 162:
+/***/ 161:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const Client = __nccwpck_require__(87)
-const Dispatcher = __nccwpck_require__(455)
-const errors = __nccwpck_require__(466)
-const Pool = __nccwpck_require__(327)
-const BalancedPool = __nccwpck_require__(365)
+const Dispatcher = __nccwpck_require__(454)
+const errors = __nccwpck_require__(465)
+const Pool = __nccwpck_require__(326)
+const BalancedPool = __nccwpck_require__(364)
 const Agent = __nccwpck_require__(5)
 const util = __nccwpck_require__(66)
 const { InvalidArgumentError } = errors
 const api = __nccwpck_require__(138)
-const buildConnector = __nccwpck_require__(261)
-const MockClient = __nccwpck_require__(195)
-const MockAgent = __nccwpck_require__(361)
-const MockPool = __nccwpck_require__(336)
-const mockErrors = __nccwpck_require__(225)
-const ProxyAgent = __nccwpck_require__(331)
-const RetryHandler = __nccwpck_require__(268)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(360)
-const DecoratorHandler = __nccwpck_require__(453)
-const RedirectHandler = __nccwpck_require__(373)
-const createRedirectInterceptor = __nccwpck_require__(249)
+const buildConnector = __nccwpck_require__(260)
+const MockClient = __nccwpck_require__(194)
+const MockAgent = __nccwpck_require__(360)
+const MockPool = __nccwpck_require__(335)
+const mockErrors = __nccwpck_require__(224)
+const ProxyAgent = __nccwpck_require__(330)
+const RetryHandler = __nccwpck_require__(267)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(359)
+const DecoratorHandler = __nccwpck_require__(452)
+const RedirectHandler = __nccwpck_require__(372)
+const createRedirectInterceptor = __nccwpck_require__(248)
 
 let hasCrypto
 try {
-  __nccwpck_require__(284)
+  __nccwpck_require__(283)
   hasCrypto = true
 } catch {
   hasCrypto = false
@@ -30229,7 +30073,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   let fetchImpl = null
   module.exports.fetch = async function fetch (resource) {
     if (!fetchImpl) {
-      fetchImpl = (__nccwpck_require__(429).fetch)
+      fetchImpl = (__nccwpck_require__(428).fetch)
     }
 
     try {
@@ -30242,11 +30086,11 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
       throw err
     }
   }
-  module.exports.Headers = __nccwpck_require__(492).Headers
+  module.exports.Headers = __nccwpck_require__(491).Headers
   module.exports.Response = __nccwpck_require__(39).Response
   module.exports.Request = __nccwpck_require__(83).Request
-  module.exports.FormData = __nccwpck_require__(203).FormData
-  module.exports.File = __nccwpck_require__(349).File
+  module.exports.FormData = __nccwpck_require__(202).FormData
+  module.exports.File = __nccwpck_require__(348).File
   module.exports.FileReader = __nccwpck_require__(93).FileReader
 
   const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(139)
@@ -30254,7 +30098,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   module.exports.setGlobalOrigin = setGlobalOrigin
   module.exports.getGlobalOrigin = getGlobalOrigin
 
-  const { CacheStorage } = __nccwpck_require__(276)
+  const { CacheStorage } = __nccwpck_require__(275)
   const { kConstruct } = __nccwpck_require__(155)
 
   // Cache & CacheStorage are tightly coupled with fetch. Even if it may run
@@ -30263,7 +30107,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
 }
 
 if (util.nodeMajor >= 16) {
-  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(369)
+  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(368)
 
   module.exports.deleteCookie = deleteCookie
   module.exports.getCookies = getCookies
@@ -30277,7 +30121,7 @@ if (util.nodeMajor >= 16) {
 }
 
 if (util.nodeMajor >= 18 && hasCrypto) {
-  const { WebSocket } = __nccwpck_require__(292)
+  const { WebSocket } = __nccwpck_require__(291)
 
   module.exports.WebSocket = WebSocket
 }
@@ -30296,7 +30140,7 @@ module.exports.mockErrors = mockErrors
 
 /***/ }),
 
-/***/ 163:
+/***/ 162:
 /***/ ((module) => {
 
 "use strict";
@@ -30304,7 +30148,7 @@ module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 164:
+/***/ 163:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30317,18 +30161,18 @@ module.exports = require("child_process");
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(211);
-tslib_1.__exportStar(__nccwpck_require__(117), exports);
-tslib_1.__exportStar(__nccwpck_require__(177), exports);
-tslib_1.__exportStar(__nccwpck_require__(121), exports);
-tslib_1.__exportStar(__nccwpck_require__(307), exports);
-tslib_1.__exportStar(__nccwpck_require__(204), exports);
-tslib_1.__exportStar(__nccwpck_require__(265), exports);
+const tslib_1 = __nccwpck_require__(210);
+tslib_1.__exportStar(__nccwpck_require__(118), exports);
+tslib_1.__exportStar(__nccwpck_require__(176), exports);
+tslib_1.__exportStar(__nccwpck_require__(122), exports);
+tslib_1.__exportStar(__nccwpck_require__(306), exports);
+tslib_1.__exportStar(__nccwpck_require__(203), exports);
+tslib_1.__exportStar(__nccwpck_require__(264), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 165:
+/***/ 164:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30338,12 +30182,12 @@ tslib_1.__exportStar(__nccwpck_require__(265), exports);
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageRetryPolicyName = void 0;
 exports.storageRetryPolicy = storageRetryPolicy;
-const abort_controller_1 = __nccwpck_require__(472);
-const core_rest_pipeline_1 = __nccwpck_require__(100);
+const abort_controller_1 = __nccwpck_require__(471);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
 const core_util_1 = __nccwpck_require__(12);
-const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(317);
+const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(316);
 const constants_js_1 = __nccwpck_require__(34);
-const utils_common_js_1 = __nccwpck_require__(451);
+const utils_common_js_1 = __nccwpck_require__(450);
 const log_js_1 = __nccwpck_require__(15);
 /**
  * Name of the {@link storageRetryPolicy}
@@ -30503,7 +30347,7 @@ function storageRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 166:
+/***/ 165:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -30519,7 +30363,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.create = void 0;
-const internal_globber_1 = __nccwpck_require__(409);
+const internal_globber_1 = __nccwpck_require__(408);
 /**
  * Constructs a globber
  *
@@ -30536,7 +30380,7 @@ exports.create = create;
 
 /***/ }),
 
-/***/ 167:
+/***/ 166:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30545,7 +30389,7 @@ exports.create = create;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.UserDelegationKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(269);
+const node_crypto_1 = __nccwpck_require__(268);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -30590,7 +30434,7 @@ exports.UserDelegationKeyCredential = UserDelegationKeyCredential;
 
 /***/ }),
 
-/***/ 168:
+/***/ 167:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30616,10 +30460,10 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(280);
-var import_typeGuards = __nccwpck_require__(474);
-var import_uuidUtils = __nccwpck_require__(376);
-var import_concat = __nccwpck_require__(295);
+var import_bytesEncoding = __nccwpck_require__(279);
+var import_typeGuards = __nccwpck_require__(473);
+var import_uuidUtils = __nccwpck_require__(375);
+var import_concat = __nccwpck_require__(294);
 function generateBoundary() {
   return `----AzSDKFormBoundary${(0, import_uuidUtils.randomUUID)()}`;
 }
@@ -30728,7 +30572,7 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 169:
+/***/ 168:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30855,7 +30699,7 @@ function requestToOptions(request) {
 
 /***/ }),
 
-/***/ 170:
+/***/ 169:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30867,7 +30711,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 171:
+/***/ 170:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30876,28 +30720,28 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Note: we do not use `export * from ...` to help tree shakers,
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-var service_type_1 = __nccwpck_require__(456);
+var service_type_1 = __nccwpck_require__(455);
 Object.defineProperty(exports, "ServiceType", ({ enumerable: true, get: function () { return service_type_1.ServiceType; } }));
 var reflection_info_1 = __nccwpck_require__(503);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
 Object.defineProperty(exports, "readMethodOption", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOption; } }));
 Object.defineProperty(exports, "readServiceOption", ({ enumerable: true, get: function () { return reflection_info_1.readServiceOption; } }));
-var rpc_error_1 = __nccwpck_require__(172);
+var rpc_error_1 = __nccwpck_require__(171);
 Object.defineProperty(exports, "RpcError", ({ enumerable: true, get: function () { return rpc_error_1.RpcError; } }));
-var rpc_options_1 = __nccwpck_require__(286);
+var rpc_options_1 = __nccwpck_require__(285);
 Object.defineProperty(exports, "mergeRpcOptions", ({ enumerable: true, get: function () { return rpc_options_1.mergeRpcOptions; } }));
-var rpc_output_stream_1 = __nccwpck_require__(298);
+var rpc_output_stream_1 = __nccwpck_require__(297);
 Object.defineProperty(exports, "RpcOutputStreamController", ({ enumerable: true, get: function () { return rpc_output_stream_1.RpcOutputStreamController; } }));
-var test_transport_1 = __nccwpck_require__(489);
+var test_transport_1 = __nccwpck_require__(488);
 Object.defineProperty(exports, "TestTransport", ({ enumerable: true, get: function () { return test_transport_1.TestTransport; } }));
 var deferred_1 = __nccwpck_require__(50);
 Object.defineProperty(exports, "Deferred", ({ enumerable: true, get: function () { return deferred_1.Deferred; } }));
 Object.defineProperty(exports, "DeferredState", ({ enumerable: true, get: function () { return deferred_1.DeferredState; } }));
-var duplex_streaming_call_1 = __nccwpck_require__(297);
+var duplex_streaming_call_1 = __nccwpck_require__(296);
 Object.defineProperty(exports, "DuplexStreamingCall", ({ enumerable: true, get: function () { return duplex_streaming_call_1.DuplexStreamingCall; } }));
-var client_streaming_call_1 = __nccwpck_require__(337);
+var client_streaming_call_1 = __nccwpck_require__(336);
 Object.defineProperty(exports, "ClientStreamingCall", ({ enumerable: true, get: function () { return client_streaming_call_1.ClientStreamingCall; } }));
-var server_streaming_call_1 = __nccwpck_require__(430);
+var server_streaming_call_1 = __nccwpck_require__(429);
 Object.defineProperty(exports, "ServerStreamingCall", ({ enumerable: true, get: function () { return server_streaming_call_1.ServerStreamingCall; } }));
 var unary_call_1 = __nccwpck_require__(53);
 Object.defineProperty(exports, "UnaryCall", ({ enumerable: true, get: function () { return unary_call_1.UnaryCall; } }));
@@ -30907,13 +30751,13 @@ Object.defineProperty(exports, "stackDuplexStreamingInterceptors", ({ enumerable
 Object.defineProperty(exports, "stackClientStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackClientStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackServerStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackServerStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackUnaryInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackUnaryInterceptors; } }));
-var server_call_context_1 = __nccwpck_require__(403);
+var server_call_context_1 = __nccwpck_require__(402);
 Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: true, get: function () { return server_call_context_1.ServerCallContextController; } }));
 
 
 /***/ }),
 
-/***/ 172:
+/***/ 171:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30957,7 +30801,7 @@ exports.RpcError = RpcError;
 
 /***/ }),
 
-/***/ 173:
+/***/ 172:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -31040,7 +30884,7 @@ function isLessThan(lhs, rhs) {
 
 /***/ }),
 
-/***/ 174:
+/***/ 173:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31049,7 +30893,7 @@ function isLessThan(lhs, rhs) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-const operation_js_1 = __nccwpck_require__(344);
+const operation_js_1 = __nccwpck_require__(343);
 const constants_js_1 = __nccwpck_require__(57);
 const poller_js_1 = __nccwpck_require__(72);
 const operation_js_2 = __nccwpck_require__(140);
@@ -31080,7 +30924,7 @@ exports.LroEngine = LroEngine;
 
 /***/ }),
 
-/***/ 175:
+/***/ 174:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -32730,7 +32574,7 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 176:
+/***/ 175:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -41073,7 +40917,7 @@ exports.BlockBlobGetBlockListExceptionHeaders = {
 
 /***/ }),
 
-/***/ 177:
+/***/ 176:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -41090,7 +40934,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 178:
+/***/ 177:
 /***/ ((module) => {
 
 "use strict";
@@ -41098,7 +40942,7 @@ module.exports = require("tty");
 
 /***/ }),
 
-/***/ 179:
+/***/ 178:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -41112,12 +40956,12 @@ exports.newPipeline = newPipeline;
 exports.getCoreClientOptions = getCoreClientOptions;
 exports.getCredentialFromPipeline = getCredentialFromPipeline;
 const core_http_compat_1 = __nccwpck_require__(69);
-const core_rest_pipeline_1 = __nccwpck_require__(100);
-const core_client_1 = __nccwpck_require__(418);
-const core_xml_1 = __nccwpck_require__(190);
-const core_auth_1 = __nccwpck_require__(490);
-const log_js_1 = __nccwpck_require__(105);
-const storage_common_1 = __nccwpck_require__(271);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_client_1 = __nccwpck_require__(417);
+const core_xml_1 = __nccwpck_require__(189);
+const core_auth_1 = __nccwpck_require__(489);
+const log_js_1 = __nccwpck_require__(106);
+const storage_common_1 = __nccwpck_require__(270);
 const constants_js_1 = __nccwpck_require__(147);
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return constants_js_1.StorageOAuthScopes; } }));
 /**
@@ -41382,7 +41226,7 @@ function isCoreHttpPolicyFactory(factory) {
 
 /***/ }),
 
-/***/ 180:
+/***/ 179:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -41415,7 +41259,7 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 
 /***/ }),
 
-/***/ 181:
+/***/ 180:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -41424,27 +41268,27 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobClient = exports.BlockBlobClient = exports.AppendBlobClient = exports.BlobClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(100);
-const core_auth_1 = __nccwpck_require__(490);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
+const core_auth_1 = __nccwpck_require__(489);
 const core_util_1 = __nccwpck_require__(12);
 const core_util_2 = __nccwpck_require__(12);
-const BlobDownloadResponse_js_1 = __nccwpck_require__(404);
-const BlobQueryResponse_js_1 = __nccwpck_require__(197);
-const storage_common_1 = __nccwpck_require__(271);
-const models_js_1 = __nccwpck_require__(395);
+const BlobDownloadResponse_js_1 = __nccwpck_require__(403);
+const BlobQueryResponse_js_1 = __nccwpck_require__(196);
+const storage_common_1 = __nccwpck_require__(270);
+const models_js_1 = __nccwpck_require__(394);
 const PageBlobRangeResponse_js_1 = __nccwpck_require__(27);
-const Pipeline_js_1 = __nccwpck_require__(179);
+const Pipeline_js_1 = __nccwpck_require__(178);
 const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(510);
-const Range_js_1 = __nccwpck_require__(103);
-const StorageClient_js_1 = __nccwpck_require__(433);
+const Range_js_1 = __nccwpck_require__(104);
+const StorageClient_js_1 = __nccwpck_require__(432);
 const Batch_js_1 = __nccwpck_require__(90);
-const storage_common_2 = __nccwpck_require__(271);
+const storage_common_2 = __nccwpck_require__(270);
 const constants_js_1 = __nccwpck_require__(147);
 const tracing_js_1 = __nccwpck_require__(29);
 const utils_common_js_1 = __nccwpck_require__(153);
-const utils_js_1 = __nccwpck_require__(198);
+const utils_js_1 = __nccwpck_require__(197);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(65);
-const BlobLeaseClient_js_1 = __nccwpck_require__(200);
+const BlobLeaseClient_js_1 = __nccwpck_require__(199);
 /**
  * A BlobClient represents a URL to an Azure Storage blob; the blob may be a block blob,
  * append blob, or page blob.
@@ -44274,17 +44118,17 @@ exports.PageBlobClient = PageBlobClient;
 
 /***/ }),
 
-/***/ 182:
+/***/ 181:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryWriter = void 0;
-const binary_format_contract_1 = __nccwpck_require__(323);
-const reflection_info_1 = __nccwpck_require__(431);
-const assert_1 = __nccwpck_require__(462);
-const pb_long_1 = __nccwpck_require__(116);
+const binary_format_contract_1 = __nccwpck_require__(322);
+const reflection_info_1 = __nccwpck_require__(430);
+const assert_1 = __nccwpck_require__(461);
+const pb_long_1 = __nccwpck_require__(117);
 /**
  * Writes proto3 messages in binary format using reflection information.
  *
@@ -44515,18 +44359,18 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 
 /***/ }),
 
-/***/ 183:
+/***/ 182:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxUnsigned16Bit } = __nccwpck_require__(443)
+const { maxUnsigned16Bit } = __nccwpck_require__(442)
 
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(284)
+  crypto = __nccwpck_require__(283)
 } catch {
 
 }
@@ -44596,7 +44440,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 184:
+/***/ 183:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -44643,13 +44487,13 @@ function isApiKeyCredential(credential) {
 
 /***/ }),
 
-/***/ 185:
+/***/ 184:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(501)
 const {
   ResponseStatusCodeError
-} = __nccwpck_require__(466)
+} = __nccwpck_require__(465)
 const { toUSVString } = __nccwpck_require__(66)
 
 async function getResolveErrorBodyCallback ({ callback, body, contentType, statusCode, statusMessage, headers }) {
@@ -44696,7 +44540,7 @@ module.exports = { getResolveErrorBodyCallback }
 
 /***/ }),
 
-/***/ 186:
+/***/ 185:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -44818,7 +44662,7 @@ exports.getSelectedOneofValue = getSelectedOneofValue;
 
 /***/ }),
 
-/***/ 187:
+/***/ 186:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44837,14 +44681,14 @@ exports.logger = (0, logger_1.createClientLogger)("core-lro");
 
 /***/ }),
 
-/***/ 188:
+/***/ 187:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 /* eslint-disable object-property-newline */
 
 
-const decodeText = __nccwpck_require__(270)
+const decodeText = __nccwpck_require__(269)
 
 const RE_ENCODED = /%[a-fA-F0-9][a-fA-F0-9]/g
 
@@ -45041,7 +44885,7 @@ module.exports = parseParams
 
 /***/ }),
 
-/***/ 189:
+/***/ 188:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45067,8 +44911,8 @@ __export(auxiliaryAuthenticationHeaderPolicy_exports, {
   auxiliaryAuthenticationHeaderPolicyName: () => auxiliaryAuthenticationHeaderPolicyName
 });
 module.exports = __toCommonJS(auxiliaryAuthenticationHeaderPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(161);
-var import_log = __nccwpck_require__(180);
+var import_tokenCycler = __nccwpck_require__(160);
+var import_log = __nccwpck_require__(179);
 const auxiliaryAuthenticationHeaderPolicyName = "auxiliaryAuthenticationHeaderPolicy";
 const AUTHORIZATION_AUXILIARY_HEADER = "x-ms-authorization-auxiliary";
 async function sendAuthorizeRequest(options) {
@@ -45134,7 +44978,7 @@ function auxiliaryAuthenticationHeaderPolicy(options) {
 
 /***/ }),
 
-/***/ 190:
+/***/ 189:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45171,7 +45015,7 @@ var import_xml_common = __nccwpck_require__(19);
 
 /***/ }),
 
-/***/ 191:
+/***/ 190:
 /***/ ((module) => {
 
 module.exports = {
@@ -45241,7 +45085,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 192:
+/***/ 191:
 /***/ ((module) => {
 
 "use strict";
@@ -45366,7 +45210,7 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 193:
+/***/ 192:
 /***/ ((module) => {
 
 "use strict";
@@ -45374,7 +45218,7 @@ module.exports = require("node:child_process");
 
 /***/ }),
 
-/***/ 194:
+/***/ 193:
 /***/ ((module) => {
 
 "use strict";
@@ -45382,13 +45226,13 @@ module.exports = require("util/types");
 
 /***/ }),
 
-/***/ 195:
+/***/ 194:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(122)
+const { promisify } = __nccwpck_require__(123)
 const Client = __nccwpck_require__(87)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
@@ -45399,10 +45243,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(448)
+} = __nccwpck_require__(447)
 const { MockInterceptor } = __nccwpck_require__(135)
-const Symbols = __nccwpck_require__(191)
-const { InvalidArgumentError } = __nccwpck_require__(466)
+const Symbols = __nccwpck_require__(190)
+const { InvalidArgumentError } = __nccwpck_require__(465)
 
 /**
  * MockClient provides an API that extends the Client to influence the mockDispatches.
@@ -45449,7 +45293,7 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 196:
+/***/ 195:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -45475,7 +45319,7 @@ __export(sha256_exports, {
   computeSha256Hmac: () => computeSha256Hmac
 });
 module.exports = __toCommonJS(sha256_exports);
-var import_node_crypto = __nccwpck_require__(269);
+var import_node_crypto = __nccwpck_require__(268);
 async function computeSha256Hmac(key, stringToSign, encoding) {
   const decodedKey = Buffer.from(key, "base64");
   return (0, import_node_crypto.createHmac)("sha256", decodedKey).update(stringToSign).digest(encoding);
@@ -45490,7 +45334,7 @@ async function computeSha256Hash(content, encoding) {
 
 /***/ }),
 
-/***/ 197:
+/***/ 196:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45500,7 +45344,7 @@ async function computeSha256Hash(content, encoding) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQueryResponse = void 0;
 const core_util_1 = __nccwpck_require__(12);
-const BlobQuickQueryStream_js_1 = __nccwpck_require__(478);
+const BlobQuickQueryStream_js_1 = __nccwpck_require__(477);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -45870,7 +45714,7 @@ exports.BlobQueryResponse = BlobQueryResponse;
 
 /***/ }),
 
-/***/ 198:
+/***/ 197:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45883,9 +45727,9 @@ exports.streamToBuffer = streamToBuffer;
 exports.streamToBuffer2 = streamToBuffer2;
 exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
-const tslib_1 = __nccwpck_require__(211);
-const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(243));
-const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(359));
+const tslib_1 = __nccwpck_require__(210);
+const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(242));
+const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(358));
 const constants_js_1 = __nccwpck_require__(147);
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
@@ -46017,7 +45861,7 @@ exports.fsCreateReadStream = node_fs_1.default.createReadStream;
 
 /***/ }),
 
-/***/ 199:
+/***/ 198:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -46299,7 +46143,7 @@ exports.varint32read = varint32read;
 
 /***/ }),
 
-/***/ 200:
+/***/ 199:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46511,15 +46355,15 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 /***/ }),
 
-/***/ 201:
+/***/ 200:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionCreate = void 0;
-const reflection_scalar_default_1 = __nccwpck_require__(440);
-const message_type_contract_1 = __nccwpck_require__(386);
+const reflection_scalar_default_1 = __nccwpck_require__(439);
+const message_type_contract_1 = __nccwpck_require__(385);
 /**
  * Creates an instance of the generic message, using the field
  * information.
@@ -46567,7 +46411,7 @@ exports.reflectionCreate = reflectionCreate;
 
 /***/ }),
 
-/***/ 202:
+/***/ 201:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46579,7 +46423,7 @@ exports.storageBrowserPolicyName = void 0;
 exports.storageBrowserPolicy = storageBrowserPolicy;
 const core_util_1 = __nccwpck_require__(12);
 const constants_js_1 = __nccwpck_require__(34);
-const utils_common_js_1 = __nccwpck_require__(451);
+const utils_common_js_1 = __nccwpck_require__(450);
 /**
  * The programmatic identifier of the StorageBrowserPolicy.
  */
@@ -46609,17 +46453,17 @@ function storageBrowserPolicy() {
 
 /***/ }),
 
-/***/ 203:
+/***/ 202:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(493)
+const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(492)
 const { kState } = __nccwpck_require__(13)
-const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(349)
-const { webidl } = __nccwpck_require__(435)
-const { Blob, File: NativeFile } = __nccwpck_require__(118)
+const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(348)
+const { webidl } = __nccwpck_require__(434)
+const { Blob, File: NativeFile } = __nccwpck_require__(119)
 
 /** @type {globalThis['File']} */
 const File = NativeFile ?? UndiciFile
@@ -46882,7 +46726,7 @@ module.exports = { FormData }
 
 /***/ }),
 
-/***/ 204:
+/***/ 203:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -46899,7 +46743,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 205:
+/***/ 204:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -46924,10 +46768,10 @@ __export(getClient_exports, {
   getClient: () => getClient
 });
 module.exports = __toCommonJS(getClient_exports);
-var import_clientHelpers = __nccwpck_require__(469);
-var import_sendRequest = __nccwpck_require__(428);
-var import_urlHelpers = __nccwpck_require__(315);
-var import_checkEnvironment = __nccwpck_require__(417);
+var import_clientHelpers = __nccwpck_require__(468);
+var import_sendRequest = __nccwpck_require__(427);
+var import_urlHelpers = __nccwpck_require__(314);
+var import_checkEnvironment = __nccwpck_require__(416);
 function getClient(endpoint, clientOptions = {}) {
   const pipeline = clientOptions.pipeline ?? (0, import_clientHelpers.createDefaultPipeline)(clientOptions);
   if (clientOptions.additionalPolicies?.length) {
@@ -47082,7 +46926,7 @@ function buildOperation(method, url, pipeline, options, allowInsecureConnection,
 
 /***/ }),
 
-/***/ 206:
+/***/ 205:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47107,8 +46951,8 @@ __export(httpClientAdapter_exports, {
   convertHttpClient: () => convertHttpClient
 });
 module.exports = __toCommonJS(httpClientAdapter_exports);
-var import_response = __nccwpck_require__(392);
-var import_util = __nccwpck_require__(108);
+var import_response = __nccwpck_require__(391);
+var import_util = __nccwpck_require__(109);
 function convertHttpClient(requestPolicyClient) {
   return {
     sendRequest: async (request) => {
@@ -47126,7 +46970,7 @@ function convertHttpClient(requestPolicyClient) {
 
 /***/ }),
 
-/***/ 207:
+/***/ 206:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47153,7 +46997,7 @@ __export(retryPolicy_exports, {
 module.exports = __toCommonJS(retryPolicy_exports);
 var import_logger = __nccwpck_require__(42);
 var import_constants = __nccwpck_require__(157);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("core-rest-pipeline retryPolicy");
 function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAULT_RETRY_POLICY_COUNT }) {
   return (0, import_policies.retryPolicy)(strategies, {
@@ -47167,7 +47011,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 
 /***/ }),
 
-/***/ 208:
+/***/ 207:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47207,7 +47051,7 @@ function getErrorMessage(e) {
 
 /***/ }),
 
-/***/ 209:
+/***/ 208:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -47246,14 +47090,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.restoreCache = exports.isFeatureAvailable = exports.FinalizeCacheError = exports.ReserveCacheError = exports.ValidationError = void 0;
-const core = __importStar(__nccwpck_require__(437));
-const path = __importStar(__nccwpck_require__(242));
+const core = __importStar(__nccwpck_require__(436));
+const path = __importStar(__nccwpck_require__(241));
 const utils = __importStar(__nccwpck_require__(73));
 const cacheHttpClient = __importStar(__nccwpck_require__(32));
 const cacheTwirpClient = __importStar(__nccwpck_require__(58));
 const config_1 = __nccwpck_require__(35);
-const tar_1 = __nccwpck_require__(419);
-const http_client_1 = __nccwpck_require__(278);
+const tar_1 = __nccwpck_require__(418);
+const http_client_1 = __nccwpck_require__(277);
 class ValidationError extends Error {
     constructor(message) {
         super(message);
@@ -47733,7 +47577,7 @@ function saveCacheV2(paths, key, options, enableCrossOsArchive = false) {
 
 /***/ }),
 
-/***/ 210:
+/***/ 209:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47759,9 +47603,9 @@ __export(extendedClient_exports, {
 });
 module.exports = __toCommonJS(extendedClient_exports);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_core_rest_pipeline = __nccwpck_require__(100);
-var import_core_client = __nccwpck_require__(418);
-var import_response = __nccwpck_require__(392);
+var import_core_rest_pipeline = __nccwpck_require__(101);
+var import_core_client = __nccwpck_require__(417);
+var import_response = __nccwpck_require__(391);
 class ExtendedServiceClient extends import_core_client.ServiceClient {
   constructor(options) {
     super(options);
@@ -47810,7 +47654,7 @@ class ExtendedServiceClient extends import_core_client.ServiceClient {
 
 /***/ }),
 
-/***/ 211:
+/***/ 210:
 /***/ ((module) => {
 
 /******************************************************************************
@@ -48268,7 +48112,7 @@ var __rewriteRelativeImportExtension;
 
 /***/ }),
 
-/***/ 212:
+/***/ 211:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48295,9 +48139,9 @@ __export(bearerTokenAuthenticationPolicy_exports, {
   parseChallenges: () => parseChallenges
 });
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(161);
-var import_log = __nccwpck_require__(180);
-var import_restError = __nccwpck_require__(340);
+var import_tokenCycler = __nccwpck_require__(160);
+var import_log = __nccwpck_require__(179);
+var import_restError = __nccwpck_require__(339);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
   try {
@@ -48487,7 +48331,7 @@ function getCaeChallengeClaims(challenges) {
 
 /***/ }),
 
-/***/ 213:
+/***/ 212:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48513,7 +48357,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const systemErrorRetryPolicyName = import_policies.systemErrorRetryPolicyName;
 function systemErrorRetryPolicy(options = {}) {
   return (0, import_policies.systemErrorRetryPolicy)(options);
@@ -48524,7 +48368,7 @@ function systemErrorRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 214:
+/***/ 213:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -48538,9 +48382,9 @@ function systemErrorRetryPolicy(options = {}) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
-const tslib_1 = __nccwpck_require__(211);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(418));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
+const tslib_1 = __nccwpck_require__(210);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(417));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing Container operations. */
 class ContainerImpl {
@@ -49252,7 +49096,7 @@ const getAccountInfoOperationSpec = {
 
 /***/ }),
 
-/***/ 215:
+/***/ 214:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -49297,7 +49141,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 216:
+/***/ 215:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49326,7 +49170,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.safeTrimTrailingSeparator = exports.normalizeSeparators = exports.hasRoot = exports.hasAbsoluteRoot = exports.ensureAbsoluteRoot = exports.dirname = void 0;
-const path = __importStar(__nccwpck_require__(242));
+const path = __importStar(__nccwpck_require__(241));
 const assert_1 = __importDefault(__nccwpck_require__(501));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -49502,7 +49346,7 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 
 /***/ }),
 
-/***/ 217:
+/***/ 216:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49535,11 +49379,11 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpProxyAgent = void 0;
-const net = __importStar(__nccwpck_require__(486));
-const tls = __importStar(__nccwpck_require__(482));
-const debug_1 = __importDefault(__nccwpck_require__(491));
-const events_1 = __nccwpck_require__(447);
-const agent_base_1 = __nccwpck_require__(234);
+const net = __importStar(__nccwpck_require__(485));
+const tls = __importStar(__nccwpck_require__(481));
+const debug_1 = __importDefault(__nccwpck_require__(490));
+const events_1 = __nccwpck_require__(446);
+const agent_base_1 = __nccwpck_require__(233);
 const url_1 = __nccwpck_require__(84);
 const debug = (0, debug_1.default)('http-proxy-agent');
 /**
@@ -49657,7 +49501,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 218:
+/***/ 217:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49694,7 +49538,7 @@ var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
 const fs = __importStar(__nccwpck_require__(507));
-const path = __importStar(__nccwpck_require__(242));
+const path = __importStar(__nccwpck_require__(241));
 _a = fs.promises
 // export const {open} = 'fs'
 , exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
@@ -49847,7 +49691,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 219:
+/***/ 218:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49856,8 +49700,8 @@ exports.getCmdPath = getCmdPath;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
-const tslib_1 = __nccwpck_require__(211);
-var poller_js_1 = __nccwpck_require__(310);
+const tslib_1 = __nccwpck_require__(210);
+var poller_js_1 = __nccwpck_require__(309);
 Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: function () { return poller_js_1.createHttpPoller; } }));
 /**
  * This can be uncommented to expose the protocol-agnostic poller
@@ -49871,14 +49715,14 @@ Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: fun
 // } from "./poller/models";
 // export { buildCreatePoller } from "./poller/poller";
 /** legacy */
-tslib_1.__exportStar(__nccwpck_require__(237), exports);
+tslib_1.__exportStar(__nccwpck_require__(236), exports);
 tslib_1.__exportStar(__nccwpck_require__(72), exports);
 tslib_1.__exportStar(__nccwpck_require__(38), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 220:
+/***/ 219:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -49924,7 +49768,7 @@ function apiVersionPolicy(options) {
 
 /***/ }),
 
-/***/ 221:
+/***/ 220:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50171,7 +50015,7 @@ exports.AbortSignal = AbortSignal;
 
 /***/ }),
 
-/***/ 222:
+/***/ 221:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50188,7 +50032,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 
 /***/ }),
 
-/***/ 223:
+/***/ 222:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50202,9 +50046,9 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
-const tslib_1 = __nccwpck_require__(211);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(418));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
+const tslib_1 = __nccwpck_require__(210);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(417));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing Service operations. */
 class ServiceImpl {
@@ -50524,7 +50368,7 @@ const filterBlobsOperationSpec = {
 
 /***/ }),
 
-/***/ 224:
+/***/ 223:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -50550,7 +50394,7 @@ __export(agentPolicy_exports, {
   agentPolicyName: () => agentPolicyName
 });
 module.exports = __toCommonJS(agentPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const agentPolicyName = import_policies.agentPolicyName;
 function agentPolicy(agent) {
   return (0, import_policies.agentPolicy)(agent);
@@ -50561,13 +50405,13 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 225:
+/***/ 224:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { UndiciError } = __nccwpck_require__(466)
+const { UndiciError } = __nccwpck_require__(465)
 
 class MockNotMatchedError extends UndiciError {
   constructor (message) {
@@ -50586,7 +50430,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 226:
+/***/ 225:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -50642,8 +50486,8 @@ exports.redactValue = redactValue;
 exports.captureProcessSnapshot = captureProcessSnapshot;
 exports.dumpDiagnostics = dumpDiagnostics;
 exports.loggingEnabled = loggingEnabled;
-const fs = __importStar(__nccwpck_require__(243));
-const node_child_process_1 = __nccwpck_require__(193);
+const fs = __importStar(__nccwpck_require__(242));
+const node_child_process_1 = __nccwpck_require__(192);
 const compile_journal_js_1 = __nccwpck_require__(79);
 const ENV_KEY_PREFIXES = [
     "INPUT_",
@@ -50957,7 +50801,7 @@ function loggingEnabled(value) {
 
 /***/ }),
 
-/***/ 227:
+/***/ 226:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51005,7 +50849,7 @@ module.exports = class PendingInterceptorsFormatter {
 
 /***/ }),
 
-/***/ 228:
+/***/ 227:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51017,7 +50861,7 @@ const runtime_2 = __nccwpck_require__(17);
 const runtime_3 = __nccwpck_require__(17);
 const runtime_4 = __nccwpck_require__(17);
 const runtime_5 = __nccwpck_require__(17);
-const cachescope_1 = __nccwpck_require__(379);
+const cachescope_1 = __nccwpck_require__(378);
 // @generated message type with reflection information, may provide speed optimized methods
 class CacheMetadata$Type extends runtime_5.MessageType {
     constructor() {
@@ -51076,7 +50920,7 @@ exports.CacheMetadata = new CacheMetadata$Type();
 
 /***/ }),
 
-/***/ 229:
+/***/ 228:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51102,7 +50946,7 @@ __export(defaultHttpClient_exports, {
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
 var import_ts_http_runtime = __nccwpck_require__(88);
-var import_wrapAbortSignal = __nccwpck_require__(424);
+var import_wrapAbortSignal = __nccwpck_require__(423);
 function createDefaultHttpClient() {
   const client = (0, import_ts_http_runtime.createDefaultHttpClient)();
   return {
@@ -51123,7 +50967,7 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 230:
+/***/ 229:
 /***/ ((module) => {
 
 "use strict";
@@ -51131,7 +50975,7 @@ module.exports = require("node:process");
 
 /***/ }),
 
-/***/ 231:
+/***/ 230:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51141,8 +50985,8 @@ module.exports = require("node:process");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRequestUrl = getRequestUrl;
 exports.appendQueryParams = appendQueryParams;
-const operationHelpers_js_1 = __nccwpck_require__(410);
-const interfaceHelpers_js_1 = __nccwpck_require__(382);
+const operationHelpers_js_1 = __nccwpck_require__(409);
+const interfaceHelpers_js_1 = __nccwpck_require__(381);
 const CollectionFormatToDelimiterMap = {
     CSV: ",",
     SSV: " ",
@@ -51375,7 +51219,7 @@ function appendQueryParams(url, queryParams, sequenceParams, noOverwrite = false
 
 /***/ }),
 
-/***/ 232:
+/***/ 231:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51401,7 +51245,7 @@ __export(decompressResponsePolicy_exports, {
   decompressResponsePolicyName: () => decompressResponsePolicyName
 });
 module.exports = __toCommonJS(decompressResponsePolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const decompressResponsePolicyName = import_policies.decompressResponsePolicyName;
 function decompressResponsePolicy() {
   return (0, import_policies.decompressResponsePolicy)();
@@ -51412,7 +51256,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 233:
+/***/ 232:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -51459,7 +51303,7 @@ function ndJsonPolicy() {
 
 /***/ }),
 
-/***/ 234:
+/***/ 233:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -51492,10 +51336,10 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Agent = void 0;
-const net = __importStar(__nccwpck_require__(486));
-const http = __importStar(__nccwpck_require__(320));
+const net = __importStar(__nccwpck_require__(485));
+const http = __importStar(__nccwpck_require__(319));
 const https_1 = __nccwpck_require__(67);
-__exportStar(__nccwpck_require__(160), exports);
+__exportStar(__nccwpck_require__(159), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
 class Agent extends http.Agent {
     constructor(opts) {
@@ -51644,7 +51488,7 @@ exports.Agent = Agent;
 
 /***/ }),
 
-/***/ 235:
+/***/ 234:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -51687,7 +51531,7 @@ exports.mergeJsonOptions = mergeJsonOptions;
 
 /***/ }),
 
-/***/ 236:
+/***/ 235:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51722,7 +51566,7 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 237:
+/***/ 236:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51731,13 +51575,13 @@ function createHttpHeaders(rawHeaders) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-var lroEngine_js_1 = __nccwpck_require__(174);
+var lroEngine_js_1 = __nccwpck_require__(173);
 Object.defineProperty(exports, "LroEngine", ({ enumerable: true, get: function () { return lroEngine_js_1.LroEngine; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 238:
+/***/ 237:
 /***/ ((module) => {
 
 "use strict";
@@ -51745,7 +51589,7 @@ module.exports = require("fs/promises");
 
 /***/ }),
 
-/***/ 239:
+/***/ 238:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51780,7 +51624,7 @@ function createEmptyPipeline() {
 
 /***/ }),
 
-/***/ 240:
+/***/ 239:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -51819,7 +51663,7 @@ __export(logger_exports, {
   setLogLevel: () => setLogLevel
 });
 module.exports = __toCommonJS(logger_exports);
-var import_debug = __toESM(__nccwpck_require__(444));
+var import_debug = __toESM(__nccwpck_require__(443));
 const TYPESPEC_RUNTIME_LOG_LEVELS = ["verbose", "info", "warning", "error"];
 const levelMap = {
   verbose: 400,
@@ -51925,7 +51769,7 @@ function createClientLogger(namespace) {
 
 /***/ }),
 
-/***/ 241:
+/***/ 240:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -51972,7 +51816,7 @@ function isTokenCredential(credential) {
 
 /***/ }),
 
-/***/ 242:
+/***/ 241:
 /***/ ((module) => {
 
 "use strict";
@@ -51980,7 +51824,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 243:
+/***/ 242:
 /***/ ((module) => {
 
 "use strict";
@@ -51988,15 +51832,15 @@ module.exports = require("node:fs");
 
 /***/ }),
 
-/***/ 244:
+/***/ 243:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(435)
+const { webidl } = __nccwpck_require__(434)
 const { kEnumerableProperty } = __nccwpck_require__(66)
-const { MessagePort } = __nccwpck_require__(309)
+const { MessagePort } = __nccwpck_require__(308)
 
 /**
  * @see https://html.spec.whatwg.org/multipage/comms.html#messageevent
@@ -52299,16 +52143,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 245:
+/***/ 244:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryWriter = exports.binaryWriteOptions = void 0;
-const pb_long_1 = __nccwpck_require__(116);
-const goog_varint_1 = __nccwpck_require__(199);
-const assert_1 = __nccwpck_require__(462);
+const pb_long_1 = __nccwpck_require__(117);
+const goog_varint_1 = __nccwpck_require__(198);
+const assert_1 = __nccwpck_require__(461);
 const defaultsWrite = {
     writeUnknownFields: true,
     writerFactory: () => new BinaryWriter(),
@@ -52539,7 +52383,7 @@ exports.BinaryWriter = BinaryWriter;
 
 /***/ }),
 
-/***/ 246:
+/***/ 245:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52548,9 +52392,9 @@ exports.BinaryWriter = BinaryWriter;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
-const AvroReadable_js_1 = __nccwpck_require__(370);
-const abort_controller_1 = __nccwpck_require__(473);
-const buffer_1 = __nccwpck_require__(118);
+const AvroReadable_js_1 = __nccwpck_require__(369);
+const abort_controller_1 = __nccwpck_require__(472);
+const buffer_1 = __nccwpck_require__(119);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
 class AvroReadableFromStream extends AvroReadable_js_1.AvroReadable {
     _position;
@@ -52636,7 +52480,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 
 /***/ }),
 
-/***/ 247:
+/***/ 246:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52645,7 +52489,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(100);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
 let _defaultHttpClient;
 function getCachedDefaultHttpClient() {
     if (!_defaultHttpClient) {
@@ -52657,7 +52501,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 248:
+/***/ 247:
 /***/ ((module) => {
 
 "use strict";
@@ -52694,13 +52538,13 @@ module.exports = class Pluralizer {
 
 /***/ }),
 
-/***/ 249:
+/***/ 248:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const RedirectHandler = __nccwpck_require__(373)
+const RedirectHandler = __nccwpck_require__(372)
 
 function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections }) {
   return (dispatch) => {
@@ -52723,7 +52567,7 @@ module.exports = createRedirectInterceptor
 
 /***/ }),
 
-/***/ 250:
+/***/ 249:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52749,7 +52593,7 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(406);
+var import_userAgentPlatform = __nccwpck_require__(405);
 var import_constants = __nccwpck_require__(46);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
@@ -52777,7 +52621,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 251:
+/***/ 250:
 /***/ ((module) => {
 
 "use strict";
@@ -52785,7 +52629,7 @@ module.exports = require("stream/web");
 
 /***/ }),
 
-/***/ 252:
+/***/ 251:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52795,7 +52639,7 @@ module.exports = require("stream/web");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getBodyAsText = getBodyAsText;
 exports.utf8ByteLength = utf8ByteLength;
-const utils_js_1 = __nccwpck_require__(198);
+const utils_js_1 = __nccwpck_require__(197);
 const constants_js_1 = __nccwpck_require__(147);
 async function getBodyAsText(batchResponse) {
     let buffer = Buffer.alloc(constants_js_1.BATCH_MAX_PAYLOAD_IN_BYTES);
@@ -52811,7 +52655,7 @@ function utf8ByteLength(str) {
 
 /***/ }),
 
-/***/ 253:
+/***/ 252:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52837,7 +52681,7 @@ __export(wrapAbortSignalLikePolicy_exports, {
   wrapAbortSignalLikePolicyName: () => wrapAbortSignalLikePolicyName
 });
 module.exports = __toCommonJS(wrapAbortSignalLikePolicy_exports);
-var import_wrapAbortSignal = __nccwpck_require__(424);
+var import_wrapAbortSignal = __nccwpck_require__(423);
 const wrapAbortSignalLikePolicyName = "wrapAbortSignalLikePolicy";
 function wrapAbortSignalLikePolicy() {
   return {
@@ -52862,7 +52706,7 @@ function wrapAbortSignalLikePolicy() {
 
 /***/ }),
 
-/***/ 254:
+/***/ 253:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52871,7 +52715,7 @@ function wrapAbortSignalLikePolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createAbortablePromise = createAbortablePromise;
-const abort_controller_1 = __nccwpck_require__(471);
+const abort_controller_1 = __nccwpck_require__(470);
 /**
  * Creates an abortable promise.
  * @param buildPromise - A function that takes the resolve and reject functions as parameters.
@@ -52914,7 +52758,7 @@ function createAbortablePromise(buildPromise, options) {
 
 /***/ }),
 
-/***/ 255:
+/***/ 254:
 /***/ ((module) => {
 
 "use strict";
@@ -52922,7 +52766,7 @@ module.exports = require("punycode");
 
 /***/ }),
 
-/***/ 256:
+/***/ 255:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52961,8 +52805,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.retryHttpClientResponse = exports.retryTypedResponse = exports.retry = exports.isRetryableStatusCode = exports.isServerErrorStatusCode = exports.isSuccessStatusCode = void 0;
-const core = __importStar(__nccwpck_require__(437));
-const http_client_1 = __nccwpck_require__(278);
+const core = __importStar(__nccwpck_require__(436));
+const http_client_1 = __nccwpck_require__(277);
 const constants_1 = __nccwpck_require__(43);
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
@@ -53066,7 +52910,7 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 
 /***/ }),
 
-/***/ 257:
+/***/ 256:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53075,9 +52919,9 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(269);
-const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(125);
-const Credential_js_1 = __nccwpck_require__(94);
+const node_crypto_1 = __nccwpck_require__(268);
+const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(126);
+const Credential_js_1 = __nccwpck_require__(95);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -53125,7 +52969,7 @@ exports.StorageSharedKeyCredential = StorageSharedKeyCredential;
 
 /***/ }),
 
-/***/ 258:
+/***/ 257:
 /***/ ((module) => {
 
 "use strict";
@@ -53133,7 +52977,7 @@ module.exports = require("node:http");
 
 /***/ }),
 
-/***/ 259:
+/***/ 258:
 /***/ ((module) => {
 
 "use strict";
@@ -53141,7 +52985,7 @@ module.exports = require("node:buffer");
 
 /***/ }),
 
-/***/ 260:
+/***/ 259:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -53171,7 +53015,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDownloadOptions = exports.getUploadOptions = void 0;
-const core = __importStar(__nccwpck_require__(437));
+const core = __importStar(__nccwpck_require__(436));
 /**
  * Returns a copy of the upload options with defaults filled in.
  *
@@ -53265,16 +53109,16 @@ exports.getDownloadOptions = getDownloadOptions;
 
 /***/ }),
 
-/***/ 261:
+/***/ 260:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const net = __nccwpck_require__(486)
+const net = __nccwpck_require__(485)
 const assert = __nccwpck_require__(501)
 const util = __nccwpck_require__(66)
-const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(466)
+const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(465)
 
 let tls // include tls conditionally since it is not always available
 
@@ -53357,7 +53201,7 @@ function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, ...o
     let socket
     if (protocol === 'https:') {
       if (!tls) {
-        tls = __nccwpck_require__(482)
+        tls = __nccwpck_require__(481)
       }
       servername = servername || options.servername || util.getServerName(host) || null
 
@@ -53462,7 +53306,7 @@ module.exports = buildConnector
 
 /***/ }),
 
-/***/ 262:
+/***/ 261:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53471,7 +53315,7 @@ module.exports = buildConnector
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageContextClient = void 0;
-const index_js_1 = __nccwpck_require__(289);
+const index_js_1 = __nccwpck_require__(288);
 /**
  * @internal
  */
@@ -53490,7 +53334,7 @@ exports.StorageContextClient = StorageContextClient;
 
 /***/ }),
 
-/***/ 263:
+/***/ 262:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53516,7 +53360,7 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const formDataPolicyName = import_policies.formDataPolicyName;
 function formDataPolicy() {
   return (0, import_policies.formDataPolicy)();
@@ -53527,7 +53371,7 @@ function formDataPolicy() {
 
 /***/ }),
 
-/***/ 264:
+/***/ 263:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53553,10 +53397,10 @@ __export(multipart_exports, {
   buildMultipartBody: () => buildMultipartBody
 });
 module.exports = __toCommonJS(multipart_exports);
-var import_restError = __nccwpck_require__(423);
-var import_httpHeaders = __nccwpck_require__(463);
-var import_bytesEncoding = __nccwpck_require__(280);
-var import_typeGuards = __nccwpck_require__(474);
+var import_restError = __nccwpck_require__(422);
+var import_httpHeaders = __nccwpck_require__(462);
+var import_bytesEncoding = __nccwpck_require__(279);
+var import_typeGuards = __nccwpck_require__(473);
 function getHeaderValue(descriptor, headerName) {
   if (descriptor.headers) {
     const actualHeaderName = Object.keys(descriptor.headers).find(
@@ -53665,7 +53509,7 @@ function buildMultipartBody(parts) {
 
 /***/ }),
 
-/***/ 265:
+/***/ 264:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -53682,7 +53526,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 266:
+/***/ 265:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53708,8 +53552,8 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_policies = __nccwpck_require__(279);
-var import_file = __nccwpck_require__(318);
+var import_policies = __nccwpck_require__(278);
+var import_file = __nccwpck_require__(317);
 const multipartPolicyName = import_policies.multipartPolicyName;
 function multipartPolicy() {
   const tspPolicy = (0, import_policies.multipartPolicy)();
@@ -53733,7 +53577,7 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 267:
+/***/ 266:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -53828,13 +53672,13 @@ exports.listEnumNumbers = listEnumNumbers;
 
 /***/ }),
 
-/***/ 268:
+/***/ 267:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(501)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(191)
-const { RequestRetryError } = __nccwpck_require__(466)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(190)
+const { RequestRetryError } = __nccwpck_require__(465)
 const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(66)
 
 function calculateRetryAfterHeader (retryAfter) {
@@ -54171,7 +54015,7 @@ module.exports = RetryHandler
 
 /***/ }),
 
-/***/ 269:
+/***/ 268:
 /***/ ((module) => {
 
 "use strict";
@@ -54179,7 +54023,7 @@ module.exports = require("node:crypto");
 
 /***/ }),
 
-/***/ 270:
+/***/ 269:
 /***/ (function(module) {
 
 "use strict";
@@ -54301,7 +54145,7 @@ module.exports = decodeText
 
 /***/ }),
 
-/***/ 271:
+/***/ 270:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -54310,32 +54154,32 @@ module.exports = decodeText
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
-const tslib_1 = __nccwpck_require__(211);
-tslib_1.__exportStar(__nccwpck_require__(348), exports);
-var cache_js_1 = __nccwpck_require__(247);
+const tslib_1 = __nccwpck_require__(210);
+tslib_1.__exportStar(__nccwpck_require__(347), exports);
+var cache_js_1 = __nccwpck_require__(246);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
 tslib_1.__exportStar(__nccwpck_require__(82), exports);
 tslib_1.__exportStar(__nccwpck_require__(154), exports);
-tslib_1.__exportStar(__nccwpck_require__(380), exports);
-tslib_1.__exportStar(__nccwpck_require__(94), exports);
-tslib_1.__exportStar(__nccwpck_require__(257), exports);
-tslib_1.__exportStar(__nccwpck_require__(317), exports);
+tslib_1.__exportStar(__nccwpck_require__(379), exports);
+tslib_1.__exportStar(__nccwpck_require__(95), exports);
+tslib_1.__exportStar(__nccwpck_require__(256), exports);
+tslib_1.__exportStar(__nccwpck_require__(316), exports);
 var RequestPolicy_js_1 = __nccwpck_require__(44);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
 tslib_1.__exportStar(__nccwpck_require__(92), exports);
-tslib_1.__exportStar(__nccwpck_require__(300), exports);
-tslib_1.__exportStar(__nccwpck_require__(202), exports);
-tslib_1.__exportStar(__nccwpck_require__(441), exports);
-tslib_1.__exportStar(__nccwpck_require__(165), exports);
-tslib_1.__exportStar(__nccwpck_require__(125), exports);
+tslib_1.__exportStar(__nccwpck_require__(299), exports);
+tslib_1.__exportStar(__nccwpck_require__(201), exports);
+tslib_1.__exportStar(__nccwpck_require__(440), exports);
+tslib_1.__exportStar(__nccwpck_require__(164), exports);
+tslib_1.__exportStar(__nccwpck_require__(126), exports);
 tslib_1.__exportStar(__nccwpck_require__(75), exports);
-tslib_1.__exportStar(__nccwpck_require__(405), exports);
-tslib_1.__exportStar(__nccwpck_require__(167), exports);
+tslib_1.__exportStar(__nccwpck_require__(404), exports);
+tslib_1.__exportStar(__nccwpck_require__(166), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 272:
+/***/ 271:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -54348,18 +54192,18 @@ tslib_1.__exportStar(__nccwpck_require__(167), exports);
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(211);
-tslib_1.__exportStar(__nccwpck_require__(223), exports);
-tslib_1.__exportStar(__nccwpck_require__(214), exports);
+const tslib_1 = __nccwpck_require__(210);
+tslib_1.__exportStar(__nccwpck_require__(222), exports);
+tslib_1.__exportStar(__nccwpck_require__(213), exports);
 tslib_1.__exportStar(__nccwpck_require__(45), exports);
-tslib_1.__exportStar(__nccwpck_require__(275), exports);
+tslib_1.__exportStar(__nccwpck_require__(274), exports);
 tslib_1.__exportStar(__nccwpck_require__(24), exports);
-tslib_1.__exportStar(__nccwpck_require__(342), exports);
+tslib_1.__exportStar(__nccwpck_require__(341), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 273:
+/***/ 272:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -54589,7 +54433,7 @@ exports.ContainerSASPermissions = ContainerSASPermissions;
 
 /***/ }),
 
-/***/ 274:
+/***/ 273:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -54615,20 +54459,20 @@ __export(createPipelineFromOptions_exports, {
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(68);
-var import_pipeline = __nccwpck_require__(239);
-var import_redirectPolicy = __nccwpck_require__(330);
-var import_userAgentPolicy = __nccwpck_require__(372);
-var import_multipartPolicy = __nccwpck_require__(266);
-var import_decompressResponsePolicy = __nccwpck_require__(232);
+var import_pipeline = __nccwpck_require__(238);
+var import_redirectPolicy = __nccwpck_require__(329);
+var import_userAgentPolicy = __nccwpck_require__(371);
+var import_multipartPolicy = __nccwpck_require__(265);
+var import_decompressResponsePolicy = __nccwpck_require__(231);
 var import_defaultRetryPolicy = __nccwpck_require__(52);
-var import_formDataPolicy = __nccwpck_require__(263);
+var import_formDataPolicy = __nccwpck_require__(262);
 var import_core_util = __nccwpck_require__(12);
-var import_proxyPolicy = __nccwpck_require__(450);
+var import_proxyPolicy = __nccwpck_require__(449);
 var import_setClientRequestIdPolicy = __nccwpck_require__(149);
-var import_agentPolicy = __nccwpck_require__(224);
-var import_tlsPolicy = __nccwpck_require__(362);
-var import_tracingPolicy = __nccwpck_require__(326);
-var import_wrapAbortSignalLikePolicy = __nccwpck_require__(253);
+var import_agentPolicy = __nccwpck_require__(223);
+var import_tlsPolicy = __nccwpck_require__(361);
+var import_tracingPolicy = __nccwpck_require__(325);
+var import_wrapAbortSignalLikePolicy = __nccwpck_require__(252);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_core_util.isNodeLike) {
@@ -54662,7 +54506,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 275:
+/***/ 274:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -54676,9 +54520,9 @@ function createPipelineFromOptions(options) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(211);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(418));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
+const tslib_1 = __nccwpck_require__(210);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(417));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing PageBlob operations. */
 class PageBlobImpl {
@@ -55132,7 +54976,7 @@ const copyIncrementalOperationSpec = {
 
 /***/ }),
 
-/***/ 276:
+/***/ 275:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55140,7 +54984,7 @@ const copyIncrementalOperationSpec = {
 
 const { kConstruct } = __nccwpck_require__(155)
 const { Cache } = __nccwpck_require__(10)
-const { webidl } = __nccwpck_require__(435)
+const { webidl } = __nccwpck_require__(434)
 const { kEnumerableProperty } = __nccwpck_require__(66)
 
 class CacheStorage {
@@ -55284,7 +55128,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 277:
+/***/ 276:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55294,8 +55138,8 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createClientPipeline = createClientPipeline;
 const deserializationPolicy_js_1 = __nccwpck_require__(85);
-const core_rest_pipeline_1 = __nccwpck_require__(100);
-const serializationPolicy_js_1 = __nccwpck_require__(467);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
+const serializationPolicy_js_1 = __nccwpck_require__(466);
 /**
  * Creates a new Pipeline for use with a Service Client.
  * Adds in deserializationPolicy by default.
@@ -55320,7 +55164,7 @@ function createClientPipeline(options = {}) {
 
 /***/ }),
 
-/***/ 278:
+/***/ 277:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -55360,11 +55204,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
-const http = __importStar(__nccwpck_require__(320));
+const http = __importStar(__nccwpck_require__(319));
 const https = __importStar(__nccwpck_require__(67));
-const pm = __importStar(__nccwpck_require__(302));
-const tunnel = __importStar(__nccwpck_require__(496));
-const undici_1 = __nccwpck_require__(162);
+const pm = __importStar(__nccwpck_require__(301));
+const tunnel = __importStar(__nccwpck_require__(495));
+const undici_1 = __nccwpck_require__(161);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -55979,7 +55823,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 279:
+/***/ 278:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -56031,20 +55875,20 @@ __export(internal_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(internal_exports);
-var import_agentPolicy = __nccwpck_require__(442);
-var import_decompressResponsePolicy = __nccwpck_require__(343);
-var import_defaultRetryPolicy = __nccwpck_require__(316);
-var import_exponentialRetryPolicy = __nccwpck_require__(498);
+var import_agentPolicy = __nccwpck_require__(441);
+var import_decompressResponsePolicy = __nccwpck_require__(342);
+var import_defaultRetryPolicy = __nccwpck_require__(315);
+var import_exponentialRetryPolicy = __nccwpck_require__(497);
 var import_retryPolicy = __nccwpck_require__(14);
 var import_systemErrorRetryPolicy = __nccwpck_require__(26);
-var import_throttlingRetryPolicy = __nccwpck_require__(497);
-var import_formDataPolicy = __nccwpck_require__(329);
-var import_logPolicy = __nccwpck_require__(101);
-var import_multipartPolicy = __nccwpck_require__(168);
+var import_throttlingRetryPolicy = __nccwpck_require__(496);
+var import_formDataPolicy = __nccwpck_require__(328);
+var import_logPolicy = __nccwpck_require__(102);
+var import_multipartPolicy = __nccwpck_require__(167);
 var import_proxyPolicy = __nccwpck_require__(37);
-var import_redirectPolicy = __nccwpck_require__(308);
-var import_tlsPolicy = __nccwpck_require__(215);
-var import_userAgentPolicy = __nccwpck_require__(346);
+var import_redirectPolicy = __nccwpck_require__(307);
+var import_tlsPolicy = __nccwpck_require__(214);
+var import_userAgentPolicy = __nccwpck_require__(345);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -56052,7 +55896,7 @@ var import_userAgentPolicy = __nccwpck_require__(346);
 
 /***/ }),
 
-/***/ 280:
+/***/ 279:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -56091,7 +55935,7 @@ function stringToUint8Array(value, format) {
 
 /***/ }),
 
-/***/ 281:
+/***/ 280:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56103,8 +55947,8 @@ exports.generateAccountSASQueryParameters = generateAccountSASQueryParameters;
 exports.generateAccountSASQueryParametersInternal = generateAccountSASQueryParametersInternal;
 const AccountSASPermissions_js_1 = __nccwpck_require__(55);
 const AccountSASResourceTypes_js_1 = __nccwpck_require__(2);
-const AccountSASServices_js_1 = __nccwpck_require__(363);
-const SasIPRange_js_1 = __nccwpck_require__(345);
+const AccountSASServices_js_1 = __nccwpck_require__(362);
+const SasIPRange_js_1 = __nccwpck_require__(344);
 const SASQueryParameters_js_1 = __nccwpck_require__(500);
 const constants_js_1 = __nccwpck_require__(147);
 const utils_common_js_1 = __nccwpck_require__(153);
@@ -56202,15 +56046,15 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 
 /***/ }),
 
-/***/ 282:
+/***/ 281:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
-const reflection_info_1 = __nccwpck_require__(431);
-const oneof_1 = __nccwpck_require__(186);
+const reflection_info_1 = __nccwpck_require__(430);
+const oneof_1 = __nccwpck_require__(185);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
     constructor(info) {
@@ -56440,7 +56284,7 @@ exports.ReflectionTypeCheck = ReflectionTypeCheck;
 
 /***/ }),
 
-/***/ 283:
+/***/ 282:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -56500,11 +56344,11 @@ exports.applyStagedToLiveRoots = applyStagedToLiveRoots;
 exports.saveSoloCache = saveSoloCache;
 exports.restoreSoloCache = restoreSoloCache;
 exports.verifyRestoredToolchain = verifyRestoredToolchain;
-const node_crypto_1 = __nccwpck_require__(269);
-const fs = __importStar(__nccwpck_require__(243));
-const fsp = __importStar(__nccwpck_require__(107));
-const path = __importStar(__nccwpck_require__(485));
-const cache = __importStar(__nccwpck_require__(209));
+const node_crypto_1 = __nccwpck_require__(268);
+const fs = __importStar(__nccwpck_require__(242));
+const fsp = __importStar(__nccwpck_require__(108));
+const path = __importStar(__nccwpck_require__(484));
+const cache = __importStar(__nccwpck_require__(208));
 const exec = __importStar(__nccwpck_require__(16));
 const cache_compress_js_1 = __nccwpck_require__(502);
 /**
@@ -56832,7 +56676,7 @@ async function verifyRestoredToolchain(opts) {
 
 /***/ }),
 
-/***/ 284:
+/***/ 283:
 /***/ ((module) => {
 
 "use strict";
@@ -56840,7 +56684,7 @@ module.exports = require("crypto");
 
 /***/ }),
 
-/***/ 285:
+/***/ 284:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -56866,7 +56710,7 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(115);
+var import_userAgentPlatform = __nccwpck_require__(116);
 var import_constants = __nccwpck_require__(157);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
@@ -56893,7 +56737,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 286:
+/***/ 285:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56967,7 +56811,7 @@ function copy(a, into) {
 
 /***/ }),
 
-/***/ 287:
+/***/ 286:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -57003,8 +56847,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
 const assert_1 = __nccwpck_require__(501);
-const path = __importStar(__nccwpck_require__(242));
-const ioUtil = __importStar(__nccwpck_require__(218));
+const path = __importStar(__nccwpck_require__(241));
+const ioUtil = __importStar(__nccwpck_require__(217));
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -57273,14 +57117,14 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 288:
+/***/ 287:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.maskSecretUrls = exports.maskSigUrl = void 0;
-const core_1 = __nccwpck_require__(437);
+const core_1 = __nccwpck_require__(436);
 /**
  * Masks the `sig` parameter in a URL and sets it as a secret.
  *
@@ -57354,7 +57198,7 @@ exports.maskSecretUrls = maskSecretUrls;
 
 /***/ }),
 
-/***/ 289:
+/***/ 288:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57368,16 +57212,16 @@ exports.maskSecretUrls = maskSecretUrls;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(211);
-tslib_1.__exportStar(__nccwpck_require__(449), exports);
-var storageClient_js_1 = __nccwpck_require__(425);
+const tslib_1 = __nccwpck_require__(210);
+tslib_1.__exportStar(__nccwpck_require__(448), exports);
+var storageClient_js_1 = __nccwpck_require__(424);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(164), exports);
+tslib_1.__exportStar(__nccwpck_require__(163), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 290:
+/***/ 289:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -57427,7 +57271,7 @@ exports.AzureKeyCredential = AzureKeyCredential;
 
 /***/ }),
 
-/***/ 291:
+/***/ 290:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57436,9 +57280,9 @@ exports.AzureKeyCredential = AzureKeyCredential;
 const {
   InvalidArgumentError,
   NotSupportedError
-} = __nccwpck_require__(466)
+} = __nccwpck_require__(465)
 const assert = __nccwpck_require__(501)
-const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(191)
+const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(190)
 const util = __nccwpck_require__(66)
 
 // tokenRegExp and headerCharRegex have been lifted from
@@ -57934,17 +57778,17 @@ module.exports = Request
 
 /***/ }),
 
-/***/ 292:
+/***/ 291:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(435)
+const { webidl } = __nccwpck_require__(434)
 const { DOMException } = __nccwpck_require__(28)
 const { URLSerializer } = __nccwpck_require__(23)
 const { getGlobalOrigin } = __nccwpck_require__(139)
-const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(443)
+const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(442)
 const {
   kWebSocketURL,
   kReadyState,
@@ -57953,14 +57797,14 @@ const {
   kResponse,
   kSentClose,
   kByteParser
-} = __nccwpck_require__(97)
+} = __nccwpck_require__(98)
 const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(54)
-const { establishWebSocketConnection } = __nccwpck_require__(350)
-const { WebsocketFrameSend } = __nccwpck_require__(183)
-const { ByteParser } = __nccwpck_require__(459)
+const { establishWebSocketConnection } = __nccwpck_require__(349)
+const { WebsocketFrameSend } = __nccwpck_require__(182)
+const { ByteParser } = __nccwpck_require__(458)
 const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(66)
-const { getGlobalDispatcher } = __nccwpck_require__(360)
-const { types } = __nccwpck_require__(122)
+const { getGlobalDispatcher } = __nccwpck_require__(359)
+const { types } = __nccwpck_require__(123)
 
 let experimentalWarned = false
 
@@ -58583,7 +58427,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 293:
+/***/ 292:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58918,7 +58762,7 @@ class AvroRecordType extends AvroType {
 
 /***/ }),
 
-/***/ 294:
+/***/ 293:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59044,7 +58888,7 @@ exports.base64encode = base64encode;
 
 /***/ }),
 
-/***/ 295:
+/***/ 294:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -59070,7 +58914,7 @@ __export(concat_exports, {
 });
 module.exports = __toCommonJS(concat_exports);
 var import_stream = __nccwpck_require__(130);
-var import_typeGuards = __nccwpck_require__(474);
+var import_typeGuards = __nccwpck_require__(473);
 async function* streamAsyncIterator() {
   const reader = this.getReader();
   try {
@@ -59131,7 +58975,7 @@ async function concat(sources) {
 
 /***/ }),
 
-/***/ 296:
+/***/ 295:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59208,7 +59052,7 @@ UsageError.isUsageErrorMessage = (msg) => {
 
 /***/ }),
 
-/***/ 297:
+/***/ 296:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -59265,7 +59109,7 @@ exports.DuplexStreamingCall = DuplexStreamingCall;
 
 /***/ }),
 
-/***/ 298:
+/***/ 297:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59443,7 +59287,7 @@ exports.RpcOutputStreamController = RpcOutputStreamController;
 
 /***/ }),
 
-/***/ 299:
+/***/ 298:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59465,7 +59309,7 @@ exports.enumToMap = enumToMap;
 
 /***/ }),
 
-/***/ 300:
+/***/ 299:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59505,7 +59349,7 @@ exports.CredentialPolicy = CredentialPolicy;
 
 /***/ }),
 
-/***/ 301:
+/***/ 300:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59514,11 +59358,11 @@ exports.CredentialPolicy = CredentialPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BatchResponseParser = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(100);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
 const core_http_compat_1 = __nccwpck_require__(69);
 const constants_js_1 = __nccwpck_require__(147);
-const BatchUtils_js_1 = __nccwpck_require__(252);
-const log_js_1 = __nccwpck_require__(105);
+const BatchUtils_js_1 = __nccwpck_require__(251);
+const log_js_1 = __nccwpck_require__(106);
 const HTTP_HEADER_DELIMITER = ": ";
 const SPACE_DELIMITER = " ";
 const NOT_FOUND = -1;
@@ -59658,7 +59502,7 @@ exports.BatchResponseParser = BatchResponseParser;
 
 /***/ }),
 
-/***/ 302:
+/***/ 301:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59760,7 +59604,7 @@ class DecodedURL extends URL {
 
 /***/ }),
 
-/***/ 303:
+/***/ 302:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59901,7 +59745,7 @@ function flattenResponse(fullResponse, responseSpec) {
 
 /***/ }),
 
-/***/ 304:
+/***/ 303:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60082,7 +59926,7 @@ exports.buildCreatePoller = buildCreatePoller;
 
 /***/ }),
 
-/***/ 305:
+/***/ 304:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60091,14 +59935,14 @@ exports.buildCreatePoller = buildCreatePoller;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(100);
-const pipeline_js_1 = __nccwpck_require__(277);
-const utils_js_1 = __nccwpck_require__(303);
-const httpClientCache_js_1 = __nccwpck_require__(381);
-const operationHelpers_js_1 = __nccwpck_require__(410);
-const urlHelpers_js_1 = __nccwpck_require__(231);
-const interfaceHelpers_js_1 = __nccwpck_require__(382);
-const log_js_1 = __nccwpck_require__(458);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
+const pipeline_js_1 = __nccwpck_require__(276);
+const utils_js_1 = __nccwpck_require__(302);
+const httpClientCache_js_1 = __nccwpck_require__(380);
+const operationHelpers_js_1 = __nccwpck_require__(409);
+const urlHelpers_js_1 = __nccwpck_require__(230);
+const interfaceHelpers_js_1 = __nccwpck_require__(381);
+const log_js_1 = __nccwpck_require__(457);
 /**
  * Initializes a new instance of the ServiceClient.
  */
@@ -60265,7 +60109,7 @@ function getCredentialScopes(options) {
 
 /***/ }),
 
-/***/ 306:
+/***/ 305:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60290,18 +60134,18 @@ __export(createPipelineFromOptions_exports, {
   createPipelineFromOptions: () => createPipelineFromOptions
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
-var import_logPolicy = __nccwpck_require__(101);
+var import_logPolicy = __nccwpck_require__(102);
 var import_pipeline = __nccwpck_require__(499);
-var import_redirectPolicy = __nccwpck_require__(308);
-var import_userAgentPolicy = __nccwpck_require__(346);
-var import_decompressResponsePolicy = __nccwpck_require__(343);
-var import_defaultRetryPolicy = __nccwpck_require__(316);
-var import_formDataPolicy = __nccwpck_require__(329);
-var import_checkEnvironment = __nccwpck_require__(417);
+var import_redirectPolicy = __nccwpck_require__(307);
+var import_userAgentPolicy = __nccwpck_require__(345);
+var import_decompressResponsePolicy = __nccwpck_require__(342);
+var import_defaultRetryPolicy = __nccwpck_require__(315);
+var import_formDataPolicy = __nccwpck_require__(328);
+var import_checkEnvironment = __nccwpck_require__(416);
 var import_proxyPolicy = __nccwpck_require__(37);
-var import_agentPolicy = __nccwpck_require__(442);
-var import_tlsPolicy = __nccwpck_require__(215);
-var import_multipartPolicy = __nccwpck_require__(168);
+var import_agentPolicy = __nccwpck_require__(441);
+var import_tlsPolicy = __nccwpck_require__(214);
+var import_multipartPolicy = __nccwpck_require__(167);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_checkEnvironment.isNodeLike) {
@@ -60331,7 +60175,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 307:
+/***/ 306:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -60348,7 +60192,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 308:
+/***/ 307:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60420,7 +60264,7 @@ async function handleRedirect(next, response, maxRetries, allowCrossOriginRedire
 
 /***/ }),
 
-/***/ 309:
+/***/ 308:
 /***/ ((module) => {
 
 "use strict";
@@ -60428,7 +60272,7 @@ module.exports = require("worker_threads");
 
 /***/ }),
 
-/***/ 310:
+/***/ 309:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60438,7 +60282,7 @@ module.exports = require("worker_threads");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
 const operation_js_1 = __nccwpck_require__(49);
-const poller_js_1 = __nccwpck_require__(304);
+const poller_js_1 = __nccwpck_require__(303);
 /**
  * Creates a poller that can be used to poll a long-running operation.
  * @param lro - Description of the long-running operation
@@ -60483,7 +60327,7 @@ exports.createHttpPoller = createHttpPoller;
 
 /***/ }),
 
-/***/ 311:
+/***/ 310:
 /***/ ((module) => {
 
 "use strict";
@@ -60491,14 +60335,14 @@ module.exports = require("perf_hooks");
 
 /***/ }),
 
-/***/ 312:
+/***/ 311:
 /***/ ((module) => {
 
 (()=>{"use strict";var t={d:(e,n)=>{for(var i in n)t.o(n,i)&&!t.o(e,i)&&Object.defineProperty(e,i,{enumerable:!0,get:n[i]})},o:(t,e)=>Object.prototype.hasOwnProperty.call(t,e),r:t=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(t,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(t,"__esModule",{value:!0})}},e={};t.r(e),t.d(e,{XMLBuilder:()=>ie,XMLParser:()=>Lt,XMLValidator:()=>se});const n=":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD",i=new RegExp("^["+n+"]["+n+"\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$");function s(t,e){const n=[];let i=e.exec(t);for(;i;){const s=[];s.startIndex=e.lastIndex-i[0].length;const r=i.length;for(let t=0;t<r;t++)s.push(i[t]);n.push(s),i=e.exec(t)}return n}const r=function(t){return!(null==i.exec(t))},o=["hasOwnProperty","toString","valueOf","__defineGetter__","__defineSetter__","__lookupGetter__","__lookupSetter__"],a=["__proto__","constructor","prototype"],h={allowBooleanAttributes:!1,unpairedTags:[]};function l(t,e){e=Object.assign({},h,e);const n=[];let i=!1,s=!1;"\ufeff"===t[0]&&(t=t.substr(1));for(let r=0;r<t.length;r++)if("<"===t[r]&&"?"===t[r+1]){if(r+=2,r=p(t,r),r.err)return r}else{if("<"!==t[r]){if(u(t[r]))continue;return b("InvalidChar","char '"+t[r]+"' is not expected.",w(t,r))}{let o=r;if(r++,"!"===t[r]){r=c(t,r);continue}{let a=!1;"/"===t[r]&&(a=!0,r++);let h="";for(;r<t.length&&">"!==t[r]&&" "!==t[r]&&"\t"!==t[r]&&"\n"!==t[r]&&"\r"!==t[r];r++)h+=t[r];if(h=h.trim(),"/"===h[h.length-1]&&(h=h.substring(0,h.length-1),r--),!E(h)){let e;return e=0===h.trim().length?"Invalid space after '<'.":"Tag '"+h+"' is an invalid name.",b("InvalidTag",e,w(t,r))}const l=g(t,r);if(!1===l)return b("InvalidAttr","Attributes for '"+h+"' have open quote.",w(t,r));let d=l.value;if(r=l.index,"/"===d[d.length-1]){const n=r-d.length;d=d.substring(0,d.length-1);const s=x(d,e);if(!0!==s)return b(s.err.code,s.err.msg,w(t,n+s.err.line));i=!0}else if(a){if(!l.tagClosed)return b("InvalidTag","Closing tag '"+h+"' doesn't have proper closing.",w(t,r));if(d.trim().length>0)return b("InvalidTag","Closing tag '"+h+"' can't have attributes or invalid starting.",w(t,o));if(0===n.length)return b("InvalidTag","Closing tag '"+h+"' has not been opened.",w(t,o));{const e=n.pop();if(h!==e.tagName){let n=w(t,e.tagStartPos);return b("InvalidTag","Expected closing tag '"+e.tagName+"' (opened in line "+n.line+", col "+n.col+") instead of closing tag '"+h+"'.",w(t,o))}0==n.length&&(s=!0)}}else{const a=x(d,e);if(!0!==a)return b(a.err.code,a.err.msg,w(t,r-d.length+a.err.line));if(!0===s)return b("InvalidXml","Multiple possible root nodes found.",w(t,r));-1!==e.unpairedTags.indexOf(h)||n.push({tagName:h,tagStartPos:o}),i=!0}for(r++;r<t.length;r++)if("<"===t[r]){if("!"===t[r+1]){r++,r=c(t,r);continue}if("?"!==t[r+1])break;if(r=p(t,++r),r.err)return r}else if("&"===t[r]){const e=N(t,r);if(-1==e)return b("InvalidChar","char '&' is not expected.",w(t,r));r=e}else if(!0===s&&!u(t[r]))return b("InvalidXml","Extra text at the end",w(t,r));"<"===t[r]&&r--}}}return i?1==n.length?b("InvalidTag","Unclosed tag '"+n[0].tagName+"'.",w(t,n[0].tagStartPos)):!(n.length>0)||b("InvalidXml","Invalid '"+JSON.stringify(n.map(t=>t.tagName),null,4).replace(/\r?\n/g,"")+"' found.",{line:1,col:1}):b("InvalidXml","Start tag expected.",1)}function u(t){return" "===t||"\t"===t||"\n"===t||"\r"===t}function p(t,e){const n=e;for(;e<t.length;e++)if("?"==t[e]||" "==t[e]){const i=t.substr(n,e-n);if(e>5&&"xml"===i)return b("InvalidXml","XML declaration allowed only at the start of the document.",w(t,e));if("?"==t[e]&&">"==t[e+1]){e++;break}continue}return e}function c(t,e){if(t.length>e+5&&"-"===t[e+1]&&"-"===t[e+2]){for(e+=3;e<t.length;e++)if("-"===t[e]&&"-"===t[e+1]&&">"===t[e+2]){e+=2;break}}else if(t.length>e+8&&"D"===t[e+1]&&"O"===t[e+2]&&"C"===t[e+3]&&"T"===t[e+4]&&"Y"===t[e+5]&&"P"===t[e+6]&&"E"===t[e+7]){let n=1;for(e+=8;e<t.length;e++)if("<"===t[e])n++;else if(">"===t[e]&&(n--,0===n))break}else if(t.length>e+9&&"["===t[e+1]&&"C"===t[e+2]&&"D"===t[e+3]&&"A"===t[e+4]&&"T"===t[e+5]&&"A"===t[e+6]&&"["===t[e+7])for(e+=8;e<t.length;e++)if("]"===t[e]&&"]"===t[e+1]&&">"===t[e+2]){e+=2;break}return e}const d='"',f="'";function g(t,e){let n="",i="",s=!1;for(;e<t.length;e++){if(t[e]===d||t[e]===f)""===i?i=t[e]:i!==t[e]||(i="");else if(">"===t[e]&&""===i){s=!0;break}n+=t[e]}return""===i&&{value:n,index:e,tagClosed:s}}const m=new RegExp("(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['\"])(([\\s\\S])*?)\\5)?","g");function x(t,e){const n=s(t,m),i={};for(let t=0;t<n.length;t++){if(0===n[t][1].length)return b("InvalidAttr","Attribute '"+n[t][2]+"' has no space in starting.",v(n[t]));if(void 0!==n[t][3]&&void 0===n[t][4])return b("InvalidAttr","Attribute '"+n[t][2]+"' is without value.",v(n[t]));if(void 0===n[t][3]&&!e.allowBooleanAttributes)return b("InvalidAttr","boolean attribute '"+n[t][2]+"' is not allowed.",v(n[t]));const s=n[t][2];if(!y(s))return b("InvalidAttr","Attribute '"+s+"' is an invalid name.",v(n[t]));if(Object.prototype.hasOwnProperty.call(i,s))return b("InvalidAttr","Attribute '"+s+"' is repeated.",v(n[t]));i[s]=1}return!0}function N(t,e){if(";"===t[++e])return-1;if("#"===t[e])return function(t,e){let n=/\d/;for("x"===t[e]&&(e++,n=/[\da-fA-F]/);e<t.length;e++){if(";"===t[e])return e;if(!t[e].match(n))break}return-1}(t,++e);let n=0;for(;e<t.length;e++,n++)if(!(t[e].match(/\w/)&&n<20)){if(";"===t[e])break;return-1}return e}function b(t,e,n){return{err:{code:t,msg:e,line:n.line||n,col:n.col}}}function y(t){return r(t)}function E(t){return r(t)}function w(t,e){const n=t.substring(0,e).split(/\r?\n/);return{line:n.length,col:n[n.length-1].length+1}}function v(t){return t.startIndex+t[1].length}const S=t=>o.includes(t)?"__"+t:t,_={preserveOrder:!1,attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,removeNSPrefix:!1,allowBooleanAttributes:!1,parseTagValue:!0,parseAttributeValue:!1,trimValues:!0,cdataPropName:!1,numberParseOptions:{hex:!0,leadingZeros:!0,eNotation:!0},tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},stopNodes:[],alwaysCreateTextNode:!1,isArray:()=>!1,commentPropName:!1,unpairedTags:[],processEntities:!0,htmlEntities:!1,entityDecoder:null,ignoreDeclaration:!1,ignorePiTags:!1,transformTagName:!1,transformAttributeName:!1,updateTag:function(t,e,n){return t},captureMetaData:!1,maxNestedTags:100,strictReservedNames:!0,jPath:!0,onDangerousProperty:S};function A(t,e){if("string"!=typeof t)return;const n=t.toLowerCase();if(o.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);if(a.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`)}function T(t,e){return"boolean"==typeof t?{enabled:t,maxEntitySize:1e4,maxExpansionDepth:1e4,maxTotalExpansions:1/0,maxExpandedLength:1e5,maxEntityCount:1e3,allowedTags:null,tagFilter:null,appliesTo:"all"}:"object"==typeof t&&null!==t?{enabled:!1!==t.enabled,maxEntitySize:Math.max(1,t.maxEntitySize??1e4),maxExpansionDepth:Math.max(1,t.maxExpansionDepth??1e4),maxTotalExpansions:Math.max(1,t.maxTotalExpansions??1/0),maxExpandedLength:Math.max(1,t.maxExpandedLength??1e5),maxEntityCount:Math.max(1,t.maxEntityCount??1e3),allowedTags:t.allowedTags??null,tagFilter:t.tagFilter??null,appliesTo:t.appliesTo??"all"}:T(!0)}const C=function(t){const e=Object.assign({},_,t),n=[{value:e.attributeNamePrefix,name:"attributeNamePrefix"},{value:e.attributesGroupName,name:"attributesGroupName"},{value:e.textNodeName,name:"textNodeName"},{value:e.cdataPropName,name:"cdataPropName"},{value:e.commentPropName,name:"commentPropName"}];for(const{value:t,name:e}of n)t&&A(t,e);return null===e.onDangerousProperty&&(e.onDangerousProperty=S),e.processEntities=T(e.processEntities,e.htmlEntities),e.unpairedTagsSet=new Set(e.unpairedTags),e.stopNodes&&Array.isArray(e.stopNodes)&&(e.stopNodes=e.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),e};let P;P="function"!=typeof Symbol?"@@xmlMetadata":Symbol("XML Node Metadata");class ${constructor(t){this.tagname=t,this.child=[],this[":@"]=Object.create(null)}add(t,e){"__proto__"===t&&(t="#__proto__"),this.child.push({[t]:e})}addChild(t,e){"__proto__"===t.tagname&&(t.tagname="#__proto__"),t[":@"]&&Object.keys(t[":@"]).length>0?this.child.push({[t.tagname]:t.child,":@":t[":@"]}):this.child.push({[t.tagname]:t.child}),void 0!==e&&(this.child[this.child.length-1][P]={startIndex:e})}static getMetaDataSymbol(){return P}}const O=":A-Za-z_À-ÖØ-öø-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�",I=":A-Za-z_À-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�𐀀-󯿿",V=I+"\\-\\.\\d·̀-ͯ҇‿-⁀",D=(t,e,n="")=>{const i=`[${t.replace(":","")}][${e.replace(":","")}]*`;return{name:new RegExp(`^[${t}][${e}]*$`,n),ncName:new RegExp(`^${i}$`,n),qName:new RegExp(`^${i}(?::${i})?$`,n),nmToken:new RegExp(`^[${e}]+$`,n),nmTokens:new RegExp(`^[${e}]+(?:\\s+[${e}]+)*$`,n)}},M=D(O,O+"\\-\\.\\d·̀-ͯ‿-⁀"),j=D(I,V,"u"),L=(t,{xmlVersion:e="1.0"}={})=>((t="1.0")=>"1.1"===t?j:M)(e).qName.test(t);class k{constructor(t,e){this.suppressValidationErr=!t,this.options=t,this.xmlVersion=e||1}setXmlVersion(t=1){this.xmlVersion=t}readDocType(t,e){const n=Object.create(null);let i=0;if("O"!==t[e+3]||"C"!==t[e+4]||"T"!==t[e+5]||"Y"!==t[e+6]||"P"!==t[e+7]||"E"!==t[e+8])throw new Error("Invalid Tag instead of DOCTYPE");{e+=9;let s=1,r=!1,o=!1,a="";for(;e<t.length;e++)if("<"!==t[e]||o)if(">"===t[e]){if(o?"-"===t[e-1]&&"-"===t[e-2]&&(o=!1,s--):s--,0===s)break}else"["===t[e]?r=!0:a+=t[e];else{if(r&&F(t,"!ENTITY",e)){let s,r;if(e+=7,[s,r,e]=this.readEntityExp(t,e+1,this.suppressValidationErr),-1===r.indexOf("&")){if(!1!==this.options.enabled&&null!=this.options.maxEntityCount&&i>=this.options.maxEntityCount)throw new Error(`Entity count (${i+1}) exceeds maximum allowed (${this.options.maxEntityCount})`);n[s]=r,i++}}else if(r&&F(t,"!ELEMENT",e)){e+=8;const{index:n}=this.readElementExp(t,e+1);e=n}else if(r&&F(t,"!ATTLIST",e))e+=8;else if(r&&F(t,"!NOTATION",e)){e+=9;const{index:n}=this.readNotationExp(t,e+1,this.suppressValidationErr);e=n}else{if(!F(t,"!--",e))throw new Error("Invalid DOCTYPE");o=!0}s++,a=""}if(0!==s)throw new Error("Unclosed DOCTYPE")}return{entities:n,i:e}}readEntityExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e])&&'"'!==t[e]&&"'"!==t[e];)e++;let i=t.substring(n,e);if(G(i,{xmlVersion:this.xmlVersion}),e=R(t,e),!this.suppressValidationErr){if("SYSTEM"===t.substring(e,e+6).toUpperCase())throw new Error("External entities are not supported");if("%"===t[e])throw new Error("Parameter entities are not supported")}let s="";if([e,s]=this.readIdentifierVal(t,e,"entity"),!1!==this.options.enabled&&null!=this.options.maxEntitySize&&s.length>this.options.maxEntitySize)throw new Error(`Entity "${i}" size (${s.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`);return[i,s,--e]}readNotationExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);!this.suppressValidationErr&&G(i,{xmlVersion:this.xmlVersion}),e=R(t,e);const s=t.substring(e,e+6).toUpperCase();if(!this.suppressValidationErr&&"SYSTEM"!==s&&"PUBLIC"!==s)throw new Error(`Expected SYSTEM or PUBLIC, found "${s}"`);e+=s.length,e=R(t,e);let r=null,o=null;if("PUBLIC"===s)[e,r]=this.readIdentifierVal(t,e,"publicIdentifier"),'"'!==t[e=R(t,e)]&&"'"!==t[e]||([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"));else if("SYSTEM"===s&&([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"),!this.suppressValidationErr&&!o))throw new Error("Missing mandatory system identifier for SYSTEM notation");return{notationName:i,publicIdentifier:r,systemIdentifier:o,index:--e}}readIdentifierVal(t,e,n){let i="";const s=t[e];if('"'!==s&&"'"!==s)throw new Error(`Expected quoted string, found "${s}"`);const r=++e;for(;e<t.length&&t[e]!==s;)e++;if(i=t.substring(r,e),t[e]!==s)throw new Error(`Unterminated ${n} value`);return[++e,i]}readElementExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);if(!this.suppressValidationErr&&!L(i,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid element name: "${i}"`);let s="";if("E"===t[e=R(t,e)]&&F(t,"MPTY",e))e+=4;else if("A"===t[e]&&F(t,"NY",e))e+=2;else if("("===t[e]){const n=++e;for(;e<t.length&&")"!==t[e];)e++;if(s=t.substring(n,e),")"!==t[e])throw new Error("Unterminated content model")}else if(!this.suppressValidationErr)throw new Error(`Invalid Element Expression, found "${t[e]}"`);return{elementName:i,contentModel:s.trim(),index:e}}readAttlistExp(t,e){let n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);for(G(i,{xmlVersion:this.xmlVersion}),n=e=R(t,e);e<t.length&&!/\s/.test(t[e]);)e++;let s=t.substring(n,e);if(!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid attribute name: "${s}"`);e=R(t,e);let r="";if("NOTATION"===t.substring(e,e+8).toUpperCase()){if(r="NOTATION","("!==t[e=R(t,e+=8)])throw new Error(`Expected '(', found "${t[e]}"`);e++;let n=[];for(;e<t.length&&")"!==t[e];){const i=e;for(;e<t.length&&"|"!==t[e]&&")"!==t[e];)e++;let s=t.substring(i,e);if(s=s.trim(),!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid notation name: "${s}"`);n.push(s),"|"===t[e]&&(e++,e=R(t,e))}if(")"!==t[e])throw new Error("Unterminated list of notations");e++,r+=" ("+n.join("|")+")"}else{const n=e;for(;e<t.length&&!/\s/.test(t[e]);)e++;r+=t.substring(n,e);const i=["CDATA","ID","IDREF","IDREFS","ENTITY","ENTITIES","NMTOKEN","NMTOKENS"];if(!this.suppressValidationErr&&!i.includes(r.toUpperCase()))throw new Error(`Invalid attribute type: "${r}"`)}e=R(t,e);let o="";return"#REQUIRED"===t.substring(e,e+8).toUpperCase()?(o="#REQUIRED",e+=8):"#IMPLIED"===t.substring(e,e+7).toUpperCase()?(o="#IMPLIED",e+=7):[e,o]=this.readIdentifierVal(t,e,"ATTLIST"),{elementName:i,attributeName:s,attributeType:r,defaultValue:o,index:e}}}const R=(t,e)=>{for(;e<t.length&&/\s/.test(t[e]);)e++;return e};function F(t,e,n){for(let i=0;i<e.length;i++)if(e[i]!==t[n+i+1])return!1;return!0}function G(t,e){if(L(t,{xmlVersion:e}))return t;throw new Error(`Invalid entity name ${t}`)}const U=/^[-+]?0x[a-fA-F0-9]+$/,B=/^0b[01]+$/,W=/^0o[0-7]+$/,z=/^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/,X={hex:!0,binary:!1,octal:!1,leadingZeros:!0,decimalPoint:".",eNotation:!0,infinity:"original"};const Y=/^([-+])?(0*)(\d*(\.\d*)?[eE][-\+]?\d+)$/;function q(t,e){const n=t.trim();if(2!==e&&8!==e||(t=n.substring(2)),parseInt)return parseInt(t,e);if(Number.parseInt)return Number.parseInt(t,e);if(window&&window.parseInt)return window.parseInt(t,e);throw new Error("parseInt, Number.parseInt, window.parseInt are not supported")}class Z{constructor(t){this._matcher=t}get separator(){return this._matcher.separator}getCurrentTag(){const t=this._matcher.path;return t.length>0?t[t.length-1].tag:void 0}getCurrentNamespace(){const t=this._matcher.path;return t.length>0?t[t.length-1].namespace:void 0}getAttrValue(t){const e=this._matcher.path;if(0!==e.length)return e[e.length-1].values?.[t]}hasAttr(t){const e=this._matcher.path;if(0===e.length)return!1;const n=e[e.length-1];return void 0!==n.values&&t in n.values}getPosition(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].position??0}getCounter(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this._matcher.path.length}toString(t,e=!0){return this._matcher.toString(t,e)}toArray(){return this._matcher.path.map(t=>t.tag)}matches(t){return this._matcher.matches(t)}matchesAny(t){return t.matchesAny(this._matcher)}}class J{constructor(t={}){this.separator=t.separator||".",this.path=[],this.siblingStacks=[],this._pathStringCache=null,this._view=new Z(this)}push(t,e=null,n=null){this._pathStringCache=null,this.path.length>0&&(this.path[this.path.length-1].values=void 0);const i=this.path.length;this.siblingStacks[i]||(this.siblingStacks[i]=new Map);const s=this.siblingStacks[i],r=n?`${n}:${t}`:t,o=s.get(r)||0;let a=0;for(const t of s.values())a+=t;s.set(r,o+1);const h={tag:t,position:a,counter:o};null!=n&&(h.namespace=n),null!=e&&(h.values=e),this.path.push(h)}pop(){if(0===this.path.length)return;this._pathStringCache=null;const t=this.path.pop();return this.siblingStacks.length>this.path.length+1&&(this.siblingStacks.length=this.path.length+1),t}updateCurrent(t){if(this.path.length>0){const e=this.path[this.path.length-1];null!=t&&(e.values=t)}}getCurrentTag(){return this.path.length>0?this.path[this.path.length-1].tag:void 0}getCurrentNamespace(){return this.path.length>0?this.path[this.path.length-1].namespace:void 0}getAttrValue(t){if(0!==this.path.length)return this.path[this.path.length-1].values?.[t]}hasAttr(t){if(0===this.path.length)return!1;const e=this.path[this.path.length-1];return void 0!==e.values&&t in e.values}getPosition(){return 0===this.path.length?-1:this.path[this.path.length-1].position??0}getCounter(){return 0===this.path.length?-1:this.path[this.path.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this.path.length}toString(t,e=!0){const n=t||this.separator;if(n===this.separator&&!0===e){if(null!==this._pathStringCache)return this._pathStringCache;const t=this.path.map(t=>t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n);return this._pathStringCache=t,t}return this.path.map(t=>e&&t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n)}toArray(){return this.path.map(t=>t.tag)}reset(){this._pathStringCache=null,this.path=[],this.siblingStacks=[]}matches(t){const e=t.segments;return 0!==e.length&&(t.hasDeepWildcard()?this._matchWithDeepWildcard(e):this._matchSimple(e))}_matchSimple(t){if(this.path.length!==t.length)return!1;for(let e=0;e<t.length;e++)if(!this._matchSegment(t[e],this.path[e],e===this.path.length-1))return!1;return!0}_matchWithDeepWildcard(t){let e=this.path.length-1,n=t.length-1;for(;n>=0&&e>=0;){const i=t[n];if("deep-wildcard"===i.type){if(n--,n<0)return!0;const i=t[n];let s=!1;for(let t=e;t>=0;t--)if(this._matchSegment(i,this.path[t],t===this.path.length-1)){e=t-1,n--,s=!0;break}if(!s)return!1}else{if(!this._matchSegment(i,this.path[e],e===this.path.length-1))return!1;e--,n--}}return n<0}_matchSegment(t,e,n){if("*"!==t.tag&&t.tag!==e.tag)return!1;if(void 0!==t.namespace&&"*"!==t.namespace&&t.namespace!==e.namespace)return!1;if(void 0!==t.attrName){if(!n)return!1;if(!e.values||!(t.attrName in e.values))return!1;if(void 0!==t.attrValue&&String(e.values[t.attrName])!==String(t.attrValue))return!1}if(void 0!==t.position){if(!n)return!1;const i=e.counter??0;if("first"===t.position&&0!==i)return!1;if("odd"===t.position&&i%2!=1)return!1;if("even"===t.position&&i%2!=0)return!1;if("nth"===t.position&&i!==t.positionValue)return!1}return!0}matchesAny(t){return t.matchesAny(this)}snapshot(){return{path:this.path.map(t=>({...t})),siblingStacks:this.siblingStacks.map(t=>new Map(t))}}restore(t){this._pathStringCache=null,this.path=t.path.map(t=>({...t})),this.siblingStacks=t.siblingStacks.map(t=>new Map(t))}readOnly(){return this._view}}class K{constructor(t,e={},n){this.pattern=t,this.separator=e.separator||".",this.segments=this._parse(t),this.data=n,this._hasDeepWildcard=this.segments.some(t=>"deep-wildcard"===t.type),this._hasAttributeCondition=this.segments.some(t=>void 0!==t.attrName),this._hasPositionSelector=this.segments.some(t=>void 0!==t.position)}_parse(t){const e=[];let n=0,i="";for(;n<t.length;)t[n]===this.separator?n+1<t.length&&t[n+1]===this.separator?(i.trim()&&(e.push(this._parseSegment(i.trim())),i=""),e.push({type:"deep-wildcard"}),n+=2):(i.trim()&&e.push(this._parseSegment(i.trim())),i="",n++):(i+=t[n],n++);return i.trim()&&e.push(this._parseSegment(i.trim())),e}_parseSegment(t){const e={type:"tag"};let n=null,i=t;const s=t.match(/^([^\[]+)(\[[^\]]*\])(.*)$/);if(s&&(i=s[1]+s[3],s[2])){const t=s[2].slice(1,-1);t&&(n=t)}let r,o,a=i;if(i.includes("::")){const e=i.indexOf("::");if(r=i.substring(0,e).trim(),a=i.substring(e+2).trim(),!r)throw new Error(`Invalid namespace in pattern: ${t}`)}let h=null;if(a.includes(":")){const t=a.lastIndexOf(":"),e=a.substring(0,t).trim(),n=a.substring(t+1).trim();["first","last","odd","even"].includes(n)||/^nth\(\d+\)$/.test(n)?(o=e,h=n):o=a}else o=a;if(!o)throw new Error(`Invalid segment pattern: ${t}`);if(e.tag=o,r&&(e.namespace=r),n)if(n.includes("=")){const t=n.indexOf("=");e.attrName=n.substring(0,t).trim(),e.attrValue=n.substring(t+1).trim()}else e.attrName=n.trim();if(h){const t=h.match(/^nth\((\d+)\)$/);t?(e.position="nth",e.positionValue=parseInt(t[1],10)):e.position=h}return e}get length(){return this.segments.length}hasDeepWildcard(){return this._hasDeepWildcard}hasAttributeCondition(){return this._hasAttributeCondition}hasPositionSelector(){return this._hasPositionSelector}toString(){return this.pattern}}class Q{constructor(){this._byDepthAndTag=new Map,this._wildcardByDepth=new Map,this._deepWildcards=[],this._patterns=new Set,this._sealed=!1}add(t){if(this._sealed)throw new TypeError("ExpressionSet is sealed. Create a new ExpressionSet to add more expressions.");if(this._patterns.has(t.pattern))return this;if(this._patterns.add(t.pattern),t.hasDeepWildcard())return this._deepWildcards.push(t),this;const e=t.length,n=t.segments[t.segments.length-1],i=n?.tag;if(i&&"*"!==i){const n=`${e}:${i}`;this._byDepthAndTag.has(n)||this._byDepthAndTag.set(n,[]),this._byDepthAndTag.get(n).push(t)}else this._wildcardByDepth.has(e)||this._wildcardByDepth.set(e,[]),this._wildcardByDepth.get(e).push(t);return this}addAll(t){for(const e of t)this.add(e);return this}has(t){return this._patterns.has(t.pattern)}get size(){return this._patterns.size}seal(){return this._sealed=!0,this}get isSealed(){return this._sealed}matchesAny(t){return null!==this.findMatch(t)}findMatch(t){const e=t.getDepth(),n=`${e}:${t.getCurrentTag()}`,i=this._byDepthAndTag.get(n);if(i)for(let e=0;e<i.length;e++)if(t.matches(i[e]))return i[e];const s=this._wildcardByDepth.get(e);if(s)for(let e=0;e<s.length;e++)if(t.matches(s[e]))return s[e];for(let e=0;e<this._deepWildcards.length;e++)if(t.matches(this._deepWildcards[e]))return this._deepWildcards[e];return null}}const H={cent:"¢",pound:"£",curren:"¤",yen:"¥",euro:"€",dollar:"$",euro:"€",fnof:"ƒ",inr:"₹",af:"؋",birr:"ብር",peso:"₱",rub:"₽",won:"₩",yuan:"¥",cedil:"¸"},tt={amp:"&",apos:"'",gt:">",lt:"<",quot:'"'},et={nbsp:" ",copy:"©",reg:"®",trade:"™",mdash:"—",ndash:"–",hellip:"…",laquo:"«",raquo:"»",lsquo:"‘",rsquo:"’",ldquo:"“",rdquo:"”",bull:"•",para:"¶",sect:"§",deg:"°",frac12:"½",frac14:"¼",frac34:"¾"},nt=new Set("!?\\\\/[]$%{}^&*()<>|+");function it(t){if("#"===t[0])throw new Error(`[EntityReplacer] Invalid character '#' in entity name: "${t}"`);for(const e of t)if(nt.has(e))throw new Error(`[EntityReplacer] Invalid character '${e}' in entity name: "${t}"`);return t}function st(...t){const e=Object.create(null);for(const n of t)if(n)for(const t of Object.keys(n)){const i=n[t];if("string"==typeof i)e[t]=i;else if(i&&"object"==typeof i&&void 0!==i.val){const n=i.val;"string"==typeof n&&(e[t]=n)}}return e}const rt="external",ot="base",at="all",ht=Object.freeze({allow:0,leave:1,remove:2,throw:3}),lt=new Set([9,10,13]);class ut{constructor(t={}){var e;this._limit=t.limit||{},this._maxTotalExpansions=this._limit.maxTotalExpansions||0,this._maxExpandedLength=this._limit.maxExpandedLength||0,this._postCheck="function"==typeof t.postCheck?t.postCheck:t=>t,this._limitTiers=(e=this._limit.applyLimitsTo??rt)&&e!==rt?e===at?new Set([at]):e===ot?new Set([ot]):Array.isArray(e)?new Set(e):new Set([rt]):new Set([rt]),this._numericAllowed=t.numericAllowed??!0,this._baseMap=st(tt,t.namedEntities||null),this._externalMap=Object.create(null),this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this._removeSet=new Set(t.remove&&Array.isArray(t.remove)?t.remove:[]),this._leaveSet=new Set(t.leave&&Array.isArray(t.leave)?t.leave:[]);const n=function(t){if(!t)return{xmlVersion:1,onLevel:ht.allow,nullLevel:ht.remove};const e=1.1===t.xmlVersion?1.1:1,n=ht[t.onNCR]??ht.allow,i=ht[t.nullNCR]??ht.remove;return{xmlVersion:e,onLevel:n,nullLevel:Math.max(i,ht.remove)}}(t.ncr);this._ncrXmlVersion=n.xmlVersion,this._ncrOnLevel=n.onLevel,this._ncrNullLevel=n.nullLevel}setExternalEntities(t){if(t)for(const e of Object.keys(t))it(e);this._externalMap=st(t)}addExternalEntity(t,e){it(t),"string"==typeof e&&-1===e.indexOf("&")&&(this._externalMap[t]=e)}addInputEntities(t){this._totalExpansions=0,this._expandedLength=0,this._inputMap=st(t)}reset(){return this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this}setXmlVersion(t){this._ncrXmlVersion=1.1===t?1.1:1}decode(t){if("string"!=typeof t||0===t.length)return t;const e=t,n=[],i=t.length;let s=0,r=0;const o=this._maxTotalExpansions>0,a=this._maxExpandedLength>0,h=o||a;for(;r<i;){if(38!==t.charCodeAt(r)){r++;continue}let e=r+1;for(;e<i&&59!==t.charCodeAt(e)&&e-r<=32;)e++;if(e>=i||59!==t.charCodeAt(e)){r++;continue}const l=t.slice(r+1,e);if(0===l.length){r++;continue}let u,p;if(this._removeSet.has(l))u="",void 0===p&&(p=rt);else{if(this._leaveSet.has(l)){r++;continue}if(35===l.charCodeAt(0)){const t=this._resolveNCR(l);if(void 0===t){r++;continue}u=t,p=ot}else{const t=this._resolveName(l);u=t?.value,p=t?.tier}}if(void 0!==u){if(r>s&&n.push(t.slice(s,r)),n.push(u),s=e+1,r=s,h&&this._tierCounts(p)){if(o&&(this._totalExpansions++,this._totalExpansions>this._maxTotalExpansions))throw new Error(`[EntityReplacer] Entity expansion count limit exceeded: ${this._totalExpansions} > ${this._maxTotalExpansions}`);if(a){const t=u.length-(l.length+2);if(t>0&&(this._expandedLength+=t,this._expandedLength>this._maxExpandedLength))throw new Error(`[EntityReplacer] Expanded content length limit exceeded: ${this._expandedLength} > ${this._maxExpandedLength}`)}}}else r++}s<i&&n.push(t.slice(s));const l=0===n.length?t:n.join("");return this._postCheck(l,e)}_tierCounts(t){return!!this._limitTiers.has(at)||this._limitTiers.has(t)}_resolveName(t){return t in this._inputMap?{value:this._inputMap[t],tier:rt}:t in this._externalMap?{value:this._externalMap[t],tier:rt}:t in this._baseMap?{value:this._baseMap[t],tier:ot}:void 0}_classifyNCR(t){return 0===t?this._ncrNullLevel:t>=55296&&t<=57343||1===this._ncrXmlVersion&&t>=1&&t<=31&&!lt.has(t)?ht.remove:-1}_applyNCRAction(t,e,n){switch(t){case ht.allow:return String.fromCodePoint(n);case ht.remove:return"";case ht.leave:return;case ht.throw:throw new Error(`[EntityDecoder] Prohibited numeric character reference &${e}; (U+${n.toString(16).toUpperCase().padStart(4,"0")})`);default:return String.fromCodePoint(n)}}_resolveNCR(t){const e=t.charCodeAt(1);let n;if(n=120===e||88===e?parseInt(t.slice(2),16):parseInt(t.slice(1),10),Number.isNaN(n)||n<0||n>1114111)return;const i=this._classifyNCR(n);if(!this._numericAllowed&&i<ht.remove)return;const s=-1===i?this._ncrOnLevel:Math.max(this._ncrOnLevel,i);return this._applyNCRAction(s,t,n)}}function pt(t,e){if(!t)return{};const n=e.attributesGroupName?t[e.attributesGroupName]:t;if(!n)return{};const i={};for(const t in n)t.startsWith(e.attributeNamePrefix)?i[t.substring(e.attributeNamePrefix.length)]=n[t]:i[t]=n[t];return i}function ct(t){if(!t||"string"!=typeof t)return;const e=t.indexOf(":");if(-1!==e&&e>0){const n=t.substring(0,e);if("xmlns"!==n)return n}}class dt{constructor(t,e){var n;this.options=t,this.currentNode=null,this.tagsNodeStack=[],this.parseXml=Nt,this.parseTextData=ft,this.resolveNameSpace=gt,this.buildAttributesMap=xt,this.isItStopNode=wt,this.replaceEntitiesValue=yt,this.readStopNodeData=At,this.saveTextToParentTag=Et,this.addChild=bt,this.ignoreAttributesFn="function"==typeof(n=this.options.ignoreAttributes)?n:Array.isArray(n)?t=>{for(const e of n){if("string"==typeof e&&t===e)return!0;if(e instanceof RegExp&&e.test(t))return!0}}:()=>!1,this.entityExpansionCount=0,this.currentExpandedLength=0;let i={...tt};this.options.entityDecoder?this.entityDecoder=this.options.entityDecoder:("object"==typeof this.options.htmlEntities?i=this.options.htmlEntities:!0===this.options.htmlEntities&&(i={...et,...H}),this.entityDecoder=new ut({namedEntities:{...i,...e},numericAllowed:this.options.htmlEntities,limit:{maxTotalExpansions:this.options.processEntities.maxTotalExpansions,maxExpandedLength:this.options.processEntities.maxExpandedLength,applyLimitsTo:this.options.processEntities.appliesTo}})),this.matcher=new J,this.readonlyMatcher=this.matcher.readOnly(),this.isCurrentNodeStopNode=!1,this.stopNodeExpressionsSet=new Q;const s=this.options.stopNodes;if(s&&s.length>0){for(let t=0;t<s.length;t++){const e=s[t];"string"==typeof e?this.stopNodeExpressionsSet.add(new K(e)):e instanceof K&&this.stopNodeExpressionsSet.add(e)}this.stopNodeExpressionsSet.seal()}}}function ft(t,e,n,i,s,r,o){const a=this.options;if(void 0!==t&&(a.trimValues&&!i&&(t=t.trim()),t.length>0)){o||(t=this.replaceEntitiesValue(t,e,n));const i=a.jPath?n.toString():n,h=a.tagValueProcessor(e,t,i,s,r);return null==h?t:typeof h!=typeof t||h!==t?h:a.trimValues||t.trim()===t?Tt(t,a.parseTagValue,a.numberParseOptions):t}}function gt(t){if(this.options.removeNSPrefix){const e=t.split(":"),n="/"===t.charAt(0)?"/":"";if("xmlns"===e[0])return"";2===e.length&&(t=n+e[1])}return t}const mt=new RegExp("([^\\s=]+)\\s*(=\\s*(['\"])([\\s\\S]*?)\\3)?","gm");function xt(t,e,n,i=!1){const r=this.options;if(!0===i||!0!==r.ignoreAttributes&&"string"==typeof t){const i=s(t,mt),o=i.length,a={},h=new Array(o);let l=!1;const u={};for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]),s=i[t][4];if(e.length&&void 0!==s){let i=s;r.trimValues&&(i=i.trim()),i=this.replaceEntitiesValue(i,n,this.readonlyMatcher),h[t]=i,u[e]=i,l=!0}}l&&"object"==typeof e&&e.updateCurrent&&e.updateCurrent(u);const p=r.jPath?e.toString():this.readonlyMatcher;let c=!1;for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]);if(this.ignoreAttributesFn(e,p))continue;let n=r.attributeNamePrefix+e;if(e.length)if(r.transformAttributeName&&(n=r.transformAttributeName(n)),n=Pt(n,r),void 0!==i[t][4]){const i=h[t],s=r.attributeValueProcessor(e,i,p);a[n]=null==s?i:typeof s!=typeof i||s!==i?s:Tt(i,r.parseAttributeValue,r.numberParseOptions),c=!0}else r.allowBooleanAttributes&&(a[n]=!0,c=!0)}if(!c)return;if(r.attributesGroupName&&!r.preserveOrder){const t={};return t[r.attributesGroupName]=a,t}return a}}const Nt=function(t){t=t.replace(/\r\n?/g,"\n");const e=new $("!xml");let n=e,i="";this.matcher.reset(),this.entityDecoder.reset(),this.entityExpansionCount=0,this.currentExpandedLength=0;const s=this.options,r=new k(s.processEntities),o=t.length;for(let a=0;a<o;a++)if("<"===t[a]){const h=t.charCodeAt(a+1);if(47===h){const e=vt(t,">",a,"Closing Tag is not closed.");let r=t.substring(a+2,e).trim();if(s.removeNSPrefix){const t=r.indexOf(":");-1!==t&&(r=r.substr(t+1))}r=Ct(s.transformTagName,r,"",s).tagName,n&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher));const o=this.matcher.getCurrentTag();if(r&&s.unpairedTagsSet.has(r))throw new Error(`Unpaired tag can not be used as closing tag: </${r}>`);o&&s.unpairedTagsSet.has(o)&&(this.matcher.pop(),this.tagsNodeStack.pop()),this.matcher.pop(),this.isCurrentNodeStopNode=!1,n=this.tagsNodeStack.pop(),i="",a=e}else if(63===h){let e=_t(t,a,!1,"?>");if(!e)throw new Error("Pi Tag is not closed.");i=this.saveTextToParentTag(i,n,this.readonlyMatcher);const o=this.buildAttributesMap(e.tagExp,this.matcher,e.tagName,!0);if(o){const t=o[this.options.attributeNamePrefix+"version"];this.entityDecoder.setXmlVersion(Number(t)||1),r.setXmlVersion(Number(t)||1)}if(s.ignoreDeclaration&&"?xml"===e.tagName||s.ignorePiTags);else{const t=new $(e.tagName);t.add(s.textNodeName,""),e.tagName!==e.tagExp&&e.attrExpPresent&&!0!==s.ignoreAttributes&&(t[":@"]=o),this.addChild(n,t,this.readonlyMatcher,a)}a=e.closeIndex+1}else if(33===h&&45===t.charCodeAt(a+2)&&45===t.charCodeAt(a+3)){const e=vt(t,"--\x3e",a+4,"Comment is not closed.");if(s.commentPropName){const r=t.substring(a+4,e-2);i=this.saveTextToParentTag(i,n,this.readonlyMatcher),n.add(s.commentPropName,[{[s.textNodeName]:r}])}a=e}else if(33===h&&68===t.charCodeAt(a+2)){const e=r.readDocType(t,a);this.entityDecoder.addInputEntities(e.entities),a=e.i}else if(33===h&&91===t.charCodeAt(a+2)){const e=vt(t,"]]>",a,"CDATA is not closed.")-2,r=t.substring(a+9,e);i=this.saveTextToParentTag(i,n,this.readonlyMatcher);let o=this.parseTextData(r,n.tagname,this.readonlyMatcher,!0,!1,!0,!0);null==o&&(o=""),s.cdataPropName?n.add(s.cdataPropName,[{[s.textNodeName]:r}]):n.add(s.textNodeName,o),a=e+2}else{let r=_t(t,a,s.removeNSPrefix);if(!r){const e=t.substring(Math.max(0,a-50),Math.min(o,a+50));throw new Error(`readTagExp returned undefined at position ${a}. Context: "${e}"`)}let h=r.tagName;const l=r.rawTagName;let u=r.tagExp,p=r.attrExpPresent,c=r.closeIndex;if(({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s)),s.strictReservedNames&&(h===s.commentPropName||h===s.cdataPropName||h===s.textNodeName||h===s.attributesGroupName))throw new Error(`Invalid tag name: ${h}`);n&&i&&"!xml"!==n.tagname&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher,!1));const d=n;d&&s.unpairedTagsSet.has(d.tagname)&&(n=this.tagsNodeStack.pop(),this.matcher.pop());let f=!1;u.length>0&&u.lastIndexOf("/")===u.length-1&&(f=!0,"/"===h[h.length-1]?(h=h.substr(0,h.length-1),u=h):u=u.substr(0,u.length-1),p=h!==u);let g,m=null,x={};g=ct(l),h!==e.tagname&&this.matcher.push(h,{},g),h!==u&&p&&(m=this.buildAttributesMap(u,this.matcher,h),m&&(x=pt(m,s))),h!==e.tagname&&(this.isCurrentNodeStopNode=this.isItStopNode());const N=a;if(this.isCurrentNodeStopNode){let e="";if(f)a=r.closeIndex;else if(s.unpairedTagsSet.has(h))a=r.closeIndex;else{const n=this.readStopNodeData(t,l,c+1);if(!n)throw new Error(`Unexpected end of ${l}`);a=n.i,e=n.tagContent}const i=new $(h);m&&(i[":@"]=m),i.add(s.textNodeName,e),this.matcher.pop(),this.isCurrentNodeStopNode=!1,this.addChild(n,i,this.readonlyMatcher,N)}else{if(f){({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s));const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1}else{if(s.unpairedTagsSet.has(h)){const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1,a=r.closeIndex;continue}{const t=new $(h);if(this.tagsNodeStack.length>s.maxNestedTags)throw new Error("Maximum nested tags exceeded");this.tagsNodeStack.push(n),m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),n=t}}i="",a=c}}}else i+=t[a];return e.child};function bt(t,e,n,i){this.options.captureMetaData||(i=void 0);const s=this.options.jPath?n.toString():n,r=this.options.updateTag(e.tagname,s,e[":@"]);!1===r||("string"==typeof r?(e.tagname=r,t.addChild(e,i)):t.addChild(e,i))}function yt(t,e,n){const i=this.options.processEntities;if(!i||!i.enabled)return t;if(i.allowedTags){const s=this.options.jPath?n.toString():n;if(!(Array.isArray(i.allowedTags)?i.allowedTags.includes(e):i.allowedTags(e,s)))return t}if(i.tagFilter){const s=this.options.jPath?n.toString():n;if(!i.tagFilter(e,s))return t}return this.entityDecoder.decode(t)}function Et(t,e,n,i){return t&&(void 0===i&&(i=0===e.child.length),void 0!==(t=this.parseTextData(t,e.tagname,n,!1,!!e[":@"]&&0!==Object.keys(e[":@"]).length,i))&&""!==t&&e.add(this.options.textNodeName,t),t=""),t}function wt(){return 0!==this.stopNodeExpressionsSet.size&&this.matcher.matchesAny(this.stopNodeExpressionsSet)}function vt(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s+e.length-1}function St(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s}function _t(t,e,n,i=">"){const s=function(t,e,n=">"){let i=0;const s=t.length,r=n.charCodeAt(0),o=n.length>1?n.charCodeAt(1):-1;let a="",h=e;for(let n=e;n<s;n++){const e=t.charCodeAt(n);if(i)e===i&&(i=0);else if(34===e||39===e)i=e;else if(e===r){if(-1===o)return a+=t.substring(h,n),{data:a,index:n};if(t.charCodeAt(n+1)===o)return a+=t.substring(h,n),{data:a,index:n}}else 9!==e||i||(a+=t.substring(h,n)+" ",h=n+1)}}(t,e+1,i);if(!s)return;let r=s.data;const o=s.index,a=r.search(/\s/);let h=r,l=!0;-1!==a&&(h=r.substring(0,a),r=r.substring(a+1).trimStart());const u=h;if(n){const t=h.indexOf(":");-1!==t&&(h=h.substr(t+1),l=h!==s.data.substr(t+1))}return{tagName:h,tagExp:r,closeIndex:o,attrExpPresent:l,rawTagName:u}}function At(t,e,n){const i=n;let s=1;const r=t.length;for(;n<r;n++)if("<"===t[n]){const r=t.charCodeAt(n+1);if(47===r){const r=St(t,">",n,`${e} is not closed`);if(t.substring(n+2,r).trim()===e&&(s--,0===s))return{tagContent:t.substring(i,n),i:r};n=r}else if(63===r)n=vt(t,"?>",n+1,"StopNode is not closed.");else if(33===r&&45===t.charCodeAt(n+2)&&45===t.charCodeAt(n+3))n=vt(t,"--\x3e",n+3,"StopNode is not closed.");else if(33===r&&91===t.charCodeAt(n+2))n=vt(t,"]]>",n,"StopNode is not closed.")-2;else{const i=_t(t,n,!1);i&&((i&&i.tagName)===e&&"/"!==i.tagExp[i.tagExp.length-1]&&s++,n=i.closeIndex)}}}function Tt(t,e,n){if(e&&"string"==typeof t){const e=t.trim();return"true"===e||"false"!==e&&function(t,e={}){if(e=Object.assign({},X,e),!t||"string"!=typeof t)return t;let n=t.trim();if(0===n.length)return t;if(void 0!==e.skipLike&&e.skipLike.test(n))return t;if("0"===n)return 0;if(e.hex&&U.test(n))return q(n,16);if(e.binary&&B.test(n))return q(n,2);if(e.octal&&W.test(n))return q(n,8);if(isFinite(n)){if(n.includes("e")||n.includes("E"))return function(t,e,n){if(!n.eNotation)return t;const i=e.match(Y);if(i){let s=i[1]||"";const r=-1===i[3].indexOf("e")?"E":"e",o=i[2],a=s?t[o.length+1]===r:t[o.length]===r;return o.length>1&&a?t:(1!==o.length||!i[3].startsWith(`.${r}`)&&i[3][0]!==r)&&o.length>0?n.leadingZeros&&!a?(e=(i[1]||"")+i[3],Number(e)):t:Number(e)}return t}(t,n,e);{const s=z.exec(n);if(s){const r=s[1]||"",o=s[2];let a=(i=s[3])&&-1!==i.indexOf(".")?("."===(i=i.replace(/0+$/,""))?i="0":"."===i[0]?i="0"+i:"."===i[i.length-1]&&(i=i.substring(0,i.length-1)),i):i;const h=r?"."===t[o.length+1]:"."===t[o.length];if(!e.leadingZeros&&(o.length>1||1===o.length&&!h))return t;{const i=Number(n),s=String(i);if(0===i)return i;if(-1!==s.search(/[eE]/))return e.eNotation?i:t;if(-1!==n.indexOf("."))return"0"===s||s===a||s===`${r}${a}`?i:t;let h=o?a:n;return o?h===s||r+h===s?i:t:h===s||h===r+s?i:t}}return t}}var i;return function(t,e,n){const i=e===1/0;switch(n.infinity.toLowerCase()){case"null":return null;case"infinity":return e;case"string":return i?"Infinity":"-Infinity";default:return t}}(t,Number(n),e)}(t,n)}return void 0!==t?t:""}function Ct(t,e,n,i){if(t){const i=t(e);n===e&&(n=i),e=i}return{tagName:e=Pt(e,i),tagExp:n}}function Pt(t,e){if(a.includes(t))throw new Error(`[SECURITY] Invalid name: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);return o.includes(t)?e.onDangerousProperty(t):t}const $t=$.getMetaDataSymbol();function Ot(t,e){if(!t||"object"!=typeof t)return{};if(!e)return t;const n={};for(const i in t)i.startsWith(e)?n[i.substring(e.length)]=t[i]:n[i]=t[i];return n}function It(t,e,n,i){return Vt(t,e,n,i)}function Vt(t,e,n,i){let s;const r={};for(let o=0;o<t.length;o++){const a=t[o],h=Dt(a);if(void 0!==h&&h!==e.textNodeName){const t=Ot(a[":@"]||{},e.attributeNamePrefix);n.push(h,t)}if(h===e.textNodeName)void 0===s?s=a[h]:s+=""+a[h];else{if(void 0===h)continue;if(a[h]){let t=Vt(a[h],e,n,i);const s=jt(t,e);if(0===Object.keys(t).length&&e.alwaysCreateTextNode&&(t[e.textNodeName]=""),a[":@"]?Mt(t,a[":@"],i,e):1!==Object.keys(t).length||void 0===t[e.textNodeName]||e.alwaysCreateTextNode?0===Object.keys(t).length&&(e.alwaysCreateTextNode?t[e.textNodeName]="":t=""):t=t[e.textNodeName],void 0!==a[$t]&&"object"==typeof t&&null!==t&&(t[$t]=a[$t]),void 0!==r[h]&&Object.prototype.hasOwnProperty.call(r,h))Array.isArray(r[h])||(r[h]=[r[h]]),r[h].push(t);else{const n=e.jPath?i.toString():i;e.isArray(h,n,s)?r[h]=[t]:r[h]=t}void 0!==h&&h!==e.textNodeName&&n.pop()}}}return"string"==typeof s?s.length>0&&(r[e.textNodeName]=s):void 0!==s&&(r[e.textNodeName]=s),r}function Dt(t){const e=Object.keys(t);for(let t=0;t<e.length;t++){const n=e[t];if(":@"!==n)return n}}function Mt(t,e,n,i){if(e){const s=Object.keys(e),r=s.length;for(let o=0;o<r;o++){const r=s[o],a=r.startsWith(i.attributeNamePrefix)?r.substring(i.attributeNamePrefix.length):r,h=i.jPath?n.toString()+"."+a:n;i.isArray(r,h,!0,!0)?t[r]=[e[r]]:t[r]=e[r]}}}function jt(t,e){const{textNodeName:n}=e,i=Object.keys(t).length;return 0===i||!(1!==i||!t[n]&&"boolean"!=typeof t[n]&&0!==t[n])}class Lt{constructor(t){this.externalEntities={},this.options=C(t)}parse(t,e){if("string"!=typeof t&&t.toString)t=t.toString();else if("string"!=typeof t)throw new Error("XML data is accepted in String or Bytes[] form.");if(e){!0===e&&(e={});const n=l(t,e);if(!0!==n)throw Error(`${n.err.msg}:${n.err.line}:${n.err.col}`)}const n=new dt(this.options,this.externalEntities),i=n.parseXml(t);return this.options.preserveOrder||void 0===i?i:It(i,this.options,n.matcher,n.readonlyMatcher)}addEntity(t,e){if(-1!==e.indexOf("&"))throw new Error("Entity value can't have '&'");if(-1!==t.indexOf("&")||-1!==t.indexOf(";"))throw new Error("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");if("&"===e)throw new Error("An entity with value '&' is not permitted");this.externalEntities[t]=e}static getMetaDataSymbol(){return $.getMetaDataSymbol()}}function kt(t){return String(t).replace(/--/g,"- -").replace(/--/g,"- -").replace(/-$/,"- ")}function Rt(t){return String(t).replace(/\]\]>/g,"]]]]><![CDATA[>")}function Ft(t){return String(t).replace(/"/g,"&quot;").replace(/'/g,"&apos;")}function Gt(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function Ut(t,e){let n="";e.format&&(n="\n");const i=[];if(e.stopNodes&&Array.isArray(e.stopNodes))for(let t=0;t<e.stopNodes.length;t++){const n=e.stopNodes[t];"string"==typeof n?i.push(new K(n)):n instanceof K&&i.push(n)}const s=function(t,e){if(!Array.isArray(t)||0===t.length)return"1.0";const n=t[0];if("?xml"===Yt(n)){const t=n[":@"];if(t){const n=e.attributeNamePrefix+"version";if(t[n])return t[n]}}return"1.0"}(t,e);return Bt(t,e,n,new J,i,s)}function Bt(t,e,n,i,s,r){let o="",a=!1;if(e.maxNestedTags&&i.getDepth()>e.maxNestedTags)throw new Error("Maximum nested tags exceeded");if(!Array.isArray(t)){if(null!=t){let n=t.toString();return n=Jt(n,e),n}return""}for(let h=0;h<t.length;h++){const l=t[h],u=Yt(l);if(void 0===u)continue;const p=u===e.textNodeName||u===e.cdataPropName||u===e.commentPropName||"?"===u[0]?u:Gt(u,!1,e,i,r),c=Wt(l[":@"],e);i.push(p,c);const d=Zt(i,s);if(p===e.textNodeName){let t=l[u];d||(t=e.tagValueProcessor(p,t),t=Jt(t,e)),a&&(o+=n),o+=t,a=!1,i.pop();continue}if(p===e.cdataPropName){a&&(o+=n),o+=`<![CDATA[${Rt(l[u][0][e.textNodeName])}]]>`,a=!1,i.pop();continue}if(p===e.commentPropName){o+=n+`\x3c!--${kt(l[u][0][e.textNodeName])}--\x3e`,a=!0,i.pop();continue}if("?"===p[0]){o+=("?xml"===p?"":n)+`<${p}${qt(l[":@"],e,d,i,r)}?>`,a=!0,i.pop();continue}let f=n;""!==f&&(f+=e.indentBy);const g=n+`<${p}${qt(l[":@"],e,d,i,r)}`;let m;m=d?zt(l[u],e):Bt(l[u],e,f,i,s,r),-1!==e.unpairedTags.indexOf(p)?e.suppressUnpairedNode?o+=g+">":o+=g+"/>":m&&0!==m.length||!e.suppressEmptyNode?m&&m.endsWith(">")?o+=g+`>${m}${n}</${p}>`:(o+=g+">",m&&""!==n&&(m.includes("/>")||m.includes("</"))?o+=n+e.indentBy+m+n:o+=m,o+=`</${p}>`):o+=g+"/>",a=!0,i.pop()}return o}function Wt(t,e){if(!t||e.ignoreAttributes)return null;const n={};let i=!1;for(let s in t)Object.prototype.hasOwnProperty.call(t,s)&&(n[s.startsWith(e.attributeNamePrefix)?s.substr(e.attributeNamePrefix.length):s]=Ft(t[s]),i=!0);return i?n:null}function zt(t,e){if(!Array.isArray(t))return null!=t?t.toString():"";let n="";for(let i=0;i<t.length;i++){const s=t[i],r=Yt(s);if(r===e.textNodeName)n+=s[r];else if(r===e.cdataPropName)n+=s[r][0][e.textNodeName];else if(r===e.commentPropName)n+=s[r][0][e.textNodeName];else{if(r&&"?"===r[0])continue;if(r){const t=Xt(s[":@"],e),i=zt(s[r],e);i&&0!==i.length?n+=`<${r}${t}>${i}</${r}>`:n+=`<${r}${t}/>`}}}return n}function Xt(t,e){let n="";if(t&&!e.ignoreAttributes)for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;let s=t[i];!0===s&&e.suppressBooleanAttributes?n+=` ${i.substr(e.attributeNamePrefix.length)}`:n+=` ${i.substr(e.attributeNamePrefix.length)}="${Ft(s)}"`}return n}function Yt(t){const e=Object.keys(t);for(let n=0;n<e.length;n++){const i=e[n];if(Object.prototype.hasOwnProperty.call(t,i)&&":@"!==i)return i}}function qt(t,e,n,i,s){let r="";if(t&&!e.ignoreAttributes)for(let o in t){if(!Object.prototype.hasOwnProperty.call(t,o))continue;const a=o.substr(e.attributeNamePrefix.length),h=n?a:Gt(a,!0,e,i,s);let l;n?l=t[o]:(l=e.attributeValueProcessor(o,t[o]),l=Jt(l,e)),!0===l&&e.suppressBooleanAttributes?r+=` ${h}`:r+=` ${h}="${Ft(l)}"`}return r}function Zt(t,e){if(!e||0===e.length)return!1;for(let n=0;n<e.length;n++)if(t.matches(e[n]))return!0;return!1}function Jt(t,e){if(t&&t.length>0&&e.processEntities)for(let n=0;n<e.entities.length;n++){const i=e.entities[n];t=t.replace(i.regex,i.val)}return t}const Kt={attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,cdataPropName:!1,format:!1,indentBy:"  ",suppressEmptyNode:!1,suppressUnpairedNode:!0,suppressBooleanAttributes:!0,tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},preserveOrder:!1,commentPropName:!1,unpairedTags:[],entities:[{regex:new RegExp("&","g"),val:"&amp;"},{regex:new RegExp(">","g"),val:"&gt;"},{regex:new RegExp("<","g"),val:"&lt;"},{regex:new RegExp("'","g"),val:"&apos;"},{regex:new RegExp('"',"g"),val:"&quot;"}],processEntities:!0,stopNodes:[],oneListGroup:!1,maxNestedTags:100,jPath:!0,sanitizeName:!1};function Qt(t){if(this.options=Object.assign({},Kt,t),this.options.stopNodes&&Array.isArray(this.options.stopNodes)&&(this.options.stopNodes=this.options.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),this.stopNodeExpressions=[],this.options.stopNodes&&Array.isArray(this.options.stopNodes))for(let t=0;t<this.options.stopNodes.length;t++){const e=this.options.stopNodes[t];"string"==typeof e?this.stopNodeExpressions.push(new K(e)):e instanceof K&&this.stopNodeExpressions.push(e)}var e;!0===this.options.ignoreAttributes||this.options.attributesGroupName?this.isAttribute=function(){return!1}:(this.ignoreAttributesFn="function"==typeof(e=this.options.ignoreAttributes)?e:Array.isArray(e)?t=>{for(const n of e){if("string"==typeof n&&t===n)return!0;if(n instanceof RegExp&&n.test(t))return!0}}:()=>!1,this.attrPrefixLen=this.options.attributeNamePrefix.length,this.isAttribute=ne),this.processTextOrObjNode=te,this.options.format?(this.indentate=ee,this.tagEndChar=">\n",this.newLine="\n"):(this.indentate=function(){return""},this.tagEndChar=">",this.newLine="")}function Ht(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function te(t,e,n,i,s){const r=this.extractAttributes(t);if(i.push(e,r),this.checkStopNode(i)){const s=this.buildRawContent(t),r=this.buildAttributesForStopNode(t);return i.pop(),this.buildObjectNode(s,e,r,n)}const o=this.j2x(t,n+1,i,s);return i.pop(),"?"===e[0]?this.buildTextValNode("",e,o.attrStr,n,i):void 0!==t[this.options.textNodeName]&&1===Object.keys(t).length?this.buildTextValNode(t[this.options.textNodeName],e,o.attrStr,n,i):this.buildObjectNode(o.val,e,o.attrStr,n)}function ee(t){return this.options.indentBy.repeat(t)}function ne(t){return!(!t.startsWith(this.options.attributeNamePrefix)||t===this.options.textNodeName)&&t.substr(this.attrPrefixLen)}Qt.prototype.build=function(t){if(this.options.preserveOrder)return Ut(t,this.options);{Array.isArray(t)&&this.options.arrayNodeName&&this.options.arrayNodeName.length>1&&(t={[this.options.arrayNodeName]:t});const e=new J,n=function(t,e){const n=t["?xml"];if(n&&"object"==typeof n){if(e.attributesGroupName&&n[e.attributesGroupName]){const t=n[e.attributesGroupName][e.attributeNamePrefix+"version"];if(t)return t}const t=n[e.attributeNamePrefix+"version"];if(t)return t}return"1.0"}(t,this.options);return this.j2x(t,0,e,n).val}},Qt.prototype.j2x=function(t,e,n,i){let s="",r="";if(this.options.maxNestedTags&&n.getDepth()>=this.options.maxNestedTags)throw new Error("Maximum nested tags exceeded");const o=this.options.jPath?n.toString():n,a=this.checkStopNode(n);for(let h in t){if(!Object.prototype.hasOwnProperty.call(t,h))continue;const l=h===this.options.textNodeName||h===this.options.cdataPropName||h===this.options.commentPropName||this.options.attributesGroupName&&h===this.options.attributesGroupName||this.isAttribute(h)||"?"===h[0]?h:Ht(h,!1,this.options,n,i);if(void 0===t[h])this.isAttribute(h)&&(r+="");else if(null===t[h])this.isAttribute(h)||l===this.options.cdataPropName||l===this.options.commentPropName?r+="":"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if(t[h]instanceof Date)r+=this.buildTextValNode(t[h],l,"",e,n);else if("object"!=typeof t[h]){const u=this.isAttribute(h);if(u&&!this.ignoreAttributesFn(u,o)){const e=Ht(u,!0,this.options,n,i);s+=this.buildAttrPairStr(e,""+t[h],a)}else if(!u)if(h===this.options.textNodeName){let e=this.options.tagValueProcessor(h,""+t[h]);r+=this.replaceEntitiesValue(e)}else{n.push(l);const i=this.checkStopNode(n);if(n.pop(),i){const n=""+t[h];r+=""===n?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+n+"</"+l+this.tagEndChar}else r+=this.buildTextValNode(t[h],l,"",e,n)}}else if(Array.isArray(t[h])){const s=t[h].length;let o="",a="";for(let u=0;u<s;u++){const s=t[h][u];if(void 0===s);else if(null===s)"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if("object"==typeof s)if(this.options.oneListGroup){n.push(l);const t=this.j2x(s,e+1,n,i);n.pop(),o+=t.val,this.options.attributesGroupName&&s.hasOwnProperty(this.options.attributesGroupName)&&(a+=t.attrStr)}else o+=this.processTextOrObjNode(s,l,e,n,i);else if(this.options.oneListGroup){let t=this.options.tagValueProcessor(l,s);t=this.replaceEntitiesValue(t),o+=t}else{n.push(l);const t=this.checkStopNode(n);if(n.pop(),t){const t=""+s;o+=""===t?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+t+"</"+l+this.tagEndChar}else o+=this.buildTextValNode(s,l,"",e,n)}}this.options.oneListGroup&&(o=this.buildObjectNode(o,l,a,e)),r+=o}else if(this.options.attributesGroupName&&h===this.options.attributesGroupName){const e=Object.keys(t[h]),r=e.length;for(let o=0;o<r;o++){const r=Ht(e[o],!0,this.options,n,i);s+=this.buildAttrPairStr(r,""+t[h][e[o]],a)}}else r+=this.processTextOrObjNode(t[h],l,e,n,i)}return{attrStr:s,val:r}},Qt.prototype.buildAttrPairStr=function(t,e,n){return n||(e=this.options.attributeValueProcessor(t,""+e),e=this.replaceEntitiesValue(e)),this.options.suppressBooleanAttributes&&"true"===e?" "+t:" "+t+'="'+Ft(e)+'"'},Qt.prototype.extractAttributes=function(t){if(!t||"object"!=typeof t)return null;const e={};let n=!1;if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const i=t[this.options.attributesGroupName];for(let t in i)Object.prototype.hasOwnProperty.call(i,t)&&(e[t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t]=Ft(i[t]),n=!0)}else for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;const s=this.isAttribute(i);s&&(e[s]=Ft(t[i]),n=!0)}return n?e:null},Qt.prototype.buildRawContent=function(t){if("string"==typeof t)return t;if("object"!=typeof t||null===t)return String(t);if(void 0!==t[this.options.textNodeName])return t[this.options.textNodeName];let e="";for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;if(this.isAttribute(n))continue;if(this.options.attributesGroupName&&n===this.options.attributesGroupName)continue;const i=t[n];if(n===this.options.textNodeName)e+=i;else if(Array.isArray(i)){for(let t of i)if("string"==typeof t||"number"==typeof t)e+=`<${n}>${t}</${n}>`;else if("object"==typeof t&&null!==t){const i=this.buildRawContent(t),s=this.buildAttributesForStopNode(t);e+=""===i?`<${n}${s}/>`:`<${n}${s}>${i}</${n}>`}}else if("object"==typeof i&&null!==i){const t=this.buildRawContent(i),s=this.buildAttributesForStopNode(i);e+=""===t?`<${n}${s}/>`:`<${n}${s}>${t}</${n}>`}else e+=`<${n}>${i}</${n}>`}return e},Qt.prototype.buildAttributesForStopNode=function(t){if(!t||"object"!=typeof t)return"";let e="";if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const n=t[this.options.attributesGroupName];for(let t in n){if(!Object.prototype.hasOwnProperty.call(n,t))continue;const i=t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t,s=n[t];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}else for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;const i=this.isAttribute(n);if(i){const s=t[n];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}return e},Qt.prototype.buildObjectNode=function(t,e,n,i){if(""===t)return"?"===e[0]?this.indentate(i)+"<"+e+n+"?"+this.tagEndChar:this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar;if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s="</"+e+this.tagEndChar,r="";return"?"===e[0]&&(r="?",s=""),!n&&""!==n||-1!==t.indexOf("<")?!1!==this.options.commentPropName&&e===this.options.commentPropName&&0===r.length?this.indentate(i)+`\x3c!--${t}--\x3e`+this.newLine:this.indentate(i)+"<"+e+n+r+this.tagEndChar+t+this.indentate(i)+s:this.indentate(i)+"<"+e+n+r+">"+t+s}},Qt.prototype.closeTag=function(t){let e="";return-1!==this.options.unpairedTags.indexOf(t)?this.options.suppressUnpairedNode||(e="/"):e=this.options.suppressEmptyNode?"/":`></${t}`,e},Qt.prototype.checkStopNode=function(t){if(!this.stopNodeExpressions||0===this.stopNodeExpressions.length)return!1;for(let e=0;e<this.stopNodeExpressions.length;e++)if(t.matches(this.stopNodeExpressions[e]))return!0;return!1},Qt.prototype.buildTextValNode=function(t,e,n,i,s){if(!1!==this.options.cdataPropName&&e===this.options.cdataPropName){const e=Rt(t);return this.indentate(i)+`<![CDATA[${e}]]>`+this.newLine}if(!1!==this.options.commentPropName&&e===this.options.commentPropName){const e=kt(t);return this.indentate(i)+`\x3c!--${e}--\x3e`+this.newLine}if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s=this.options.tagValueProcessor(e,t);return s=this.replaceEntitiesValue(s),""===s?this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar:this.indentate(i)+"<"+e+n+">"+s+"</"+e+this.tagEndChar}},Qt.prototype.replaceEntitiesValue=function(t){if(t&&t.length>0&&this.options.processEntities)for(let e=0;e<this.options.entities.length;e++){const n=this.options.entities[e];t=t.replace(n.regex,n.val)}return t};const ie=Qt,se={validate:l};module.exports=e})();
 
 /***/ }),
 
-/***/ 313:
+/***/ 312:
 /***/ ((module) => {
 
 "use strict";
@@ -60506,7 +60350,7 @@ module.exports = require("node:string_decoder");
 
 /***/ }),
 
-/***/ 314:
+/***/ 313:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -60524,7 +60368,7 @@ var KnownEncryptionAlgorithmType;
 
 /***/ }),
 
-/***/ 315:
+/***/ 314:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -60753,7 +60597,7 @@ function replaceAll(value, searchValue, replaceValue) {
 
 /***/ }),
 
-/***/ 316:
+/***/ 315:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60779,7 +60623,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(378);
+var import_exponentialRetryStrategy = __nccwpck_require__(377);
 var import_throttlingRetryStrategy = __nccwpck_require__(33);
 var import_retryPolicy = __nccwpck_require__(14);
 var import_constants = __nccwpck_require__(46);
@@ -60799,7 +60643,7 @@ function defaultRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 317:
+/***/ 316:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60811,7 +60655,7 @@ exports.StorageRetryPolicyFactory = exports.NewRetryPolicyFactory = exports.Stor
 const StorageRetryPolicy_js_1 = __nccwpck_require__(80);
 Object.defineProperty(exports, "StorageRetryPolicy", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.StorageRetryPolicy; } }));
 Object.defineProperty(exports, "NewRetryPolicyFactory", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.NewRetryPolicyFactory; } }));
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(397);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(396);
 Object.defineProperty(exports, "StorageRetryPolicyType", ({ enumerable: true, get: function () { return StorageRetryPolicyType_js_1.StorageRetryPolicyType; } }));
 /**
  * StorageRetryPolicyFactory is a factory class helping generating {@link StorageRetryPolicy} objects.
@@ -60840,7 +60684,7 @@ exports.StorageRetryPolicyFactory = StorageRetryPolicyFactory;
 
 /***/ }),
 
-/***/ 318:
+/***/ 317:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60946,7 +60790,7 @@ function toArrayBuffer(source) {
 
 /***/ }),
 
-/***/ 319:
+/***/ 318:
 /***/ ((module) => {
 
 "use strict";
@@ -61051,7 +60895,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 320:
+/***/ 319:
 /***/ ((module) => {
 
 "use strict";
@@ -61059,7 +60903,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 321:
+/***/ 320:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -61078,7 +60922,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 322:
+/***/ 321:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61108,7 +60952,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-const path = __importStar(__nccwpck_require__(242));
+const path = __importStar(__nccwpck_require__(241));
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
  * replaced with /.
@@ -61147,7 +60991,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 323:
+/***/ 322:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -61255,7 +61099,7 @@ var WireType;
 
 /***/ }),
 
-/***/ 324:
+/***/ 323:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61265,18 +61109,18 @@ var WireType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatch = void 0;
 const core_util_1 = __nccwpck_require__(12);
-const core_auth_1 = __nccwpck_require__(490);
-const core_rest_pipeline_1 = __nccwpck_require__(100);
+const core_auth_1 = __nccwpck_require__(489);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
 const core_util_2 = __nccwpck_require__(12);
-const storage_common_1 = __nccwpck_require__(271);
-const Clients_js_1 = __nccwpck_require__(181);
-const Mutex_js_1 = __nccwpck_require__(494);
-const Pipeline_js_1 = __nccwpck_require__(179);
+const storage_common_1 = __nccwpck_require__(270);
+const Clients_js_1 = __nccwpck_require__(180);
+const Mutex_js_1 = __nccwpck_require__(493);
+const Pipeline_js_1 = __nccwpck_require__(178);
 const utils_common_js_1 = __nccwpck_require__(153);
-const core_xml_1 = __nccwpck_require__(190);
+const core_xml_1 = __nccwpck_require__(189);
 const constants_js_1 = __nccwpck_require__(147);
 const tracing_js_1 = __nccwpck_require__(29);
-const core_client_1 = __nccwpck_require__(418);
+const core_client_1 = __nccwpck_require__(417);
 /**
  * A BlobBatch represents an aggregated set of operations on blobs.
  * Currently, only `delete` and `setAccessTier` are supported.
@@ -61540,7 +61384,7 @@ function batchHeaderFilterPolicy() {
 
 /***/ }),
 
-/***/ 325:
+/***/ 324:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61549,17 +61393,17 @@ function batchHeaderFilterPolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = exports.AvroReadable = exports.AvroReader = void 0;
-var AvroReader_js_1 = __nccwpck_require__(400);
+var AvroReader_js_1 = __nccwpck_require__(399);
 Object.defineProperty(exports, "AvroReader", ({ enumerable: true, get: function () { return AvroReader_js_1.AvroReader; } }));
-var AvroReadable_js_1 = __nccwpck_require__(370);
+var AvroReadable_js_1 = __nccwpck_require__(369);
 Object.defineProperty(exports, "AvroReadable", ({ enumerable: true, get: function () { return AvroReadable_js_1.AvroReadable; } }));
-var AvroReadableFromStream_js_1 = __nccwpck_require__(246);
+var AvroReadableFromStream_js_1 = __nccwpck_require__(245);
 Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, get: function () { return AvroReadableFromStream_js_1.AvroReadableFromStream; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 326:
+/***/ 325:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61587,10 +61431,10 @@ __export(tracingPolicy_exports, {
 module.exports = __toCommonJS(tracingPolicy_exports);
 var import_core_tracing = __nccwpck_require__(81);
 var import_constants = __nccwpck_require__(157);
-var import_userAgent = __nccwpck_require__(285);
-var import_log = __nccwpck_require__(180);
+var import_userAgent = __nccwpck_require__(284);
+var import_log = __nccwpck_require__(179);
 var import_core_util = __nccwpck_require__(12);
-var import_restError = __nccwpck_require__(340);
+var import_restError = __nccwpck_require__(339);
 var import_util = __nccwpck_require__(145);
 const tracingPolicyName = "tracingPolicy";
 function tracingPolicy(options = {}) {
@@ -61705,7 +61549,7 @@ function tryProcessResponse(span, response) {
 
 /***/ }),
 
-/***/ 327:
+/***/ 326:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61717,14 +61561,14 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher
-} = __nccwpck_require__(353)
+} = __nccwpck_require__(352)
 const Client = __nccwpck_require__(87)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(466)
+} = __nccwpck_require__(465)
 const util = __nccwpck_require__(66)
-const { kUrl, kInterceptors } = __nccwpck_require__(191)
-const buildConnector = __nccwpck_require__(261)
+const { kUrl, kInterceptors } = __nccwpck_require__(190)
+const buildConnector = __nccwpck_require__(260)
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -61821,7 +61665,7 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 328:
+/***/ 327:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61847,7 +61691,7 @@ __export(oauth2AuthenticationPolicy_exports, {
   oauth2AuthenticationPolicyName: () => oauth2AuthenticationPolicyName
 });
 module.exports = __toCommonJS(oauth2AuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(413);
+var import_checkInsecureConnection = __nccwpck_require__(412);
 const oauth2AuthenticationPolicyName = "oauth2AuthenticationPolicy";
 function oauth2AuthenticationPolicy(options) {
   return {
@@ -61873,7 +61717,7 @@ function oauth2AuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 329:
+/***/ 328:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61899,9 +61743,9 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(280);
-var import_checkEnvironment = __nccwpck_require__(417);
-var import_httpHeaders = __nccwpck_require__(463);
+var import_bytesEncoding = __nccwpck_require__(279);
+var import_checkEnvironment = __nccwpck_require__(416);
+var import_httpHeaders = __nccwpck_require__(462);
 const formDataPolicyName = "formDataPolicy";
 function formDataToFormDataMap(formData) {
   const formDataMap = {};
@@ -61989,7 +61833,7 @@ async function prepareFormData(formData, request) {
 
 /***/ }),
 
-/***/ 330:
+/***/ 329:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62015,7 +61859,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const redirectPolicyName = import_policies.redirectPolicyName;
 function redirectPolicy(options = {}) {
   return (0, import_policies.redirectPolicy)(options);
@@ -62026,19 +61870,19 @@ function redirectPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 331:
+/***/ 330:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(191)
+const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(190)
 const { URL } = __nccwpck_require__(84)
 const Agent = __nccwpck_require__(5)
-const Pool = __nccwpck_require__(327)
+const Pool = __nccwpck_require__(326)
 const DispatcherBase = __nccwpck_require__(59)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(466)
-const buildConnector = __nccwpck_require__(261)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(465)
+const buildConnector = __nccwpck_require__(260)
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -62223,18 +62067,18 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 332:
+/***/ 331:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonReader = void 0;
-const json_typings_1 = __nccwpck_require__(377);
-const base64_1 = __nccwpck_require__(294);
-const reflection_info_1 = __nccwpck_require__(431);
-const pb_long_1 = __nccwpck_require__(116);
-const assert_1 = __nccwpck_require__(462);
+const json_typings_1 = __nccwpck_require__(376);
+const base64_1 = __nccwpck_require__(293);
+const reflection_info_1 = __nccwpck_require__(430);
+const pb_long_1 = __nccwpck_require__(117);
+const assert_1 = __nccwpck_require__(461);
 const reflection_long_convert_1 = __nccwpck_require__(156);
 /**
  * Reads proto3 messages in canonical JSON format using reflection information.
@@ -62548,7 +62392,7 @@ exports.ReflectionJsonReader = ReflectionJsonReader;
 
 /***/ }),
 
-/***/ 333:
+/***/ 332:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -62838,7 +62682,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 334:
+/***/ 333:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -62921,7 +62765,7 @@ exports.utf8read = utf8read;
 
 /***/ }),
 
-/***/ 335:
+/***/ 334:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62930,8 +62774,8 @@ exports.utf8read = utf8read;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = createTracingClient;
-const instrumenter_js_1 = __nccwpck_require__(387);
-const tracingContext_js_1 = __nccwpck_require__(354);
+const instrumenter_js_1 = __nccwpck_require__(386);
+const tracingContext_js_1 = __nccwpck_require__(353);
 /**
  * Creates a new tracing client.
  *
@@ -63009,14 +62853,14 @@ function createTracingClient(options) {
 
 /***/ }),
 
-/***/ 336:
+/***/ 335:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(122)
-const Pool = __nccwpck_require__(327)
+const { promisify } = __nccwpck_require__(123)
+const Pool = __nccwpck_require__(326)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
   kDispatches,
@@ -63026,10 +62870,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(448)
+} = __nccwpck_require__(447)
 const { MockInterceptor } = __nccwpck_require__(135)
-const Symbols = __nccwpck_require__(191)
-const { InvalidArgumentError } = __nccwpck_require__(466)
+const Symbols = __nccwpck_require__(190)
+const { InvalidArgumentError } = __nccwpck_require__(465)
 
 /**
  * MockPool provides an API that extends the Pool to influence the mockDispatches.
@@ -63076,7 +62920,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 337:
+/***/ 336:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -63134,7 +62978,7 @@ exports.ClientStreamingCall = ClientStreamingCall;
 
 /***/ }),
 
-/***/ 338:
+/***/ 337:
 /***/ ((module) => {
 
 module.exports = function (xs, fn) {
@@ -63154,7 +62998,7 @@ var isArray = Array.isArray || function (xs) {
 
 /***/ }),
 
-/***/ 339:
+/***/ 338:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -63202,8 +63046,8 @@ exports.createLogger = createLogger;
 exports.colorForceEnvironment = colorForceEnvironment;
 exports.formatLogLine = formatLogLine;
 exports.isTimestampsEnabled = isTimestampsEnabled;
-const core = __importStar(__nccwpck_require__(437));
-const fs = __importStar(__nccwpck_require__(243));
+const core = __importStar(__nccwpck_require__(436));
+const fs = __importStar(__nccwpck_require__(242));
 function makeFileLogger(env) {
     const logPath = (env["SETUP_SOLDR_LOG"] ?? "").trim();
     if (!logPath)
@@ -63325,7 +63169,7 @@ function isTimestampsEnabled(env) {
 
 /***/ }),
 
-/***/ 340:
+/***/ 339:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -63362,7 +63206,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 341:
+/***/ 340:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -63373,11 +63217,11 @@ const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(466)
+} = __nccwpck_require__(465)
 const util = __nccwpck_require__(66)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(185)
-const { AsyncResource } = __nccwpck_require__(407)
-const { addSignal, removeSignal } = __nccwpck_require__(102)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(184)
+const { AsyncResource } = __nccwpck_require__(406)
+const { addSignal, removeSignal } = __nccwpck_require__(103)
 
 class StreamHandler extends AsyncResource {
   constructor (opts, factory, callback) {
@@ -63590,7 +63434,7 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 342:
+/***/ 341:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -63604,9 +63448,9 @@ module.exports = stream
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(211);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(418));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
+const tslib_1 = __nccwpck_require__(210);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(417));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(62));
 /** Class containing BlockBlob operations. */
 class BlockBlobImpl {
@@ -63970,7 +63814,7 @@ const getBlockListOperationSpec = {
 
 /***/ }),
 
-/***/ 343:
+/***/ 342:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -64015,7 +63859,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 344:
+/***/ 343:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -64025,7 +63869,7 @@ function decompressResponsePolicy() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GenericPollOperation = void 0;
 const operation_js_1 = __nccwpck_require__(49);
-const logger_js_1 = __nccwpck_require__(187);
+const logger_js_1 = __nccwpck_require__(186);
 const createStateProxy = () => ({
     initState: (config) => ({ config, isStarted: true }),
     setCanceled: (state) => (state.isCancelled = true),
@@ -64110,7 +63954,7 @@ exports.GenericPollOperation = GenericPollOperation;
 
 /***/ }),
 
-/***/ 345:
+/***/ 344:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -64133,7 +63977,7 @@ function ipRangeToString(ipRange) {
 
 /***/ }),
 
-/***/ 346:
+/***/ 345:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -64159,7 +64003,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(250);
+var import_userAgent = __nccwpck_require__(249);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -64181,7 +64025,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 347:
+/***/ 346:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -64189,7 +64033,7 @@ function userAgentPolicy(options = {}) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getUserAgentString = void 0;
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const packageJson = __nccwpck_require__(446);
+const packageJson = __nccwpck_require__(445);
 /**
  * Ensure that this User Agent String is used in all HTTP calls so that we can monitor telemetry between different versions of this package
  */
@@ -64201,7 +64045,7 @@ exports.getUserAgentString = getUserAgentString;
 
 /***/ }),
 
-/***/ 348:
+/***/ 347:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -64210,8 +64054,8 @@ exports.getUserAgentString = getUserAgentString;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BufferScheduler = void 0;
-const events_1 = __nccwpck_require__(447);
-const PooledBuffer_js_1 = __nccwpck_require__(355);
+const events_1 = __nccwpck_require__(446);
+const PooledBuffer_js_1 = __nccwpck_require__(354);
 /**
  * This class accepts a Node.js Readable stream as input, and keeps reading data
  * from the stream into the internal buffer structure, until it reaches maxBuffers.
@@ -64490,17 +64334,17 @@ exports.BufferScheduler = BufferScheduler;
 
 /***/ }),
 
-/***/ 349:
+/***/ 348:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Blob, File: NativeFile } = __nccwpck_require__(118)
-const { types } = __nccwpck_require__(122)
+const { Blob, File: NativeFile } = __nccwpck_require__(119)
+const { types } = __nccwpck_require__(123)
 const { kState } = __nccwpck_require__(13)
-const { isBlobLike } = __nccwpck_require__(493)
-const { webidl } = __nccwpck_require__(435)
+const { isBlobLike } = __nccwpck_require__(492)
+const { webidl } = __nccwpck_require__(434)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(23)
 const { kEnumerableProperty } = __nccwpck_require__(66)
 const encoder = new TextEncoder()
@@ -64842,27 +64686,27 @@ module.exports = { File, FileLike, isFileLike }
 
 /***/ }),
 
-/***/ 350:
+/***/ 349:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const diagnosticsChannel = __nccwpck_require__(141)
-const { uid, states } = __nccwpck_require__(443)
+const { uid, states } = __nccwpck_require__(442)
 const {
   kReadyState,
   kSentClose,
   kByteParser,
   kReceivedClose
-} = __nccwpck_require__(97)
+} = __nccwpck_require__(98)
 const { fireEvent, failWebsocketConnection } = __nccwpck_require__(54)
-const { CloseEvent } = __nccwpck_require__(244)
+const { CloseEvent } = __nccwpck_require__(243)
 const { makeRequest } = __nccwpck_require__(83)
-const { fetching } = __nccwpck_require__(429)
-const { Headers } = __nccwpck_require__(492)
-const { getGlobalDispatcher } = __nccwpck_require__(360)
-const { kHeadersList } = __nccwpck_require__(191)
+const { fetching } = __nccwpck_require__(428)
+const { Headers } = __nccwpck_require__(491)
+const { getGlobalDispatcher } = __nccwpck_require__(359)
+const { kHeadersList } = __nccwpck_require__(190)
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -64872,7 +64716,7 @@ channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(284)
+  crypto = __nccwpck_require__(283)
 } catch {
 
 }
@@ -65141,7 +64985,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 351:
+/***/ 350:
 /***/ ((module) => {
 
 "use strict";
@@ -65157,7 +65001,7 @@ module.exports = (flag, argv = process.argv) => {
 
 /***/ }),
 
-/***/ 352:
+/***/ 351:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65182,8 +65026,8 @@ __export(restError_exports, {
   createRestError: () => createRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_restError = __nccwpck_require__(423);
-var import_httpHeaders = __nccwpck_require__(463);
+var import_restError = __nccwpck_require__(422);
+var import_httpHeaders = __nccwpck_require__(462);
 function createRestError(messageOrResponse, response) {
   const resp = typeof messageOrResponse === "string" ? response : messageOrResponse;
   const internalError = resp.body?.error ?? resp.body;
@@ -65213,15 +65057,15 @@ function statusCodeToNumber(statusCode) {
 
 /***/ }),
 
-/***/ 353:
+/***/ 352:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const DispatcherBase = __nccwpck_require__(59)
-const FixedQueue = __nccwpck_require__(192)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(191)
+const FixedQueue = __nccwpck_require__(191)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(190)
 const PoolStats = __nccwpck_require__(20)
 
 const kClients = Symbol('clients')
@@ -65415,7 +65259,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 354:
+/***/ 353:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65475,7 +65319,7 @@ exports.TracingContextImpl = TracingContextImpl;
 
 /***/ }),
 
-/***/ 355:
+/***/ 354:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65484,9 +65328,9 @@ exports.TracingContextImpl = TracingContextImpl;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
-const tslib_1 = __nccwpck_require__(211);
-const BuffersStream_js_1 = __nccwpck_require__(368);
-const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(259));
+const tslib_1 = __nccwpck_require__(210);
+const BuffersStream_js_1 = __nccwpck_require__(367);
+const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(258));
 /**
  * maxBufferLength is max size of each buffer in the pooled buffers.
  */
@@ -65582,7 +65426,7 @@ exports.PooledBuffer = PooledBuffer;
 
 /***/ }),
 
-/***/ 356:
+/***/ 355:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65607,7 +65451,7 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_nodeHttpClient = __nccwpck_require__(420);
+var import_nodeHttpClient = __nccwpck_require__(419);
 function createDefaultHttpClient() {
   return (0, import_nodeHttpClient.createNodeHttpClient)();
 }
@@ -65618,16 +65462,16 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 357:
+/***/ 356:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { AsyncResource } = __nccwpck_require__(407)
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(466)
+const { AsyncResource } = __nccwpck_require__(406)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(465)
 const util = __nccwpck_require__(66)
-const { addSignal, removeSignal } = __nccwpck_require__(102)
+const { addSignal, removeSignal } = __nccwpck_require__(103)
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -65730,7 +65574,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 358:
+/***/ 357:
 /***/ ((module) => {
 
 /**
@@ -65899,7 +65743,7 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 359:
+/***/ 358:
 /***/ ((module) => {
 
 "use strict";
@@ -65907,7 +65751,7 @@ module.exports = require("node:util");
 
 /***/ }),
 
-/***/ 360:
+/***/ 359:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65916,7 +65760,7 @@ module.exports = require("node:util");
 // We include a version number for the Dispatcher API. In case of breaking changes,
 // this version number must be increased to avoid conflicts.
 const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
-const { InvalidArgumentError } = __nccwpck_require__(466)
+const { InvalidArgumentError } = __nccwpck_require__(465)
 const Agent = __nccwpck_require__(5)
 
 if (getGlobalDispatcher() === undefined) {
@@ -65947,13 +65791,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 361:
+/***/ 360:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(191)
+const { kClients } = __nccwpck_require__(190)
 const Agent = __nccwpck_require__(5)
 const {
   kAgent,
@@ -65965,14 +65809,14 @@ const {
   kGetNetConnect,
   kOptions,
   kFactory
-} = __nccwpck_require__(448)
-const MockClient = __nccwpck_require__(195)
-const MockPool = __nccwpck_require__(336)
+} = __nccwpck_require__(447)
+const MockClient = __nccwpck_require__(194)
+const MockPool = __nccwpck_require__(335)
 const { matchValue, buildMockOptions } = __nccwpck_require__(7)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(466)
-const Dispatcher = __nccwpck_require__(455)
-const Pluralizer = __nccwpck_require__(248)
-const PendingInterceptorsFormatter = __nccwpck_require__(227)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(465)
+const Dispatcher = __nccwpck_require__(454)
+const Pluralizer = __nccwpck_require__(247)
+const PendingInterceptorsFormatter = __nccwpck_require__(226)
 
 class FakeWeakRef {
   constructor (value) {
@@ -66126,7 +65970,7 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 362:
+/***/ 361:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -66152,7 +65996,7 @@ __export(tlsPolicy_exports, {
   tlsPolicyName: () => tlsPolicyName
 });
 module.exports = __toCommonJS(tlsPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const tlsPolicyName = import_policies.tlsPolicyName;
 function tlsPolicy(tlsSettings) {
   return (0, import_policies.tlsPolicy)(tlsSettings);
@@ -66163,7 +66007,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 363:
+/***/ 362:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -66252,7 +66096,7 @@ exports.AccountSASServices = AccountSASServices;
 
 /***/ }),
 
-/***/ 364:
+/***/ 363:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -66278,7 +66122,7 @@ __export(bearerAuthenticationPolicy_exports, {
   bearerAuthenticationPolicyName: () => bearerAuthenticationPolicyName
 });
 module.exports = __toCommonJS(bearerAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(413);
+var import_checkInsecureConnection = __nccwpck_require__(412);
 const bearerAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function bearerAuthenticationPolicy(options) {
   return {
@@ -66306,7 +66150,7 @@ function bearerAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 365:
+/***/ 364:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66315,7 +66159,7 @@ function bearerAuthenticationPolicy(options) {
 const {
   BalancedPoolMissingUpstreamError,
   InvalidArgumentError
-} = __nccwpck_require__(466)
+} = __nccwpck_require__(465)
 const {
   PoolBase,
   kClients,
@@ -66323,9 +66167,9 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(353)
-const Pool = __nccwpck_require__(327)
-const { kUrl, kInterceptors } = __nccwpck_require__(191)
+} = __nccwpck_require__(352)
+const Pool = __nccwpck_require__(326)
+const { kUrl, kInterceptors } = __nccwpck_require__(190)
 const { parseOrigin } = __nccwpck_require__(66)
 const kFactory = Symbol('factory')
 
@@ -66504,7 +66348,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 366:
+/***/ 365:
 /***/ ((module) => {
 
 "use strict";
@@ -66512,7 +66356,7 @@ module.exports = require("node:os");
 
 /***/ }),
 
-/***/ 367:
+/***/ 366:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -66556,7 +66400,7 @@ function operationOptionsToRequestParameters(options) {
 
 /***/ }),
 
-/***/ 368:
+/***/ 367:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66565,7 +66409,7 @@ function operationOptionsToRequestParameters(options) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BuffersStream = void 0;
-const node_stream_1 = __nccwpck_require__(408);
+const node_stream_1 = __nccwpck_require__(407);
 /**
  * This class generates a readable stream from the data in an array of buffers.
  */
@@ -66664,16 +66508,16 @@ exports.BuffersStream = BuffersStream;
 
 /***/ }),
 
-/***/ 369:
+/***/ 368:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { parseSetCookie } = __nccwpck_require__(402)
-const { stringify } = __nccwpck_require__(390)
-const { webidl } = __nccwpck_require__(435)
-const { Headers } = __nccwpck_require__(492)
+const { parseSetCookie } = __nccwpck_require__(401)
+const { stringify } = __nccwpck_require__(389)
+const { webidl } = __nccwpck_require__(434)
+const { Headers } = __nccwpck_require__(491)
 
 /**
  * @typedef {Object} Cookie
@@ -66855,7 +66699,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 370:
+/***/ 369:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -66871,7 +66715,7 @@ exports.AvroReadable = AvroReadable;
 
 /***/ }),
 
-/***/ 371:
+/***/ 370:
 /***/ ((module) => {
 
 "use strict";
@@ -66879,7 +66723,7 @@ module.exports = require("node:https");
 
 /***/ }),
 
-/***/ 372:
+/***/ 371:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -66905,7 +66749,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(285);
+var import_userAgent = __nccwpck_require__(284);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -66926,17 +66770,17 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 373:
+/***/ 372:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const util = __nccwpck_require__(66)
-const { kBodyUsed } = __nccwpck_require__(191)
+const { kBodyUsed } = __nccwpck_require__(190)
 const assert = __nccwpck_require__(501)
-const { InvalidArgumentError } = __nccwpck_require__(466)
-const EE = __nccwpck_require__(447)
+const { InvalidArgumentError } = __nccwpck_require__(465)
+const EE = __nccwpck_require__(446)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
 
@@ -67155,7 +66999,7 @@ module.exports = RedirectHandler
 
 /***/ }),
 
-/***/ 374:
+/***/ 373:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67181,7 +67025,7 @@ function arraysEqual(a, b) {
 
 /***/ }),
 
-/***/ 375:
+/***/ 374:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67207,7 +67051,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const exponentialRetryPolicyName = import_policies.exponentialRetryPolicyName;
 function exponentialRetryPolicy(options = {}) {
   return (0, import_policies.exponentialRetryPolicy)(options);
@@ -67218,7 +67062,7 @@ function exponentialRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 376:
+/***/ 375:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -67253,7 +67097,7 @@ function randomUUID() {
 
 /***/ }),
 
-/***/ 377:
+/***/ 376:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67286,7 +67130,7 @@ exports.isJsonObject = isJsonObject;
 
 /***/ }),
 
-/***/ 378:
+/***/ 377:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67313,7 +67157,7 @@ __export(exponentialRetryStrategy_exports, {
   isSystemError: () => isSystemError
 });
 module.exports = __toCommonJS(exponentialRetryStrategy_exports);
-var import_delay = __nccwpck_require__(452);
+var import_delay = __nccwpck_require__(451);
 var import_throttlingRetryStrategy = __nccwpck_require__(33);
 const DEFAULT_CLIENT_RETRY_INTERVAL = 1e3;
 const DEFAULT_CLIENT_MAX_RETRY_INTERVAL = 1e3 * 64;
@@ -67359,7 +67203,7 @@ function isSystemError(err) {
 
 /***/ }),
 
-/***/ 379:
+/***/ 378:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67429,7 +67273,7 @@ exports.CacheScope = new CacheScope$Type();
 
 /***/ }),
 
-/***/ 380:
+/***/ 379:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67439,7 +67283,7 @@ exports.CacheScope = new CacheScope$Type();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredential = void 0;
 const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(92);
-const Credential_js_1 = __nccwpck_require__(94);
+const Credential_js_1 = __nccwpck_require__(95);
 /**
  * AnonymousCredential provides a credentialPolicyCreator member used to create
  * AnonymousCredentialPolicy objects. AnonymousCredentialPolicy is used with
@@ -67462,7 +67306,7 @@ exports.AnonymousCredential = AnonymousCredential;
 
 /***/ }),
 
-/***/ 381:
+/***/ 380:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67471,7 +67315,7 @@ exports.AnonymousCredential = AnonymousCredential;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(100);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
 let cachedHttpClient;
 function getCachedDefaultHttpClient() {
     if (!cachedHttpClient) {
@@ -67483,7 +67327,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 382:
+/***/ 381:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67493,7 +67337,7 @@ function getCachedDefaultHttpClient() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getStreamingResponseStatusCodes = getStreamingResponseStatusCodes;
 exports.getPathStringFromParameter = getPathStringFromParameter;
-const serializer_js_1 = __nccwpck_require__(457);
+const serializer_js_1 = __nccwpck_require__(456);
 /**
  * Gets the list of status codes for streaming responses.
  * @internal
@@ -67533,27 +67377,27 @@ function getPathStringFromParameter(parameter) {
 
 /***/ }),
 
-/***/ 383:
+/***/ 382:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobServiceClient = void 0;
-const core_auth_1 = __nccwpck_require__(490);
-const core_rest_pipeline_1 = __nccwpck_require__(100);
+const core_auth_1 = __nccwpck_require__(489);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
 const core_util_1 = __nccwpck_require__(12);
-const Pipeline_js_1 = __nccwpck_require__(179);
+const Pipeline_js_1 = __nccwpck_require__(178);
 const ContainerClient_js_1 = __nccwpck_require__(61);
 const utils_common_js_1 = __nccwpck_require__(153);
-const storage_common_1 = __nccwpck_require__(271);
+const storage_common_1 = __nccwpck_require__(270);
 const utils_common_js_2 = __nccwpck_require__(153);
 const tracing_js_1 = __nccwpck_require__(29);
-const BlobBatchClient_js_1 = __nccwpck_require__(384);
-const StorageClient_js_1 = __nccwpck_require__(433);
+const BlobBatchClient_js_1 = __nccwpck_require__(383);
+const StorageClient_js_1 = __nccwpck_require__(432);
 const AccountSASPermissions_js_1 = __nccwpck_require__(55);
-const AccountSASSignatureValues_js_1 = __nccwpck_require__(281);
-const AccountSASServices_js_1 = __nccwpck_require__(363);
+const AccountSASSignatureValues_js_1 = __nccwpck_require__(280);
+const AccountSASServices_js_1 = __nccwpck_require__(362);
 /**
  * A BlobServiceClient represents a Client to the Azure Storage Blob service allowing you
  * to manipulate blob containers.
@@ -68246,7 +68090,7 @@ exports.BlobServiceClient = BlobServiceClient;
 
 /***/ }),
 
-/***/ 384:
+/***/ 383:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68255,13 +68099,13 @@ exports.BlobServiceClient = BlobServiceClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatchClient = void 0;
-const BatchResponseParser_js_1 = __nccwpck_require__(301);
-const BatchUtils_js_1 = __nccwpck_require__(252);
-const BlobBatch_js_1 = __nccwpck_require__(324);
+const BatchResponseParser_js_1 = __nccwpck_require__(300);
+const BatchUtils_js_1 = __nccwpck_require__(251);
+const BlobBatch_js_1 = __nccwpck_require__(323);
 const tracing_js_1 = __nccwpck_require__(29);
-const storage_common_1 = __nccwpck_require__(271);
-const StorageContextClient_js_1 = __nccwpck_require__(262);
-const Pipeline_js_1 = __nccwpck_require__(179);
+const storage_common_1 = __nccwpck_require__(270);
+const StorageContextClient_js_1 = __nccwpck_require__(261);
+const Pipeline_js_1 = __nccwpck_require__(178);
 const utils_common_js_1 = __nccwpck_require__(153);
 /**
  * A BlobBatchClient allows you to make batched requests to the Azure Storage Blob service.
@@ -68429,15 +68273,15 @@ exports.BlobBatchClient = BlobBatchClient;
 
 /***/ }),
 
-/***/ 385:
+/***/ 384:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const Decoder = __nccwpck_require__(40)
-const decodeText = __nccwpck_require__(270)
-const getLimit = __nccwpck_require__(461)
+const decodeText = __nccwpck_require__(269)
+const getLimit = __nccwpck_require__(460)
 
 const RE_CHARSET = /^charset$/i
 
@@ -68627,7 +68471,7 @@ module.exports = UrlEncoded
 
 /***/ }),
 
-/***/ 386:
+/***/ 385:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -68645,7 +68489,7 @@ exports.MESSAGE_TYPE = Symbol.for("protobuf-ts/message-type");
 
 /***/ }),
 
-/***/ 387:
+/***/ 386:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68657,8 +68501,8 @@ exports.createDefaultTracingSpan = createDefaultTracingSpan;
 exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
-const tracingContext_js_1 = __nccwpck_require__(354);
-const state_js_1 = __nccwpck_require__(95);
+const tracingContext_js_1 = __nccwpck_require__(353);
+const state_js_1 = __nccwpck_require__(96);
 function createDefaultTracingSpan() {
     return {
         end: () => {
@@ -68721,7 +68565,7 @@ function getInstrumenter() {
 
 /***/ }),
 
-/***/ 388:
+/***/ 387:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -68786,9 +68630,9 @@ exports.snapshotSourceMtimes = snapshotSourceMtimes;
 exports.replaySourceMtimes = replaySourceMtimes;
 exports.writeSnapshotFile = writeSnapshotFile;
 exports.readSnapshotFile = readSnapshotFile;
-const fs = __importStar(__nccwpck_require__(243));
-const path = __importStar(__nccwpck_require__(485));
-const node_crypto_1 = __nccwpck_require__(269);
+const fs = __importStar(__nccwpck_require__(242));
+const path = __importStar(__nccwpck_require__(484));
+const node_crypto_1 = __nccwpck_require__(268);
 const normalize_source_mtime_js_1 = __nccwpck_require__(77);
 exports.SNAPSHOT_FILENAME = "setup-soldr-source-mtimes.json";
 async function hashFile(absolute) {
@@ -68958,17 +68802,17 @@ function readSnapshotFile(filePath) {
 
 /***/ }),
 
-/***/ 389:
+/***/ 388:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
-const binary_format_contract_1 = __nccwpck_require__(323);
-const reflection_info_1 = __nccwpck_require__(431);
+const binary_format_contract_1 = __nccwpck_require__(322);
+const reflection_info_1 = __nccwpck_require__(430);
 const reflection_long_convert_1 = __nccwpck_require__(156);
-const reflection_scalar_default_1 = __nccwpck_require__(440);
+const reflection_scalar_default_1 = __nccwpck_require__(439);
 /**
  * Reads proto3 messages in binary format using reflection information.
  *
@@ -69149,7 +68993,7 @@ exports.ReflectionBinaryReader = ReflectionBinaryReader;
 
 /***/ }),
 
-/***/ 390:
+/***/ 389:
 /***/ ((module) => {
 
 "use strict";
@@ -69431,7 +69275,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 391:
+/***/ 390:
 /***/ ((module) => {
 
 "use strict";
@@ -69439,7 +69283,7 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 392:
+/***/ 391:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69465,8 +69309,8 @@ __export(response_exports, {
   toPipelineResponse: () => toPipelineResponse
 });
 module.exports = __toCommonJS(response_exports);
-var import_core_rest_pipeline = __nccwpck_require__(100);
-var import_util = __nccwpck_require__(108);
+var import_core_rest_pipeline = __nccwpck_require__(101);
+var import_util = __nccwpck_require__(109);
 const originalResponse = /* @__PURE__ */ Symbol("Original FullOperationResponse");
 function toCompatResponse(response, options) {
   let request = (0, import_util.toWebResourceLike)(response.request);
@@ -69522,7 +69366,7 @@ function toPipelineResponse(compatResponse) {
 
 /***/ }),
 
-/***/ 393:
+/***/ 392:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -69548,7 +69392,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOptions = void 0;
-const core = __importStar(__nccwpck_require__(437));
+const core = __importStar(__nccwpck_require__(436));
 /**
  * Returns a copy with defaults filled in.
  */
@@ -69579,7 +69423,7 @@ exports.getOptions = getOptions;
 
 /***/ }),
 
-/***/ 394:
+/***/ 393:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69587,7 +69431,7 @@ exports.getOptions = getOptions;
 
 /* istanbul ignore file: only for Node 12 */
 
-const { kConnected, kSize } = __nccwpck_require__(191)
+const { kConnected, kSize } = __nccwpck_require__(190)
 
 class CompatWeakRef {
   constructor (value) {
@@ -69635,7 +69479,7 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 395:
+/***/ 394:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69763,19 +69607,19 @@ function getBlobServiceAccountAudience(storageAccountName) {
 
 /***/ }),
 
-/***/ 396:
+/***/ 395:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(408).Writable)
-const { inherits } = __nccwpck_require__(359)
+const WritableStream = (__nccwpck_require__(407).Writable)
+const { inherits } = __nccwpck_require__(358)
 const Dicer = __nccwpck_require__(11)
 
 const MultipartParser = __nccwpck_require__(0)
-const UrlencodedParser = __nccwpck_require__(385)
-const parseParams = __nccwpck_require__(188)
+const UrlencodedParser = __nccwpck_require__(384)
+const parseParams = __nccwpck_require__(187)
 
 function Busboy (opts) {
   if (!(this instanceof Busboy)) { return new Busboy(opts) }
@@ -69856,7 +69700,7 @@ module.exports.Dicer = Dicer
 
 /***/ }),
 
-/***/ 397:
+/***/ 396:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69883,7 +69727,7 @@ var StorageRetryPolicyType;
 
 /***/ }),
 
-/***/ 398:
+/***/ 397:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -69984,7 +69828,7 @@ exports.getDetails = getDetails;
 
 /***/ }),
 
-/***/ 399:
+/***/ 398:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -69994,7 +69838,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseProxyResponse = void 0;
-const debug_1 = __importDefault(__nccwpck_require__(491));
+const debug_1 = __importDefault(__nccwpck_require__(490));
 const debug = (0, debug_1.default)('https-proxy-agent:parse-proxy-response');
 function parseProxyResponse(socket) {
     return new Promise((resolve, reject) => {
@@ -70092,7 +69936,7 @@ exports.parseProxyResponse = parseProxyResponse;
 
 /***/ }),
 
-/***/ 400:
+/***/ 399:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70103,9 +69947,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReader = void 0;
 // TODO: Do a review of non-interfaces
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
-const AvroConstants_js_1 = __nccwpck_require__(222);
-const AvroParser_js_1 = __nccwpck_require__(293);
-const utils_common_js_1 = __nccwpck_require__(374);
+const AvroConstants_js_1 = __nccwpck_require__(221);
+const AvroParser_js_1 = __nccwpck_require__(292);
+const utils_common_js_1 = __nccwpck_require__(373);
 class AvroReader {
     _dataStream;
     _headerStream;
@@ -70219,7 +70063,7 @@ exports.AvroReader = AvroReader;
 
 /***/ }),
 
-/***/ 401:
+/***/ 400:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70229,13 +70073,13 @@ exports.CacheService = exports.GetCacheEntryDownloadURLResponse = exports.GetCac
 // @generated by protobuf-ts 2.9.1 with parameter long_type_string,client_none,generate_dependencies
 // @generated from protobuf file "results/api/v1/cache.proto" (package "github.actions.results.api.v1", syntax proto3)
 // tslint:disable
-const runtime_rpc_1 = __nccwpck_require__(171);
+const runtime_rpc_1 = __nccwpck_require__(170);
 const runtime_1 = __nccwpck_require__(17);
 const runtime_2 = __nccwpck_require__(17);
 const runtime_3 = __nccwpck_require__(17);
 const runtime_4 = __nccwpck_require__(17);
 const runtime_5 = __nccwpck_require__(17);
-const cachemetadata_1 = __nccwpck_require__(228);
+const cachemetadata_1 = __nccwpck_require__(227);
 // @generated message type with reflection information, may provide speed optimized methods
 class CreateCacheEntryRequest$Type extends runtime_5.MessageType {
     constructor() {
@@ -70628,14 +70472,14 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 
 /***/ }),
 
-/***/ 402:
+/***/ 401:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(126)
-const { isCTLExcludingHtab } = __nccwpck_require__(390)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(127)
+const { isCTLExcludingHtab } = __nccwpck_require__(389)
 const { collectASequenceOfCodePointsFast } = __nccwpck_require__(23)
 const assert = __nccwpck_require__(501)
 
@@ -70953,7 +70797,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 403:
+/***/ 402:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -71021,7 +70865,7 @@ exports.ServerCallContextController = ServerCallContextController;
 
 /***/ }),
 
-/***/ 404:
+/***/ 403:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71031,7 +70875,7 @@ exports.BlobDownloadResponse = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core_util_1 = __nccwpck_require__(12);
-const RetriableReadableStream_js_1 = __nccwpck_require__(470);
+const RetriableReadableStream_js_1 = __nccwpck_require__(469);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -71497,7 +71341,7 @@ exports.BlobDownloadResponse = BlobDownloadResponse;
 
 /***/ }),
 
-/***/ 405:
+/***/ 404:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -71542,7 +71386,7 @@ function storageRequestFailureDetailsParserPolicy() {
 
 /***/ }),
 
-/***/ 406:
+/***/ 405:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -71578,8 +71422,8 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(366));
-var import_node_process = __toESM(__nccwpck_require__(230));
+var import_node_os = __toESM(__nccwpck_require__(365));
+var import_node_process = __toESM(__nccwpck_require__(229));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -71602,7 +71446,7 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 407:
+/***/ 406:
 /***/ ((module) => {
 
 "use strict";
@@ -71610,7 +71454,7 @@ module.exports = require("async_hooks");
 
 /***/ }),
 
-/***/ 408:
+/***/ 407:
 /***/ ((module) => {
 
 "use strict";
@@ -71618,7 +71462,7 @@ module.exports = require("node:stream");
 
 /***/ }),
 
-/***/ 409:
+/***/ 408:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -71672,13 +71516,13 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DefaultGlobber = void 0;
-const core = __importStar(__nccwpck_require__(437));
+const core = __importStar(__nccwpck_require__(436));
 const fs = __importStar(__nccwpck_require__(507));
-const globOptionsHelper = __importStar(__nccwpck_require__(393));
-const path = __importStar(__nccwpck_require__(242));
+const globOptionsHelper = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(241));
 const patternHelper = __importStar(__nccwpck_require__(41));
 const internal_match_kind_1 = __nccwpck_require__(504);
-const internal_pattern_1 = __nccwpck_require__(479);
+const internal_pattern_1 = __nccwpck_require__(478);
 const internal_search_state_1 = __nccwpck_require__(4);
 const IS_WINDOWS = process.platform === 'win32';
 class DefaultGlobber {
@@ -71860,7 +71704,7 @@ exports.DefaultGlobber = DefaultGlobber;
 
 /***/ }),
 
-/***/ 410:
+/***/ 409:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71870,7 +71714,7 @@ exports.DefaultGlobber = DefaultGlobber;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOperationArgumentValueFromParameter = getOperationArgumentValueFromParameter;
 exports.getOperationRequestInfo = getOperationRequestInfo;
-const state_js_1 = __nccwpck_require__(321);
+const state_js_1 = __nccwpck_require__(320);
 /**
  * @internal
  * Retrieves the value to use for a given operation argument
@@ -71965,16 +71809,16 @@ function getOperationRequestInfo(request) {
 
 /***/ }),
 
-/***/ 411:
+/***/ 410:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(466)
-const { AsyncResource } = __nccwpck_require__(407)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(465)
+const { AsyncResource } = __nccwpck_require__(406)
 const util = __nccwpck_require__(66)
-const { addSignal, removeSignal } = __nccwpck_require__(102)
+const { addSignal, removeSignal } = __nccwpck_require__(103)
 const assert = __nccwpck_require__(501)
 
 class UpgradeHandler extends AsyncResource {
@@ -72078,14 +71922,14 @@ module.exports = upgrade
 
 /***/ }),
 
-/***/ 412:
+/***/ 411:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const os = __nccwpck_require__(91);
-const tty = __nccwpck_require__(178);
-const hasFlag = __nccwpck_require__(351);
+const tty = __nccwpck_require__(177);
+const hasFlag = __nccwpck_require__(350);
 
 const {env} = process;
 
@@ -72221,7 +72065,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 413:
+/***/ 412:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -72283,7 +72127,7 @@ function ensureSecureConnection(request, options) {
 
 /***/ }),
 
-/***/ 414:
+/***/ 413:
 /***/ ((module) => {
 
 "use strict";
@@ -72291,14 +72135,14 @@ module.exports = require("node:url");
 
 /***/ }),
 
-/***/ 415:
+/***/ 414:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CacheServiceClientProtobuf = exports.CacheServiceClientJSON = void 0;
-const cache_1 = __nccwpck_require__(401);
+const cache_1 = __nccwpck_require__(400);
 class CacheServiceClientJSON {
     constructor(rpc) {
         this.rpc = rpc;
@@ -72366,7 +72210,7 @@ exports.CacheServiceClientProtobuf = CacheServiceClientProtobuf;
 
 /***/ }),
 
-/***/ 416:
+/***/ 415:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -72415,7 +72259,7 @@ function decodeStringToString(value) {
 
 /***/ }),
 
-/***/ 417:
+/***/ 416:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -72460,7 +72304,7 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 
 /***/ }),
 
-/***/ 418:
+/***/ 417:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72469,31 +72313,31 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.authorizeRequestOnTenantChallenge = exports.authorizeRequestOnClaimChallenge = exports.serializationPolicyName = exports.serializationPolicy = exports.deserializationPolicyName = exports.deserializationPolicy = exports.XML_CHARKEY = exports.XML_ATTRKEY = exports.createClientPipeline = exports.ServiceClient = exports.MapperTypeNames = exports.createSerializer = void 0;
-var serializer_js_1 = __nccwpck_require__(457);
+var serializer_js_1 = __nccwpck_require__(456);
 Object.defineProperty(exports, "createSerializer", ({ enumerable: true, get: function () { return serializer_js_1.createSerializer; } }));
 Object.defineProperty(exports, "MapperTypeNames", ({ enumerable: true, get: function () { return serializer_js_1.MapperTypeNames; } }));
-var serviceClient_js_1 = __nccwpck_require__(305);
+var serviceClient_js_1 = __nccwpck_require__(304);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
-var pipeline_js_1 = __nccwpck_require__(277);
+var pipeline_js_1 = __nccwpck_require__(276);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
-var interfaces_js_1 = __nccwpck_require__(98);
+var interfaces_js_1 = __nccwpck_require__(99);
 Object.defineProperty(exports, "XML_ATTRKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_ATTRKEY; } }));
 Object.defineProperty(exports, "XML_CHARKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_CHARKEY; } }));
 var deserializationPolicy_js_1 = __nccwpck_require__(85);
 Object.defineProperty(exports, "deserializationPolicy", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicy; } }));
 Object.defineProperty(exports, "deserializationPolicyName", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicyName; } }));
-var serializationPolicy_js_1 = __nccwpck_require__(467);
+var serializationPolicy_js_1 = __nccwpck_require__(466);
 Object.defineProperty(exports, "serializationPolicy", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicy; } }));
 Object.defineProperty(exports, "serializationPolicyName", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicyName; } }));
-var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(111);
+var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(112);
 Object.defineProperty(exports, "authorizeRequestOnClaimChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnClaimChallenge_js_1.authorizeRequestOnClaimChallenge; } }));
-var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(169);
+var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(168);
 Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnTenantChallenge_js_1.authorizeRequestOnTenantChallenge; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 419:
+/***/ 418:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -72533,9 +72377,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTar = exports.extractTar = exports.listTar = void 0;
 const exec_1 = __nccwpck_require__(16);
-const io = __importStar(__nccwpck_require__(287));
+const io = __importStar(__nccwpck_require__(286));
 const fs_1 = __nccwpck_require__(507);
-const path = __importStar(__nccwpck_require__(242));
+const path = __importStar(__nccwpck_require__(241));
 const utils = __importStar(__nccwpck_require__(73));
 const constants_1 = __nccwpck_require__(43);
 const IS_WINDOWS = process.platform === 'win32';
@@ -72772,7 +72616,7 @@ exports.createTar = createTar;
 
 /***/ }),
 
-/***/ 420:
+/***/ 419:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -72808,15 +72652,15 @@ __export(nodeHttpClient_exports, {
   getBodyLength: () => getBodyLength
 });
 module.exports = __toCommonJS(nodeHttpClient_exports);
-var import_node_http = __toESM(__nccwpck_require__(258));
-var import_node_https = __toESM(__nccwpck_require__(371));
-var import_node_zlib = __toESM(__nccwpck_require__(495));
-var import_node_stream = __nccwpck_require__(408);
+var import_node_http = __toESM(__nccwpck_require__(257));
+var import_node_https = __toESM(__nccwpck_require__(370));
+var import_node_zlib = __toESM(__nccwpck_require__(494));
+var import_node_stream = __nccwpck_require__(407);
 var import_AbortError = __nccwpck_require__(9);
-var import_httpHeaders = __nccwpck_require__(463);
-var import_restError = __nccwpck_require__(423);
+var import_httpHeaders = __nccwpck_require__(462);
+var import_restError = __nccwpck_require__(422);
 var import_log = __nccwpck_require__(150);
-var import_sanitizer = __nccwpck_require__(120);
+var import_sanitizer = __nccwpck_require__(121);
 const DEFAULT_TLS_SETTINGS = {};
 function isReadableStream(body) {
   return body && typeof body.pipe === "function";
@@ -73121,13 +72965,13 @@ function createNodeHttpClient() {
 
 /***/ }),
 
-/***/ 421:
+/***/ 420:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(435)
+const { webidl } = __nccwpck_require__(434)
 
 const kState = Symbol('ProgressEvent state')
 
@@ -73207,7 +73051,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 422:
+/***/ 421:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -73240,10 +73084,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const crypto = __importStar(__nccwpck_require__(284));
+const crypto = __importStar(__nccwpck_require__(283));
 const fs = __importStar(__nccwpck_require__(507));
 const os = __importStar(__nccwpck_require__(91));
-const utils_1 = __nccwpck_require__(481);
+const utils_1 = __nccwpck_require__(480);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -73276,7 +73120,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 423:
+/***/ 422:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -73304,7 +73148,7 @@ __export(restError_exports, {
 module.exports = __toCommonJS(restError_exports);
 var import_error = __nccwpck_require__(152);
 var import_inspect = __nccwpck_require__(1);
-var import_sanitizer = __nccwpck_require__(120);
+var import_sanitizer = __nccwpck_require__(121);
 const errorSanitizer = new import_sanitizer.Sanitizer();
 class RestError extends Error {
   /**
@@ -73378,7 +73222,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 424:
+/***/ 423:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -73431,7 +73275,7 @@ function wrapAbortSignalLike(abortSignalLike) {
 
 /***/ }),
 
-/***/ 425:
+/***/ 424:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73445,9 +73289,9 @@ function wrapAbortSignalLike(abortSignalLike) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(211);
+const tslib_1 = __nccwpck_require__(210);
 const coreHttpCompat = tslib_1.__importStar(__nccwpck_require__(69));
-const index_js_1 = __nccwpck_require__(272);
+const index_js_1 = __nccwpck_require__(271);
 class StorageClient extends coreHttpCompat.ExtendedServiceClient {
     url;
     version;
@@ -73504,7 +73348,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 426:
+/***/ 425:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73513,36 +73357,36 @@ exports.StorageClient = StorageClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = exports.StorageSharedKeyCredentialPolicy = exports.StorageSharedKeyCredential = exports.StorageRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = exports.Credential = exports.CredentialPolicy = exports.BaseRequestPolicy = exports.AnonymousCredentialPolicy = exports.AnonymousCredential = exports.StorageOAuthScopes = exports.newPipeline = exports.isPipelineLike = exports.Pipeline = exports.getBlobServiceAccountAudience = exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTier = exports.generateBlobSASQueryParameters = exports.generateAccountSASQueryParameters = void 0;
-const tslib_1 = __nccwpck_require__(211);
-const core_rest_pipeline_1 = __nccwpck_require__(100);
+const tslib_1 = __nccwpck_require__(210);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
-tslib_1.__exportStar(__nccwpck_require__(383), exports);
-tslib_1.__exportStar(__nccwpck_require__(181), exports);
+tslib_1.__exportStar(__nccwpck_require__(382), exports);
+tslib_1.__exportStar(__nccwpck_require__(180), exports);
 tslib_1.__exportStar(__nccwpck_require__(61), exports);
-tslib_1.__exportStar(__nccwpck_require__(200), exports);
+tslib_1.__exportStar(__nccwpck_require__(199), exports);
 tslib_1.__exportStar(__nccwpck_require__(55), exports);
 tslib_1.__exportStar(__nccwpck_require__(2), exports);
-tslib_1.__exportStar(__nccwpck_require__(363), exports);
-var AccountSASSignatureValues_js_1 = __nccwpck_require__(281);
+tslib_1.__exportStar(__nccwpck_require__(362), exports);
+var AccountSASSignatureValues_js_1 = __nccwpck_require__(280);
 Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(324), exports);
-tslib_1.__exportStar(__nccwpck_require__(384), exports);
-tslib_1.__exportStar(__nccwpck_require__(170), exports);
-tslib_1.__exportStar(__nccwpck_require__(480), exports);
+tslib_1.__exportStar(__nccwpck_require__(323), exports);
+tslib_1.__exportStar(__nccwpck_require__(383), exports);
+tslib_1.__exportStar(__nccwpck_require__(169), exports);
+tslib_1.__exportStar(__nccwpck_require__(479), exports);
 var BlobSASSignatureValues_js_1 = __nccwpck_require__(65);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(273), exports);
-var models_js_1 = __nccwpck_require__(395);
+tslib_1.__exportStar(__nccwpck_require__(272), exports);
+var models_js_1 = __nccwpck_require__(394);
 Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: function () { return models_js_1.BlockBlobTier; } }));
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
 Object.defineProperty(exports, "getBlobServiceAccountAudience", ({ enumerable: true, get: function () { return models_js_1.getBlobServiceAccountAudience; } }));
-var Pipeline_js_1 = __nccwpck_require__(179);
+var Pipeline_js_1 = __nccwpck_require__(178);
 Object.defineProperty(exports, "Pipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.Pipeline; } }));
 Object.defineProperty(exports, "isPipelineLike", ({ enumerable: true, get: function () { return Pipeline_js_1.isPipelineLike; } }));
 Object.defineProperty(exports, "newPipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.newPipeline; } }));
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return Pipeline_js_1.StorageOAuthScopes; } }));
-var storage_common_1 = __nccwpck_require__(271);
+var storage_common_1 = __nccwpck_require__(270);
 Object.defineProperty(exports, "AnonymousCredential", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredential; } }));
 Object.defineProperty(exports, "AnonymousCredentialPolicy", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredentialPolicy; } }));
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return storage_common_1.BaseRequestPolicy; } }));
@@ -73556,21 +73400,21 @@ Object.defineProperty(exports, "StorageSharedKeyCredentialPolicy", ({ enumerable
 Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
 tslib_1.__exportStar(__nccwpck_require__(500), exports);
-tslib_1.__exportStar(__nccwpck_require__(314), exports);
-var log_js_1 = __nccwpck_require__(105);
+tslib_1.__exportStar(__nccwpck_require__(313), exports);
+var log_js_1 = __nccwpck_require__(106);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 427:
+/***/ 426:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SPECIAL_HEADERS = exports.HEADER_STATE = exports.MINOR = exports.MAJOR = exports.CONNECTION_TOKEN_CHARS = exports.HEADER_CHARS = exports.TOKEN = exports.STRICT_TOKEN = exports.HEX = exports.URL_CHAR = exports.STRICT_URL_CHAR = exports.USERINFO_CHARS = exports.MARK = exports.ALPHANUM = exports.NUM = exports.HEX_MAP = exports.NUM_MAP = exports.ALPHA = exports.FINISH = exports.H_METHOD_MAP = exports.METHOD_MAP = exports.METHODS_RTSP = exports.METHODS_ICE = exports.METHODS_HTTP = exports.METHODS = exports.LENIENT_FLAGS = exports.FLAGS = exports.TYPE = exports.ERROR = void 0;
-const utils_1 = __nccwpck_require__(299);
+const utils_1 = __nccwpck_require__(298);
 // C headers
 var ERROR;
 (function (ERROR) {
@@ -73848,7 +73692,7 @@ exports.SPECIAL_HEADERS = {
 
 /***/ }),
 
-/***/ 428:
+/***/ 427:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -73874,12 +73718,12 @@ __export(sendRequest_exports, {
   sendRequest: () => sendRequest
 });
 module.exports = __toCommonJS(sendRequest_exports);
-var import_restError = __nccwpck_require__(423);
-var import_httpHeaders = __nccwpck_require__(463);
-var import_pipelineRequest = __nccwpck_require__(114);
-var import_clientHelpers = __nccwpck_require__(469);
-var import_typeGuards = __nccwpck_require__(474);
-var import_multipart = __nccwpck_require__(264);
+var import_restError = __nccwpck_require__(422);
+var import_httpHeaders = __nccwpck_require__(462);
+var import_pipelineRequest = __nccwpck_require__(115);
+var import_clientHelpers = __nccwpck_require__(468);
+var import_typeGuards = __nccwpck_require__(473);
+var import_multipart = __nccwpck_require__(263);
 async function sendRequest(method, url, pipeline, options = {}, customHttpClient) {
   const httpClient = customHttpClient ?? (0, import_clientHelpers.getCachedDefaultHttpsClient)();
   const request = buildPipelineRequest(method, url, options);
@@ -74032,7 +73876,7 @@ function createParseError(response, err) {
 
 /***/ }),
 
-/***/ 429:
+/***/ 428:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74047,9 +73891,9 @@ const {
   filterResponse,
   makeResponse
 } = __nccwpck_require__(39)
-const { Headers } = __nccwpck_require__(492)
+const { Headers } = __nccwpck_require__(491)
 const { Request, makeRequest } = __nccwpck_require__(83)
-const zlib = __nccwpck_require__(391)
+const zlib = __nccwpck_require__(390)
 const {
   bytesMatch,
   makePolicyContainer,
@@ -74079,7 +73923,7 @@ const {
   urlIsLocal,
   urlIsHttpHttpsScheme,
   urlHasHttpsScheme
-} = __nccwpck_require__(493)
+} = __nccwpck_require__(492)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(13)
 const assert = __nccwpck_require__(501)
 const { safelyExtractBody } = __nccwpck_require__(22)
@@ -74091,15 +73935,15 @@ const {
   subresourceSet,
   DOMException
 } = __nccwpck_require__(28)
-const { kHeadersList } = __nccwpck_require__(191)
-const EE = __nccwpck_require__(447)
+const { kHeadersList } = __nccwpck_require__(190)
+const EE = __nccwpck_require__(446)
 const { Readable, pipeline } = __nccwpck_require__(130)
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(66)
 const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(23)
-const { TransformStream } = __nccwpck_require__(251)
-const { getGlobalDispatcher } = __nccwpck_require__(360)
-const { webidl } = __nccwpck_require__(435)
-const { STATUS_CODES } = __nccwpck_require__(320)
+const { TransformStream } = __nccwpck_require__(250)
+const { getGlobalDispatcher } = __nccwpck_require__(359)
+const { webidl } = __nccwpck_require__(434)
+const { STATUS_CODES } = __nccwpck_require__(319)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
 /** @type {import('buffer').resolveObjectURL} */
@@ -74841,7 +74685,7 @@ function schemeFetch (fetchParams) {
     }
     case 'blob:': {
       if (!resolveObjectURL) {
-        resolveObjectURL = (__nccwpck_require__(118).resolveObjectURL)
+        resolveObjectURL = (__nccwpck_require__(119).resolveObjectURL)
       }
 
       // 1. Let blobURLEntry be request’s current URL’s blob URL entry.
@@ -75840,7 +75684,7 @@ async function httpNetworkFetch (
   // cancelAlgorithm set to cancelAlgorithm, highWaterMark set to
   // highWaterMark, and sizeAlgorithm set to sizeAlgorithm.
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(251).ReadableStream)
+    ReadableStream = (__nccwpck_require__(250).ReadableStream)
   }
 
   const stream = new ReadableStream(
@@ -76188,7 +76032,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 430:
+/***/ 429:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -76246,14 +76090,14 @@ exports.ServerStreamingCall = ServerStreamingCall;
 
 /***/ }),
 
-/***/ 431:
+/***/ 430:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.readMessageOption = exports.readFieldOption = exports.readFieldOptions = exports.normalizeFieldInfo = exports.RepeatType = exports.LongType = exports.ScalarType = void 0;
-const lower_camel_case_1 = __nccwpck_require__(432);
+const lower_camel_case_1 = __nccwpck_require__(431);
 /**
  * Scalar value types. This is a subset of field types declared by protobuf
  * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
@@ -76412,7 +76256,7 @@ exports.readMessageOption = readMessageOption;
 
 /***/ }),
 
-/***/ 432:
+/***/ 431:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -76455,7 +76299,7 @@ exports.lowerCamelCase = lowerCamelCase;
 
 /***/ }),
 
-/***/ 433:
+/***/ 432:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76464,8 +76308,8 @@ exports.lowerCamelCase = lowerCamelCase;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const StorageContextClient_js_1 = __nccwpck_require__(262);
-const Pipeline_js_1 = __nccwpck_require__(179);
+const StorageContextClient_js_1 = __nccwpck_require__(261);
+const Pipeline_js_1 = __nccwpck_require__(178);
 const utils_common_js_1 = __nccwpck_require__(153);
 /**
  * A StorageClient represents a based URL class for {@link BlobServiceClient}, {@link ContainerClient}
@@ -76518,7 +76362,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 434:
+/***/ 433:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76593,14 +76437,14 @@ function parseHeaderValueAsNumber(response, headerName) {
 
 /***/ }),
 
-/***/ 435:
+/***/ 434:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { types } = __nccwpck_require__(122)
-const { hasOwn, toUSVString } = __nccwpck_require__(493)
+const { types } = __nccwpck_require__(123)
+const { hasOwn, toUSVString } = __nccwpck_require__(492)
 
 /** @type {import('../../types/webidl').Webidl} */
 const webidl = {}
@@ -77247,15 +77091,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 436:
+/***/ 435:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /**
  * Module dependencies.
  */
 
-const tty = __nccwpck_require__(178);
-const util = __nccwpck_require__(122);
+const tty = __nccwpck_require__(177);
+const util = __nccwpck_require__(123);
 
 /**
  * This is the Node.js implementation of `debug()`.
@@ -77281,7 +77125,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = __nccwpck_require__(412);
+	const supportsColor = __nccwpck_require__(411);
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [
@@ -77517,7 +77361,7 @@ formatters.O = function (v) {
 
 /***/ }),
 
-/***/ 437:
+/***/ 436:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -77557,10 +77401,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.platform = exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = exports.markdownSummary = exports.summary = exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(509);
-const file_command_1 = __nccwpck_require__(422);
-const utils_1 = __nccwpck_require__(481);
+const file_command_1 = __nccwpck_require__(421);
+const utils_1 = __nccwpck_require__(480);
 const os = __importStar(__nccwpck_require__(91));
-const path = __importStar(__nccwpck_require__(242));
+const path = __importStar(__nccwpck_require__(241));
 const oidc_utils_1 = __nccwpck_require__(133);
 /**
  * The code to exit an action
@@ -77846,29 +77690,29 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(333);
+var summary_1 = __nccwpck_require__(332);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(333);
+var summary_2 = __nccwpck_require__(332);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(322);
+var path_utils_1 = __nccwpck_require__(321);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
 /**
  * Platform utilities exports
  */
-exports.platform = __importStar(__nccwpck_require__(398));
+exports.platform = __importStar(__nccwpck_require__(397));
 //# sourceMappingURL=core.js.map
 
 /***/ }),
 
-/***/ 438:
+/***/ 437:
 /***/ ((module) => {
 
 "use strict";
@@ -77886,14 +77730,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 439:
+/***/ 438:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionEquals = void 0;
-const reflection_info_1 = __nccwpck_require__(431);
+const reflection_info_1 = __nccwpck_require__(430);
 /**
  * Determines whether two message of the same type have the same field values.
  * Checks for deep equality, traversing repeated fields, oneof groups, maps
@@ -77971,16 +77815,16 @@ function repeatedMsgEq(type, a, b) {
 
 /***/ }),
 
-/***/ 440:
+/***/ 439:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
-const reflection_info_1 = __nccwpck_require__(431);
+const reflection_info_1 = __nccwpck_require__(430);
 const reflection_long_convert_1 = __nccwpck_require__(156);
-const pb_long_1 = __nccwpck_require__(116);
+const pb_long_1 = __nccwpck_require__(117);
 /**
  * Creates the default value for a scalar type.
  */
@@ -78016,7 +77860,7 @@ exports.reflectionScalarDefault = reflectionScalarDefault;
 
 /***/ }),
 
-/***/ 441:
+/***/ 440:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -78054,7 +77898,7 @@ function storageCorrectContentLengthPolicy() {
 
 /***/ }),
 
-/***/ 442:
+/***/ 441:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -78099,7 +77943,7 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 443:
+/***/ 442:
 /***/ ((module) => {
 
 "use strict";
@@ -78158,7 +78002,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 444:
+/***/ 443:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -78183,7 +78027,7 @@ __export(debug_exports, {
   default: () => debug_default
 });
 module.exports = __toCommonJS(debug_exports);
-var import_log = __nccwpck_require__(465);
+var import_log = __nccwpck_require__(464);
 const debugEnvVariable = typeof process !== "undefined" && process.env && process.env.DEBUG || void 0;
 let enabledString;
 let enabledNamespaces = [];
@@ -78348,7 +78192,7 @@ var debug_default = debugObj;
 
 /***/ }),
 
-/***/ 445:
+/***/ 444:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* eslint-env browser */
@@ -78627,7 +78471,7 @@ formatters.j = function (v) {
 
 /***/ }),
 
-/***/ 446:
+/***/ 445:
 /***/ ((module) => {
 
 "use strict";
@@ -78635,7 +78479,7 @@ module.exports = /*#__PURE__*/JSON.parse('{"name":"@actions/cache","version":"4.
 
 /***/ }),
 
-/***/ 447:
+/***/ 446:
 /***/ ((module) => {
 
 "use strict";
@@ -78643,7 +78487,7 @@ module.exports = require("events");
 
 /***/ }),
 
-/***/ 448:
+/***/ 447:
 /***/ ((module) => {
 
 "use strict";
@@ -78674,7 +78518,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 449:
+/***/ 448:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -78948,7 +78792,7 @@ var KnownStorageErrorCode;
 
 /***/ }),
 
-/***/ 450:
+/***/ 449:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -78975,7 +78819,7 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(278);
 const proxyPolicyName = import_policies.proxyPolicyName;
 function getDefaultProxySettings(proxyUrl) {
   return (0, import_policies.getDefaultProxySettings)(proxyUrl);
@@ -78989,7 +78833,7 @@ function proxyPolicy(proxySettings, options) {
 
 /***/ }),
 
-/***/ 451:
+/***/ 450:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -79024,7 +78868,7 @@ exports.attachCredential = attachCredential;
 exports.httpAuthorizationToString = httpAuthorizationToString;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(100);
+const core_rest_pipeline_1 = __nccwpck_require__(101);
 const core_util_1 = __nccwpck_require__(12);
 const constants_js_1 = __nccwpck_require__(34);
 /**
@@ -79569,7 +79413,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 452:
+/***/ 451:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -79594,7 +79438,7 @@ __export(delay_exports, {
   calculateRetryDelay: () => calculateRetryDelay
 });
 module.exports = __toCommonJS(delay_exports);
-var import_random = __nccwpck_require__(483);
+var import_random = __nccwpck_require__(482);
 function calculateRetryDelay(retryAttempt, config) {
   const exponentialDelay = config.retryDelayInMs * Math.pow(2, retryAttempt);
   const clampedDelay = Math.min(config.maxRetryDelayInMs, exponentialDelay);
@@ -79608,7 +79452,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 453:
+/***/ 452:
 /***/ ((module) => {
 
 "use strict";
@@ -79651,7 +79495,7 @@ module.exports = class DecoratorHandler {
 
 /***/ }),
 
-/***/ 454:
+/***/ 453:
 /***/ ((module) => {
 
 "use strict";
@@ -79673,13 +79517,13 @@ module.exports = function basename (path) {
 
 /***/ }),
 
-/***/ 455:
+/***/ 454:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = __nccwpck_require__(447)
+const EventEmitter = __nccwpck_require__(446)
 
 class Dispatcher extends EventEmitter {
   dispatch () {
@@ -79700,7 +79544,7 @@ module.exports = Dispatcher
 
 /***/ }),
 
-/***/ 456:
+/***/ 455:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -79720,7 +79564,7 @@ exports.ServiceType = ServiceType;
 
 /***/ }),
 
-/***/ 457:
+/***/ 456:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -79730,10 +79574,10 @@ exports.ServiceType = ServiceType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
-const tslib_1 = __nccwpck_require__(211);
-const base64 = tslib_1.__importStar(__nccwpck_require__(416));
-const interfaces_js_1 = __nccwpck_require__(98);
-const utils_js_1 = __nccwpck_require__(303);
+const tslib_1 = __nccwpck_require__(210);
+const base64 = tslib_1.__importStar(__nccwpck_require__(415));
+const interfaces_js_1 = __nccwpck_require__(99);
+const utils_js_1 = __nccwpck_require__(302);
 class SerializerImpl {
     modelMappers;
     isXML;
@@ -80653,7 +80497,7 @@ exports.MapperTypeNames = {
 
 /***/ }),
 
-/***/ 458:
+/***/ 457:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80668,7 +80512,7 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 
 /***/ }),
 
-/***/ 459:
+/***/ 458:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80676,10 +80520,10 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 
 const { Writable } = __nccwpck_require__(130)
 const diagnosticsChannel = __nccwpck_require__(141)
-const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(443)
-const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(97)
+const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(442)
+const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(98)
 const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(54)
-const { WebsocketFrameSend } = __nccwpck_require__(183)
+const { WebsocketFrameSend } = __nccwpck_require__(182)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -81020,7 +80864,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 460:
+/***/ 459:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -81080,12 +80924,12 @@ exports.restoreCookCache = restoreCookCache;
 exports.saveCookCache = saveCookCache;
 exports.parseCookFlags = parseCookFlags;
 exports.canonicalizeCookFlags = canonicalizeCookFlags;
-const node_crypto_1 = __nccwpck_require__(269);
-const fs = __importStar(__nccwpck_require__(243));
-const fsp = __importStar(__nccwpck_require__(107));
-const path = __importStar(__nccwpck_require__(485));
+const node_crypto_1 = __nccwpck_require__(268);
+const fs = __importStar(__nccwpck_require__(242));
+const fsp = __importStar(__nccwpck_require__(108));
+const path = __importStar(__nccwpck_require__(484));
 const exec = __importStar(__nccwpck_require__(16));
-const cache = __importStar(__nccwpck_require__(209));
+const cache = __importStar(__nccwpck_require__(208));
 const cache_compress_js_1 = __nccwpck_require__(502);
 const COOK_KEY_PREFIX = "cook";
 /**
@@ -81348,7 +81192,7 @@ function canonicalizeCookFlags(flags) {
 
 /***/ }),
 
-/***/ 461:
+/***/ 460:
 /***/ ((module) => {
 
 "use strict";
@@ -81372,7 +81216,7 @@ module.exports = function getLimit (limits, name, defaultLimit) {
 
 /***/ }),
 
-/***/ 462:
+/***/ 461:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -81423,7 +81267,7 @@ exports.assertFloat32 = assertFloat32;
 
 /***/ }),
 
-/***/ 463:
+/***/ 462:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -81536,10 +81380,10 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 464:
+/***/ 463:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __nccwpck_require__(338);
+var concatMap = __nccwpck_require__(337);
 var balanced = __nccwpck_require__(131);
 
 module.exports = expandTop;
@@ -81746,7 +81590,7 @@ function expand(str, max, isTop) {
 
 /***/ }),
 
-/***/ 465:
+/***/ 464:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -81781,9 +81625,9 @@ __export(log_exports, {
   log: () => log
 });
 module.exports = __toCommonJS(log_exports);
-var import_node_os = __nccwpck_require__(366);
-var import_node_util = __toESM(__nccwpck_require__(359));
-var import_node_process = __toESM(__nccwpck_require__(230));
+var import_node_os = __nccwpck_require__(365);
+var import_node_util = __toESM(__nccwpck_require__(358));
+var import_node_process = __toESM(__nccwpck_require__(229));
 function log(message, ...args) {
   import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
 }
@@ -81794,7 +81638,7 @@ function log(message, ...args) {
 
 /***/ }),
 
-/***/ 466:
+/***/ 465:
 /***/ ((module) => {
 
 "use strict";
@@ -82032,7 +81876,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 467:
+/***/ 466:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82044,10 +81888,10 @@ exports.serializationPolicyName = void 0;
 exports.serializationPolicy = serializationPolicy;
 exports.serializeHeaders = serializeHeaders;
 exports.serializeRequestBody = serializeRequestBody;
-const interfaces_js_1 = __nccwpck_require__(98);
-const operationHelpers_js_1 = __nccwpck_require__(410);
-const serializer_js_1 = __nccwpck_require__(457);
-const interfaceHelpers_js_1 = __nccwpck_require__(382);
+const interfaces_js_1 = __nccwpck_require__(99);
+const operationHelpers_js_1 = __nccwpck_require__(409);
+const serializer_js_1 = __nccwpck_require__(456);
+const interfaceHelpers_js_1 = __nccwpck_require__(381);
 /**
  * The programmatic identifier of the serializationPolicy.
  */
@@ -82196,19 +82040,19 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 /***/ }),
 
-/***/ 468:
+/***/ 467:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(486);
-var tls = __nccwpck_require__(482);
-var http = __nccwpck_require__(320);
+var net = __nccwpck_require__(485);
+var tls = __nccwpck_require__(481);
+var http = __nccwpck_require__(319);
 var https = __nccwpck_require__(67);
-var events = __nccwpck_require__(447);
+var events = __nccwpck_require__(446);
 var assert = __nccwpck_require__(501);
-var util = __nccwpck_require__(122);
+var util = __nccwpck_require__(123);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -82468,7 +82312,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 469:
+/***/ 468:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -82494,14 +82338,14 @@ __export(clientHelpers_exports, {
   getCachedDefaultHttpsClient: () => getCachedDefaultHttpsClient
 });
 module.exports = __toCommonJS(clientHelpers_exports);
-var import_defaultHttpClient = __nccwpck_require__(356);
-var import_createPipelineFromOptions = __nccwpck_require__(306);
-var import_apiVersionPolicy = __nccwpck_require__(220);
-var import_credentials = __nccwpck_require__(184);
+var import_defaultHttpClient = __nccwpck_require__(355);
+var import_createPipelineFromOptions = __nccwpck_require__(305);
+var import_apiVersionPolicy = __nccwpck_require__(219);
+var import_credentials = __nccwpck_require__(183);
 var import_apiKeyAuthenticationPolicy = __nccwpck_require__(86);
 var import_basicAuthenticationPolicy = __nccwpck_require__(151);
-var import_bearerAuthenticationPolicy = __nccwpck_require__(364);
-var import_oauth2AuthenticationPolicy = __nccwpck_require__(328);
+var import_bearerAuthenticationPolicy = __nccwpck_require__(363);
+var import_oauth2AuthenticationPolicy = __nccwpck_require__(327);
 let cachedHttpClient;
 function createDefaultPipeline(options = {}) {
   const pipeline = (0, import_createPipelineFromOptions.createPipelineFromOptions)(options);
@@ -82541,7 +82385,7 @@ function getCachedDefaultHttpsClient() {
 
 /***/ }),
 
-/***/ 470:
+/***/ 469:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82550,8 +82394,8 @@ function getCachedDefaultHttpsClient() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetriableReadableStream = void 0;
-const abort_controller_1 = __nccwpck_require__(473);
-const node_stream_1 = __nccwpck_require__(408);
+const abort_controller_1 = __nccwpck_require__(472);
+const node_stream_1 = __nccwpck_require__(407);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -82679,6 +82523,21 @@ exports.RetriableReadableStream = RetriableReadableStream;
 
 /***/ }),
 
+/***/ 470:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.AbortError = void 0;
+var AbortError_js_1 = __nccwpck_require__(476);
+Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
 /***/ 471:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -82688,7 +82547,7 @@ exports.RetriableReadableStream = RetriableReadableStream;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(477);
+var AbortError_js_1 = __nccwpck_require__(474);
 Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
 //# sourceMappingURL=index.js.map
 
@@ -82710,21 +82569,6 @@ Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function 
 /***/ }),
 
 /***/ 473:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(476);
-Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
-//# sourceMappingURL=index.js.map
-
-/***/ }),
-
-/***/ 474:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -82774,6 +82618,44 @@ function isBlob(x) {
 0 && (0);
 //# sourceMappingURL=typeGuards.js.map
 
+
+/***/ }),
+
+/***/ 474:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.AbortError = void 0;
+/**
+ * This error is thrown when an asynchronous operation has been aborted.
+ * Check for this error by testing the `name` that the name property of the
+ * error matches `"AbortError"`.
+ *
+ * @example
+ * ```ts
+ * const controller = new AbortController();
+ * controller.abort();
+ * try {
+ *   doAsyncWork(controller.signal)
+ * } catch (e) {
+ *   if (e.name === 'AbortError') {
+ *     // handle abort error here.
+ *   }
+ * }
+ * ```
+ */
+class AbortError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "AbortError";
+    }
+}
+exports.AbortError = AbortError;
+//# sourceMappingURL=AbortError.js.map
 
 /***/ }),
 
@@ -82854,44 +82736,6 @@ exports.AbortError = AbortError;
 /***/ }),
 
 /***/ 477:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AbortError = void 0;
-/**
- * This error is thrown when an asynchronous operation has been aborted.
- * Check for this error by testing the `name` that the name property of the
- * error matches `"AbortError"`.
- *
- * @example
- * ```ts
- * const controller = new AbortController();
- * controller.abort();
- * try {
- *   doAsyncWork(controller.signal)
- * } catch (e) {
- *   if (e.name === 'AbortError') {
- *     // handle abort error here.
- *   }
- * }
- * ```
- */
-class AbortError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = "AbortError";
-    }
-}
-exports.AbortError = AbortError;
-//# sourceMappingURL=AbortError.js.map
-
-/***/ }),
-
-/***/ 478:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82900,8 +82744,8 @@ exports.AbortError = AbortError;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQuickQueryStream = void 0;
-const node_stream_1 = __nccwpck_require__(408);
-const index_js_1 = __nccwpck_require__(325);
+const node_stream_1 = __nccwpck_require__(407);
+const index_js_1 = __nccwpck_require__(324);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -83018,7 +82862,7 @@ exports.BlobQuickQueryStream = BlobQuickQueryStream;
 
 /***/ }),
 
-/***/ 479:
+/***/ 478:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -83048,12 +82892,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
 const os = __importStar(__nccwpck_require__(91));
-const path = __importStar(__nccwpck_require__(242));
-const pathHelper = __importStar(__nccwpck_require__(216));
+const path = __importStar(__nccwpck_require__(241));
+const pathHelper = __importStar(__nccwpck_require__(215));
 const assert_1 = __importDefault(__nccwpck_require__(501));
-const minimatch_1 = __nccwpck_require__(123);
+const minimatch_1 = __nccwpck_require__(124);
 const internal_match_kind_1 = __nccwpck_require__(504);
-const internal_path_1 = __nccwpck_require__(119);
+const internal_path_1 = __nccwpck_require__(120);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, isImplicitPattern = false, segments, homedir) {
@@ -83280,7 +83124,7 @@ exports.Pattern = Pattern;
 
 /***/ }),
 
-/***/ 480:
+/***/ 479:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -83484,7 +83328,7 @@ exports.BlobSASPermissions = BlobSASPermissions;
 
 /***/ }),
 
-/***/ 481:
+/***/ 480:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -83531,7 +83375,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 482:
+/***/ 481:
 /***/ ((module) => {
 
 "use strict";
@@ -83539,7 +83383,7 @@ module.exports = require("tls");
 
 /***/ }),
 
-/***/ 483:
+/***/ 482:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -83577,7 +83421,7 @@ function getRandomIntegerInclusive(min, max) {
 
 /***/ }),
 
-/***/ 484:
+/***/ 483:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -83649,7 +83493,7 @@ function readRawInputs(env) {
 
 /***/ }),
 
-/***/ 485:
+/***/ 484:
 /***/ ((module) => {
 
 "use strict";
@@ -83657,7 +83501,7 @@ module.exports = require("node:path");
 
 /***/ }),
 
-/***/ 486:
+/***/ 485:
 /***/ ((module) => {
 
 "use strict";
@@ -83665,7 +83509,7 @@ module.exports = require("net");
 
 /***/ }),
 
-/***/ 487:
+/***/ 486:
 /***/ ((module) => {
 
 "use strict";
@@ -83673,7 +83517,7 @@ module.exports = require("timers");
 
 /***/ }),
 
-/***/ 488:
+/***/ 487:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -83683,11 +83527,11 @@ const Readable = __nccwpck_require__(128)
 const {
   InvalidArgumentError,
   RequestAbortedError
-} = __nccwpck_require__(466)
+} = __nccwpck_require__(465)
 const util = __nccwpck_require__(66)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(185)
-const { AsyncResource } = __nccwpck_require__(407)
-const { addSignal, removeSignal } = __nccwpck_require__(102)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(184)
+const { AsyncResource } = __nccwpck_require__(406)
+const { addSignal, removeSignal } = __nccwpck_require__(103)
 
 class RequestHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -83861,7 +83705,7 @@ module.exports.RequestHandler = RequestHandler
 
 /***/ }),
 
-/***/ 489:
+/***/ 488:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -83877,14 +83721,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TestTransport = void 0;
-const rpc_error_1 = __nccwpck_require__(172);
+const rpc_error_1 = __nccwpck_require__(171);
 const runtime_1 = __nccwpck_require__(17);
-const rpc_output_stream_1 = __nccwpck_require__(298);
-const rpc_options_1 = __nccwpck_require__(286);
+const rpc_output_stream_1 = __nccwpck_require__(297);
+const rpc_options_1 = __nccwpck_require__(285);
 const unary_call_1 = __nccwpck_require__(53);
-const server_streaming_call_1 = __nccwpck_require__(430);
-const client_streaming_call_1 = __nccwpck_require__(337);
-const duplex_streaming_call_1 = __nccwpck_require__(297);
+const server_streaming_call_1 = __nccwpck_require__(429);
+const client_streaming_call_1 = __nccwpck_require__(336);
+const duplex_streaming_call_1 = __nccwpck_require__(296);
 /**
  * Transport for testing.
  */
@@ -84190,14 +84034,14 @@ class TestInputStream {
 
 /***/ }),
 
-/***/ 490:
+/***/ 489:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isTokenCredential = exports.isSASCredential = exports.AzureSASCredential = exports.isNamedKeyCredential = exports.AzureNamedKeyCredential = exports.isKeyCredential = exports.AzureKeyCredential = void 0;
-var azureKeyCredential_js_1 = __nccwpck_require__(290);
+var azureKeyCredential_js_1 = __nccwpck_require__(289);
 Object.defineProperty(exports, "AzureKeyCredential", ({ enumerable: true, get: function () { return azureKeyCredential_js_1.AzureKeyCredential; } }));
 var keyCredential_js_1 = __nccwpck_require__(36);
 Object.defineProperty(exports, "isKeyCredential", ({ enumerable: true, get: function () { return keyCredential_js_1.isKeyCredential; } }));
@@ -84207,13 +84051,13 @@ Object.defineProperty(exports, "isNamedKeyCredential", ({ enumerable: true, get:
 var azureSASCredential_js_1 = __nccwpck_require__(31);
 Object.defineProperty(exports, "AzureSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.AzureSASCredential; } }));
 Object.defineProperty(exports, "isSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.isSASCredential; } }));
-var tokenCredential_js_1 = __nccwpck_require__(241);
+var tokenCredential_js_1 = __nccwpck_require__(240);
 Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: function () { return tokenCredential_js_1.isTokenCredential; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 491:
+/***/ 490:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /**
@@ -84222,15 +84066,15 @@ Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: fu
  */
 
 if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
-	module.exports = __nccwpck_require__(445);
+	module.exports = __nccwpck_require__(444);
 } else {
-	module.exports = __nccwpck_require__(436);
+	module.exports = __nccwpck_require__(435);
 }
 
 
 /***/ }),
 
-/***/ 492:
+/***/ 491:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84238,16 +84082,16 @@ if (typeof process === 'undefined' || process.type === 'renderer' || process.bro
 
 
 
-const { kHeadersList, kConstruct } = __nccwpck_require__(191)
+const { kHeadersList, kConstruct } = __nccwpck_require__(190)
 const { kGuard } = __nccwpck_require__(13)
 const { kEnumerableProperty } = __nccwpck_require__(66)
 const {
   makeIterator,
   isValidHeaderName,
   isValidHeaderValue
-} = __nccwpck_require__(493)
-const util = __nccwpck_require__(122)
-const { webidl } = __nccwpck_require__(435)
+} = __nccwpck_require__(492)
+const util = __nccwpck_require__(123)
+const { webidl } = __nccwpck_require__(434)
 const assert = __nccwpck_require__(501)
 
 const kHeadersMap = Symbol('headers map')
@@ -84831,7 +84675,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 493:
+/***/ 492:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84839,10 +84683,10 @@ module.exports = {
 
 const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(28)
 const { getGlobalOrigin } = __nccwpck_require__(139)
-const { performance } = __nccwpck_require__(311)
+const { performance } = __nccwpck_require__(310)
 const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(66)
 const assert = __nccwpck_require__(501)
-const { isUint8Array } = __nccwpck_require__(194)
+const { isUint8Array } = __nccwpck_require__(193)
 
 let supportedHashes = []
 
@@ -84851,7 +84695,7 @@ let supportedHashes = []
 let crypto
 
 try {
-  crypto = __nccwpck_require__(284)
+  crypto = __nccwpck_require__(283)
   const possibleRelevantHashes = ['sha256', 'sha384', 'sha512']
   supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
 /* c8 ignore next 3 */
@@ -85804,7 +85648,7 @@ let ReadableStream = globalThis.ReadableStream
 
 function isReadableStreamLike (stream) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(251).ReadableStream)
+    ReadableStream = (__nccwpck_require__(250).ReadableStream)
   }
 
   return stream instanceof ReadableStream || (
@@ -85983,7 +85827,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 494:
+/***/ 493:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -86059,7 +85903,7 @@ exports.Mutex = Mutex;
 
 /***/ }),
 
-/***/ 495:
+/***/ 494:
 /***/ ((module) => {
 
 "use strict";
@@ -86067,15 +85911,15 @@ module.exports = require("node:zlib");
 
 /***/ }),
 
-/***/ 496:
+/***/ 495:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(468);
+module.exports = __nccwpck_require__(467);
 
 
 /***/ }),
 
-/***/ 497:
+/***/ 496:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -86120,7 +85964,7 @@ function throttlingRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 498:
+/***/ 497:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -86146,7 +85990,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(378);
+var import_exponentialRetryStrategy = __nccwpck_require__(377);
 var import_retryPolicy = __nccwpck_require__(14);
 var import_constants = __nccwpck_require__(46);
 const exponentialRetryPolicyName = "exponentialRetryPolicy";
@@ -86166,6 +86010,431 @@ function exponentialRetryPolicy(options = {}) {
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=exponentialRetryPolicy.js.map
+
+
+/***/ }),
+
+/***/ 498:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr#98 PR3 — insights-mode renderer + GitHub annotation builder.
+// setup-soldr#98 PR4 — multi-step session aggregator + roll-up renderer.
+//
+// PR3 surface (insights):
+//   - `renderInsights(payload)` consumes the `diagnoses[]` array shipped by
+//     `soldr cache report --json` (schema defined in zackees/soldr#321) and
+//     produces a Markdown block (per-diagnosis <details> with severity emoji,
+//     headline, evidence tables, suggested_fix blockquote) plus a list of
+//     GitHub workflow-command annotations (::warning::/::notice:: with
+//     optional file= pins) ready to forward to core.warning / core.notice.
+//
+// PR4 surface (multi-step aggregation):
+//   - `collectArchivedSessionStats(archiveDir)` walks
+//     `<cache-dir>/logs/archive/<session-id>/last-session-stats.json`
+//     (the soldr#379 `--archive-logs` layout) and returns one parsed JSON
+//     object per session.
+//   - `aggregateSessions(statsFiles)` rolls every per-session payload up
+//     into a single `MultiSessionRollup` (totals + weighted hit rate +
+//     per-session breakdown).
+//   - `renderMultiSessionRollup(rollup)` emits a collapsed <details>
+//     block titled "Multi-step roll-up (N sessions)" with the aggregate
+//     scalars at the top and a per-session table beneath. Renders the
+//     empty string when sessionCount <= 1 so the existing single-session
+//     surface stays the single source of truth on jobs that only run one
+//     cargo command.
+//
+// All renderers are pure — no I/O, no @actions/* imports — so they stay
+// trivially unit-testable. The post-step wires their output into the
+// step-summary append + the @actions/core annotation surface.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.renderInsights = renderInsights;
+exports.collectArchivedSessionStats = collectArchivedSessionStats;
+exports.aggregateSessions = aggregateSessions;
+exports.renderMultiSessionRollup = renderMultiSessionRollup;
+const fs = __importStar(__nccwpck_require__(242));
+const path = __importStar(__nccwpck_require__(484));
+/** Markdown table cell escaping — keeps the table grid intact. */
+function cell(value) {
+    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+/**
+ * Severity → leading emoji. Maps "high" to a red circle (loudest signal in
+ * a step summary), "medium" to yellow, "low" to green. Unknown severities
+ * fall back to the medium glyph so the renderer never throws on a typo
+ * from a future soldr release.
+ */
+function severityEmoji(severity) {
+    switch ((severity ?? "").toLowerCase()) {
+        case "high":
+            return "🔴";
+        case "medium":
+            return "🟡";
+        case "low":
+            return "🟢";
+        default:
+            return "🟡";
+    }
+}
+/**
+ * Severity → GitHub workflow-command verb. "high" gets `::warning::` so it
+ * surfaces in the PR Files-Changed view; "medium"/"low" get `::notice::`
+ * (less intrusive — annotation-tray only). Unknown severities default to
+ * notice, the more conservative choice.
+ */
+function severityCommand(severity) {
+    return (severity ?? "").toLowerCase() === "high" ? "warning" : "notice";
+}
+/** Human-readable ms → seconds when ≥ 1s, otherwise verbatim ms. */
+function fmtMs(ms) {
+    if (!Number.isFinite(ms) || ms < 0)
+        return `${ms} ms`;
+    if (ms >= 1000)
+        return `${(ms / 1000).toFixed(1)}s`;
+    return `${ms} ms`;
+}
+/**
+ * Strip newlines from a string before splicing it into a GitHub workflow
+ * command. The `::warning ::<msg>` syntax breaks if `<msg>` contains a
+ * literal `\n` (the runner stops parsing at the line break). URL-encoded
+ * `%0A` is the documented escape; the actions/core library uses the same
+ * transform internally.
+ */
+function escapeAnnotationMessage(msg) {
+    return msg.replace(/\r?\n/g, "%0A").replace(/\r/g, "%0D");
+}
+/**
+ * Pull the first miss-reason entry that has a file path. Used to pin the
+ * workflow annotation to a specific source file when one is available.
+ * Falls back to undefined when no entry carries a file (e.g. all misses
+ * are flag-driven).
+ */
+function pickFile(evidence) {
+    const top = evidence?.miss_reasons_top;
+    if (!Array.isArray(top))
+        return undefined;
+    for (const entry of top) {
+        if (entry && typeof entry.file === "string" && entry.file.length > 0) {
+            return entry.file;
+        }
+    }
+    return undefined;
+}
+function renderMissReasonsTable(rows) {
+    if (rows.length === 0)
+        return [];
+    const out = [];
+    out.push("| Category | File/Flag | Misses |");
+    out.push("| --- | --- | --- |");
+    for (const row of rows) {
+        const category = typeof row.category === "string" ? row.category : "";
+        const fileOrFlag = typeof row.file === "string" && row.file.length > 0
+            ? row.file
+            : typeof row.flag === "string"
+                ? row.flag
+                : "";
+        const misses = typeof row.misses === "number" && Number.isFinite(row.misses)
+            ? String(row.misses)
+            : "";
+        out.push(`| ${cell(category)} | ${cell(fileOrFlag)} | ${misses} |`);
+    }
+    return out;
+}
+function renderSlowestMissesList(rows) {
+    if (rows.length === 0)
+        return [];
+    const out = ["", "**Slowest misses:**", ""];
+    for (const row of rows) {
+        const crateName = typeof row.crate === "string" ? row.crate : "(unknown)";
+        const ms = typeof row.ms === "number" ? row.ms : 0;
+        const reason = typeof row.miss_reason === "string" ? row.miss_reason : "";
+        const reasonText = reason ? ` — ${reason}` : "";
+        out.push(`- ${crateName}: ${fmtMs(ms)} (${ms} ms)${reasonText}`);
+    }
+    return out;
+}
+function renderOneDiagnosis(diag) {
+    const emoji = severityEmoji(diag.severity);
+    const headline = typeof diag.headline === "string" ? diag.headline : "(no headline)";
+    const lines = [];
+    lines.push("<details>");
+    lines.push(`<summary>${emoji} ${headline}</summary>`);
+    lines.push("");
+    const evidence = diag.evidence;
+    const missRows = Array.isArray(evidence?.miss_reasons_top)
+        ? evidence.miss_reasons_top
+        : [];
+    if (missRows.length > 0) {
+        lines.push("**Top miss reasons:**", "");
+        lines.push(...renderMissReasonsTable(missRows));
+    }
+    const slowest = Array.isArray(evidence?.slowest_misses)
+        ? evidence.slowest_misses
+        : [];
+    if (slowest.length > 0) {
+        lines.push(...renderSlowestMissesList(slowest));
+    }
+    if (evidence && typeof evidence.wasted_ms === "number" && Number.isFinite(evidence.wasted_ms)) {
+        lines.push("", `**Wasted compile time:** ${fmtMs(evidence.wasted_ms)}`);
+    }
+    if (typeof diag.suggested_fix === "string" && diag.suggested_fix.length > 0) {
+        lines.push("");
+        // Render the suggested fix as a Markdown blockquote so it stands
+        // out from the evidence body — the user's eye goes straight to the
+        // "what do I do about this" line.
+        lines.push(`> ${diag.suggested_fix}`);
+    }
+    lines.push("");
+    lines.push("</details>");
+    return lines;
+}
+function buildAnnotation(diag) {
+    const verb = severityCommand(diag.severity);
+    const file = pickFile(diag.evidence);
+    const headline = typeof diag.headline === "string" ? diag.headline : "(no headline)";
+    const message = escapeAnnotationMessage(headline);
+    if (file) {
+        return `::${verb} file=${file},line=1::${message}`;
+    }
+    return `::${verb}::${message}`;
+}
+/**
+ * Render the insights surface from a parsed `soldr cache report --json`
+ * payload. Tolerant of every optional field — a payload from an older
+ * soldr (no `diagnoses` array) returns an empty result without throwing.
+ */
+function renderInsights(payload) {
+    const raw = payload?.["diagnoses"];
+    if (!Array.isArray(raw) || raw.length === 0) {
+        return { markdown: "", annotations: [] };
+    }
+    const diagnoses = raw;
+    const markdownChunks = [];
+    const annotations = [];
+    for (const diag of diagnoses) {
+        markdownChunks.push(...renderOneDiagnosis(diag));
+        annotations.push(buildAnnotation(diag));
+    }
+    return {
+        markdown: markdownChunks.join("\n"),
+        annotations,
+    };
+}
+/** Number coercion that tolerates undefined / non-finite values. */
+function numField(stats, key) {
+    const value = stats[key];
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+function strField(stats, key) {
+    const value = stats[key];
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+/**
+ * Walk `<archiveDir>/<session-id>/last-session-stats.json` and return one
+ * parsed JSON object per session. Missing dir → empty array (most common
+ * case — first run of a job, no archive present yet). Invalid JSON
+ * entries are silently skipped so one corrupt file doesn't poison the
+ * whole roll-up. Non-object payloads are also skipped.
+ */
+function collectArchivedSessionStats(archiveDir) {
+    if (!archiveDir)
+        return [];
+    let entries;
+    try {
+        const stat = fs.statSync(archiveDir);
+        if (!stat.isDirectory())
+            return [];
+        entries = fs.readdirSync(archiveDir, { withFileTypes: true });
+    }
+    catch {
+        return [];
+    }
+    const out = [];
+    for (const ent of entries) {
+        if (!ent.isDirectory())
+            continue;
+        const statsPath = path.join(archiveDir, ent.name, "last-session-stats.json");
+        let raw;
+        try {
+            raw = fs.readFileSync(statsPath, "utf8");
+        }
+        catch {
+            continue;
+        }
+        let parsed;
+        try {
+            parsed = JSON.parse(raw);
+        }
+        catch {
+            continue;
+        }
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+            continue;
+        const stats = parsed;
+        // Default the session_id to the on-disk dir name if the JSON itself
+        // didn't carry one — gives the per-session table something to render
+        // even when older soldr versions skipped writing the field.
+        if (typeof stats["session_id"] !== "string") {
+            stats["session_id"] = ent.name;
+        }
+        out.push(stats);
+    }
+    return out;
+}
+/**
+ * Roll a list of per-session `last-session-stats.json` payloads up into
+ * one aggregate. Entries with `status` != "ok" (e.g. "missing", "invalid")
+ * are skipped — they carry no compilation counters worth summing.
+ */
+function aggregateSessions(statsFiles) {
+    let totalHits = 0;
+    let totalMisses = 0;
+    let totalCompilations = 0;
+    let totalTimeSavedMs = 0;
+    let totalBytesRead = 0;
+    let totalBytesWritten = 0;
+    const sessions = [];
+    for (const raw of statsFiles) {
+        if (!raw || typeof raw !== "object")
+            continue;
+        const status = strField(raw, "status");
+        // Treat a missing `status` as "ok" so callers that hand us a bare
+        // last_session payload (no envelope status field) still aggregate.
+        if (status !== undefined && status !== "ok")
+            continue;
+        const hits = numField(raw, "hits") ?? 0;
+        const misses = numField(raw, "misses") ?? 0;
+        const compilations = numField(raw, "compilations") ?? hits + misses;
+        const timeSavedMs = numField(raw, "time_saved_ms") ?? 0;
+        const bytesRead = numField(raw, "bytes_read") ?? 0;
+        const bytesWritten = numField(raw, "bytes_written") ?? 0;
+        const hitRate = numField(raw, "hit_rate") ?? null;
+        const sessionId = strField(raw, "session_id") ?? `session-${sessions.length + 1}`;
+        totalHits += hits;
+        totalMisses += misses;
+        totalCompilations += compilations;
+        totalTimeSavedMs += timeSavedMs;
+        totalBytesRead += bytesRead;
+        totalBytesWritten += bytesWritten;
+        sessions.push({ sessionId, hits, misses, hitRate, timeSavedMs });
+    }
+    const overallHitRate = totalCompilations > 0 ? totalHits / totalCompilations : null;
+    return {
+        sessionCount: sessions.length,
+        totalHits,
+        totalMisses,
+        totalCompilations,
+        overallHitRate,
+        totalTimeSavedMs,
+        totalBytesRead,
+        totalBytesWritten,
+        sessions,
+    };
+}
+/** ms → "12.4s" / "850 ms" — matches the existing PR1 single-session table. */
+function fmtMsRollup(ms) {
+    if (!Number.isFinite(ms) || ms < 0)
+        return `${ms} ms`;
+    if (ms >= 1000)
+        return `${(ms / 1000).toFixed(1)}s`;
+    return `${ms} ms`;
+}
+/** bytes → "412.0 MB" etc — same scale as post.ts's fmtBytes. */
+function fmtBytesRollup(n) {
+    if (!Number.isFinite(n) || n < 0)
+        return `${n} B`;
+    if (n >= 1_073_741_824)
+        return `${(n / 1_073_741_824).toFixed(1)} GB`;
+    if (n >= 1_048_576)
+        return `${(n / 1_048_576).toFixed(1)} MB`;
+    if (n >= 1_024)
+        return `${(n / 1_024).toFixed(1)} KB`;
+    return `${n} B`;
+}
+/** Percentage formatter with the trailing "%". Null/undefined → "n/a". */
+function fmtPct(rate) {
+    if (rate === null || rate === undefined || !Number.isFinite(rate))
+        return "n/a";
+    return `${(rate * 100).toFixed(1)}%`;
+}
+/** Cell-escape pipes and newlines to keep the Markdown table grid intact. */
+function rollupCell(value) {
+    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+/**
+ * Render the multi-step roll-up as a Markdown `<details>` block titled
+ * "Multi-step roll-up (N sessions)". Aggregate scalars table sits at the
+ * top, per-session table below. Returns the empty string when the job
+ * only saw one session (or none) — the existing single-session renderer
+ * already covers that case and a roll-up would be redundant noise.
+ */
+function renderMultiSessionRollup(rollup) {
+    if (rollup.sessionCount <= 1)
+        return "";
+    const lines = [];
+    lines.push("<details>");
+    lines.push(`<summary>Multi-step roll-up (${rollup.sessionCount} sessions)</summary>`);
+    lines.push("");
+    lines.push("| Metric | Value |");
+    lines.push("| --- | --- |");
+    lines.push(`| Sessions | ${rollup.sessionCount} |`);
+    lines.push(`| Total compilations | ${rollup.totalCompilations} |`);
+    lines.push(`| Total hits | ${rollup.totalHits} |`);
+    lines.push(`| Total misses | ${rollup.totalMisses} |`);
+    lines.push(`| Overall hit rate | ${fmtPct(rollup.overallHitRate)} |`);
+    if (rollup.totalTimeSavedMs > 0) {
+        lines.push(`| Time saved (est.) | ${fmtMsRollup(rollup.totalTimeSavedMs)} |`);
+    }
+    if (rollup.totalBytesRead > 0) {
+        lines.push(`| Bytes read | ${fmtBytesRollup(rollup.totalBytesRead)} |`);
+    }
+    if (rollup.totalBytesWritten > 0) {
+        lines.push(`| Bytes written | ${fmtBytesRollup(rollup.totalBytesWritten)} |`);
+    }
+    lines.push("");
+    lines.push("| Session | Hits | Misses | Hit rate | Time saved |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const row of rollup.sessions) {
+        lines.push(`| ${rollupCell(row.sessionId)} | ${row.hits} | ${row.misses} | ${fmtPct(row.hitRate)} | ${fmtMsRollup(row.timeSavedMs)} |`);
+    }
+    lines.push("");
+    lines.push("</details>");
+    return lines.join("\n");
+}
 
 
 /***/ }),
@@ -86393,7 +86662,7 @@ function createEmptyPipeline() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SASQueryParameters = exports.SASProtocol = void 0;
-const SasIPRange_js_1 = __nccwpck_require__(345);
+const SasIPRange_js_1 = __nccwpck_require__(344);
 const utils_common_js_1 = __nccwpck_require__(153);
 /**
  * Protocols for generated SAS.
@@ -86817,11 +87086,11 @@ exports.walkDirSize = walkDirSize;
 exports.detectCompressMagic = detectCompressMagic;
 exports.decompressCache = decompressCache;
 exports.compressCache = compressCache;
-const fs = __importStar(__nccwpck_require__(107));
-const path = __importStar(__nccwpck_require__(485));
-const core = __importStar(__nccwpck_require__(437));
+const fs = __importStar(__nccwpck_require__(108));
+const path = __importStar(__nccwpck_require__(484));
+const core = __importStar(__nccwpck_require__(436));
 const exec = __importStar(__nccwpck_require__(16));
-const io = __importStar(__nccwpck_require__(287));
+const io = __importStar(__nccwpck_require__(286));
 /**
  * Recursively walk a directory and sum file sizes.
  */
@@ -87052,7 +87321,7 @@ function parseLevel(value) {
  * Bubbles non-zero exit codes from either side.
  */
 async function runPipe(producer, consumer) {
-    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 193, 23));
+    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 192, 23));
     const [pCmd, pArgs] = producer;
     const [cCmd, cArgs] = consumer;
     await new Promise((resolve, reject) => {
@@ -87256,7 +87525,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.shutdownCacheDaemons = shutdownCacheDaemons;
 const exec = __importStar(__nccwpck_require__(16));
-const io = __importStar(__nccwpck_require__(287));
+const io = __importStar(__nccwpck_require__(286));
 async function exists(cmd) {
     try {
         await io.which(cmd, true);
@@ -87381,19 +87650,19 @@ async function shutdownCacheDaemons(opts) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(386);
-const reflection_info_1 = __nccwpck_require__(431);
-const reflection_type_check_1 = __nccwpck_require__(282);
-const reflection_json_reader_1 = __nccwpck_require__(332);
+const message_type_contract_1 = __nccwpck_require__(385);
+const reflection_info_1 = __nccwpck_require__(430);
+const reflection_type_check_1 = __nccwpck_require__(281);
+const reflection_json_reader_1 = __nccwpck_require__(331);
 const reflection_json_writer_1 = __nccwpck_require__(89);
-const reflection_binary_reader_1 = __nccwpck_require__(389);
-const reflection_binary_writer_1 = __nccwpck_require__(182);
-const reflection_create_1 = __nccwpck_require__(201);
+const reflection_binary_reader_1 = __nccwpck_require__(388);
+const reflection_binary_writer_1 = __nccwpck_require__(181);
+const reflection_create_1 = __nccwpck_require__(200);
 const reflection_merge_partial_1 = __nccwpck_require__(136);
-const json_typings_1 = __nccwpck_require__(377);
-const json_format_contract_1 = __nccwpck_require__(235);
-const reflection_equals_1 = __nccwpck_require__(439);
-const binary_writer_1 = __nccwpck_require__(245);
+const json_typings_1 = __nccwpck_require__(376);
+const json_format_contract_1 = __nccwpck_require__(234);
+const reflection_equals_1 = __nccwpck_require__(438);
+const binary_writer_1 = __nccwpck_require__(244);
 const binary_reader_1 = __nccwpck_require__(134);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
 const messageTypeDescriptor = baseDescriptors[message_type_contract_1.MESSAGE_TYPE] = {};
@@ -87680,7 +87949,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
 const os = __importStar(__nccwpck_require__(91));
-const utils_1 = __nccwpck_require__(481);
+const utils_1 = __nccwpck_require__(480);
 /**
  * Commands
  *
@@ -87762,7 +88031,7 @@ function escapeProperty(s) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBeginCopyFromUrlPoller = void 0;
 const core_util_1 = __nccwpck_require__(12);
-const core_lro_1 = __nccwpck_require__(219);
+const core_lro_1 = __nccwpck_require__(218);
 /**
  * This is the poller returned by {@link BlobClient.beginCopyFromURL}.
  * This can not be instantiated directly outside of this package.
@@ -88076,7 +88345,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(127);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(94);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/src/lib/compile-cache-stats.ts
+++ b/src/lib/compile-cache-stats.ts
@@ -1,18 +1,35 @@
 // setup-soldr#98 PR3 — insights-mode renderer + GitHub annotation builder.
+// setup-soldr#98 PR4 — multi-step session aggregator + roll-up renderer.
 //
-// Consumes the `diagnoses[]` array shipped by `soldr cache report --json`
-// (schema defined in zackees/soldr#321) and produces:
+// PR3 surface (insights):
+//   - `renderInsights(payload)` consumes the `diagnoses[]` array shipped by
+//     `soldr cache report --json` (schema defined in zackees/soldr#321) and
+//     produces a Markdown block (per-diagnosis <details> with severity emoji,
+//     headline, evidence tables, suggested_fix blockquote) plus a list of
+//     GitHub workflow-command annotations (::warning::/::notice:: with
+//     optional file= pins) ready to forward to core.warning / core.notice.
 //
-//   - A Markdown block (per-diagnosis <details> with severity emoji,
-//     headline, evidence tables, and a suggested_fix blockquote) suitable
-//     for appending to $GITHUB_STEP_SUMMARY.
-//   - A list of GitHub workflow-command annotations
-//     (::warning::/::notice:: with optional file= pins) ready to be
-//     forwarded to core.warning / core.notice in the post-step runner.
+// PR4 surface (multi-step aggregation):
+//   - `collectArchivedSessionStats(archiveDir)` walks
+//     `<cache-dir>/logs/archive/<session-id>/last-session-stats.json`
+//     (the soldr#379 `--archive-logs` layout) and returns one parsed JSON
+//     object per session.
+//   - `aggregateSessions(statsFiles)` rolls every per-session payload up
+//     into a single `MultiSessionRollup` (totals + weighted hit rate +
+//     per-session breakdown).
+//   - `renderMultiSessionRollup(rollup)` emits a collapsed <details>
+//     block titled "Multi-step roll-up (N sessions)" with the aggregate
+//     scalars at the top and a per-session table beneath. Renders the
+//     empty string when sessionCount <= 1 so the existing single-session
+//     surface stays the single source of truth on jobs that only run one
+//     cargo command.
 //
-// The renderer is pure — no I/O, no @actions/* imports — so it stays
-// trivially unit-testable. The post-step wires its output into the
+// All renderers are pure — no I/O, no @actions/* imports — so they stay
+// trivially unit-testable. The post-step wires their output into the
 // step-summary append + the @actions/core annotation surface.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 interface MissReason {
   category?: string;
@@ -227,4 +244,221 @@ export function renderInsights(payload: Record<string, unknown>): InsightsRender
     markdown: markdownChunks.join("\n"),
     annotations,
   };
+}
+
+// ---------------------------------------------------------------------------
+// PR4 — Multi-step session aggregation.
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-session row inside a multi-step roll-up. Mirrors the four scalars a
+ * downstream consumer most often wants to surface (session id, hits,
+ * misses, hit rate, wall-clock saved). `hitRate` is null when the session
+ * payload didn't carry one (very old soldr, or zero compilations).
+ */
+export interface MultiSessionRow {
+  sessionId: string;
+  hits: number;
+  misses: number;
+  hitRate: number | null;
+  timeSavedMs: number;
+}
+
+/**
+ * Roll-up over every per-invocation `last-session-stats.json` archived
+ * under `<cache-dir>/logs/archive/<session-id>/`. `overallHitRate` is
+ * weighted across compilations (NOT the unweighted mean of per-session
+ * rates) so a job that runs `cargo build` + `cargo test` reports a hit
+ * rate that reflects actual cache effectiveness across the whole job.
+ * `null` when no compilations happened across any session — never NaN.
+ */
+export interface MultiSessionRollup {
+  sessionCount: number;
+  totalHits: number;
+  totalMisses: number;
+  totalCompilations: number;
+  overallHitRate: number | null;
+  totalTimeSavedMs: number;
+  totalBytesRead: number;
+  totalBytesWritten: number;
+  sessions: MultiSessionRow[];
+}
+
+/** Number coercion that tolerates undefined / non-finite values. */
+function numField(stats: Record<string, unknown>, key: string): number | undefined {
+  const value = stats[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function strField(stats: Record<string, unknown>, key: string): string | undefined {
+  const value = stats[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Walk `<archiveDir>/<session-id>/last-session-stats.json` and return one
+ * parsed JSON object per session. Missing dir → empty array (most common
+ * case — first run of a job, no archive present yet). Invalid JSON
+ * entries are silently skipped so one corrupt file doesn't poison the
+ * whole roll-up. Non-object payloads are also skipped.
+ */
+export function collectArchivedSessionStats(archiveDir: string): Array<Record<string, unknown>> {
+  if (!archiveDir) return [];
+  let entries: fs.Dirent[];
+  try {
+    const stat = fs.statSync(archiveDir);
+    if (!stat.isDirectory()) return [];
+    entries = fs.readdirSync(archiveDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: Array<Record<string, unknown>> = [];
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    const statsPath = path.join(archiveDir, ent.name, "last-session-stats.json");
+    let raw: string;
+    try {
+      raw = fs.readFileSync(statsPath, "utf8");
+    } catch {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+    const stats = parsed as Record<string, unknown>;
+    // Default the session_id to the on-disk dir name if the JSON itself
+    // didn't carry one — gives the per-session table something to render
+    // even when older soldr versions skipped writing the field.
+    if (typeof stats["session_id"] !== "string") {
+      stats["session_id"] = ent.name;
+    }
+    out.push(stats);
+  }
+  return out;
+}
+
+/**
+ * Roll a list of per-session `last-session-stats.json` payloads up into
+ * one aggregate. Entries with `status` != "ok" (e.g. "missing", "invalid")
+ * are skipped — they carry no compilation counters worth summing.
+ */
+export function aggregateSessions(
+  statsFiles: Array<Record<string, unknown>>,
+): MultiSessionRollup {
+  let totalHits = 0;
+  let totalMisses = 0;
+  let totalCompilations = 0;
+  let totalTimeSavedMs = 0;
+  let totalBytesRead = 0;
+  let totalBytesWritten = 0;
+  const sessions: MultiSessionRow[] = [];
+  for (const raw of statsFiles) {
+    if (!raw || typeof raw !== "object") continue;
+    const status = strField(raw, "status");
+    // Treat a missing `status` as "ok" so callers that hand us a bare
+    // last_session payload (no envelope status field) still aggregate.
+    if (status !== undefined && status !== "ok") continue;
+    const hits = numField(raw, "hits") ?? 0;
+    const misses = numField(raw, "misses") ?? 0;
+    const compilations = numField(raw, "compilations") ?? hits + misses;
+    const timeSavedMs = numField(raw, "time_saved_ms") ?? 0;
+    const bytesRead = numField(raw, "bytes_read") ?? 0;
+    const bytesWritten = numField(raw, "bytes_written") ?? 0;
+    const hitRate = numField(raw, "hit_rate") ?? null;
+    const sessionId = strField(raw, "session_id") ?? `session-${sessions.length + 1}`;
+    totalHits += hits;
+    totalMisses += misses;
+    totalCompilations += compilations;
+    totalTimeSavedMs += timeSavedMs;
+    totalBytesRead += bytesRead;
+    totalBytesWritten += bytesWritten;
+    sessions.push({ sessionId, hits, misses, hitRate, timeSavedMs });
+  }
+  const overallHitRate = totalCompilations > 0 ? totalHits / totalCompilations : null;
+  return {
+    sessionCount: sessions.length,
+    totalHits,
+    totalMisses,
+    totalCompilations,
+    overallHitRate,
+    totalTimeSavedMs,
+    totalBytesRead,
+    totalBytesWritten,
+    sessions,
+  };
+}
+
+/** ms → "12.4s" / "850 ms" — matches the existing PR1 single-session table. */
+function fmtMsRollup(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return `${ms} ms`;
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${ms} ms`;
+}
+
+/** bytes → "412.0 MB" etc — same scale as post.ts's fmtBytes. */
+function fmtBytesRollup(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return `${n} B`;
+  if (n >= 1_073_741_824) return `${(n / 1_073_741_824).toFixed(1)} GB`;
+  if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(1)} MB`;
+  if (n >= 1_024) return `${(n / 1_024).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+/** Percentage formatter with the trailing "%". Null/undefined → "n/a". */
+function fmtPct(rate: number | null | undefined): string {
+  if (rate === null || rate === undefined || !Number.isFinite(rate)) return "n/a";
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+/** Cell-escape pipes and newlines to keep the Markdown table grid intact. */
+function rollupCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+/**
+ * Render the multi-step roll-up as a Markdown `<details>` block titled
+ * "Multi-step roll-up (N sessions)". Aggregate scalars table sits at the
+ * top, per-session table below. Returns the empty string when the job
+ * only saw one session (or none) — the existing single-session renderer
+ * already covers that case and a roll-up would be redundant noise.
+ */
+export function renderMultiSessionRollup(rollup: MultiSessionRollup): string {
+  if (rollup.sessionCount <= 1) return "";
+  const lines: string[] = [];
+  lines.push("<details>");
+  lines.push(`<summary>Multi-step roll-up (${rollup.sessionCount} sessions)</summary>`);
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| Sessions | ${rollup.sessionCount} |`);
+  lines.push(`| Total compilations | ${rollup.totalCompilations} |`);
+  lines.push(`| Total hits | ${rollup.totalHits} |`);
+  lines.push(`| Total misses | ${rollup.totalMisses} |`);
+  lines.push(`| Overall hit rate | ${fmtPct(rollup.overallHitRate)} |`);
+  if (rollup.totalTimeSavedMs > 0) {
+    lines.push(`| Time saved (est.) | ${fmtMsRollup(rollup.totalTimeSavedMs)} |`);
+  }
+  if (rollup.totalBytesRead > 0) {
+    lines.push(`| Bytes read | ${fmtBytesRollup(rollup.totalBytesRead)} |`);
+  }
+  if (rollup.totalBytesWritten > 0) {
+    lines.push(`| Bytes written | ${fmtBytesRollup(rollup.totalBytesWritten)} |`);
+  }
+  lines.push("");
+  lines.push("| Session | Hits | Misses | Hit rate | Time saved |");
+  lines.push("| --- | --- | --- | --- | --- |");
+  for (const row of rollup.sessions) {
+    lines.push(
+      `| ${rollupCell(row.sessionId)} | ${row.hits} | ${row.misses} | ${fmtPct(
+        row.hitRate,
+      )} | ${fmtMsRollup(row.timeSavedMs)} |`,
+    );
+  }
+  lines.push("");
+  lines.push("</details>");
+  return lines.join("\n");
 }

--- a/src/post.ts
+++ b/src/post.ts
@@ -20,7 +20,13 @@ import { saveMiniCache } from "./lib/soldr-mini-cache.js";
 import { createLogger } from "./lib/log-utils.js";
 import { shutdownCacheDaemons } from "./lib/shutdown-cache.js";
 import { StatsCollector } from "./lib/stats-collector.js";
-import { renderInsights } from "./lib/compile-cache-stats.js";
+import {
+  aggregateSessions,
+  collectArchivedSessionStats,
+  renderInsights,
+  renderMultiSessionRollup,
+  type MultiSessionRollup,
+} from "./lib/compile-cache-stats.js";
 import { captureProcessSnapshot, dumpDiagnostics, loggingEnabled } from "./lib/diagnostics.js";
 import { readRawInputs } from "./lib/raw-inputs.js";
 import {
@@ -91,6 +97,14 @@ export interface FinalCacheSummary {
   zccache_session: ZccacheSessionSummary;
   /** Added in setup-soldr#98. Populated by post-step from `soldr cache report --json`. */
   compile_cache_report: SoldrCacheReportSummary;
+  /**
+   * Added in setup-soldr#98 PR4. Roll-up over every per-invocation session
+   * archived under `<build-cache>/logs/archive/<session-id>/` via
+   * `soldr cache shutdown --archive-logs` (soldr#379). Present unconditionally
+   * but `sessionCount` is 0 on jobs where no archive directory was created
+   * (e.g. soldr too old, or only one cargo command ran with no archival).
+   */
+  multi_session_rollup: MultiSessionRollup;
 }
 
 interface RestoreState {
@@ -428,6 +442,14 @@ export function buildFinalCacheSummary(
     }),
     zccache_session: readZccacheSessionSummary(result.buildCache.path),
     compile_cache_report: readSoldrCacheReport(process.env["SOLDR_BINARY"]?.trim(), passthrough),
+    // PR4 — walk the per-session archive that soldr#379's
+    // `cache shutdown --archive-logs` populates between cargo invocations
+    // and roll the per-session stats up into a single job-wide aggregate.
+    // Empty archive (no archival happened, or only one session ran) leaves
+    // `sessionCount=0`, which makes the renderer / outputs no-op.
+    multi_session_rollup: aggregateSessions(
+      collectArchivedSessionStats(path.join(result.buildCache.path, "logs", "archive")),
+    ),
   };
 }
 
@@ -626,6 +648,16 @@ export function formatFinalCacheSummaryMarkdown(
   summary: FinalCacheSummary,
   compileCacheStats: CompileCacheStatsMode = "summarize",
 ): string {
+  // PR4 — multi-step roll-up. Renders only when >1 sessions were
+  // archived AND the user didn't opt out via compile-cache-stats=none.
+  // The block sits between the layer table and the per-session compile
+  // cache section so the high-level "what happened across the whole job"
+  // signal lands first, with the per-invocation breakdown beneath.
+  const multiStepBlock =
+    compileCacheStats !== "none"
+      ? renderMultiSessionRollup(summary.multi_session_rollup)
+      : "";
+  const multiStepLines = multiStepBlock.length > 0 ? ["", multiStepBlock] : [];
   const lines = [
     "## setup-soldr final cache summary",
     "",
@@ -635,6 +667,7 @@ export function formatFinalCacheSummaryMarkdown(
     `| ${tableRow("target cache", summary.target_cache)} |`,
     `| ${tableRow("build cache", summary.build_cache)} |`,
     `| ${tableRow("cargo registry cache", summary.cargo_registry_cache)} |`,
+    ...multiStepLines,
     "",
     "### zccache session",
     "",
@@ -652,6 +685,23 @@ export function formatFinalCacheSummaryMarkdown(
     "",
   ];
   return `${lines.join("\n")}\n`;
+}
+
+/**
+ * PR4 — emit the multi-step roll-up's scalar outputs. Skipped when
+ * `sessionCount <= 1` so single-session jobs don't surface a misleading
+ * roll-up to downstream workflow steps. Exported so the post-step `run()`
+ * function and the contract tests can drive it the same way.
+ */
+export function setMultiSessionOutputs(rollup: {
+  sessionCount: number;
+  overallHitRate: number | null;
+}): void {
+  if (rollup.sessionCount <= 1) return;
+  core.setOutput("compile-cache-sessions-total", String(rollup.sessionCount));
+  if (rollup.overallHitRate !== null && Number.isFinite(rollup.overallHitRate)) {
+    core.setOutput("compile-cache-overall-hit-rate", String(rollup.overallHitRate));
+  }
 }
 
 function logFinalCacheSummary(summary: FinalCacheSummary, log: (msg: string) => void): void {
@@ -1242,6 +1292,11 @@ export async function run(): Promise<void> {
   logFinalCacheSummary(finalSummary, log);
   if (compileCacheStats !== "none") {
     setCompileCacheOutputs(finalSummary.compile_cache_report, compileCacheStats);
+    // PR4 — surface the two job-wide scalar outputs alongside the
+    // existing per-session outputs. The setter no-ops when the archive
+    // walker didn't find >1 sessions, so single-session jobs see no
+    // change in behavior.
+    setMultiSessionOutputs(finalSummary.multi_session_rollup);
   }
   writeStepSummary(formatFinalCacheSummaryMarkdown(finalSummary, compileCacheStats), log);
 

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -115,6 +115,8 @@ EXPECTED_OUTPUTS = {
     "compile-cache-bytes-written",
     "compile-cache-rollups-json",
     "compile-cache-summary-json",
+    "compile-cache-sessions-total",
+    "compile-cache-overall-hit-rate",
 }
 
 


### PR DESCRIPTION
## Summary

Final PR of the setup-soldr#98 rollout (PRs 1, 2, 3 already shipped). Walks the per-session archive that soldr#379's `cache shutdown --archive-logs` populates between cargo invocations and rolls every per-session payload into one job-wide aggregate, surfaced as both a `$GITHUB_STEP_SUMMARY` block and scalar action outputs.

- Closes #98 (final PR of 4 in the rollout — PRs 1, 2, 3 already shipped).
- Wave 1.2 of zackees/soldr#514. Closes #98 will auto-close zackees/soldr#321 (parent epic) via sub-issue tracking.
- TDD verified: 19 new tests written first, all initially red before implementation, all green after.

## What ships

### Aggregator (`src/lib/compile-cache-stats.ts`)

Three new pure functions (no I/O outside `collectArchivedSessionStats`'s fs walk, no `@actions/*` imports — all unit-testable):

- `collectArchivedSessionStats(archiveDir)` — walks `<archive>/<session-id>/last-session-stats.json` files and returns parsed payloads. Missing dir, invalid JSON, and non-object payloads are silently skipped so one corrupt file doesn't poison the roll-up.
- `aggregateSessions(statsFiles)` — sums hits/misses/compilations/time-saved/bytes-read/bytes-written across every `status: "ok"` entry. `overallHitRate` is **weighted** (totalHits / totalCompilations), not the unweighted mean of per-session rates. Returns `null` (never NaN) when no compilations happened.
- `renderMultiSessionRollup(rollup)` — emits a collapsed `<details>` block titled "Multi-step roll-up (N sessions)" with an aggregate-scalars table at the top and a per-session table beneath. Returns `""` when `sessionCount <= 1` so the existing single-session surface stays the single source of truth on jobs that only ran one cargo command.

### Post-step wiring (`src/post.ts`)

- `FinalCacheSummary.multi_session_rollup: MultiSessionRollup` — populated unconditionally in `buildFinalCacheSummary` from `<build-cache>/logs/archive/`. `sessionCount: 0` on jobs without an archive dir, so the renderer / outputs no-op naturally.
- The roll-up block is spliced into `formatFinalCacheSummaryMarkdown` between the layer table and the per-session compile cache section. Works in all three rendering modes (`summarize`, `detailed`, `insights`); suppressed by `compile-cache-stats: none`.
- New exported `setMultiSessionOutputs({sessionCount, overallHitRate})` — skipped when `sessionCount <= 1` so downstream workflow steps can use `if: \${{ steps.setup.outputs.compile-cache-sessions-total }}` as a feature gate.

### Action outputs (`action.yml`)

Two new scalar outputs, consistent with PR1's `compile-cache-*` naming:

| Output | Source |
|---|---|
| `compile-cache-sessions-total` | `rollup.sessionCount` (only set when > 1) |
| `compile-cache-overall-hit-rate` | `rollup.overallHitRate` weighted across the job (0.0–1.0) |

`tests/test_action_target_cache_wiring.py`'s `EXPECTED_OUTPUTS` set extended so the public-surface contract test stays green.

## Test plan (TDD)

- [x] Wrote 19 PR4 tests first against the PR3 baseline (`__tests__/compile-cache-stats.test.ts`). All 19 were RED before any implementation landed — confirmed via `node --test compile-cache-stats.test.ts` → `pass 23, fail 18` (one test was a typo'd module-shape check that also went green naturally once the aggregator was exported, total newly-asserted contract: 19 cases).
- [x] Implemented `aggregateSessions` + `collectArchivedSessionStats` + `renderMultiSessionRollup` in `src/lib/compile-cache-stats.ts`.
- [x] Wired the rollup into `buildFinalCacheSummary` and `formatFinalCacheSummaryMarkdown` in `src/post.ts`.
- [x] Added `setMultiSessionOutputs` export + wired into `run()` after the existing `setCompileCacheOutputs` call.
- [x] Extended action.yml with two new outputs + updated `EXPECTED_OUTPUTS` contract test.
- [x] All tests GREEN: `npm test` → `384 passed, 0 failed, 5 skipped` (was 365 before this PR).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` regenerates `dist/post.js`.
- [x] Python contract test green: `pytest tests/test_action_target_cache_wiring.py` → `3 passed`.

## Invariants preserved

- Single-session path is unchanged on jobs that ran one cargo command. `renderMultiSessionRollup` returns `""` and `setMultiSessionOutputs` is a no-op when `sessionCount <= 1`.
- No new external dependencies — reuses `node:fs` / `node:path` for the archive walk and the existing `@actions/core` for output writes.
- `compile-cache-stats: none` continues to suppress every compile-cache surface (including the new roll-up block).
- Works with whatever `soldr cache shutdown --archive-logs <dir>` already produces — no soldr-side changes needed.