### PR TITLE
fix(bench): isolate warm cache layers

### DIFF
--- a/__tests__/bench-paths.test.ts
+++ b/__tests__/bench-paths.test.ts
@@ -150,12 +150,12 @@ test("build layer uses ZCCACHE_CACHE_DIR", async () => {
   assert.equal(first.basename, "zccache");
 });
 
-test("cook snapshots target/deps while target snapshots the whole target dir", async () => {
+test("cook snapshots release deps while target snapshots the whole target dir", async () => {
   const benchPaths = await loadBenchPaths();
   const tgt = benchPaths.pathsForLayer("target", { env: FAKE_ENV, workloadDir: FAKE_WORKLOAD });
   const cook = benchPaths.pathsForLayer("cook", { env: FAKE_ENV, workloadDir: FAKE_WORKLOAD });
   assert.deepEqual(tgt.map(asPath), [`${FAKE_WORKLOAD}/target`]);
-  assert.deepEqual(cook.map(asPath), [`${FAKE_WORKLOAD}/target/deps`]);
+  assert.deepEqual(cook.map(asPath), [`${FAKE_WORKLOAD}/target/release/deps`]);
 });
 
 test("all-on deduplicates overlapping paths", async () => {
@@ -166,7 +166,7 @@ test("all-on deduplicates overlapping paths", async () => {
   assert.ok(ps.some((p) => p.basename === "registry"));
   assert.ok(ps.some((p) => p.basename === "toolchains"));
   assert.ok(keys.includes(`${FAKE_WORKLOAD}/target`));
-  assert.ok(!keys.includes(`${FAKE_WORKLOAD}/target/deps`), "whole target snapshot should cover cook target/deps");
+  assert.ok(!keys.includes(`${FAKE_WORKLOAD}/target/release/deps`), "whole target snapshot should cover cook deps");
 });
 
 test("unknown layer throws", async () => {

--- a/scripts/bench-cache-cell.mjs
+++ b/scripts/bench-cache-cell.mjs
@@ -8,7 +8,8 @@
 //   1. Prepare a clean workload checkout under ${RUNNER_TEMP}/workload
 //   2. Cold build (cargo build --release in the workload dir) — record wall clock
 //   3. Snapshot layer paths -> ${RUNNER_TEMP}/sim-cache/<layer>__<i>.tar.zst (tar+zstd -19 --long=27)
-//   4. (build-affecting layers only) Wipe layer paths and target/, then restore from snapshot
+//   4. (build-affecting layers only) Wipe layer paths, target/, and any
+//      out-of-scope zccache state, then restore from snapshot
 //   5. (build-affecting layers only) Warm build — record wall clock
 //
 // The solo-toolchain cell supports a separate --pre-snapshot-out mode. The
@@ -155,6 +156,15 @@ if (snapshots.length > 0) {
 if (shouldWarmBuild && shouldWipe) {
   await rmrf(env.CARGO_TARGET_DIR);
   log(`[bench] wiped CARGO_TARGET_DIR before warm build: ${env.CARGO_TARGET_DIR}`);
+}
+
+if (shouldWipeBuildCacheBeforeWarm(args.layer)) {
+  let wipedBuildPaths = 0;
+  for (const p of pathsForLayer("build", { env, workloadDir })) {
+    await rmrf(path.join(p.parent, p.basename));
+    wipedBuildPaths++;
+  }
+  log(`[bench] wiped build-cache path(s) before warm build: ${wipedBuildPaths}`);
 }
 
 if (snapshots.length > 0) {
@@ -355,6 +365,10 @@ function unsafePathKeys(layer, env, workloadDir) {
     for (const p of pathsForLayer(name, { env, workloadDir })) keys.add(pathKey(p));
   }
   return keys;
+}
+
+function shouldWipeBuildCacheBeforeWarm(layer) {
+  return BUILD_AFFECTING.has(layer) && !WIPE_UNSAFE.has(layer) && layer !== "build" && layer !== "all-on";
 }
 
 function pathKey(p) {

--- a/scripts/bench-paths.mjs
+++ b/scripts/bench-paths.mjs
@@ -89,7 +89,7 @@ export function pathsForLayer(layer, opts = {}) {
         { parent: cargoHome, basename: ".global-cache" },
       ];
     case "cook":
-      return [{ parent: path.join(workloadDir, "target"), basename: "deps" }];
+      return [{ parent: path.join(workloadDir, "target", "release"), basename: "deps" }];
     case "build":
       return [{ parent: path.dirname(zccacheDir), basename: path.basename(zccacheDir) }];
     case "target":

--- a/scripts/bench-workloads/README.md
+++ b/scripts/bench-workloads/README.md
@@ -8,4 +8,4 @@ Rust crates used by `.github/workflows/bench-cache-modes.yml` and `scripts/bench
 
 Add new workloads by dropping another directory here and extending the `workload` choice list in the workflow. `Cargo.lock` is **not** checked in — the benchmark intentionally resolves fresh on each cold run so that registry-cache invalidation behaviour is observable.
 
-For build-affecting cache layers, the benchmark wipes `target/` between cold and warm phases so warm results come from the restored cache layer, not leftover workspace state. The `cook` layer snapshots `target/deps`; the `target` layer snapshots the whole `target/` tree.
+For build-affecting cache layers, the benchmark wipes `target/` between cold and warm phases so warm results come from the restored cache layer, not leftover workspace state. The `cook` layer snapshots `target/release/deps`; the `target` layer snapshots the whole `target/` tree.


### PR DESCRIPTION
## Summary
- snapshot release-profile cook output at `target/release/deps` so the cook row is non-empty after `cargo build --release`
- wipe out-of-scope zccache state before warm builds for `cargo-registry`, `cook`, and `target`, leaving zccache restored only for the `build` and `all-on` layer measurements
- update bench path coverage and workload docs for the release deps path

Refs #184

## Test plan
- [x] `node --check scripts/bench-cache-cell.mjs`
- [x] `node --test --test-timeout=120000 --experimental-strip-types --import ./__tests__/register-loader.mjs __tests__/bench-paths.test.ts`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `python -m pytest tests/`
- [x] `git diff --check`

## Rerun evidence
The first post-#185 workflow rerun (`26456882052`) proved the workflow executes but showed `cook` archived 0 MB and non-build warm rows were still benefiting from the cold zccache directory. This PR addresses those remaining matrix interpretation gaps before the release bump/tag stage.