### PR TITLE
bench: add real cache smoke and cook-production shaping

### DIFF
--- a/.github/workflows/bench-cache-modes.yml
+++ b/.github/workflows/bench-cache-modes.yml
@@ -33,6 +33,14 @@ on:
         description: "Timeout for each benchmark cell. Partial CSV artifacts are still uploaded on failure/timeout."
         required: false
         default: "30"
+      cache_backend:
+        description: "Benchmark backend: local tar/zstd only, or local tar/zstd plus a small real actions/cache target-cache smoke."
+        required: false
+        type: choice
+        default: "local-tar-zstd"
+        options:
+          - local-tar-zstd
+          - local-tar-zstd+actions-cache-smoke
 
 permissions:
   contents: read
@@ -140,9 +148,83 @@ jobs:
           path: bench-${{ matrix.os }}-${{ matrix.layer }}-r${{ matrix.rep }}.csv
           if-no-files-found: warn
 
+  real-cache-save:
+    name: Real actions/cache target save
+    needs: expand
+    if: ${{ inputs.cache_backend == 'local-tar-zstd+actions-cache-smoke' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install script dependencies
+        run: npm ci
+
+      - name: Save real target cache
+        env:
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          node scripts/bench-real-cache-smoke.mjs \
+            --mode=save \
+            --layer=target \
+            --workload=${{ inputs.workload }} \
+            --rep=1 \
+            --out=bench-real-cache-state.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bench-real-cache-state
+          path: bench-real-cache-state.json
+          if-no-files-found: error
+
+  real-cache-restore:
+    name: Real actions/cache target restore
+    needs: real-cache-save
+    if: ${{ inputs.cache_backend == 'local-tar-zstd+actions-cache-smoke' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install script dependencies
+        run: npm ci
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: bench-real-cache-state
+
+      - name: Restore real target cache
+        env:
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          node scripts/bench-real-cache-smoke.mjs \
+            --mode=restore \
+            --layer=target \
+            --workload=${{ inputs.workload }} \
+            --rep=1 \
+            --state=bench-real-cache-state.json \
+            --out=bench-ubuntu-24.04-target-real-cache-r1.csv
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bench-ubuntu-24.04-target-real-cache-r1
+          path: bench-ubuntu-24.04-target-real-cache-r1.csv
+          if-no-files-found: warn
+
   collate:
     name: Collate results
-    needs: bench
+    needs:
+      - bench
+      - real-cache-restore
     if: always()
     runs-on: ubuntu-24.04
     steps:

--- a/README.md
+++ b/README.md
@@ -577,7 +577,11 @@ for the current workload.
 
 `bench-cache-modes.yml` labels synthetic local tar/zstd results in the CSV and
 summary. Use `break_even_warm_hits` rather than restore-only net benefit when
-deciding whether a cache layer belongs in the default path.
+deciding whether a cache layer belongs in the default path. For a small real
+service check, dispatch the workflow with
+`cache_backend=local-tar-zstd+actions-cache-smoke`; this keeps the normal local
+matrix and adds a two-job target-cache save/restore smoke using
+`@actions/cache`, emitted as `cache_backend=actions-cache`.
 
 ## Known limitations
 

--- a/__tests__/bench-scripts.test.ts
+++ b/__tests__/bench-scripts.test.ts
@@ -8,6 +8,30 @@ import { test } from "node:test";
 
 const execFileAsync = promisify(execFile);
 
+async function writeNodeShim(binDir: string, name: string, source: string): Promise<string> {
+  const scriptPath = path.join(binDir, `${name}.cjs`);
+  await fs.writeFile(scriptPath, source, "utf8");
+
+  if (process.platform === "win32") {
+    const shimPath = path.join(binDir, `${name}.cmd`);
+    await fs.writeFile(
+      shimPath,
+      `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`,
+      "utf8",
+    );
+    return shimPath;
+  }
+
+  const shimPath = path.join(binDir, name);
+  await fs.writeFile(
+    shimPath,
+    `#!/usr/bin/env sh\nexec "${process.execPath}" "${scriptPath}" "$@"\n`,
+    "utf8",
+  );
+  await fs.chmod(shimPath, 0o755);
+  return shimPath;
+}
+
 test("collate-bench appends amortized payback fields", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "setup-soldr-collate-"));
   await fs.mkdir(path.join(dir, "cell"), { recursive: true });
@@ -54,6 +78,7 @@ test("render-bench-summary reports methodology, aggregates, and amortized flags"
   assert.match(stdout, /### Rep aggregates/);
   assert.match(stdout, /break_even_warm_hits=15\.38/);
   assert.match(stdout, /inflated_mb=806/);
+  assert.match(stdout, /actions-cache/);
 });
 
 test("bench-cache-cell writes a labeled partial-safe CSV in dry-run mode", async () => {
@@ -167,14 +192,107 @@ test("bench-cache-cell falls back to zccache stop before snapshot", async () => 
   }
 });
 
-test("bench-cache-cell treats cook-production as build-affecting", async () => {
+test("bench-cache-cell runs cook-production cook before cold cargo build and emits warm row", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "setup-soldr-cell-cook-prod-"));
   const home = path.join(dir, "home");
   const runnerTemp = path.join(dir, "runner-temp");
+  const binDir = path.join(dir, "bin");
+  const eventsFile = path.join(dir, "events.log");
   await fs.mkdir(path.join(home, ".cargo"), { recursive: true });
   await fs.mkdir(path.join(home, ".rustup"), { recursive: true });
   await fs.mkdir(runnerTemp, { recursive: true });
+  await fs.mkdir(binDir, { recursive: true });
   const out = path.join(dir, "bench.csv");
+  const soldrShim = await writeNodeShim(binDir, "soldr", `
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+const events = process.env.BENCH_EVENT_LOG;
+function log(line) { fs.appendFileSync(events, line + "\\n"); }
+log("soldr " + args.join(" "));
+if (args[0] === "cook") {
+  const target = path.join(process.cwd(), "target");
+  fs.mkdirSync(target, { recursive: true });
+  fs.writeFileSync(path.join(target, "cook-output.txt"), "cook\\n");
+  process.exit(0);
+}
+if (args[0] === "cache" && args[1] === "shutdown") process.exit(0);
+process.exit(2);
+`);
+  await writeNodeShim(binDir, "cargo", `
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+const events = process.env.BENCH_EVENT_LOG;
+fs.appendFileSync(events, "cargo " + args.join(" ") + "\\n");
+const target = process.env.CARGO_TARGET_DIR || path.join(process.cwd(), "target");
+fs.mkdirSync(target, { recursive: true });
+fs.writeFileSync(path.join(target, "user-build.txt"), "cargo\\n");
+`);
+  await writeNodeShim(binDir, "tar", `
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+const events = process.env.BENCH_EVENT_LOG;
+function log(line) { fs.appendFileSync(events, line + "\\n"); }
+function restoreTarget(root) {
+  const target = path.join(root, "target");
+  fs.mkdirSync(target, { recursive: true });
+  fs.writeFileSync(path.join(target, "cook-output.txt"), "cook\\n");
+}
+if (args.includes("-cf")) {
+  const archive = args[args.indexOf("-cf") + 1];
+  const parent = args[args.indexOf("-C") + 1];
+  const basename = args[args.length - 1];
+  const target = path.join(parent, basename);
+  log("archive create hasCook=" + fs.existsSync(path.join(target, "cook-output.txt")) + " hasUser=" + fs.existsSync(path.join(target, "user-build.txt")));
+  fs.mkdirSync(path.dirname(archive), { recursive: true });
+  fs.writeFileSync(archive, "archive\\n");
+  process.exit(0);
+}
+if (args.includes("-xf")) {
+  const root = args[args.indexOf("-C") + 1];
+  log("archive extract");
+  restoreTarget(root);
+  process.exit(0);
+}
+process.exit(2);
+`);
+  await writeNodeShim(binDir, "bash", `
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+const script = args[1] || "";
+const events = process.env.BENCH_EVENT_LOG;
+function log(line) { fs.appendFileSync(events, line + "\\n"); }
+function token(pattern) {
+  const match = pattern.exec(script);
+  return match && (match[1] || match[2] || match[3] || match[4]);
+}
+function restoreTarget(root) {
+  const target = path.join(root, "target");
+  fs.mkdirSync(target, { recursive: true });
+  fs.writeFileSync(path.join(target, "cook-output.txt"), "cook\\n");
+}
+if (script.includes("tar -cf -")) {
+  const parent = token(/ -C (?:"([^"]+)"|(\\S+)) /);
+  const basenameMatch = / -C (?:"[^"]+"|\\S+) (?:"([^"]+)"|(\\S+)) \\|/.exec(script);
+  const basename = basenameMatch && (basenameMatch[1] || basenameMatch[2]);
+  const archive = token(/ -o (?:"([^"]+)"|(\\S+))$/);
+  const target = path.join(parent, basename);
+  log("archive create hasCook=" + fs.existsSync(path.join(target, "cook-output.txt")) + " hasUser=" + fs.existsSync(path.join(target, "user-build.txt")));
+  fs.mkdirSync(path.dirname(archive), { recursive: true });
+  fs.writeFileSync(archive, "archive\\n");
+  process.exit(0);
+}
+if (script.includes("tar -xf -")) {
+  const root = token(/ -C (?:"([^"]+)"|(\\S+))$/);
+  log("archive extract");
+  restoreTarget(root);
+  process.exit(0);
+}
+process.exit(2);
+`);
 
   await execFileAsync(process.execPath, [
     "scripts/bench-cache-cell.mjs",
@@ -185,7 +303,6 @@ test("bench-cache-cell treats cook-production as build-affecting", async () => {
   ], {
     env: {
       ...process.env,
-      BENCH_SKIP_BUILD: "1",
       RUNNER_OS: "Linux",
       RUNNER_TEMP: runnerTemp,
       HOME: home,
@@ -195,9 +312,24 @@ test("bench-cache-cell treats cook-production as build-affecting", async () => {
       ZCCACHE_CACHE_DIR: path.join(home, ".cache", "zccache"),
       SETUP_SOLDR_CACHE_PATH: path.join(runnerTemp, "setup-soldr-cache"),
       SOLDR_INSTALL_DIR: path.join(runnerTemp, "setup-soldr-tools"),
+      SOLDR_BINARY: soldrShim,
+      BENCH_EVENT_LOG: eventsFile,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
     },
   });
 
   const csv = await fs.readFile(out, "utf8");
   assert.ok(csv.split(/\r?\n/).some((line) => line.includes(",cook-production,warm,")));
+  const events = (await fs.readFile(eventsFile, "utf8")).trim().split(/\r?\n/);
+  const soldrCook = events.findIndex((line) => line === "soldr cook --release");
+  const archiveCreate = events.findIndex((line) => line.startsWith("archive create "));
+  const firstCargo = events.findIndex((line) => line === "cargo build --release --quiet");
+  assert.notEqual(soldrCook, -1);
+  assert.notEqual(archiveCreate, -1);
+  assert.notEqual(firstCargo, -1);
+  assert.ok(soldrCook < archiveCreate);
+  assert.ok(archiveCreate < firstCargo);
+  assert.match(events[archiveCreate]!, /hasCook=true/);
+  assert.match(events[archiveCreate]!, /hasUser=false/);
+  assert.equal(events.filter((line) => line === "cargo build --release --quiet").length, 2);
 });

--- a/scripts/bench-cache-cell.mjs
+++ b/scripts/bench-cache-cell.mjs
@@ -7,6 +7,8 @@
 // Per-cell flow:
 //   1. Prepare a clean workload checkout under ${RUNNER_TEMP}/workload
 //   2. Cold build (cargo build --release in the workload dir) — record wall clock
+//      For cook-production, run `soldr cook` and snapshot its target/ output
+//      before this user build, matching production cook-cache save timing.
 //   3. Snapshot layer paths -> ${RUNNER_TEMP}/sim-cache/<layer>__<i>.tar.zst (tar+zstd -19 --long=27)
 //   4. (build-affecting layers only) Wipe layer paths, target/, and any
 //      out-of-scope zccache state, then restore from snapshot
@@ -53,6 +55,8 @@ const runnerTemp = process.env.RUNNER_TEMP ?? os.tmpdir();
 const runnerOs = process.env.RUNNER_OS ?? process.platform;
 const cacheBackend = args["cache-backend"] ?? process.env.BENCH_CACHE_BACKEND ?? "local-tar-zstd";
 const compressionModel = args["compression-model"] ?? process.env.BENCH_COMPRESSION_MODEL ?? "zstd-19-long27";
+const cookProduction = args.layer === "cook-production";
+const cookFlags = parseCookFlags(args["cook-flags"] ?? process.env.BENCH_COOK_FLAGS ?? "--release");
 
 const workloadSrc = path.resolve("scripts", "bench-workloads", args.workload);
 const workloadDir = path.join(runnerTemp, "bench-workload");
@@ -87,6 +91,17 @@ const preSnapshotStates = tracksSoloToolchainDelta
     : await snapshotPathStates(soloToolchainBasePaths)
   : null;
 
+let snapshotResult = null;
+let coldPrebuildS = 0;
+if (cookProduction) {
+  const tCookStart = nowMs();
+  await runSoldrCook(workloadDir, env, cookFlags);
+  coldPrebuildS = (nowMs() - tCookStart) / 1000;
+  log(`[bench] cook-production prebuild wall=${coldPrebuildS.toFixed(2)}s`);
+  await quiesceCacheDaemonsBeforeSnapshot(env, workloadDir);
+  snapshotResult = await snapshotLayer();
+}
+
 // --- 1. cold build -----------------------------------------------------------
 const tColdStart = nowMs();
 let wallColdS = 0;
@@ -95,57 +110,17 @@ if (skipBuild) {
 } else {
   await runCargoBuild(workloadDir, env);
 }
-wallColdS = (nowMs() - tColdStart) / 1000;
+wallColdS = coldPrebuildS + (nowMs() - tColdStart) / 1000;
 log(`[bench] cold build wall=${wallColdS.toFixed(2)}s`);
 
-await quiesceCacheDaemonsBeforeSnapshot(env, workloadDir);
-
-// --- 2. snapshot -------------------------------------------------------------
-let snapshotPaths = layerPaths;
-let soloToolchainDeltaPaths = [];
-if (preSnapshotStates) {
-  soloToolchainDeltaPaths = await materializeDeltaPaths(
-    soloToolchainBasePaths,
-    preSnapshotStates,
-    path.join(runnerTemp, "sim-delta", args.layer, "solo-toolchain"),
-  );
-  snapshotPaths = args.layer === "solo-toolchain"
-    ? soloToolchainDeltaPaths
-    : dedupeLayerPaths([...layerPaths, ...soloToolchainDeltaPaths]);
-}
-const soloToolchainDeltaEmpty = args.layer === "solo-toolchain" && preSnapshotStates && snapshotPaths.length === 0;
-const allOnSoloToolchainDeltaEmpty = args.layer === "all-on" && preSnapshotStates && soloToolchainDeltaPaths.length === 0;
-if (soloToolchainDeltaEmpty) {
-  log(`[bench] solo-toolchain delta is empty; emitting mechanics row without save/restore`);
-} else if (allOnSoloToolchainDeltaEmpty) {
-  log(`[bench] all-on solo-toolchain delta is empty; runner-image toolchains excluded from snapshot`);
+if (!snapshotResult) {
+  await quiesceCacheDaemonsBeforeSnapshot(env, workloadDir);
+  snapshotResult = await snapshotLayer();
+} else {
+  await quiesceCacheDaemonsBeforeSnapshot(env, workloadDir);
 }
 
-const snapshots = [];
-let totalCompressedMb = 0;
-let totalInflatedMb = 0;
-let saveTimeS = 0;
-for (let i = 0; i < snapshotPaths.length; i++) {
-  const p = snapshotPaths[i];
-  const archivePath = path.join(simCacheDir, `${args.layer}__${i}.tar.zst`);
-  const inflated = await dirSizeBytes(path.join(p.parent, p.basename));
-  if (inflated === 0) {
-    log(`[bench] skip empty path ${p.parent}/${p.basename}`);
-    continue;
-  }
-  const t0 = nowMs();
-  await tarZstdCreate(archivePath, p.parent, p.basename);
-  saveTimeS += (nowMs() - t0) / 1000;
-  const compressed = await statSizeBytes(archivePath);
-  snapshots.push({ ...p, archivePath, compressedBytes: compressed, inflatedBytes: inflated });
-  totalCompressedMb += compressed / 1_000_000;
-  totalInflatedMb += inflated / 1_000_000;
-  log(`[bench] snap ${p.basename}: inflated=${(inflated / 1_000_000).toFixed(1)}MB compressed=${(compressed / 1_000_000).toFixed(1)}MB`);
-}
-
-const compressedMb = round(totalCompressedMb, 2);
-const inflatedMb = round(totalInflatedMb, 2);
-const ratio = totalInflatedMb > 0 ? round(totalInflatedMb / Math.max(totalCompressedMb, 0.001), 2) : 0;
+const { snapshots, saveTimeS, compressedMb, inflatedMb, ratio, soloToolchainDeltaEmpty } = snapshotResult;
 
 csvRows.push(csvRow({
   os: runnerOs, layer: args.layer, phase: "cold", wallClockS: round(wallColdS, 2),
@@ -238,6 +213,14 @@ function parseArgs(argv) {
   return out;
 }
 
+function parseCookFlags(raw) {
+  return raw
+    .trim()
+    .split(/\s+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 function die(msg) { console.error(`bench-cache-cell: ${msg}`); process.exit(2); }
 function log(msg) { console.log(msg); }
 function nowMs() { return Number(process.hrtime.bigint() / 1_000_000n); }
@@ -255,6 +238,56 @@ function csvRow(r) {
 async function writeCsv(rows) {
   await fsp.mkdir(path.dirname(path.resolve(out)), { recursive: true });
   await fsp.writeFile(out, [csvHeader(), ...rows].join("\n") + "\n", "utf8");
+}
+
+async function snapshotLayer() {
+  // --- 2. snapshot -----------------------------------------------------------
+  let snapshotPaths = layerPaths;
+  let soloToolchainDeltaPaths = [];
+  if (preSnapshotStates) {
+    soloToolchainDeltaPaths = await materializeDeltaPaths(
+      soloToolchainBasePaths,
+      preSnapshotStates,
+      path.join(runnerTemp, "sim-delta", args.layer, "solo-toolchain"),
+    );
+    snapshotPaths = args.layer === "solo-toolchain"
+      ? soloToolchainDeltaPaths
+      : dedupeLayerPaths([...layerPaths, ...soloToolchainDeltaPaths]);
+  }
+  const soloToolchainDeltaEmpty = args.layer === "solo-toolchain" && preSnapshotStates && snapshotPaths.length === 0;
+  const allOnSoloToolchainDeltaEmpty = args.layer === "all-on" && preSnapshotStates && soloToolchainDeltaPaths.length === 0;
+  if (soloToolchainDeltaEmpty) {
+    log(`[bench] solo-toolchain delta is empty; emitting mechanics row without save/restore`);
+  } else if (allOnSoloToolchainDeltaEmpty) {
+    log(`[bench] all-on solo-toolchain delta is empty; runner-image toolchains excluded from snapshot`);
+  }
+
+  const snapshots = [];
+  let totalCompressedMb = 0;
+  let totalInflatedMb = 0;
+  let saveTimeS = 0;
+  for (let i = 0; i < snapshotPaths.length; i++) {
+    const p = snapshotPaths[i];
+    const archivePath = path.join(simCacheDir, `${args.layer}__${i}.tar.zst`);
+    const inflated = await dirSizeBytes(path.join(p.parent, p.basename));
+    if (inflated === 0) {
+      log(`[bench] skip empty path ${p.parent}/${p.basename}`);
+      continue;
+    }
+    const t0 = nowMs();
+    await tarZstdCreate(archivePath, p.parent, p.basename);
+    saveTimeS += (nowMs() - t0) / 1000;
+    const compressed = await statSizeBytes(archivePath);
+    snapshots.push({ ...p, archivePath, compressedBytes: compressed, inflatedBytes: inflated });
+    totalCompressedMb += compressed / 1_000_000;
+    totalInflatedMb += inflated / 1_000_000;
+    log(`[bench] snap ${p.basename}: inflated=${(inflated / 1_000_000).toFixed(1)}MB compressed=${(compressed / 1_000_000).toFixed(1)}MB`);
+  }
+
+  const compressedMb = round(totalCompressedMb, 2);
+  const inflatedMb = round(totalInflatedMb, 2);
+  const ratio = totalInflatedMb > 0 ? round(totalInflatedMb / Math.max(totalCompressedMb, 0.001), 2) : 0;
+  return { snapshots, saveTimeS, compressedMb, inflatedMb, ratio, soloToolchainDeltaEmpty };
 }
 
 async function prepareWorkload(src, dest) {
@@ -450,7 +483,7 @@ async function dirSizeBytes(dir) {
 
 function run(cmd, argv, opts = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, argv, { stdio: "inherit", ...opts });
+    const child = spawn(cmd, argv, spawnOptionsForCommand(cmd, { stdio: "inherit", ...opts }));
     child.on("error", reject);
     child.on("exit", (code) => code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`)));
   });
@@ -460,7 +493,7 @@ function runBestEffort(cmd, argv, opts = {}) {
   return new Promise((resolve) => {
     let child;
     try {
-      child = spawn(cmd, argv, { stdio: ["ignore", "pipe", "pipe"], ...opts });
+      child = spawn(cmd, argv, spawnOptionsForCommand(cmd, { stdio: ["ignore", "pipe", "pipe"], ...opts }));
     } catch (err) {
       resolve({ status: "error", code: null, stderr: "", error: err });
       return;
@@ -470,6 +503,39 @@ function runBestEffort(cmd, argv, opts = {}) {
     child.on("error", (err) => resolve({ status: "error", code: null, stderr, error: err }));
     child.on("exit", (code) => resolve({ status: "exit", code, stderr, error: null }));
   });
+}
+
+function spawnOptionsForCommand(cmd, opts) {
+  if (shouldUseWindowsCommandShell(cmd, opts.env)) {
+    return { ...opts, shell: true };
+  }
+  return opts;
+}
+
+function shouldUseWindowsCommandShell(cmd, envExt) {
+  if (process.platform !== "win32") return false;
+  const ext = path.extname(cmd).toLowerCase();
+  if (ext === ".cmd" || ext === ".bat") return true;
+  if (ext) return false;
+
+  const hasPathSeparator = cmd.includes(path.sep) || cmd.includes("/");
+  const candidates = hasPathSeparator
+    ? [path.dirname(cmd)]
+    : envPathValue(envExt).split(path.delimiter).filter((entry) => entry.length > 0);
+  const basename = hasPathSeparator ? path.basename(cmd) : cmd;
+  for (const dir of candidates) {
+    if (fs.existsSync(path.join(dir, `${basename}.com`)) || fs.existsSync(path.join(dir, `${basename}.exe`))) {
+      return false;
+    }
+    if (fs.existsSync(path.join(dir, `${basename}.bat`)) || fs.existsSync(path.join(dir, `${basename}.cmd`))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function envPathValue(envExt) {
+  return envExt?.PATH ?? envExt?.Path ?? envExt?.path ?? process.env.PATH ?? process.env.Path ?? "";
 }
 
 async function quiesceCacheDaemonsBeforeSnapshot(envExt, workloadDir) {
@@ -550,6 +616,13 @@ function shellEscape(s) {
   // input rather than emit a buggy escape.
   if (/['"`$\\\n]/.test(s)) throw new Error(`refusing to shell-escape unsafe path: ${s}`);
   return /[ ()]/.test(s) ? `"${s}"` : s;
+}
+
+async function runSoldrCook(dir, envExt, flags) {
+  const soldr = envExt.SOLDR_BINARY?.trim() || "soldr";
+  const printableFlags = flags.length > 0 ? ` ${flags.join(" ")}` : "";
+  log(`[bench] running production cook before cold build: ${soldr} cook${printableFlags}`);
+  await run(soldr, ["cook", ...flags], { cwd: dir, env: envExt });
 }
 
 async function runCargoBuild(dir, envExt) {

--- a/scripts/bench-real-cache-smoke.mjs
+++ b/scripts/bench-real-cache-smoke.mjs
@@ -1,0 +1,175 @@
+// bench-real-cache-smoke.mjs - tiny Actions-cache validation path for the
+// cache-mode benchmark. It runs as two jobs: save a real cache entry after a
+// cold build, then restore that entry in a downstream job and emit normal
+// bench CSV rows.
+
+import * as cache from "@actions/cache";
+import { spawn } from "node:child_process";
+import * as fsp from "node:fs/promises";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const mode = args.mode;
+if (mode !== "save" && mode !== "restore") die("missing or invalid --mode=save|restore");
+
+const layer = args.layer ?? "target";
+if (layer !== "target") die("real-cache smoke currently supports --layer=target only");
+
+const workload = args.workload ?? "demo-small";
+const rep = Number(args.rep ?? 1);
+const out = args.out ?? (mode === "save" ? "bench-real-cache-state.json" : "bench-real-cache.csv");
+const runnerTemp = process.env.RUNNER_TEMP ?? os.tmpdir();
+const runnerOs = process.env.RUNNER_OS ?? process.platform;
+const workloadSrc = path.resolve("scripts", "bench-workloads", workload);
+const workloadDir = path.join(runnerTemp, "bench-real-cache-workload");
+const targetDir = path.join(workloadDir, "target");
+const env = { ...process.env, CARGO_TARGET_DIR: targetDir };
+
+if (mode === "save") {
+  await prepareWorkload(workloadSrc, workloadDir);
+  const tCold = nowMs();
+  await run("cargo", ["build", "--release", "--quiet"], { cwd: workloadDir, env });
+  const coldWallS = secondsSince(tCold);
+  const inflatedMb = round((await dirSizeBytes(targetDir)) / 1_000_000, 2);
+  const key = [
+    "setup-soldr-bench-real",
+    sanitize(runnerOs),
+    layer,
+    sanitize(workload),
+    `r${rep}`,
+    process.env.GITHUB_RUN_ID ?? "local",
+    process.env.GITHUB_RUN_ATTEMPT ?? "1",
+  ].join("-");
+
+  const tSave = nowMs();
+  const cacheId = await cache.saveCache([targetDir], key);
+  const saveTimeS = secondsSince(tSave);
+  await writeJson(out, {
+    version: 1,
+    key,
+    cacheId,
+    os: runnerOs,
+    layer,
+    workload,
+    rep,
+    coldWallS: round(coldWallS, 2),
+    saveTimeS: round(saveTimeS, 2),
+    inflatedMb,
+  });
+  console.log(`[bench-real-cache] saved key=${key} id=${cacheId} cold=${coldWallS.toFixed(2)}s save=${saveTimeS.toFixed(2)}s`);
+} else {
+  const statePath = args.state;
+  if (!statePath) die("restore mode requires --state=<json>");
+  const state = JSON.parse(await fsp.readFile(statePath, "utf8"));
+  if (state?.version !== 1 || !state.key) die(`invalid state file: ${statePath}`);
+
+  await prepareWorkload(workloadSrc, workloadDir);
+  const tRestore = nowMs();
+  const matchedKey = await cache.restoreCache([targetDir], state.key);
+  const restoreTimeS = secondsSince(tRestore);
+  if (!matchedKey) die(`real cache restore missed key ${state.key}`);
+
+  const tWarm = nowMs();
+  await run("cargo", ["build", "--release", "--quiet"], { cwd: workloadDir, env });
+  const warmWallS = secondsSince(tWarm);
+  await writeCsv(out, state, {
+    warmWallS: round(warmWallS, 2),
+    restoreTimeS: round(restoreTimeS, 2),
+  });
+  console.log(`[bench-real-cache] restored key=${matchedKey} warm=${warmWallS.toFixed(2)}s restore=${restoreTimeS.toFixed(2)}s`);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (const a of argv) {
+    const m = /^--([^=]+)=(.*)$/.exec(a);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+function die(msg) {
+  console.error(`bench-real-cache-smoke: ${msg}`);
+  process.exit(2);
+}
+
+function nowMs() { return Number(process.hrtime.bigint() / 1_000_000n); }
+function secondsSince(t0) { return (nowMs() - t0) / 1000; }
+function round(n, d) { return Math.round(n * 10 ** d) / 10 ** d; }
+function sanitize(s) { return String(s).replace(/[^A-Za-z0-9_.-]+/g, "-"); }
+
+async function writeJson(file, payload) {
+  await fsp.mkdir(path.dirname(path.resolve(file)), { recursive: true });
+  await fsp.writeFile(file, JSON.stringify(payload, null, 2) + "\n", "utf8");
+}
+
+async function writeCsv(file, state, warm) {
+  const header = "os,layer,phase,wall_clock_s,save_time_s,restore_time_s,compressed_mb,inflated_mb,ratio,workload,rep,cache_backend,compression_model";
+  const common = {
+    os: state.os ?? runnerOs,
+    layer: state.layer ?? layer,
+    workload: state.workload ?? workload,
+    rep: state.rep ?? rep,
+    inflatedMb: state.inflatedMb ?? "",
+  };
+  const rows = [
+    [common.os, common.layer, "cold", state.coldWallS, state.saveTimeS, "", "", common.inflatedMb, "", common.workload, common.rep, "actions-cache", "actions/cache-service"].join(","),
+    [common.os, common.layer, "warm", warm.warmWallS, "", warm.restoreTimeS, "", common.inflatedMb, "", common.workload, common.rep, "actions-cache", "actions/cache-service"].join(","),
+  ];
+  await fsp.mkdir(path.dirname(path.resolve(file)), { recursive: true });
+  await fsp.writeFile(file, [header, ...rows].join("\n") + "\n", "utf8");
+}
+
+async function prepareWorkload(src, dest) {
+  await rmrf(dest);
+  await fsp.mkdir(path.dirname(dest), { recursive: true });
+  await copyDir(src, dest);
+  await rmrf(path.join(dest, "target"));
+}
+
+async function copyDir(src, dest) {
+  await fsp.mkdir(dest, { recursive: true });
+  for (const entry of await fsp.readdir(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "target") continue;
+      await copyDir(s, d);
+    } else if (entry.isFile()) {
+      await fsp.copyFile(s, d);
+    }
+  }
+}
+
+async function rmrf(p) {
+  await fsp.rm(p, { recursive: true, force: true }).catch(() => undefined);
+}
+
+async function dirSizeBytes(dir) {
+  let total = 0;
+  async function walk(d) {
+    let entries;
+    try { entries = await fsp.readdir(d, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) await walk(full);
+      else if (e.isFile()) {
+        try { total += (await fsp.stat(full)).size; } catch { /* ignore */ }
+      } else if (e.isSymbolicLink()) {
+        try { total += Math.max(1, Buffer.byteLength(await fsp.readlink(full))); } catch { /* ignore */ }
+      }
+    }
+  }
+  if (fs.existsSync(dir)) await walk(dir);
+  return total;
+}
+
+function run(cmd, argv, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, argv, { stdio: "inherit", ...opts });
+    child.on("error", reject);
+    child.on("exit", (code) => code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`)));
+  });
+}

--- a/scripts/render-bench-summary.mjs
+++ b/scripts/render-bench-summary.mjs
@@ -52,6 +52,7 @@ if (cols.cacheBackend >= 0 || cols.compressionModel >= 0) {
     out.push(`- Compression model(s): ${uniqueValues(rows, cols.compressionModel).map(code).join(", ")}`);
   }
   out.push("- Rows using `local-tar-zstd` are synthetic local archive measurements, not direct Actions cache upload/download timings.");
+  out.push("- Rows using `actions-cache` are opt-in smoke measurements from the GitHub Actions cache service for save/restore timing validation.");
 }
 
 const aggregates = warmAggregates(rows, cols);

--- a/tests/test_bench_cache_modes_workflow.py
+++ b/tests/test_bench_cache_modes_workflow.py
@@ -27,6 +27,8 @@ def test_benchmark_workflow_exposes_bounded_dispatch_inputs() -> None:
 
     assert "cell_timeout_minutes" in inputs
     assert inputs["cell_timeout_minutes"]["default"] == "30"
+    assert inputs["cache_backend"]["default"] == "local-tar-zstd"
+    assert "local-tar-zstd+actions-cache-smoke" in inputs["cache_backend"]["options"]
     assert "cook-production" in inputs["layers"]["default"]
     assert "cook-production" in inputs["layers"]["description"]
 
@@ -51,3 +53,22 @@ def test_all_on_captures_toolchain_baseline_for_delta_only_payload() -> None:
 
     capture = next(step for step in bench_steps if step.get("name") == "Capture pre-soldr toolchain snapshot")
     assert "matrix.layer == 'all-on'" in capture["if"]
+
+
+def test_real_cache_smoke_backend_is_opt_in_and_collated() -> None:
+    workflow = _load_workflow()
+    save_job = workflow["jobs"]["real-cache-save"]
+    restore_job = workflow["jobs"]["real-cache-restore"]
+
+    assert save_job["if"] == "${{ inputs.cache_backend == 'local-tar-zstd+actions-cache-smoke' }}"
+    assert restore_job["needs"] == "real-cache-save"
+    save_step = next(step for step in save_job["steps"] if step.get("name") == "Save real target cache")
+    restore_step = next(step for step in restore_job["steps"] if step.get("name") == "Restore real target cache")
+    assert "scripts/bench-real-cache-smoke.mjs" in save_step["run"]
+    assert "--mode=save" in save_step["run"]
+    assert "scripts/bench-real-cache-smoke.mjs" in restore_step["run"]
+    assert "--mode=restore" in restore_step["run"]
+
+    collate_needs = workflow["jobs"]["collate"]["needs"]
+    assert "bench" in collate_needs
+    assert "real-cache-restore" in collate_needs


### PR DESCRIPTION
## Summary
- make the `cook-production` benchmark run `soldr cook` and snapshot post-cook `target/` before the user build, instead of snapshotting a post-build target tree
- add an opt-in `cache_backend=local-tar-zstd+actions-cache-smoke` benchmark mode that saves/restores a target-cache row through the real GitHub Actions cache service
- label real-cache rows in the rendered benchmark methodology and document how to run the smoke path

## Sub-agent work
- Explorer agents audited #188/#189/#191/#192/#193/#198 and confirmed the next slice should improve evidence quality before policy changes.
- Worker agent implemented the cook-production benchmark behavior in `scripts/bench-cache-cell.mjs` and its focused tests.
- Main agent implemented the workflow/docs/summary real-cache smoke path and integrated the final diff.

## Validation
- [x] `node --test --test-timeout=120000 --experimental-strip-types --import ./__tests__/register-loader.mjs __tests__/bench-scripts.test.ts`
- [x] `python -m pytest tests/test_bench_cache_modes_workflow.py`
- [x] `node --check scripts/bench-real-cache-smoke.mjs`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `python -m pytest tests/test_bench_cache_modes_workflow.py tests/test_action_target_cache_wiring.py tests/test_release_rollout_contract.py tests/test_zccache_build_demo_workflow.py`
- [x] `npm run build` (succeeded; generated Windows ncc churn was restored because no bundled source changed)
- [x] `git diff --check`

Refs #191.
Refs #192.
Refs #198.