### PR TITLE
fix: use cache actions for real-cache benchmark smoke

### DIFF
--- a/.github/workflows/bench-cache-modes.yml
+++ b/.github/workflows/bench-cache-modes.yml
@@ -160,10 +160,8 @@ jobs:
           node-version: 22
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install script dependencies
-        run: npm ci
-
       - name: Save real target cache
+        id: real-save-prepare
         env:
           RUNNER_OS: ${{ runner.os }}
           RUNNER_TEMP: ${{ runner.temp }}
@@ -174,6 +172,23 @@ jobs:
             --workload=${{ inputs.workload }} \
             --rep=1 \
             --out=bench-real-cache-state.json
+
+      - name: Mark real cache save start
+        id: real-save-start
+        run: echo "ms=$(node -e 'process.stdout.write(String(Date.now()))')" >> "$GITHUB_OUTPUT"
+
+      - name: Save real target cache entry
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.real-save-prepare.outputs.path }}
+          key: ${{ steps.real-save-prepare.outputs.key }}
+
+      - name: Finalize real cache save timing
+        run: |
+          node scripts/bench-real-cache-smoke.mjs \
+            --mode=finalize-save \
+            --state=bench-real-cache-state.json \
+            --save-start-ms=${{ steps.real-save-start.outputs.ms }}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -193,14 +208,35 @@ jobs:
           node-version: 22
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install script dependencies
-        run: npm ci
-
       - uses: actions/download-artifact@v4
         with:
           name: bench-real-cache-state
 
-      - name: Restore real target cache
+      - name: Prepare real target cache restore
+        id: real-restore-prepare
+        env:
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          node scripts/bench-real-cache-smoke.mjs \
+            --mode=prepare-restore \
+            --layer=target \
+            --workload=${{ inputs.workload }} \
+            --rep=1 \
+            --state=bench-real-cache-state.json
+
+      - name: Mark real cache restore start
+        id: real-restore-start
+        run: echo "ms=$(node -e 'process.stdout.write(String(Date.now()))')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore real target cache entry
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.real-restore-prepare.outputs.path }}
+          key: ${{ steps.real-restore-prepare.outputs.key }}
+          fail-on-cache-miss: true
+
+      - name: Emit real target cache row
         env:
           RUNNER_OS: ${{ runner.os }}
           RUNNER_TEMP: ${{ runner.temp }}
@@ -211,6 +247,7 @@ jobs:
             --workload=${{ inputs.workload }} \
             --rep=1 \
             --state=bench-real-cache-state.json \
+            --restore-start-ms=${{ steps.real-restore-start.outputs.ms }} \
             --out=bench-ubuntu-24.04-target-real-cache-r1.csv
 
       - uses: actions/upload-artifact@v4

--- a/scripts/bench-real-cache-smoke.mjs
+++ b/scripts/bench-real-cache-smoke.mjs
@@ -1,9 +1,9 @@
-// bench-real-cache-smoke.mjs - tiny Actions-cache validation path for the
-// cache-mode benchmark. It runs as two jobs: save a real cache entry after a
-// cold build, then restore that entry in a downstream job and emit normal
-// bench CSV rows.
+// bench-real-cache-smoke.mjs - state/CVS helper for the cache-mode benchmark's
+// real Actions cache validation path. The workflow performs the actual
+// save/restore through actions/cache/save and actions/cache/restore; this script
+// prepares the workload, records timings around those action steps, and emits
+// normal bench CSV rows.
 
-import * as cache from "@actions/cache";
 import { spawn } from "node:child_process";
 import * as fsp from "node:fs/promises";
 import * as fs from "node:fs";
@@ -12,7 +12,9 @@ import * as path from "node:path";
 
 const args = parseArgs(process.argv.slice(2));
 const mode = args.mode;
-if (mode !== "save" && mode !== "restore") die("missing or invalid --mode=save|restore");
+if (!["save", "finalize-save", "prepare-restore", "restore"].includes(mode)) {
+  die("missing or invalid --mode=save|finalize-save|prepare-restore|restore");
+}
 
 const layer = args.layer ?? "target";
 if (layer !== "target") die("real-cache smoke currently supports --layer=target only");
@@ -43,33 +45,46 @@ if (mode === "save") {
     process.env.GITHUB_RUN_ATTEMPT ?? "1",
   ].join("-");
 
-  const tSave = nowMs();
-  const cacheId = await cache.saveCache([targetDir], key);
-  const saveTimeS = secondsSince(tSave);
   await writeJson(out, {
     version: 1,
     key,
-    cacheId,
     os: runnerOs,
     layer,
     workload,
     rep,
     coldWallS: round(coldWallS, 2),
-    saveTimeS: round(saveTimeS, 2),
+    saveTimeS: "",
     inflatedMb,
   });
-  console.log(`[bench-real-cache] saved key=${key} id=${cacheId} cold=${coldWallS.toFixed(2)}s save=${saveTimeS.toFixed(2)}s`);
+  await writeOutputs({ key, path: targetDir });
+  console.log(`[bench-real-cache] prepared key=${key} path=${targetDir} cold=${coldWallS.toFixed(2)}s`);
+} else if (mode === "finalize-save") {
+  const statePath = args.state;
+  if (!statePath) die("finalize-save mode requires --state=<json>");
+  const saveStartMs = Number(args["save-start-ms"]);
+  if (!Number.isFinite(saveStartMs)) die("finalize-save mode requires --save-start-ms=<epoch-ms>");
+  const state = JSON.parse(await fsp.readFile(statePath, "utf8"));
+  if (state?.version !== 1 || !state.key) die(`invalid state file: ${statePath}`);
+  state.saveTimeS = round((Date.now() - saveStartMs) / 1000, 2);
+  await writeJson(statePath, state);
+  console.log(`[bench-real-cache] finalized save key=${state.key} save=${state.saveTimeS}s`);
+} else if (mode === "prepare-restore") {
+  const statePath = args.state;
+  if (!statePath) die("prepare-restore mode requires --state=<json>");
+  const state = JSON.parse(await fsp.readFile(statePath, "utf8"));
+  if (state?.version !== 1 || !state.key) die(`invalid state file: ${statePath}`);
+  await prepareWorkload(workloadSrc, workloadDir);
+  await writeOutputs({ key: state.key, path: targetDir });
+  console.log(`[bench-real-cache] prepared restore key=${state.key} path=${targetDir}`);
 } else {
   const statePath = args.state;
   if (!statePath) die("restore mode requires --state=<json>");
   const state = JSON.parse(await fsp.readFile(statePath, "utf8"));
   if (state?.version !== 1 || !state.key) die(`invalid state file: ${statePath}`);
-
-  await prepareWorkload(workloadSrc, workloadDir);
-  const tRestore = nowMs();
-  const matchedKey = await cache.restoreCache([targetDir], state.key);
-  const restoreTimeS = secondsSince(tRestore);
-  if (!matchedKey) die(`real cache restore missed key ${state.key}`);
+  const restoreStartMs = Number(args["restore-start-ms"]);
+  if (!Number.isFinite(restoreStartMs)) die("restore mode requires --restore-start-ms=<epoch-ms>");
+  const restoreTimeS = (Date.now() - restoreStartMs) / 1000;
+  if (!fs.existsSync(targetDir)) die(`real cache restore produced no target dir for key ${state.key}`);
 
   const tWarm = nowMs();
   await run("cargo", ["build", "--release", "--quiet"], { cwd: workloadDir, env });
@@ -78,7 +93,7 @@ if (mode === "save") {
     warmWallS: round(warmWallS, 2),
     restoreTimeS: round(restoreTimeS, 2),
   });
-  console.log(`[bench-real-cache] restored key=${matchedKey} warm=${warmWallS.toFixed(2)}s restore=${restoreTimeS.toFixed(2)}s`);
+  console.log(`[bench-real-cache] restored key=${state.key} warm=${warmWallS.toFixed(2)}s restore=${restoreTimeS.toFixed(2)}s`);
 }
 
 function parseArgs(argv) {
@@ -103,6 +118,13 @@ function sanitize(s) { return String(s).replace(/[^A-Za-z0-9_.-]+/g, "-"); }
 async function writeJson(file, payload) {
   await fsp.mkdir(path.dirname(path.resolve(file)), { recursive: true });
   await fsp.writeFile(file, JSON.stringify(payload, null, 2) + "\n", "utf8");
+}
+
+async function writeOutputs(outputs) {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file) return;
+  const lines = Object.entries(outputs).map(([k, v]) => `${k}=${v}`);
+  await fsp.appendFile(file, lines.join("\n") + "\n", "utf8");
 }
 
 async function writeCsv(file, state, warm) {

--- a/tests/test_bench_cache_modes_workflow.py
+++ b/tests/test_bench_cache_modes_workflow.py
@@ -63,9 +63,18 @@ def test_real_cache_smoke_backend_is_opt_in_and_collated() -> None:
     assert save_job["if"] == "${{ inputs.cache_backend == 'local-tar-zstd+actions-cache-smoke' }}"
     assert restore_job["needs"] == "real-cache-save"
     save_step = next(step for step in save_job["steps"] if step.get("name") == "Save real target cache")
-    restore_step = next(step for step in restore_job["steps"] if step.get("name") == "Restore real target cache")
+    save_action = next(step for step in save_job["steps"] if step.get("uses") == "actions/cache/save@v4")
+    restore_prepare = next(step for step in restore_job["steps"] if step.get("name") == "Prepare real target cache restore")
+    restore_action = next(step for step in restore_job["steps"] if step.get("uses") == "actions/cache/restore@v4")
+    restore_step = next(step for step in restore_job["steps"] if step.get("name") == "Emit real target cache row")
     assert "scripts/bench-real-cache-smoke.mjs" in save_step["run"]
     assert "--mode=save" in save_step["run"]
+    assert save_action["with"]["path"] == "${{ steps.real-save-prepare.outputs.path }}"
+    assert save_action["with"]["key"] == "${{ steps.real-save-prepare.outputs.key }}"
+    assert "--mode=prepare-restore" in restore_prepare["run"]
+    assert restore_action["with"]["path"] == "${{ steps.real-restore-prepare.outputs.path }}"
+    assert restore_action["with"]["key"] == "${{ steps.real-restore-prepare.outputs.key }}"
+    assert restore_action["with"]["fail-on-cache-miss"] is True
     assert "scripts/bench-real-cache-smoke.mjs" in restore_step["run"]
     assert "--mode=restore" in restore_step["run"]
 


### PR DESCRIPTION
## Summary
- replace direct `@actions/cache` toolkit calls in the real-cache benchmark helper with supported `actions/cache/save@v4` and `actions/cache/restore@v4` workflow steps
- keep the helper responsible for workload prep, state, and CSV row emission only
- measure save/restore action-step wall time around the cache actions for benchmark metadata

## Why
The first post-merge benchmark run proved the local matrix works but the real-cache smoke failed with `Cache Service Url not found` when the toolkit cache client ran inside a plain `run:` step:
https://github.com/zackees/setup-soldr/actions/runs/26470976040

## Validation
- [x] `node --check scripts/bench-real-cache-smoke.mjs`
- [x] `python -m pytest tests/test_bench_cache_modes_workflow.py`
- [x] `node --test --test-timeout=120000 --experimental-strip-types --import ./__tests__/register-loader.mjs __tests__/bench-scripts.test.ts`
- [x] `npm run typecheck`
- [x] `git diff --check`

Refs #191.
Refs #198.