### PR TITLE
chore(release): record v0.9.10 rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## v0.9.10 - 2026-05-26
+
+- Fixed cache-mode benchmark methodology so the matrix now measures distinct
+  build-affecting layers instead of reusing warmed target or zccache state.
+- Added runner-image delta measurement for the solo-toolchain benchmark path.
+- Verified the repaired default benchmark run:
+  <https://github.com/zackees/setup-soldr/actions/runs/26457448768>.
+


### PR DESCRIPTION
## Summary

Records the v0.9.10 rollout after the cache-mode benchmark methodology fixes in #185 and #186.

The action release version is represented by Git tags in this repository; there was no tracked `v0.9.9` file to bump. This PR adds a changelog entry so the combined v0.9.10 release has a tracked release note before tagging.

## Verification

- [x] `Bench cache modes` rerun succeeded: https://github.com/zackees/setup-soldr/actions/runs/26457448768
- [x] Matrix gates from #184 passed: non-zero warm rows, build archive > 0 MB, cook < target, solo-toolchain save < 10s
- [x] `git diff --check`

Closes no issues directly; #184 closes after this merges and tags are pushed.