### PR TITLE
chore(release): prepare setup-soldr v0.9.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## v0.9.11 - 2026-05-28
+
+- Add the cleanup sub-action for workflows that need to quiesce soldr/zccache
+  before post-job cache saves.
+- Formalize `prebuild-deps: soldr-cook`, including layered cook cache support
+  for soldr `0.7.38+`.
+- Harden the real-cache benchmark workflow so warm/cold setup-soldr paths use
+  real GitHub cache actions and stable cook-production shaping.
 - Default to soldr `0.7.42`, and seed zccache from the zccache trio bundled
   inside soldr release archives before using the legacy cross-repo zccache
   release fallback.


### PR DESCRIPTION
## Summary
- record setup-soldr v0.9.11 in the changelog
- include the cleanup action/workflow, soldr-cook, real-cache benchmark, and bundled zccache rollout updates now on main

## Verification
- npm run typecheck
- python -m pytest tests/test_release_rollout_contract.py -q
- git diff --check
