### PR TITLE
fix(bench): repair cache-mode methodology

### DIFF
--- a/.github/workflows/bench-cache-modes.yml
+++ b/.github/workflows/bench-cache-modes.yml
@@ -73,6 +73,32 @@ jobs:
       - name: Install Rust (stable, default profile)
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Build in-tree action
+        run: |
+          npm ci
+          npm run build
+
+      - name: Capture pre-soldr toolchain snapshot
+        if: ${{ matrix.layer == 'solo-toolchain' }}
+        env:
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          node scripts/bench-cache-cell.mjs \
+            --layer=solo-toolchain \
+            --workload=${{ inputs.workload }} \
+            --rep=${{ matrix.rep }} \
+            --pre-snapshot-out=${{ runner.temp }}/bench-solo-toolchain-pre.json
+
+      - name: Install and wire zccache
+        uses: ./
+        with:
+          cache: false
+          build-cache: false
+          target-cache: false
+          cargo-registry-cache: false
+          shims: true
+
       - name: Ensure zstd present (linux/macos preinstalled; windows ships bsdtar)
         shell: bash
         run: |
@@ -87,11 +113,17 @@ jobs:
         env:
           RUNNER_OS: ${{ runner.os }}
           RUNNER_TEMP: ${{ runner.temp }}
+          # cache:false disables actions/cache writes during the setup step.
+          # Re-enable soldr's local zccache wrapper for this benchmark process.
+          SOLDR_BUILD_CACHE_MODE: full
+          SETUP_SOLDR_BUILD_CACHE_MODE: once
+          SOLDR_TARGET_CACHE_MODE: off
         run: |
           node scripts/bench-cache-cell.mjs \
             --layer=${{ matrix.layer }} \
             --workload=${{ inputs.workload }} \
             --rep=${{ matrix.rep }} \
+            --pre-snapshot-in=${{ runner.temp }}/bench-solo-toolchain-pre.json \
             --out=bench-${{ matrix.os }}-${{ matrix.layer }}-r${{ matrix.rep }}.csv
 
       - uses: actions/upload-artifact@v4

--- a/__tests__/bench-paths.test.ts
+++ b/__tests__/bench-paths.test.ts
@@ -8,9 +8,24 @@ import * as path from "node:path";
 // existing test-file convention (see main.test.ts).
 type BenchPaths = {
   LAYER_NAMES: ReadonlyArray<string>;
-  pathsForLayer: (layer: string, opts?: { env?: NodeJS.ProcessEnv; workloadDir?: string }) =>
+  pathsForLayer: (
+    layer: string,
+    opts?: { env?: NodeJS.ProcessEnv; workloadDir?: string; soloToolchainDelta?: SnapshotDiff },
+  ) =>
     Array<{ parent: string; basename: string }>;
+  pathsForSoloToolchainDelta: (delta?: SnapshotDiff) => Array<{ parent: string; basename: string }>;
   isActiveLayer: (layer: string) => boolean;
+};
+
+type SnapshotEntry = {
+  root: string;
+  relpath: string;
+  kind?: "file" | "symlink" | "directory";
+};
+
+type SnapshotDiff = {
+  added?: SnapshotEntry[];
+  changed?: Array<{ after: SnapshotEntry }>;
 };
 
 async function loadBenchPaths(): Promise<BenchPaths> {
@@ -27,6 +42,10 @@ const FAKE_ENV = {
 };
 
 const FAKE_WORKLOAD = "/work/setup-soldr/scripts/bench-workloads/demo-small";
+
+function asPath(p: { parent: string; basename: string }): string {
+  return path.join(p.parent, p.basename).replace(/\\/g, "/");
+}
 
 test("LAYER_NAMES covers the issue inventory (baseline + 7 prod + all-on)", async () => {
   const benchPaths = await loadBenchPaths();
@@ -79,8 +98,47 @@ test("cargo-registry bundles the three ~/.cargo siblings", async () => {
 test("solo-toolchain spans rustup + cargo bin", async () => {
   const benchPaths = await loadBenchPaths();
   const ps = benchPaths.pathsForLayer("solo-toolchain", { env: FAKE_ENV, workloadDir: FAKE_WORKLOAD });
-  const tuples = ps.map((p) => `${p.parent}/${p.basename}`).sort();
+  const tuples = ps.map(asPath).sort();
   assert.deepEqual(tuples, ["/home/runner/.cargo/bin", "/home/runner/.rustup/toolchains"]);
+});
+
+test("solo-toolchain can resolve exact paths from a pre/post snapshot delta", async () => {
+  const benchPaths = await loadBenchPaths();
+  const delta: SnapshotDiff = {
+    added: [
+      { root: "/home/runner/.rustup/toolchains", relpath: "stable-x86_64-unknown-linux-gnu/bin/rustc", kind: "file" },
+      { root: "/home/runner/.cargo/bin", relpath: "cargo-soldr", kind: "symlink" },
+      { root: "/home/runner/.cargo/bin", relpath: "cargo-soldr", kind: "symlink" },
+    ],
+    changed: [
+      { after: { root: "/home/runner/.rustup/toolchains", relpath: "stable-x86_64-unknown-linux-gnu/lib/libstd.rlib", kind: "file" } },
+    ],
+  };
+
+  const ps = benchPaths.pathsForLayer("solo-toolchain", {
+    env: FAKE_ENV,
+    workloadDir: FAKE_WORKLOAD,
+    soloToolchainDelta: delta,
+  });
+
+  assert.deepEqual(ps.map(asPath).sort(), [
+    "/home/runner/.cargo/bin/cargo-soldr",
+    "/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc",
+    "/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/libstd.rlib",
+  ]);
+});
+
+test("solo-toolchain delta API returns no paths for an empty delta", async () => {
+  const benchPaths = await loadBenchPaths();
+  assert.deepEqual(benchPaths.pathsForSoloToolchainDelta({ added: [], changed: [] }), []);
+  assert.deepEqual(
+    benchPaths.pathsForLayer("solo-toolchain", {
+      env: FAKE_ENV,
+      workloadDir: FAKE_WORKLOAD,
+      soloToolchainDelta: { added: [], changed: [] },
+    }),
+    [],
+  );
 });
 
 test("build layer uses ZCCACHE_CACHE_DIR", async () => {
@@ -92,21 +150,23 @@ test("build layer uses ZCCACHE_CACHE_DIR", async () => {
   assert.equal(first.basename, "zccache");
 });
 
-test("target + cook both point at workload's target dir (overlap is real)", async () => {
+test("cook snapshots target/deps while target snapshots the whole target dir", async () => {
   const benchPaths = await loadBenchPaths();
   const tgt = benchPaths.pathsForLayer("target", { env: FAKE_ENV, workloadDir: FAKE_WORKLOAD });
   const cook = benchPaths.pathsForLayer("cook", { env: FAKE_ENV, workloadDir: FAKE_WORKLOAD });
-  assert.deepEqual(tgt, cook);
+  assert.deepEqual(tgt.map(asPath), [`${FAKE_WORKLOAD}/target`]);
+  assert.deepEqual(cook.map(asPath), [`${FAKE_WORKLOAD}/target/deps`]);
 });
 
 test("all-on deduplicates overlapping paths", async () => {
   const benchPaths = await loadBenchPaths();
   const ps = benchPaths.pathsForLayer("all-on", { env: FAKE_ENV, workloadDir: FAKE_WORKLOAD });
-  const keys = ps.map((p) => `${p.parent}::${p.basename}`);
+  const keys = ps.map(asPath);
   assert.equal(new Set(keys).size, keys.length, "all-on must dedupe");
   assert.ok(ps.some((p) => p.basename === "registry"));
   assert.ok(ps.some((p) => p.basename === "toolchains"));
-  assert.ok(ps.some((p) => p.basename === "target"));
+  assert.ok(keys.includes(`${FAKE_WORKLOAD}/target`));
+  assert.ok(!keys.includes(`${FAKE_WORKLOAD}/target/deps`), "whole target snapshot should cover cook target/deps");
 });
 
 test("unknown layer throws", async () => {

--- a/scripts/bench-cache-cell.mjs
+++ b/scripts/bench-cache-cell.mjs
@@ -8,8 +8,13 @@
 //   1. Prepare a clean workload checkout under ${RUNNER_TEMP}/workload
 //   2. Cold build (cargo build --release in the workload dir) — record wall clock
 //   3. Snapshot layer paths -> ${RUNNER_TEMP}/sim-cache/<layer>__<i>.tar.zst (tar+zstd -19 --long=27)
-//   4. (build-affecting layers only) Wipe layer paths, then restore from snapshot
+//   4. (build-affecting layers only) Wipe layer paths and target/, then restore from snapshot
 //   5. (build-affecting layers only) Warm build — record wall clock
+//
+// The solo-toolchain cell supports a separate --pre-snapshot-out mode. The
+// workflow runs that before setup-soldr, then passes --pre-snapshot-in to the
+// measured cell so only toolchain files added on top of the runner image are
+// archived.
 //
 // For layers that don't affect the workload's build (solo-toolchain, soldr-mini,
 // setup-cache, baseline), the warm row is omitted; the CSV downstream treats
@@ -51,12 +56,27 @@ const workloadDir = path.join(runnerTemp, "bench-workload");
 const simCacheDir = path.join(runnerTemp, "sim-cache");
 await fsp.mkdir(simCacheDir, { recursive: true });
 
-await prepareWorkload(workloadSrc, workloadDir);
-
 const env = { ...process.env, CARGO_TARGET_DIR: path.join(workloadDir, "target") };
 const layerPaths = pathsForLayer(args.layer, { env, workloadDir });
 
 log(`[bench] layer=${args.layer} workload=${args.workload} rep=${rep} paths=${layerPaths.length}`);
+
+if (args["pre-snapshot-out"]) {
+  if (args.layer !== "solo-toolchain") die("--pre-snapshot-out is only supported for --layer=solo-toolchain");
+  await writePathStates(args["pre-snapshot-out"], layerPaths);
+  log(`[bench] wrote pre-snapshot ${args["pre-snapshot-out"]}`);
+  process.exit(0);
+}
+
+await prepareWorkload(workloadSrc, workloadDir);
+
+// solo-toolchain overlaps runner-image state. Capture that baseline before the
+// setup-soldr action runs, then only archive post-setup/cold added files.
+const preSnapshotStates = args.layer === "solo-toolchain"
+  ? args["pre-snapshot-in"]
+    ? await readPathStates(args["pre-snapshot-in"])
+    : await snapshotPathStates(layerPaths)
+  : null;
 
 // --- 1. cold build -----------------------------------------------------------
 const tColdStart = nowMs();
@@ -70,12 +90,20 @@ wallColdS = (nowMs() - tColdStart) / 1000;
 log(`[bench] cold build wall=${wallColdS.toFixed(2)}s`);
 
 // --- 2. snapshot -------------------------------------------------------------
+const snapshotPaths = preSnapshotStates
+  ? await materializeDeltaPaths(layerPaths, preSnapshotStates, path.join(runnerTemp, "sim-delta", args.layer))
+  : layerPaths;
+const soloToolchainDeltaEmpty = preSnapshotStates && snapshotPaths.length === 0;
+if (soloToolchainDeltaEmpty) {
+  log(`[bench] solo-toolchain delta is empty; emitting mechanics row without save/restore`);
+}
+
 const snapshots = [];
 let totalCompressedMb = 0;
 let totalInflatedMb = 0;
 let saveTimeS = 0;
-for (let i = 0; i < layerPaths.length; i++) {
-  const p = layerPaths[i];
+for (let i = 0; i < snapshotPaths.length; i++) {
+  const p = snapshotPaths[i];
   const archivePath = path.join(simCacheDir, `${args.layer}__${i}.tar.zst`);
   const inflated = await dirSizeBytes(path.join(p.parent, p.basename));
   if (inflated === 0) {
@@ -107,21 +135,33 @@ csv.push(csvRow({
 // --- 3 + 4 + 5: restore + warm (only for build-affecting + wipe-safe) --------
 const shouldWipe = !WIPE_UNSAFE.has(args.layer) && isActiveLayer(args.layer);
 const shouldWarmBuild = BUILD_AFFECTING.has(args.layer) && isActiveLayer(args.layer);
+const unsafeSnapshotKeys = unsafePathKeys(args.layer, env, workloadDir);
 let restoreTimeS = 0;
 
 if (snapshots.length > 0) {
   if (shouldWipe) {
+    let wiped = 0;
     for (const s of snapshots) {
+      if (unsafeSnapshotKeys.has(pathKey(s))) continue;
       await rmrf(path.join(s.parent, s.basename));
+      wiped++;
     }
-    log(`[bench] wiped ${snapshots.length} path(s)`);
+    log(`[bench] wiped ${wiped} path(s)`);
   } else if (isActiveLayer(args.layer)) {
     log(`[bench] layer ${args.layer} is wipe-unsafe; restoring into side dirs for mechanics measurement only`);
   }
+}
 
+if (shouldWarmBuild && shouldWipe) {
+  await rmrf(env.CARGO_TARGET_DIR);
+  log(`[bench] wiped CARGO_TARGET_DIR before warm build: ${env.CARGO_TARGET_DIR}`);
+}
+
+if (snapshots.length > 0) {
   for (const s of snapshots) {
-    const restoreRoot = shouldWipe ? s.parent : path.join(runnerTemp, "sim-restore", args.layer);
-    if (!shouldWipe) await fsp.mkdir(restoreRoot, { recursive: true });
+    const restoreLive = shouldWipe && !unsafeSnapshotKeys.has(pathKey(s));
+    const restoreRoot = restoreLive ? s.parent : path.join(runnerTemp, "sim-restore", args.layer);
+    if (!restoreLive) await fsp.mkdir(restoreRoot, { recursive: true });
     const t0 = nowMs();
     await tarZstdExtract(s.archivePath, restoreRoot);
     restoreTimeS += (nowMs() - t0) / 1000;
@@ -141,7 +181,7 @@ if (shouldWarmBuild) {
     compressedMb, inflatedMb, ratio,
     workload: args.workload, rep,
   }));
-} else if (snapshots.length > 0) {
+} else if (snapshots.length > 0 || soloToolchainDeltaEmpty) {
   // emit a mechanics-only row so downstream collation has size/save/restore numbers
   csv.push(csvRow({
     os: runnerOs, layer: args.layer, phase: "mech", wallClockS: "",
@@ -208,6 +248,119 @@ async function statSizeBytes(p) {
   try { return (await fsp.stat(p)).size; } catch { return 0; }
 }
 
+async function snapshotPathStates(paths) {
+  const states = new Map();
+  for (const p of paths) {
+    states.set(path.resolve(p.parent, p.basename), await fileStateMap(path.join(p.parent, p.basename)));
+  }
+  return states;
+}
+
+async function writePathStates(outPath, paths) {
+  const states = await snapshotPathStates(paths);
+  const payload = {
+    version: 1,
+    roots: [...states].map(([root, entries]) => ({
+      root,
+      entries: [...entries],
+    })),
+  };
+  await fsp.mkdir(path.dirname(outPath), { recursive: true });
+  await fsp.writeFile(outPath, JSON.stringify(payload), "utf8");
+}
+
+async function readPathStates(inPath) {
+  if (!inPath) throw new Error("no pre-snapshot input");
+  const payload = JSON.parse(await fsp.readFile(inPath, "utf8"));
+  if (payload?.version !== 1 || !Array.isArray(payload.roots)) {
+    throw new Error(`invalid pre-snapshot file: ${inPath}`);
+  }
+  const states = new Map();
+  for (const root of payload.roots) {
+    if (typeof root?.root !== "string" || !Array.isArray(root.entries)) continue;
+    states.set(path.resolve(root.root), new Map(root.entries));
+  }
+  return states;
+}
+
+async function materializeDeltaPaths(paths, beforeStates, deltaRoot) {
+  await rmrf(deltaRoot);
+  const deltaPaths = [];
+  for (const p of paths) {
+    const srcRoot = path.join(p.parent, p.basename);
+    const before = beforeStates.get(path.resolve(srcRoot)) ?? new Map();
+    const after = await fileStateMap(srcRoot);
+    let copied = 0;
+    for (const [rel, state] of after) {
+      if (before.has(rel)) continue;
+      const dest = path.join(deltaRoot, p.basename, rel);
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
+      await copyEntry(path.join(srcRoot, rel), dest, state);
+      copied++;
+    }
+    if (copied > 0) {
+      deltaPaths.push({ parent: deltaRoot, basename: p.basename });
+      log(`[bench] solo-toolchain delta ${p.basename}: ${copied} added entr${copied === 1 ? "y" : "ies"}`);
+    }
+  }
+  return deltaPaths;
+}
+
+async function fileStateMap(root) {
+  const out = new Map();
+  async function walk(d, relBase) {
+    let entries;
+    try { entries = await fsp.readdir(d, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const full = path.join(d, e.name);
+      const rel = relBase ? path.join(relBase, e.name) : e.name;
+      if (e.isDirectory()) {
+        await walk(full, rel);
+      } else if (e.isSymbolicLink()) {
+        try {
+          const linkTarget = await fsp.readlink(full);
+          out.set(rel, { kind: "symlink", linkTarget });
+        } catch { /* ignore */ }
+      } else if (e.isFile()) {
+        try {
+          const st = await fsp.stat(full);
+          out.set(rel, { kind: "file", size: st.size });
+        } catch { /* ignore */ }
+      }
+    }
+  }
+  if (fs.existsSync(root)) await walk(root, "");
+  return out;
+}
+
+async function copyEntry(src, dest, state) {
+  if (state?.kind === "symlink") {
+    await fsp.symlink(state.linkTarget, dest).catch(async () => {
+      const resolved = path.resolve(path.dirname(src), state.linkTarget);
+      await fsp.copyFile(resolved, dest);
+    });
+    return;
+  }
+  await fsp.copyFile(src, dest);
+}
+
+function unsafePathKeys(layer, env, workloadDir) {
+  const keys = new Set();
+  if (WIPE_UNSAFE.has(layer)) {
+    for (const p of pathsForLayer(layer, { env, workloadDir })) keys.add(pathKey(p));
+    return keys;
+  }
+  if (layer !== "all-on") return keys;
+  for (const name of WIPE_UNSAFE) {
+    for (const p of pathsForLayer(name, { env, workloadDir })) keys.add(pathKey(p));
+  }
+  return keys;
+}
+
+function pathKey(p) {
+  return path.resolve(p.parent, p.basename);
+}
+
 async function dirSizeBytes(dir) {
   let total = 0;
   async function walk(d) {
@@ -218,6 +371,8 @@ async function dirSizeBytes(dir) {
       if (e.isDirectory()) await walk(full);
       else if (e.isFile()) {
         try { total += (await fsp.stat(full)).size; } catch { /* ignore */ }
+      } else if (e.isSymbolicLink()) {
+        try { total += Math.max(1, Buffer.byteLength(await fsp.readlink(full))); } catch { /* ignore */ }
       }
     }
   }

--- a/scripts/bench-paths.d.mts
+++ b/scripts/bench-paths.d.mts
@@ -9,11 +9,25 @@ export interface LayerPath {
   basename: string;
 }
 
+export interface SnapshotEntry {
+  root: string;
+  relpath: string;
+  kind?: "file" | "symlink" | "directory";
+}
+
+export interface SnapshotDiff {
+  added?: SnapshotEntry[];
+  changed?: Array<{ after: SnapshotEntry }>;
+}
+
 export interface PathsForLayerOpts {
   env?: NodeJS.ProcessEnv;
   workloadDir?: string;
+  soloToolchainDelta?: SnapshotDiff;
 }
 
 export function pathsForLayer(layer: string, opts?: PathsForLayerOpts): LayerPath[];
+
+export function pathsForSoloToolchainDelta(delta?: SnapshotDiff): LayerPath[];
 
 export function isActiveLayer(layer: string): boolean;

--- a/scripts/bench-paths.mjs
+++ b/scripts/bench-paths.mjs
@@ -39,10 +39,23 @@ export const LAYER_NAMES = Object.freeze([
  */
 
 /**
+ * @typedef {object} SnapshotEntry
+ * @property {string} root
+ * @property {string} relpath
+ * @property {"file"|"symlink"|"directory"} [kind]
+ */
+
+/**
+ * @typedef {object} SnapshotDiff
+ * @property {SnapshotEntry[]} [added]
+ * @property {{after: SnapshotEntry}[]} [changed]
+ */
+
+/**
  * Resolve the on-disk paths for a given layer.
  *
  * @param {string} layer
- * @param {{env?: NodeJS.ProcessEnv, workloadDir?: string}} [opts]
+ * @param {{env?: NodeJS.ProcessEnv, workloadDir?: string, soloToolchainDelta?: SnapshotDiff}} [opts]
  * @returns {LayerPath[]}
  */
 export function pathsForLayer(layer, opts = {}) {
@@ -62,6 +75,9 @@ export function pathsForLayer(layer, opts = {}) {
     case "soldr-mini":
       return [{ parent: path.dirname(soldrInstallDir), basename: path.basename(soldrInstallDir) }];
     case "solo-toolchain":
+      if (Object.prototype.hasOwnProperty.call(opts, "soloToolchainDelta")) {
+        return pathsForSoloToolchainDelta(opts.soloToolchainDelta);
+      }
       return [
         { parent: rustupHome, basename: "toolchains" },
         { parent: cargoHome, basename: "bin" },
@@ -73,7 +89,7 @@ export function pathsForLayer(layer, opts = {}) {
         { parent: cargoHome, basename: ".global-cache" },
       ];
     case "cook":
-      return [{ parent: workloadDir, basename: "target" }];
+      return [{ parent: path.join(workloadDir, "target"), basename: "deps" }];
     case "build":
       return [{ parent: path.dirname(zccacheDir), basename: path.basename(zccacheDir) }];
     case "target":
@@ -81,15 +97,11 @@ export function pathsForLayer(layer, opts = {}) {
     case "setup-cache":
       return [{ parent: path.dirname(setupCachePath), basename: path.basename(setupCachePath) }];
     case "all-on": {
-      const seen = new Set();
       const acc = [];
       for (const name of LAYER_NAMES) {
         if (name === "baseline" || name === "all-on") continue;
         for (const p of pathsForLayer(name, opts)) {
-          const key = `${p.parent}::${p.basename}`;
-          if (seen.has(key)) continue;
-          seen.add(key);
-          acc.push(p);
+          addDedupedPath(acc, p);
         }
       }
       return acc;
@@ -97,6 +109,64 @@ export function pathsForLayer(layer, opts = {}) {
     default:
       throw new Error(`pathsForLayer: unknown layer '${layer}'`);
   }
+}
+
+/**
+ * Convert a toolchain snapshot diff into exact path tuples for the bench
+ * driver. Removed entries are intentionally ignored: there is nothing to
+ * archive from the post-install filesystem for them.
+ *
+ * @param {SnapshotDiff | undefined} delta
+ * @returns {LayerPath[]}
+ */
+export function pathsForSoloToolchainDelta(delta) {
+  if (!delta) return [];
+  const acc = [];
+  for (const entry of delta.added ?? []) addSnapshotEntryPath(acc, entry);
+  for (const change of delta.changed ?? []) addSnapshotEntryPath(acc, change.after);
+  return acc;
+}
+
+/**
+ * @param {LayerPath[]} acc
+ * @param {SnapshotEntry | undefined} entry
+ */
+function addSnapshotEntryPath(acc, entry) {
+  if (!entry?.root || !entry.relpath) return;
+  const relDir = path.dirname(entry.relpath);
+  const parent = relDir === "." ? entry.root : path.join(entry.root, relDir);
+  addDedupedPath(acc, { parent, basename: path.basename(entry.relpath) });
+}
+
+/**
+ * Dedupe both exact duplicates and paths already covered by a parent tuple.
+ * This keeps all-on from snapshotting target/deps separately when target is
+ * already part of the layer set.
+ *
+ * @param {LayerPath[]} acc
+ * @param {LayerPath} candidate
+ */
+function addDedupedPath(acc, candidate) {
+  const candidateTarget = path.resolve(candidate.parent, candidate.basename);
+  for (let i = 0; i < acc.length; i++) {
+    const existingTarget = path.resolve(acc[i].parent, acc[i].basename);
+    if (pathCovers(existingTarget, candidateTarget)) return;
+    if (pathCovers(candidateTarget, existingTarget)) {
+      acc.splice(i, 1);
+      i--;
+    }
+  }
+  acc.push(candidate);
+}
+
+/**
+ * @param {string} parentTarget
+ * @param {string} childTarget
+ */
+function pathCovers(parentTarget, childTarget) {
+  if (parentTarget === childTarget) return true;
+  const rel = path.relative(parentTarget, childTarget);
+  return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
 }
 
 /**

--- a/scripts/bench-workloads/README.md
+++ b/scripts/bench-workloads/README.md
@@ -7,3 +7,5 @@ Rust crates used by `.github/workflows/bench-cache-modes.yml` and `scripts/bench
 | `demo-small` | tiny — `serde`, `clap`, `anyhow`, `serde_json`. Exercises registry + zccache without dragging cold-build past ~60 s. | < 60 s |
 
 Add new workloads by dropping another directory here and extending the `workload` choice list in the workflow. `Cargo.lock` is **not** checked in — the benchmark intentionally resolves fresh on each cold run so that registry-cache invalidation behaviour is observable.
+
+For build-affecting cache layers, the benchmark wipes `target/` between cold and warm phases so warm results come from the restored cache layer, not leftover workspace state. The `cook` layer snapshots `target/deps`; the `target` layer snapshots the whole `target/` tree.


### PR DESCRIPTION
## Summary
- wipe `target/` before warm builds for build-affecting benchmark layers so warm rows cannot reuse leftover local build artifacts
- wire the benchmark workflow through the in-tree action with shims enabled, while keeping actions/cache writes disabled for the bench setup step
- split cook vs target snapshots (`target/deps` vs whole `target/`) and add solo-toolchain pre/post delta snapshot support
- document the benchmark workload assumptions and update path registry coverage

Closes #180
Closes #181
Closes #182
Closes #183
Refs #184

## Test plan
- [x] `node --check scripts/bench-cache-cell.mjs`
- [x] `node --test --test-timeout=120000 --experimental-strip-types --import ./__tests__/register-loader.mjs __tests__/bench-paths.test.ts`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `python -m pytest tests/`
- [x] `actionlint .github/workflows/bench-cache-modes.yml`
- [x] `git diff --check`
- [x] dry-run solo-toolchain empty delta with `BENCH_SKIP_BUILD=1`
- [x] dry-run target warm phase with `BENCH_SKIP_BUILD=1`