### PR TITLE
fix: quiesce build cache before benchmark snapshots

### DIFF
--- a/__tests__/bench-scripts.test.ts
+++ b/__tests__/bench-scripts.test.ts
@@ -95,6 +95,78 @@ test("bench-cache-cell writes a labeled partial-safe CSV in dry-run mode", async
   assert.doesNotMatch(csv, /toolchains/);
 });
 
+test("bench-cache-cell falls back to zccache stop before snapshot", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "setup-soldr-cell-stop-"));
+  const home = path.join(dir, "home");
+  const runnerTemp = path.join(dir, "runner-temp");
+  const binDir = path.join(dir, "bin");
+  const argsFile = path.join(dir, "zccache-args.txt");
+  await fs.mkdir(path.join(home, ".cargo"), { recursive: true });
+  await fs.mkdir(path.join(home, ".rustup"), { recursive: true });
+  await fs.mkdir(runnerTemp, { recursive: true });
+  await fs.mkdir(binDir, { recursive: true });
+  const out = path.join(dir, "bench.csv");
+
+  const soldrShim = path.join(binDir, process.platform === "win32" ? "soldr.cmd" : "soldr");
+  const zccacheShim = path.join(binDir, process.platform === "win32" ? "zccache.cmd" : "zccache");
+  if (process.platform === "win32") {
+    await fs.writeFile(
+      soldrShim,
+      "@echo off\r\necho error: unexpected argument 'shutdown' found 1>&2\r\nexit /b 2\r\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      zccacheShim,
+      `@echo off\r\necho %* > "${argsFile}"\r\nexit /b 0\r\n`,
+      "utf8",
+    );
+  } else {
+    await fs.writeFile(
+      soldrShim,
+      "#!/usr/bin/env sh\necho \"error: unexpected argument 'shutdown' found\" >&2\nexit 2\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      zccacheShim,
+      `#!/usr/bin/env sh\nprintf '%s\\n' "$*" > '${argsFile}'\n`,
+      "utf8",
+    );
+    await fs.chmod(soldrShim, 0o755);
+    await fs.chmod(zccacheShim, 0o755);
+  }
+
+  const result = await execFileAsync(process.execPath, [
+    "scripts/bench-cache-cell.mjs",
+    "--layer=baseline",
+    "--workload=demo-small",
+    "--rep=1",
+    "--out=" + out,
+  ], {
+    env: {
+      ...process.env,
+      BENCH_SKIP_BUILD: "1",
+      RUNNER_OS: "Linux",
+      RUNNER_TEMP: runnerTemp,
+      HOME: home,
+      USERPROFILE: home,
+      CARGO_HOME: path.join(home, ".cargo"),
+      RUSTUP_HOME: path.join(home, ".rustup"),
+      ZCCACHE_CACHE_DIR: path.join(home, ".cache", "zccache"),
+      SETUP_SOLDR_CACHE_PATH: path.join(runnerTemp, "setup-soldr-cache"),
+      SOLDR_BINARY: soldrShim,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+  });
+
+  assert.match(
+    result.stdout + result.stderr,
+    /falling back to zccache stop/,
+  );
+  if (process.platform !== "win32") {
+    assert.equal((await fs.readFile(argsFile, "utf8")).trim(), "stop");
+  }
+});
+
 test("bench-cache-cell treats cook-production as build-affecting", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "setup-soldr-cell-cook-prod-"));
   const home = path.join(dir, "home");

--- a/scripts/bench-cache-cell.mjs
+++ b/scripts/bench-cache-cell.mjs
@@ -98,6 +98,8 @@ if (skipBuild) {
 wallColdS = (nowMs() - tColdStart) / 1000;
 log(`[bench] cold build wall=${wallColdS.toFixed(2)}s`);
 
+await quiesceCacheDaemonsBeforeSnapshot(env, workloadDir);
+
 // --- 2. snapshot -------------------------------------------------------------
 let snapshotPaths = layerPaths;
 let soloToolchainDeltaPaths = [];
@@ -452,6 +454,70 @@ function run(cmd, argv, opts = {}) {
     child.on("error", reject);
     child.on("exit", (code) => code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`)));
   });
+}
+
+function runBestEffort(cmd, argv, opts = {}) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(cmd, argv, { stdio: ["ignore", "pipe", "pipe"], ...opts });
+    } catch (err) {
+      resolve({ status: "error", code: null, stderr: "", error: err });
+      return;
+    }
+    let stderr = "";
+    child.stderr?.on("data", (data) => { stderr += data.toString(); });
+    child.on("error", (err) => resolve({ status: "error", code: null, stderr, error: err }));
+    child.on("exit", (code) => resolve({ status: "exit", code, stderr, error: null }));
+  });
+}
+
+async function quiesceCacheDaemonsBeforeSnapshot(envExt, workloadDir) {
+  const buildCachePath = pathsForLayer("build", { env: envExt, workloadDir })[0];
+  const buildCacheDir = path.join(buildCachePath.parent, buildCachePath.basename);
+  const logsArchiveDir = path.join(buildCacheDir, "logs", "archive");
+  const soldr = envExt.SOLDR_BINARY?.trim() || "soldr";
+
+  log(`[bench] quiescing cache daemon(s) before snapshot`);
+  const soldrResult = await runBestEffort(
+    soldr,
+    ["cache", "shutdown", "--archive-logs", logsArchiveDir],
+    { env: envExt },
+  );
+  if (soldrResult.status === "exit" && soldrResult.code === 0) {
+    log(`[bench] soldr cache shutdown completed`);
+    return;
+  }
+
+  const canFallback =
+    soldrResult.status === "error" ||
+    (soldrResult.code === 2 && looksLikeUnsupportedSoldrShutdown(soldrResult.stderr));
+  if (!canFallback) {
+    log(`[bench] soldr cache shutdown exit ${soldrResult.code}; continuing best-effort without fallback`);
+    return;
+  }
+
+  log(`[bench] soldr cache shutdown unavailable; falling back to zccache stop`);
+  const zccacheResult = await runBestEffort("zccache", ["stop"], { env: envExt });
+  if (zccacheResult.status === "exit" && zccacheResult.code === 0) {
+    log(`[bench] zccache stop completed`);
+  } else if (zccacheResult.status === "error") {
+    log(`[bench] zccache stop spawn failed; continuing best-effort`);
+  } else {
+    log(`[bench] zccache stop exit ${zccacheResult.code}; continuing best-effort`);
+  }
+}
+
+function looksLikeUnsupportedSoldrShutdown(stderr) {
+  const s = stderr.toLowerCase();
+  return (
+    s.includes("unrecognized subcommand") ||
+    s.includes("unknown subcommand") ||
+    s.includes("invalid subcommand") ||
+    s.includes("unexpected argument") ||
+    s.includes("tool not found") ||
+    s.includes("no release found")
+  );
 }
 
 async function tarZstdCreate(archivePath, parent, basename) {


### PR DESCRIPTION
## Summary
- quiesce soldr/zccache before benchmark build-cache snapshots so live daemon state is flushed before tar.zst capture
- align benchmark fallback with the current production path: use `soldr cache shutdown`, then direct `zccache stop` when shutdown is unsupported
- add regression coverage for benchmark quiescing and fallback behavior

## Release sequencing
- zccache 1.11.2 is published: https://github.com/zackees/zccache/releases/tag/1.11.2
- soldr v0.7.37 is published: https://github.com/zackees/soldr/releases/tag/v0.7.37
- setup-soldr main already moved the default soldr version to 0.7.37 before this PR

## Validation
- npm test
- npm run typecheck
- npm run build
- node --test --test-timeout=120000 --experimental-strip-types --import ./__tests__/register-loader.mjs __tests__/bench-scripts.test.ts