### PR TITLE
fix(diag): resolve compile journal under the private-daemon layout (#247)

### DIFF
--- a/__tests__/post.test.ts
+++ b/__tests__/post.test.ts
@@ -15,6 +15,59 @@ test("src/post.ts imports cleanly and exposes `run`", async () => {
   assert.equal(typeof mod.run, "function");
 });
 
+test("#247 resolveZccacheSessionJournalPath finds the journal under the private-daemon layout", async () => {
+  const mod = (await import("../src/post.js")) as {
+    resolveZccacheSessionJournalPath: (cacheDir: string) => string;
+  };
+  const root = mkTmp("journal-private-");
+  try {
+    const cache = path.join(root, "zccache");
+    // soldr's private daemon session layout: NOT <cache>/logs/, but
+    // <cache>/private/<id>/logs/last-session.jsonl
+    const sessLogs = path.join(cache, "private", "soldr-dev-abc123", "logs");
+    fs.mkdirSync(sessLogs, { recursive: true });
+    const journal = path.join(sessLogs, "last-session.jsonl");
+    fs.writeFileSync(journal, '{"outcome":"miss"}\n');
+
+    const resolved = mod.resolveZccacheSessionJournalPath(cache);
+    assert.equal(resolved, journal);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("#247 resolveZccacheSessionJournalPath falls back to the bare logs path when nothing exists", async () => {
+  const mod = (await import("../src/post.js")) as {
+    resolveZccacheSessionJournalPath: (cacheDir: string) => string;
+  };
+  const root = mkTmp("journal-empty-");
+  try {
+    const cache = path.join(root, "zccache");
+    fs.mkdirSync(cache, { recursive: true });
+    const resolved = mod.resolveZccacheSessionJournalPath(cache);
+    assert.equal(resolved, path.join(cache, "logs", "last-session.jsonl"));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("#247 resolveZccacheSessionJournalPath prefers the bare logs path when present (legacy layout)", async () => {
+  const mod = (await import("../src/post.js")) as {
+    resolveZccacheSessionJournalPath: (cacheDir: string) => string;
+  };
+  const root = mkTmp("journal-legacy-");
+  try {
+    const cache = path.join(root, "zccache");
+    fs.mkdirSync(path.join(cache, "logs"), { recursive: true });
+    const bare = path.join(cache, "logs", "last-session.jsonl");
+    fs.writeFileSync(bare, '{"outcome":"hit"}\n');
+    const resolved = mod.resolveZccacheSessionJournalPath(cache);
+    assert.equal(resolved, bare);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("post.run no-ops when no resolveResult state present", async () => {
   const mod = (await import("../src/post.js")) as { run: () => Promise<void> };
   // Make sure GITHUB_STATE points at a temp file with no key set.

--- a/dist/post.js
+++ b/dist/post.js
@@ -15,12 +15,12 @@
 //     -- this will require modifications to utils.parseParams
 
 const { Readable } = __nccwpck_require__(409)
-const { inherits } = __nccwpck_require__(359)
+const { inherits } = __nccwpck_require__(360)
 
 const Dicer = __nccwpck_require__(11)
 
-const parseParams = __nccwpck_require__(187)
-const decodeText = __nccwpck_require__(269)
+const parseParams = __nccwpck_require__(188)
+const decodeText = __nccwpck_require__(270)
 const basename = __nccwpck_require__(457)
 const getLimit = __nccwpck_require__(463)
 
@@ -340,7 +340,7 @@ __export(inspect_exports, {
   custom: () => custom
 });
 module.exports = __toCommonJS(inspect_exports);
-var import_node_util = __nccwpck_require__(359);
+var import_node_util = __nccwpck_require__(360);
 const custom = import_node_util.inspect.custom;
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -470,16 +470,16 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = exports.downloadCacheHttpClient = exports.DownloadProgress = void 0;
 const core = __importStar(__nccwpck_require__(439));
-const http_client_1 = __nccwpck_require__(278);
+const http_client_1 = __nccwpck_require__(279);
 const storage_blob_1 = __nccwpck_require__(427);
 const buffer = __importStar(__nccwpck_require__(118));
 const fs = __importStar(__nccwpck_require__(507));
-const stream = __importStar(__nccwpck_require__(129));
+const stream = __importStar(__nccwpck_require__(130));
 const util = __importStar(__nccwpck_require__(122));
 const utils = __importStar(__nccwpck_require__(73));
 const constants_1 = __nccwpck_require__(44);
-const requestUtils_1 = __nccwpck_require__(255);
-const abort_controller_1 = __nccwpck_require__(221);
+const requestUtils_1 = __nccwpck_require__(256);
+const abort_controller_1 = __nccwpck_require__(222);
 /**
  * Pipes the body of a HTTP response to a stream
  *
@@ -840,12 +840,12 @@ exports.SearchState = SearchState;
 
 
 const { InvalidArgumentError } = __nccwpck_require__(468)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(190)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(191)
 const DispatcherBase = __nccwpck_require__(60)
-const Pool = __nccwpck_require__(327)
+const Pool = __nccwpck_require__(328)
 const Client = __nccwpck_require__(86)
 const util = __nccwpck_require__(67)
-const createRedirectInterceptor = __nccwpck_require__(248)
+const createRedirectInterceptor = __nccwpck_require__(249)
 const { WeakRef, FinalizationRegistry } = __nccwpck_require__(395)()
 
 const kOnConnect = Symbol('onConnect')
@@ -1071,7 +1071,7 @@ function isNamedKeyCredential(credential) {
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(225)
+const { MockNotMatchedError } = __nccwpck_require__(226)
 const {
   kDispatches,
   kMockAgent,
@@ -1080,7 +1080,7 @@ const {
   kGetNetConnect
 } = __nccwpck_require__(450)
 const { buildURL, nop } = __nccwpck_require__(67)
-const { STATUS_CODES } = __nccwpck_require__(320)
+const { STATUS_CODES } = __nccwpck_require__(321)
 const {
   types: {
     isPromise
@@ -1515,10 +1515,10 @@ class AbortError extends Error {
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(154)
+const { kConstruct } = __nccwpck_require__(155)
 const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(77)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(67)
-const { kHeadersList } = __nccwpck_require__(190)
+const { kHeadersList } = __nccwpck_require__(191)
 const { webidl } = __nccwpck_require__(436)
 const { Response, cloneResponse } = __nccwpck_require__(40)
 const { Request } = __nccwpck_require__(81)
@@ -2362,7 +2362,7 @@ module.exports = {
 
 
 const WritableStream = (__nccwpck_require__(409).Writable)
-const inherits = (__nccwpck_require__(359).inherits)
+const inherits = (__nccwpck_require__(360).inherits)
 
 const StreamSearch = __nccwpck_require__(113)
 
@@ -2594,15 +2594,15 @@ exports.isObject = isObject;
 exports.randomUUID = randomUUID;
 exports.uint8ArrayToString = uint8ArrayToString;
 exports.stringToUint8Array = stringToUint8Array;
-const tslib_1 = __nccwpck_require__(210);
-const tspRuntime = tslib_1.__importStar(__nccwpck_require__(144));
+const tslib_1 = __nccwpck_require__(211);
+const tspRuntime = tslib_1.__importStar(__nccwpck_require__(145));
 var aborterUtils_js_1 = __nccwpck_require__(99);
 Object.defineProperty(exports, "cancelablePromiseRace", ({ enumerable: true, get: function () { return aborterUtils_js_1.cancelablePromiseRace; } }));
-var createAbortablePromise_js_1 = __nccwpck_require__(253);
+var createAbortablePromise_js_1 = __nccwpck_require__(254);
 Object.defineProperty(exports, "createAbortablePromise", ({ enumerable: true, get: function () { return createAbortablePromise_js_1.createAbortablePromise; } }));
 var delay_js_1 = __nccwpck_require__(112);
 Object.defineProperty(exports, "delay", ({ enumerable: true, get: function () { return delay_js_1.delay; } }));
-var error_js_1 = __nccwpck_require__(207);
+var error_js_1 = __nccwpck_require__(208);
 Object.defineProperty(exports, "getErrorMessage", ({ enumerable: true, get: function () { return error_js_1.getErrorMessage; } }));
 var typeGuards_js_1 = __nccwpck_require__(109);
 Object.defineProperty(exports, "isDefined", ({ enumerable: true, get: function () { return typeGuards_js_1.isDefined; } }));
@@ -2780,7 +2780,7 @@ module.exports = __toCommonJS(retryPolicy_exports);
 var import_helpers = __nccwpck_require__(435);
 var import_restError = __nccwpck_require__(424);
 var import_AbortError = __nccwpck_require__(9);
-var import_logger = __nccwpck_require__(239);
+var import_logger = __nccwpck_require__(240);
 var import_constants = __nccwpck_require__(47);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("ts-http-runtime retryPolicy");
 const retryPolicyName = "retryPolicy";
@@ -2937,7 +2937,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
-const string_decoder_1 = __nccwpck_require__(147);
+const string_decoder_1 = __nccwpck_require__(148);
 const tr = __importStar(__nccwpck_require__(124));
 /**
  * Exec a command.
@@ -3026,23 +3026,23 @@ var json_typings_1 = __nccwpck_require__(378);
 Object.defineProperty(exports, "typeofJsonValue", ({ enumerable: true, get: function () { return json_typings_1.typeofJsonValue; } }));
 Object.defineProperty(exports, "isJsonObject", ({ enumerable: true, get: function () { return json_typings_1.isJsonObject; } }));
 // Base 64 encoding
-var base64_1 = __nccwpck_require__(293);
+var base64_1 = __nccwpck_require__(294);
 Object.defineProperty(exports, "base64decode", ({ enumerable: true, get: function () { return base64_1.base64decode; } }));
 Object.defineProperty(exports, "base64encode", ({ enumerable: true, get: function () { return base64_1.base64encode; } }));
 // UTF8 encoding
-var protobufjs_utf8_1 = __nccwpck_require__(334);
+var protobufjs_utf8_1 = __nccwpck_require__(335);
 Object.defineProperty(exports, "utf8read", ({ enumerable: true, get: function () { return protobufjs_utf8_1.utf8read; } }));
 // Binary format contracts, options for reading and writing, for example
-var binary_format_contract_1 = __nccwpck_require__(323);
+var binary_format_contract_1 = __nccwpck_require__(324);
 Object.defineProperty(exports, "WireType", ({ enumerable: true, get: function () { return binary_format_contract_1.WireType; } }));
 Object.defineProperty(exports, "mergeBinaryOptions", ({ enumerable: true, get: function () { return binary_format_contract_1.mergeBinaryOptions; } }));
 Object.defineProperty(exports, "UnknownFieldHandler", ({ enumerable: true, get: function () { return binary_format_contract_1.UnknownFieldHandler; } }));
 // Standard IBinaryReader implementation
-var binary_reader_1 = __nccwpck_require__(133);
+var binary_reader_1 = __nccwpck_require__(134);
 Object.defineProperty(exports, "BinaryReader", ({ enumerable: true, get: function () { return binary_reader_1.BinaryReader; } }));
 Object.defineProperty(exports, "binaryReadOptions", ({ enumerable: true, get: function () { return binary_reader_1.binaryReadOptions; } }));
 // Standard IBinaryWriter implementation
-var binary_writer_1 = __nccwpck_require__(244);
+var binary_writer_1 = __nccwpck_require__(245);
 Object.defineProperty(exports, "BinaryWriter", ({ enumerable: true, get: function () { return binary_writer_1.BinaryWriter; } }));
 Object.defineProperty(exports, "binaryWriteOptions", ({ enumerable: true, get: function () { return binary_writer_1.binaryWriteOptions; } }));
 // Int64 and UInt64 implementations required for the binary format
@@ -3050,7 +3050,7 @@ var pb_long_1 = __nccwpck_require__(116);
 Object.defineProperty(exports, "PbLong", ({ enumerable: true, get: function () { return pb_long_1.PbLong; } }));
 Object.defineProperty(exports, "PbULong", ({ enumerable: true, get: function () { return pb_long_1.PbULong; } }));
 // JSON format contracts, options for reading and writing, for example
-var json_format_contract_1 = __nccwpck_require__(234);
+var json_format_contract_1 = __nccwpck_require__(235);
 Object.defineProperty(exports, "jsonReadOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonReadOptions; } }));
 Object.defineProperty(exports, "jsonWriteOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonWriteOptions; } }));
 Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: function () { return json_format_contract_1.mergeJsonOptions; } }));
@@ -3070,35 +3070,35 @@ Object.defineProperty(exports, "readFieldOptions", ({ enumerable: true, get: fun
 Object.defineProperty(exports, "readFieldOption", ({ enumerable: true, get: function () { return reflection_info_1.readFieldOption; } }));
 Object.defineProperty(exports, "readMessageOption", ({ enumerable: true, get: function () { return reflection_info_1.readMessageOption; } }));
 // Message operations via reflection
-var reflection_type_check_1 = __nccwpck_require__(282);
+var reflection_type_check_1 = __nccwpck_require__(283);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
-var reflection_create_1 = __nccwpck_require__(200);
+var reflection_create_1 = __nccwpck_require__(201);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
 var reflection_scalar_default_1 = __nccwpck_require__(442);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
-var reflection_merge_partial_1 = __nccwpck_require__(135);
+var reflection_merge_partial_1 = __nccwpck_require__(136);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
 var reflection_equals_1 = __nccwpck_require__(441);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
 var reflection_binary_reader_1 = __nccwpck_require__(390);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
-var reflection_binary_writer_1 = __nccwpck_require__(181);
+var reflection_binary_writer_1 = __nccwpck_require__(182);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
-var reflection_json_reader_1 = __nccwpck_require__(332);
+var reflection_json_reader_1 = __nccwpck_require__(333);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
 var reflection_json_writer_1 = __nccwpck_require__(88);
 Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get: function () { return reflection_json_writer_1.ReflectionJsonWriter; } }));
 var reflection_contains_message_type_1 = __nccwpck_require__(49);
 Object.defineProperty(exports, "containsMessageType", ({ enumerable: true, get: function () { return reflection_contains_message_type_1.containsMessageType; } }));
 // Oneof helpers
-var oneof_1 = __nccwpck_require__(185);
+var oneof_1 = __nccwpck_require__(186);
 Object.defineProperty(exports, "isOneofGroup", ({ enumerable: true, get: function () { return oneof_1.isOneofGroup; } }));
 Object.defineProperty(exports, "setOneofValue", ({ enumerable: true, get: function () { return oneof_1.setOneofValue; } }));
 Object.defineProperty(exports, "getOneofValue", ({ enumerable: true, get: function () { return oneof_1.getOneofValue; } }));
 Object.defineProperty(exports, "clearOneofValue", ({ enumerable: true, get: function () { return oneof_1.clearOneofValue; } }));
 Object.defineProperty(exports, "getSelectedOneofValue", ({ enumerable: true, get: function () { return oneof_1.getSelectedOneofValue; } }));
 // Enum object type guard and reflection util, may be interesting to the user.
-var enum_object_1 = __nccwpck_require__(266);
+var enum_object_1 = __nccwpck_require__(267);
 Object.defineProperty(exports, "listEnumValues", ({ enumerable: true, get: function () { return enum_object_1.listEnumValues; } }));
 Object.defineProperty(exports, "listEnumNames", ({ enumerable: true, get: function () { return enum_object_1.listEnumNames; } }));
 Object.defineProperty(exports, "listEnumNumbers", ({ enumerable: true, get: function () { return enum_object_1.listEnumNumbers; } }));
@@ -3190,7 +3190,7 @@ const XML_CHARKEY = "_";
 /***/ 20:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(190)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(191)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -3254,7 +3254,7 @@ __export(throttlingRetryPolicy_exports, {
   throttlingRetryPolicyName: () => throttlingRetryPolicyName
 });
 module.exports = __toCommonJS(throttlingRetryPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(280);
 const throttlingRetryPolicyName = import_policies.throttlingRetryPolicyName;
 function throttlingRetryPolicy(options = {}) {
   return (0, import_policies.throttlingRetryPolicy)(options);
@@ -3281,21 +3281,21 @@ const {
   createDeferredPromise,
   fullyReadBody
 } = __nccwpck_require__(495)
-const { FormData } = __nccwpck_require__(202)
+const { FormData } = __nccwpck_require__(203)
 const { kState } = __nccwpck_require__(13)
 const { webidl } = __nccwpck_require__(436)
 const { DOMException, structuredClone } = __nccwpck_require__(28)
 const { Blob, File: NativeFile } = __nccwpck_require__(118)
-const { kBodyUsed } = __nccwpck_require__(190)
+const { kBodyUsed } = __nccwpck_require__(191)
 const assert = __nccwpck_require__(503)
 const { isErrored } = __nccwpck_require__(67)
-const { isUint8Array, isArrayBuffer } = __nccwpck_require__(193)
-const { File: UndiciFile } = __nccwpck_require__(349)
+const { isUint8Array, isArrayBuffer } = __nccwpck_require__(194)
+const { File: UndiciFile } = __nccwpck_require__(350)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(23)
 
 let random
 try {
-  const crypto = __nccwpck_require__(268)
+  const crypto = __nccwpck_require__(269)
   random = (max) => crypto.randomInt(0, max)
 } catch {
   random = (max) => Math.floor(Math.random(max))
@@ -3311,7 +3311,7 @@ const textDecoder = new TextDecoder()
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 function extractBody (object, keepalive = false) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(250).ReadableStream)
+    ReadableStream = (__nccwpck_require__(251).ReadableStream)
   }
 
   // 1. Let stream be null.
@@ -3532,7 +3532,7 @@ function extractBody (object, keepalive = false) {
 function safelyExtractBody (object, keepalive = false) {
   if (!ReadableStream) {
     // istanbul ignore next
-    ReadableStream = (__nccwpck_require__(250).ReadableStream)
+    ReadableStream = (__nccwpck_require__(251).ReadableStream)
   }
 
   // To safely extract a body and a `Content-Type` value from
@@ -4534,9 +4534,9 @@ module.exports = {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(419));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(63));
 /** Class containing AppendBlob operations. */
 class AppendBlobImpl {
@@ -4943,7 +4943,7 @@ function rangeResponseFromModel(response) {
 "use strict";
 
 
-const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(309)
+const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(310)
 
 const corsSafeListedMethods = ['GET', 'HEAD', 'POST']
 const corsSafeListedMethodsSet = new Set(corsSafeListedMethods)
@@ -5106,7 +5106,7 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tracingClient = void 0;
 const core_tracing_1 = __nccwpck_require__(79);
-const constants_js_1 = __nccwpck_require__(146);
+const constants_js_1 = __nccwpck_require__(147);
 /**
  * Creates a span using the global tracer.
  * @internal
@@ -5231,17 +5231,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.reserveCache = exports.downloadCache = exports.getCacheEntry = void 0;
 const core = __importStar(__nccwpck_require__(439));
-const http_client_1 = __nccwpck_require__(278);
+const http_client_1 = __nccwpck_require__(279);
 const auth_1 = __nccwpck_require__(25);
 const fs = __importStar(__nccwpck_require__(507));
 const url_1 = __nccwpck_require__(82);
 const utils = __importStar(__nccwpck_require__(73));
-const uploadUtils_1 = __nccwpck_require__(158);
+const uploadUtils_1 = __nccwpck_require__(159);
 const downloadUtils_1 = __nccwpck_require__(3);
-const options_1 = __nccwpck_require__(259);
-const requestUtils_1 = __nccwpck_require__(255);
+const options_1 = __nccwpck_require__(260);
+const requestUtils_1 = __nccwpck_require__(256);
 const config_1 = __nccwpck_require__(35);
-const user_agent_1 = __nccwpck_require__(347);
+const user_agent_1 = __nccwpck_require__(348);
 function getCacheApiUrl(resource) {
     const baseUrl = (0, config_1.getCacheServiceURL)();
     if (!baseUrl) {
@@ -5695,9 +5695,9 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_https_proxy_agent = __nccwpck_require__(131);
-var import_http_proxy_agent = __nccwpck_require__(217);
-var import_log = __nccwpck_require__(149);
+var import_https_proxy_agent = __nccwpck_require__(132);
+var import_http_proxy_agent = __nccwpck_require__(218);
+var import_log = __nccwpck_require__(150);
 const HTTPS_PROXY = "HTTPS_PROXY";
 const HTTP_PROXY = "HTTP_PROXY";
 const ALL_PROXY = "ALL_PROXY";
@@ -5922,13 +5922,13 @@ exports.saveCookCache = saveCookCache;
 exports.saveLayeredCookCache = saveLayeredCookCache;
 exports.parseCookFlags = parseCookFlags;
 exports.canonicalizeCookFlags = canonicalizeCookFlags;
-const node_crypto_1 = __nccwpck_require__(268);
-const fs = __importStar(__nccwpck_require__(242));
+const node_crypto_1 = __nccwpck_require__(269);
+const fs = __importStar(__nccwpck_require__(243));
 const fsp = __importStar(__nccwpck_require__(107));
 const path = __importStar(__nccwpck_require__(487));
 const exec = __importStar(__nccwpck_require__(16));
-const cache = __importStar(__nccwpck_require__(208));
-const cache_compress_js_1 = __nccwpck_require__(272);
+const cache = __importStar(__nccwpck_require__(209));
+const cache_compress_js_1 = __nccwpck_require__(273);
 const COOK_KEY_PREFIX = "cook";
 const COOK_BASE_KEY_PREFIX = "cook-base-v2";
 const COOK_DELTA_KEY_PREFIX = "cook-delta-v2";
@@ -6557,14 +6557,14 @@ const {
 } = __nccwpck_require__(28)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(13)
 const { webidl } = __nccwpck_require__(436)
-const { FormData } = __nccwpck_require__(202)
-const { getGlobalOrigin } = __nccwpck_require__(138)
+const { FormData } = __nccwpck_require__(203)
+const { getGlobalOrigin } = __nccwpck_require__(139)
 const { URLSerializer } = __nccwpck_require__(23)
-const { kHeadersList, kConstruct } = __nccwpck_require__(190)
+const { kHeadersList, kConstruct } = __nccwpck_require__(191)
 const assert = __nccwpck_require__(503)
 const { types } = __nccwpck_require__(122)
 
-const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(250).ReadableStream)
+const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(251).ReadableStream)
 const textEncoder = new TextEncoder('utf-8')
 
 // https://fetch.spec.whatwg.org/#response-class
@@ -7198,7 +7198,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
-const pathHelper = __importStar(__nccwpck_require__(215));
+const pathHelper = __importStar(__nccwpck_require__(216));
 const internal_match_kind_1 = __nccwpck_require__(505);
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -7285,7 +7285,7 @@ exports.AzureLogger = void 0;
 exports.setLogLevel = setLogLevel;
 exports.getLogLevel = getLogLevel;
 exports.createClientLogger = createClientLogger;
-const logger_1 = __nccwpck_require__(145);
+const logger_1 = __nccwpck_require__(146);
 const context = (0, logger_1.createLoggerContext)({
     logLevelEnvVarName: "AZURE_LOG_LEVEL",
     namespace: "azure",
@@ -7437,9 +7437,9 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(419));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(63));
 /** Class containing Blob operations. */
 class BlobImpl {
@@ -8589,8 +8589,8 @@ exports.containsMessageType = containsMessageType;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollHttpOperation = exports.isOperationError = exports.getResourceLocation = exports.getOperationStatus = exports.getOperationLocation = exports.initHttpOperation = exports.getStatusFromInitialResponse = exports.getErrorFromResponse = exports.parseRetryAfter = exports.inferLroMode = void 0;
-const operation_js_1 = __nccwpck_require__(139);
-const logger_js_1 = __nccwpck_require__(186);
+const operation_js_1 = __nccwpck_require__(140);
+const logger_js_1 = __nccwpck_require__(187);
 function getOperationLocationPollingUrl(inputs) {
     const { azureAsyncOperation, operationLocation } = inputs;
     return operationLocation !== null && operationLocation !== void 0 ? operationLocation : azureAsyncOperation;
@@ -8994,7 +8994,7 @@ const { getEncoding } = __nccwpck_require__(96)
 const { DOMException } = __nccwpck_require__(28)
 const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(23)
 const { types } = __nccwpck_require__(122)
-const { StringDecoder } = __nccwpck_require__(147)
+const { StringDecoder } = __nccwpck_require__(148)
 const { btoa } = __nccwpck_require__(118)
 
 /** @type {PropertyDescriptor} */
@@ -9402,7 +9402,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(280);
 const defaultRetryPolicyName = import_policies.defaultRetryPolicyName;
 function defaultRetryPolicy(options = {}) {
   return (0, import_policies.defaultRetryPolicy)(options);
@@ -9478,7 +9478,7 @@ exports.UnaryCall = UnaryCall;
 
 const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(97)
 const { states, opcodes } = __nccwpck_require__(445)
-const { MessageEvent, ErrorEvent } = __nccwpck_require__(243)
+const { MessageEvent, ErrorEvent } = __nccwpck_require__(244)
 
 /* globals Blob */
 
@@ -9960,14 +9960,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.internalCacheTwirpClient = void 0;
 const core_1 = __nccwpck_require__(439);
-const user_agent_1 = __nccwpck_require__(347);
-const errors_1 = __nccwpck_require__(295);
+const user_agent_1 = __nccwpck_require__(348);
+const errors_1 = __nccwpck_require__(296);
 const config_1 = __nccwpck_require__(35);
 const cacheUtils_1 = __nccwpck_require__(73);
 const auth_1 = __nccwpck_require__(25);
-const http_client_1 = __nccwpck_require__(278);
+const http_client_1 = __nccwpck_require__(279);
 const cache_twirp_client_1 = __nccwpck_require__(416);
-const util_1 = __nccwpck_require__(287);
+const util_1 = __nccwpck_require__(288);
 /**
  * This class is a wrapper around the CacheServiceClientJSON class generated by Twirp.
  *
@@ -10124,7 +10124,7 @@ const {
   ClientClosedError,
   InvalidArgumentError
 } = __nccwpck_require__(468)
-const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(190)
+const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(191)
 
 const kDestroyed = Symbol('destroyed')
 const kClosed = Symbol('closed')
@@ -10393,14 +10393,14 @@ exports.ContainerClient = void 0;
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(12);
 const core_auth_1 = __nccwpck_require__(492);
-const storage_common_1 = __nccwpck_require__(270);
-const Pipeline_js_1 = __nccwpck_require__(178);
+const storage_common_1 = __nccwpck_require__(271);
+const Pipeline_js_1 = __nccwpck_require__(179);
 const StorageClient_js_1 = __nccwpck_require__(434);
 const tracing_js_1 = __nccwpck_require__(29);
-const utils_common_js_1 = __nccwpck_require__(152);
+const utils_common_js_1 = __nccwpck_require__(153);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(66);
-const BlobLeaseClient_js_1 = __nccwpck_require__(199);
-const Clients_js_1 = __nccwpck_require__(180);
+const BlobLeaseClient_js_1 = __nccwpck_require__(200);
+const Clients_js_1 = __nccwpck_require__(181);
 const BlobBatchClient_js_1 = __nccwpck_require__(385);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
@@ -11703,7 +11703,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.action3 = exports.action2 = exports.leaseId1 = exports.action1 = exports.proposedLeaseId = exports.duration = exports.action = exports.comp10 = exports.sourceLeaseId = exports.sourceContainerName = exports.comp9 = exports.deletedContainerVersion = exports.deletedContainerName = exports.comp8 = exports.containerAcl = exports.comp7 = exports.comp6 = exports.ifUnmodifiedSince = exports.ifModifiedSince = exports.leaseId = exports.preventEncryptionScopeOverride = exports.defaultEncryptionScope = exports.access = exports.metadata = exports.restype2 = exports.where = exports.comp5 = exports.multipartContentType = exports.contentLength = exports.comp4 = exports.body = exports.restype1 = exports.comp3 = exports.keyInfo = exports.include = exports.maxPageSize = exports.marker = exports.prefix = exports.comp2 = exports.comp1 = exports.accept1 = exports.requestId = exports.version = exports.timeoutInSeconds = exports.comp = exports.restype = exports.url = exports.accept = exports.blobServiceProperties = exports.contentType = void 0;
 exports.copySourceTags = exports.copySourceAuthorization = exports.sourceContentMD5 = exports.xMsRequiresSync = exports.legalHold1 = exports.sealBlob = exports.blobTagsString = exports.copySource = exports.sourceIfTags = exports.sourceIfNoneMatch = exports.sourceIfMatch = exports.sourceIfUnmodifiedSince = exports.sourceIfModifiedSince = exports.rehydratePriority = exports.tier = exports.comp14 = exports.encryptionScope = exports.legalHold = exports.comp13 = exports.immutabilityPolicyMode = exports.immutabilityPolicyExpiry = exports.comp12 = exports.blobContentDisposition = exports.blobContentLanguage = exports.blobContentEncoding = exports.blobContentMD5 = exports.blobContentType = exports.blobCacheControl = exports.expiresOn = exports.expiryOptions = exports.comp11 = exports.blobDeleteType = exports.deleteSnapshots = exports.ifTags = exports.ifNoneMatch = exports.ifMatch = exports.encryptionAlgorithm = exports.encryptionKeySha256 = exports.encryptionKey = exports.rangeGetContentCRC64 = exports.rangeGetContentMD5 = exports.range = exports.versionId = exports.snapshot = exports.delimiter = exports.startFrom = exports.include1 = exports.proposedLeaseId1 = exports.action4 = exports.breakPeriod = void 0;
 exports.listType = exports.comp25 = exports.blocks = exports.blockId = exports.comp24 = exports.copySourceBlobProperties = exports.blobType2 = exports.comp23 = exports.sourceRange1 = exports.appendPosition = exports.maxSize = exports.comp22 = exports.blobType1 = exports.comp21 = exports.sequenceNumberAction = exports.prevSnapshotUrl = exports.prevsnapshot = exports.comp20 = exports.range1 = exports.sourceContentCrc64 = exports.sourceRange = exports.sourceUrl = exports.pageWrite1 = exports.ifSequenceNumberEqualTo = exports.ifSequenceNumberLessThan = exports.ifSequenceNumberLessThanOrEqualTo = exports.pageWrite = exports.comp19 = exports.accept2 = exports.body1 = exports.contentType1 = exports.blobSequenceNumber = exports.blobContentLength = exports.blobType = exports.transactionalContentCrc64 = exports.transactionalContentMD5 = exports.tags = exports.ifNoneMatch1 = exports.ifMatch1 = exports.ifUnmodifiedSince1 = exports.ifModifiedSince1 = exports.comp18 = exports.comp17 = exports.queryRequest = exports.tier1 = exports.comp16 = exports.copyId = exports.copyActionAbortConstant = exports.comp15 = exports.fileRequestIntent = void 0;
-const mappers_js_1 = __nccwpck_require__(175);
+const mappers_js_1 = __nccwpck_require__(176);
 exports.contentType = {
     parameterPath: ["options", "contentType"],
     mapper: {
@@ -13379,7 +13379,7 @@ exports.listType = {
 "use strict";
 
 
-const inherits = (__nccwpck_require__(359).inherits)
+const inherits = (__nccwpck_require__(360).inherits)
 const ReadableStream = (__nccwpck_require__(409).Readable)
 
 function PartStream (opts) {
@@ -13413,13 +13413,13 @@ exports.generateBlobSASQueryParametersInternal = generateBlobSASQueryParametersI
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const BlobSASPermissions_js_1 = __nccwpck_require__(483);
-const ContainerSASPermissions_js_1 = __nccwpck_require__(273);
-const storage_common_1 = __nccwpck_require__(270);
-const SasIPRange_js_1 = __nccwpck_require__(345);
+const ContainerSASPermissions_js_1 = __nccwpck_require__(274);
+const storage_common_1 = __nccwpck_require__(271);
+const SasIPRange_js_1 = __nccwpck_require__(346);
 const SASQueryParameters_js_1 = __nccwpck_require__(502);
-const constants_js_1 = __nccwpck_require__(146);
-const utils_common_js_1 = __nccwpck_require__(152);
-const storage_common_2 = __nccwpck_require__(270);
+const constants_js_1 = __nccwpck_require__(147);
+const utils_common_js_1 = __nccwpck_require__(153);
+const storage_common_2 = __nccwpck_require__(271);
 function generateBlobSASQueryParameters(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName) {
     return generateBlobSASQueryParametersInternal(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName).sasQueryParameters;
 }
@@ -14086,14 +14086,14 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 
 
 const assert = __nccwpck_require__(503)
-const { kDestroyed, kBodyUsed } = __nccwpck_require__(190)
-const { IncomingMessage } = __nccwpck_require__(320)
-const stream = __nccwpck_require__(129)
+const { kDestroyed, kBodyUsed } = __nccwpck_require__(191)
+const { IncomingMessage } = __nccwpck_require__(321)
+const stream = __nccwpck_require__(130)
 const net = __nccwpck_require__(488)
 const { InvalidArgumentError } = __nccwpck_require__(468)
 const { Blob } = __nccwpck_require__(118)
 const nodeUtil = __nccwpck_require__(122)
-const { stringify } = __nccwpck_require__(128)
+const { stringify } = __nccwpck_require__(129)
 const { headerNameLowerCasedRecord } = __nccwpck_require__(71)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
@@ -14463,7 +14463,7 @@ async function * convertIterableToBuffer (iterable) {
 let ReadableStream
 function ReadableStreamFrom (iterable) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(250).ReadableStream)
+    ReadableStream = (__nccwpck_require__(251).ReadableStream)
   }
 
   if (ReadableStream.from) {
@@ -14643,8 +14643,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(179);
-var import_policies = __nccwpck_require__(279);
+var import_log = __nccwpck_require__(180);
+var import_policies = __nccwpck_require__(280);
 const logPolicyName = import_policies.logPolicyName;
 function logPolicy(options = {}) {
   return (0, import_policies.logPolicy)({
@@ -14690,11 +14690,11 @@ __export(src_exports, {
   toHttpHeadersLike: () => import_util.toHttpHeadersLike
 });
 module.exports = __toCommonJS(src_exports);
-var import_extendedClient = __nccwpck_require__(209);
+var import_extendedClient = __nccwpck_require__(210);
 var import_response = __nccwpck_require__(393);
 var import_requestPolicyFactoryPolicy = __nccwpck_require__(61);
 var import_disableKeepAlivePolicy = __nccwpck_require__(8);
-var import_httpClientAdapter = __nccwpck_require__(205);
+var import_httpClientAdapter = __nccwpck_require__(206);
 var import_util = __nccwpck_require__(108);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -15287,12 +15287,12 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
 const core = __importStar(__nccwpck_require__(439));
 const exec = __importStar(__nccwpck_require__(16));
-const glob = __importStar(__nccwpck_require__(165));
-const io = __importStar(__nccwpck_require__(286));
-const crypto = __importStar(__nccwpck_require__(283));
+const glob = __importStar(__nccwpck_require__(166));
+const io = __importStar(__nccwpck_require__(287));
+const crypto = __importStar(__nccwpck_require__(284));
 const fs = __importStar(__nccwpck_require__(507));
-const path = __importStar(__nccwpck_require__(241));
-const semver = __importStar(__nccwpck_require__(174));
+const path = __importStar(__nccwpck_require__(242));
+const semver = __importStar(__nccwpck_require__(175));
 const util = __importStar(__nccwpck_require__(122));
 const constants_1 = __nccwpck_require__(44);
 const versionSalt = '1.0';
@@ -15480,10 +15480,10 @@ module.exports = 'AGFzbQEAAAABMAhgAX8Bf2ADf39/AX9gBH9/f38Bf2AAAGADf39/AGABfwBgAn
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageSharedKeyCredentialPolicyName = void 0;
 exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
-const node_crypto_1 = __nccwpck_require__(268);
+const node_crypto_1 = __nccwpck_require__(269);
 const constants_js_1 = __nccwpck_require__(34);
 const utils_common_js_1 = __nccwpck_require__(454);
-const SharedKeyComparator_js_1 = __nccwpck_require__(172);
+const SharedKeyComparator_js_1 = __nccwpck_require__(173);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
  */
@@ -15664,10 +15664,10 @@ exports.isGitRepo = isGitRepo;
 exports.listTrackedFiles = listTrackedFiles;
 exports.normalizeWorkspace = normalizeWorkspace;
 exports.normalizeSourceMtime = normalizeSourceMtime;
-const fs = __importStar(__nccwpck_require__(242));
+const fs = __importStar(__nccwpck_require__(243));
 const path = __importStar(__nccwpck_require__(487));
 const exec = __importStar(__nccwpck_require__(16));
-const log_utils_js_1 = __nccwpck_require__(339);
+const log_utils_js_1 = __nccwpck_require__(340);
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 // Globs evaluated against the repo-relative POSIX path of each tracked file.
 const INCLUDE_GLOBS = [
@@ -16198,7 +16198,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = exports.useInstrumenter = void 0;
 var instrumenter_js_1 = __nccwpck_require__(388);
 Object.defineProperty(exports, "useInstrumenter", ({ enumerable: true, get: function () { return instrumenter_js_1.useInstrumenter; } }));
-var tracingClient_js_1 = __nccwpck_require__(335);
+var tracingClient_js_1 = __nccwpck_require__(336);
 Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: function () { return tracingClient_js_1.createTracingClient; } }));
 //# sourceMappingURL=index.js.map
 
@@ -16248,9 +16248,9 @@ const {
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(13)
 const { webidl } = __nccwpck_require__(436)
-const { getGlobalOrigin } = __nccwpck_require__(138)
+const { getGlobalOrigin } = __nccwpck_require__(139)
 const { URLSerializer } = __nccwpck_require__(23)
-const { kHeadersList, kConstruct } = __nccwpck_require__(190)
+const { kHeadersList, kConstruct } = __nccwpck_require__(191)
 const assert = __nccwpck_require__(503)
 const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(449)
 
@@ -16739,7 +16739,7 @@ class Request {
 
       // 2. Set finalBody to the result of creating a proxy for inputBody.
       if (!TransformStream) {
-        TransformStream = (__nccwpck_require__(250).TransformStream)
+        TransformStream = (__nccwpck_require__(251).TransformStream)
       }
 
       // https://streams.spec.whatwg.org/#readablestream-create-a-proxy
@@ -17483,11 +17483,11 @@ exports.buildMiniCacheKey = buildMiniCacheKey;
 exports.restoreMiniCache = restoreMiniCache;
 exports.saveMiniCache = saveMiniCache;
 exports.isEligibleForMiniCache = isEligibleForMiniCache;
-const fs = __importStar(__nccwpck_require__(242));
+const fs = __importStar(__nccwpck_require__(243));
 const fsp = __importStar(__nccwpck_require__(107));
 const path = __importStar(__nccwpck_require__(487));
-const cache = __importStar(__nccwpck_require__(208));
-const cache_compress_js_1 = __nccwpck_require__(272);
+const cache = __importStar(__nccwpck_require__(209));
+const cache_compress_js_1 = __nccwpck_require__(273);
 const MINI_KEY_PREFIX = "soldr-mini";
 /**
  * Build the mini-cache key. Deliberately coarse — only the dimensions
@@ -17725,11 +17725,11 @@ function apiKeyAuthenticationPolicy(options) {
 
 const assert = __nccwpck_require__(503)
 const net = __nccwpck_require__(488)
-const http = __nccwpck_require__(320)
-const { pipeline } = __nccwpck_require__(129)
+const http = __nccwpck_require__(321)
+const { pipeline } = __nccwpck_require__(130)
 const util = __nccwpck_require__(67)
-const timers = __nccwpck_require__(319)
-const Request = __nccwpck_require__(290)
+const timers = __nccwpck_require__(320)
+const Request = __nccwpck_require__(291)
 const DispatcherBase = __nccwpck_require__(60)
 const {
   RequestContentLengthMismatchError,
@@ -17745,7 +17745,7 @@ const {
   ResponseExceededMaxSizeError,
   ClientDestroyedError
 } = __nccwpck_require__(468)
-const buildConnector = __nccwpck_require__(260)
+const buildConnector = __nccwpck_require__(261)
 const {
   kUrl,
   kReset,
@@ -17797,7 +17797,7 @@ const {
   kHTTP2BuildRequest,
   kHTTP2CopyHeaders,
   kHTTP1BuildRequest
-} = __nccwpck_require__(190)
+} = __nccwpck_require__(191)
 
 /** @type {import('http2')} */
 let http2
@@ -17830,7 +17830,7 @@ const kClosedResolve = Symbol('kClosedResolve')
 const channels = {}
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(140)
+  const diagnosticsChannel = __nccwpck_require__(141)
   channels.sendHeaders = diagnosticsChannel.channel('undici:client:sendHeaders')
   channels.beforeConnect = diagnosticsChannel.channel('undici:client:beforeConnect')
   channels.connectError = diagnosticsChannel.channel('undici:client:connectError')
@@ -18204,7 +18204,7 @@ function onHTTP2GoAway (code) {
 }
 
 const constants = __nccwpck_require__(428)
-const createRedirectInterceptor = __nccwpck_require__(248)
+const createRedirectInterceptor = __nccwpck_require__(249)
 const EMPTY_BUF = Buffer.alloc(0)
 
 async function lazyllhttp () {
@@ -20045,16 +20045,16 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 var import_AbortError = __nccwpck_require__(9);
-var import_logger = __nccwpck_require__(239);
+var import_logger = __nccwpck_require__(240);
 var import_httpHeaders = __nccwpck_require__(465);
 var import_pipelineRequest = __nccwpck_require__(114);
 var import_pipeline = __nccwpck_require__(501);
 var import_restError = __nccwpck_require__(424);
-var import_bytesEncoding = __nccwpck_require__(280);
-var import_defaultHttpClient = __nccwpck_require__(356);
-var import_getClient = __nccwpck_require__(204);
+var import_bytesEncoding = __nccwpck_require__(281);
+var import_defaultHttpClient = __nccwpck_require__(357);
+var import_getClient = __nccwpck_require__(205);
 var import_operationOptionHelpers = __nccwpck_require__(368);
-var import_restError2 = __nccwpck_require__(352);
+var import_restError2 = __nccwpck_require__(353);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -20069,7 +20069,7 @@ var import_restError2 = __nccwpck_require__(352);
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
-const base64_1 = __nccwpck_require__(293);
+const base64_1 = __nccwpck_require__(294);
 const pb_long_1 = __nccwpck_require__(116);
 const reflection_info_1 = __nccwpck_require__(432);
 const assert_1 = __nccwpck_require__(464);
@@ -20458,7 +20458,7 @@ module.exports = require("os");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredentialPolicy = void 0;
-const CredentialPolicy_js_1 = __nccwpck_require__(300);
+const CredentialPolicy_js_1 = __nccwpck_require__(301);
 /**
  * AnonymousCredentialPolicy is used with HTTP(S) requests that read public resources
  * or for use with Shared Access Signatures (SAS).
@@ -21408,32 +21408,32 @@ __export(src_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(src_exports);
-var import_pipeline = __nccwpck_require__(238);
-var import_createPipelineFromOptions = __nccwpck_require__(274);
-var import_defaultHttpClient = __nccwpck_require__(228);
-var import_httpHeaders = __nccwpck_require__(235);
+var import_pipeline = __nccwpck_require__(239);
+var import_createPipelineFromOptions = __nccwpck_require__(275);
+var import_defaultHttpClient = __nccwpck_require__(229);
+var import_httpHeaders = __nccwpck_require__(236);
 var import_pipelineRequest = __nccwpck_require__(18);
-var import_restError = __nccwpck_require__(340);
-var import_decompressResponsePolicy = __nccwpck_require__(231);
+var import_restError = __nccwpck_require__(341);
+var import_decompressResponsePolicy = __nccwpck_require__(232);
 var import_exponentialRetryPolicy = __nccwpck_require__(376);
-var import_setClientRequestIdPolicy = __nccwpck_require__(148);
+var import_setClientRequestIdPolicy = __nccwpck_require__(149);
 var import_logPolicy = __nccwpck_require__(69);
-var import_multipartPolicy = __nccwpck_require__(265);
+var import_multipartPolicy = __nccwpck_require__(266);
 var import_proxyPolicy = __nccwpck_require__(452);
-var import_redirectPolicy = __nccwpck_require__(330);
-var import_systemErrorRetryPolicy = __nccwpck_require__(212);
+var import_redirectPolicy = __nccwpck_require__(331);
+var import_systemErrorRetryPolicy = __nccwpck_require__(213);
 var import_throttlingRetryPolicy = __nccwpck_require__(21);
-var import_retryPolicy = __nccwpck_require__(206);
-var import_tracingPolicy = __nccwpck_require__(326);
+var import_retryPolicy = __nccwpck_require__(207);
+var import_tracingPolicy = __nccwpck_require__(327);
 var import_defaultRetryPolicy = __nccwpck_require__(53);
 var import_userAgentPolicy = __nccwpck_require__(373);
 var import_tlsPolicy = __nccwpck_require__(363);
-var import_formDataPolicy = __nccwpck_require__(262);
-var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(211);
-var import_ndJsonPolicy = __nccwpck_require__(232);
-var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(188);
-var import_agentPolicy = __nccwpck_require__(224);
-var import_file = __nccwpck_require__(318);
+var import_formDataPolicy = __nccwpck_require__(263);
+var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(212);
+var import_ndJsonPolicy = __nccwpck_require__(233);
+var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(189);
+var import_agentPolicy = __nccwpck_require__(225);
+var import_file = __nccwpck_require__(319);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 
@@ -21466,7 +21466,7 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(149);
+var import_log = __nccwpck_require__(150);
 var import_sanitizer = __nccwpck_require__(120);
 const logPolicyName = "logPolicy";
 function logPolicy(options = {}) {
@@ -21598,7 +21598,7 @@ const {
   Readable,
   Duplex,
   PassThrough
-} = __nccwpck_require__(129)
+} = __nccwpck_require__(130)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
@@ -21869,8 +21869,8 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 "use strict";
 
 
-const EventEmitter = (__nccwpck_require__(142).EventEmitter)
-const inherits = (__nccwpck_require__(359).inherits)
+const EventEmitter = (__nccwpck_require__(143).EventEmitter)
+const inherits = (__nccwpck_require__(360).inherits)
 const getLimit = __nccwpck_require__(463)
 
 const StreamSearch = __nccwpck_require__(113)
@@ -22396,8 +22396,8 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.delay = delay;
 exports.calculateRetryDelay = calculateRetryDelay;
-const createAbortablePromise_js_1 = __nccwpck_require__(253);
-const util_1 = __nccwpck_require__(144);
+const createAbortablePromise_js_1 = __nccwpck_require__(254);
+const util_1 = __nccwpck_require__(145);
 const StandardAbortMessage = "The delay was aborted.";
 /**
  * A wrapper for setTimeout that resolves a promise after timeInMs milliseconds.
@@ -22468,8 +22468,8 @@ function calculateRetryDelay(retryAttempt, config) {
  * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
-const EventEmitter = (__nccwpck_require__(142).EventEmitter)
-const inherits = (__nccwpck_require__(359).inherits)
+const EventEmitter = (__nccwpck_require__(143).EventEmitter)
+const inherits = (__nccwpck_require__(360).inherits)
 
 function SBMH (needle) {
   if (typeof needle === 'string') {
@@ -22788,7 +22788,7 @@ __export(userAgentPlatform_exports, {
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
 var import_node_os = __toESM(__nccwpck_require__(367));
-var import_node_process = __toESM(__nccwpck_require__(229));
+var import_node_process = __toESM(__nccwpck_require__(230));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -22818,7 +22818,7 @@ async function setPlatformSpecificData(map) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PbLong = exports.PbULong = exports.detectBi = void 0;
-const goog_varint_1 = __nccwpck_require__(198);
+const goog_varint_1 = __nccwpck_require__(199);
 let BI;
 function detectBi() {
     const dv = new DataView(new ArrayBuffer(8));
@@ -23111,8 +23111,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
-const path = __importStar(__nccwpck_require__(241));
-const pathHelper = __importStar(__nccwpck_require__(215));
+const path = __importStar(__nccwpck_require__(242));
+const pathHelper = __importStar(__nccwpck_require__(216));
 const assert_1 = __importDefault(__nccwpck_require__(503));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -23227,7 +23227,7 @@ __export(sanitizer_exports, {
   Sanitizer: () => Sanitizer
 });
 module.exports = __toCommonJS(sanitizer_exports);
-var import_object = __nccwpck_require__(143);
+var import_object = __nccwpck_require__(144);
 const RedactedString = "REDACTED";
 const defaultAllowedHeaderNames = [
   "x-ms-client-request-id",
@@ -23407,7 +23407,7 @@ module.exports = require("util");
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
-var path = (function () { try { return __nccwpck_require__(241) } catch (e) {}}()) || {
+var path = (function () { try { return __nccwpck_require__(242) } catch (e) {}}()) || {
   sep: '/'
 }
 minimatch.sep = path.sep
@@ -24450,10 +24450,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
 const os = __importStar(__nccwpck_require__(90));
 const events = __importStar(__nccwpck_require__(449));
-const child = __importStar(__nccwpck_require__(162));
-const path = __importStar(__nccwpck_require__(241));
-const io = __importStar(__nccwpck_require__(286));
-const ioUtil = __importStar(__nccwpck_require__(218));
+const child = __importStar(__nccwpck_require__(163));
+const path = __importStar(__nccwpck_require__(242));
+const io = __importStar(__nccwpck_require__(287));
+const ioUtil = __importStar(__nccwpck_require__(219));
 const timers_1 = __nccwpck_require__(489);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
@@ -25039,6 +25039,1823 @@ class ExecState extends events.EventEmitter {
 /***/ }),
 
 /***/ 125:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr post-job entry point. Owned by Agent 2.
+//
+// Runs in the post-job phase via action.yml's `post: dist/post.js`. This is
+// the architectural fix for zackees/setup-soldr#70 — it lets us tar+zstd
+// the build-cache (and optionally cargo-registry) directories BEFORE
+// @actions/cache's post-save uploads them, so the wire format is zstd on
+// every platform (including Windows-x64 where actions/cache@v5 still
+// falls back to gzip).
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.resolveJournalPrintRaw = resolveJournalPrintRaw;
+exports.resolveZccacheSessionJournalPath = resolveZccacheSessionJournalPath;
+exports.buildFinalCacheSummary = buildFinalCacheSummary;
+exports.formatFinalCacheSummaryMarkdown = formatFinalCacheSummaryMarkdown;
+exports.setMultiSessionOutputs = setMultiSessionOutputs;
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(243));
+const path = __importStar(__nccwpck_require__(487));
+const node_child_process_1 = __nccwpck_require__(193);
+const core = __importStar(__nccwpck_require__(439));
+const cache = __importStar(__nccwpck_require__(209));
+const cache_compress_js_1 = __nccwpck_require__(273);
+const solo_toolchain_cache_js_1 = __nccwpck_require__(471);
+const cook_cache_js_1 = __nccwpck_require__(38);
+const soldr_mini_cache_js_1 = __nccwpck_require__(84);
+const log_utils_js_1 = __nccwpck_require__(340);
+const shutdown_cache_js_1 = __nccwpck_require__(298);
+const stats_collector_js_1 = __nccwpck_require__(453);
+const compile_cache_stats_js_1 = __nccwpck_require__(217);
+const diagnostics_js_1 = __nccwpck_require__(438);
+const raw_inputs_js_1 = __nccwpck_require__(92);
+const source_mtime_snapshot_js_1 = __nccwpck_require__(389);
+function dirExists(p) {
+    try {
+        return fs.statSync(p).isDirectory();
+    }
+    catch {
+        return false;
+    }
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+function cachePathExists(p) {
+    try {
+        if (!p.includes("*"))
+            return fs.existsSync(p);
+        const firstStar = p.indexOf("*");
+        const slash = Math.max(p.lastIndexOf(path.sep, firstStar), p.lastIndexOf("/", firstStar), p.lastIndexOf("\\", firstStar));
+        const dir = slash >= 0 ? p.slice(0, slash) : ".";
+        const prefix = p.slice(slash + 1, firstStar);
+        return fs.readdirSync(dir).some((entry) => entry.startsWith(prefix));
+    }
+    catch {
+        return false;
+    }
+}
+function stateBool(name, fallback = false) {
+    const value = core.getState(name).trim().toLowerCase();
+    if (value === "true")
+        return true;
+    if (value === "false")
+        return false;
+    return fallback;
+}
+/**
+ * Decide whether the post-phase diagnostic dump includes the verbatim
+ * per-rustc-invocation JSONL stream. The raw stream is large (thousands
+ * of records / 20-30 MB on the demo warm build) and dominates Post Setup
+ * Soldr wall-clock when emitted. Default: mirror debug mode (preserves
+ * pre-existing behavior for workflows that already opted into debug).
+ * Explicit values "true"/"false"/"on"/"off"/"yes"/"no"/"1"/"0" override.
+ */
+function resolveJournalPrintRaw(rawValue, debugMode) {
+    const v = (rawValue ?? "").trim().toLowerCase();
+    if (v === "")
+        return debugMode;
+    if (v === "true" || v === "1" || v === "yes" || v === "on")
+        return true;
+    if (v === "false" || v === "0" || v === "no" || v === "off")
+        return false;
+    return debugMode;
+}
+function readRestoreState() {
+    return {
+        setupCacheEnabled: stateBool("setupCacheEnabled"),
+        setupCacheExactHit: stateBool("setupCacheExactHit"),
+        setupCacheMatchedKey: core.getState("setupCacheMatchedKey"),
+        targetCacheEnabled: stateBool("targetCacheEnabled"),
+        targetCacheExactHit: stateBool("targetCacheExactHit"),
+        targetCacheMatchedKey: core.getState("targetCacheMatchedKey"),
+        buildCacheEnabled: stateBool("buildCacheEnabled"),
+        buildCacheExactHit: stateBool("buildCacheExactHit"),
+        buildCacheMatchedKey: core.getState("buildCacheMatchedKey"),
+        cargoRegistryCacheEnabled: stateBool("cargoRegistryCacheEnabled"),
+        cargoRegistryCacheExactHit: stateBool("cargoRegistryCacheExactHit"),
+        cargoRegistryCacheMatchedKey: core.getState("cargoRegistryCacheMatchedKey"),
+    };
+}
+function disabledSave() {
+    return { status: "disabled" };
+}
+// setup-cache is intentionally restore-only. Its restore is kept so the
+// action's `cache-hit` output (wired from setupCacheExactHit in main.ts)
+// retains its public contract for downstream workflows, but the save path
+// is permanently inert: the soldr binary moved to soldr-mini-cache (#142)
+// and the rustup toolchain state moved to solo-toolchain-cache (#139),
+// both of which are content-addressable and coarser-keyed. Wiring a save
+// here would re-introduce a duplicate path and defeat those layers' LRU
+// access pattern. See setup-soldr#151 for the full decision rationale.
+function notManagedSave() {
+    return { status: "not-managed-in-post" };
+}
+function restoreStatus(enabled, exactHit, matchedKey) {
+    if (!enabled)
+        return "disabled";
+    if (exactHit)
+        return "exact-hit";
+    if (matchedKey.trim())
+        return "restore-key-hit";
+    return "miss";
+}
+function parseByteCount(raw, inputName, log) {
+    const value = (raw ?? "").trim();
+    if (!value || value === "0")
+        return null;
+    const match = /^(\d+(?:\.\d+)?)\s*([kmgt]?i?b?|b)?$/i.exec(value);
+    if (!match) {
+        core.warning(`setup-soldr: ignoring invalid ${inputName} value '${value}'`);
+        return null;
+    }
+    const amountText = match[1];
+    if (amountText === undefined)
+        return null;
+    const amount = Number(amountText);
+    if (!Number.isFinite(amount) || amount < 0) {
+        core.warning(`setup-soldr: ignoring invalid ${inputName} value '${value}'`);
+        return null;
+    }
+    const unit = (match[2] ?? "b").toLowerCase();
+    const multiplier = unit === "k" || unit === "kb" || unit === "kib"
+        ? 1024
+        : unit === "m" || unit === "mb" || unit === "mib"
+            ? 1024 ** 2
+            : unit === "g" || unit === "gb" || unit === "gib"
+                ? 1024 ** 3
+                : unit === "t" || unit === "tb" || unit === "tib"
+                    ? 1024 ** 4
+                    : 1;
+    const parsed = Math.floor(amount * multiplier);
+    if (parsed <= 0)
+        return null;
+    log(`cache-payload-policy: ${inputName}=${parsed} bytes`);
+    return parsed;
+}
+function parseTopN(raw, log) {
+    const value = (raw ?? "").trim();
+    if (!value)
+        return 10;
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+        core.warning(`setup-soldr: ignoring invalid cache-payload-top-n value '${value}'`);
+        return 10;
+    }
+    const topN = Math.max(0, Math.min(50, Math.floor(parsed)));
+    log(`cache-payload-policy: cache-payload-top-n=${topN}`);
+    return topN;
+}
+function resolveCachePayloadPolicy(inputs, log) {
+    const action = (inputs.cachePayloadOversizeAction || "skip").trim().toLowerCase();
+    let oversizeAction = "skip";
+    if (action === "fail") {
+        oversizeAction = "fail";
+    }
+    else if (action && action !== "skip") {
+        core.warning(`setup-soldr: ignoring invalid cache-payload-oversize-action value '${inputs.cachePayloadOversizeAction}'`);
+    }
+    return {
+        warnBytes: parseByteCount(inputs.cachePayloadWarnBytes || "512MiB", "cache-payload-warn-bytes", log),
+        maxBytes: parseByteCount(inputs.cachePayloadMaxBytes, "cache-payload-max-bytes", log),
+        oversizeAction,
+        topN: parseTopN(inputs.cachePayloadTopN, log),
+    };
+}
+async function saveOne(opts) {
+    const { cacheDir, codec, level, key, matchedKey, label, debug, log, extraBasenames, payloadProfile, payloadPolicy } = opts;
+    const withStats = (r) => Object.assign(r, {
+        archiveBytes: null,
+        inflatedBytes: null,
+        fileCount: null,
+        payload: null,
+    });
+    if (!dirExists(cacheDir)) {
+        log(`${label}: cache dir ${cacheDir} does not exist, skipping save`);
+        return withStats({ status: "missing-dir-skip", cache_dir: cacheDir });
+    }
+    if (matchedKey === key) {
+        log(`${label}: exact cache hit on ${key}, skipping save`);
+        return withStats({ status: "exact-hit-skip", cache_dir: cacheDir });
+    }
+    let archiveBytes = null;
+    let archivePath = null;
+    let inflatedBytes = null;
+    let fileCount = null;
+    let payload = null;
+    // Per-phase save timing (#214): separate the archive+compress phase from the
+    // cache reservation+upload phase so a slow Windows post step is diagnosable.
+    let compressMs = 0;
+    let uploadMs = 0;
+    const compressStart = Date.now();
+    try {
+        const result = await (0, cache_compress_js_1.compressCache)({
+            cacheDir,
+            codec,
+            level,
+            debug,
+            log,
+            extraBasenames,
+            payloadWarnBytes: payloadPolicy.warnBytes,
+            payloadMaxBytes: payloadPolicy.maxBytes,
+            payloadOversizeAction: payloadPolicy.oversizeAction,
+            payloadTopN: payloadPolicy.topN,
+            payloadProfile,
+            label,
+        });
+        archivePath = result.archivePath;
+        archiveBytes = result.archiveBytes || null;
+        inflatedBytes = result.inflatedBytes;
+        fileCount = result.fileCount;
+        payload = result.payload;
+        compressMs = Date.now() - compressStart;
+        if (result.skippedReason === "payload-too-large") {
+            log(`${label}: payload exceeded cache-payload-max-bytes, skipping save`);
+            return {
+                status: "oversize-skip",
+                cache_dir: cacheDir,
+                archiveBytes,
+                inflatedBytes,
+                fileCount,
+                payload,
+                phaseTimings: { compressMs },
+            };
+        }
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log(`${label}: compression failed: ${message}`);
+        return withStats({ status: "failed", cache_dir: cacheDir, error: message });
+    }
+    const pathsToSave = archivePath ? [archivePath] : [cacheDir];
+    try {
+        const uploadStart = Date.now();
+        const id = await cache.saveCache(pathsToSave, key);
+        uploadMs = Date.now() - uploadStart;
+        log(`${label}: saved cache id=${id} key=${key} via ${archivePath ? "tar.zst" : "default"} ` +
+            `(compress=${compressMs}ms upload=${uploadMs}ms)`);
+        return {
+            status: "saved",
+            cache_dir: cacheDir,
+            archive_path: archivePath ?? undefined,
+            saved_paths: pathsToSave,
+            cache_id: id,
+            archiveBytes,
+            inflatedBytes,
+            fileCount,
+            payload,
+            phaseTimings: { compressMs, uploadMs },
+        };
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log(`${label}: save failed: ${message}`);
+        return {
+            status: "failed",
+            cache_dir: cacheDir,
+            archive_path: archivePath ?? undefined,
+            saved_paths: pathsToSave,
+            error: message,
+            archiveBytes,
+            inflatedBytes,
+            fileCount,
+            payload,
+            phaseTimings: { compressMs, uploadMs },
+        };
+    }
+}
+function cacheLayerSummary(opts) {
+    const matchedKey = opts.matchedKey.trim();
+    return {
+        enabled: opts.enabled,
+        key: opts.key,
+        matched_key: matchedKey,
+        exact_hit: opts.enabled ? opts.exactHit : false,
+        restore_status: restoreStatus(opts.enabled, opts.exactHit, matchedKey),
+        save: opts.save,
+    };
+}
+function readSoldrCacheReport(soldrBinary, passthrough) {
+    if (passthrough) {
+        // Short-circuit when the main step installed a passthrough stub
+        // (enable=false). Skips spawning a .cmd on Windows (where
+        // child_process.spawnSync can't launch shell scripts directly) and
+        // documents the passthrough state in the post-step summary.
+        return {
+            status: "ok",
+            soldr_version: "passthrough",
+            report: {
+                notes: ["setup-soldr enable=false: soldr passthrough stub"],
+                last_session: null,
+                rollups: null,
+            },
+        };
+    }
+    if (!soldrBinary || !fileExists(soldrBinary)) {
+        return {
+            status: "missing-binary",
+            error: soldrBinary === undefined
+                ? "SOLDR_BINARY env var not set"
+                : `soldr binary at ${soldrBinary} does not exist`,
+        };
+    }
+    // Use spawnSync so the post step has no async dependencies. The
+    // report subcommand is fast (sub-100ms) — never worth pulling in
+    // @actions/exec just for one shell-out.
+    const child = (0, node_child_process_1.spawnSync)(soldrBinary, ["cache", "report", "--json"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+    });
+    if (child.error) {
+        return {
+            status: "error",
+            error: `failed to spawn soldr: ${child.error.message}`,
+        };
+    }
+    const stdout = (child.stdout || "").trim();
+    const stderr = (child.stderr || "").trim();
+    if (child.status !== 0) {
+        const combined = `${stderr}\n${stdout}`;
+        if (/unrecognized subcommand|invalid value for|unknown sub[- ]?command/i.test(combined) &&
+            /\breport\b/.test(combined)) {
+            return {
+                status: "unsupported",
+                error: stderr || stdout || `soldr exited ${child.status}`,
+            };
+        }
+        return {
+            status: "error",
+            error: stderr || stdout || `soldr exited ${child.status}`,
+        };
+    }
+    let report;
+    try {
+        const parsed = JSON.parse(stdout);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            return {
+                status: "error",
+                error: "soldr cache report --json returned a non-object payload",
+            };
+        }
+        report = parsed;
+    }
+    catch (err) {
+        return {
+            status: "error",
+            error: `failed to parse soldr cache report JSON: ${err instanceof Error ? err.message : String(err)}`,
+        };
+    }
+    const soldrVersion = typeof report["soldr_version"] === "string" ? report["soldr_version"] : undefined;
+    const zccacheVersion = typeof report["managed_zccache_version"] === "string"
+        ? report["managed_zccache_version"]
+        : undefined;
+    return {
+        status: "ok",
+        soldr_version: soldrVersion,
+        managed_zccache_version: zccacheVersion,
+        report,
+    };
+}
+function readZccacheSessionSummary(buildCachePath) {
+    const statsPath = resolveZccacheSessionStatsPath(buildCachePath);
+    if (!fileExists(statsPath)) {
+        return { stats_path: statsPath, present: false, status: "missing" };
+    }
+    try {
+        const parsed = JSON.parse(fs.readFileSync(statsPath, "utf8"));
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            return {
+                stats_path: statsPath,
+                present: true,
+                status: "invalid",
+                error: "stats JSON was not an object",
+            };
+        }
+        const stats = parsed;
+        const status = typeof stats["status"] === "string" ? stats["status"] : "unknown";
+        return { stats_path: statsPath, present: true, status, stats };
+    }
+    catch (err) {
+        return {
+            stats_path: statsPath,
+            present: true,
+            status: "invalid",
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+}
+/**
+ * Resolve a per-session zccache log file (e.g. `last-session-stats.json` or
+ * `last-session.jsonl`) across the layouts soldr may use. soldr's private
+ * daemon sessions write under `<cache>/private/<session-id>/logs/`, NOT the
+ * bare `<cache>/logs/` — so a path built with just `<cache>/logs/<file>` is
+ * silently empty under the default layout (setup-soldr#247). Probe, in order:
+ *   1. `<cache>/logs/<file>` (legacy / non-private layout)
+ *   2. `<cache>/private/<id>/logs/<file>` and `<cache>/private/<id>/<file>`
+ *   3. `<cache>/logs/archive/<session>/logs/<file>` and `.../<file>`
+ * most-recent-mtime wins; falls back to the legacy default path.
+ */
+function resolveZccacheSessionFilePath(buildCachePath, filename) {
+    const defaultPath = path.join(buildCachePath, "logs", filename);
+    if (fileExists(defaultPath))
+        return defaultPath;
+    const candidates = [
+        ...collectSessionFileCandidates(path.join(buildCachePath, "private"), filename),
+        ...collectSessionFileCandidates(path.join(buildCachePath, "logs", "archive"), filename),
+    ];
+    candidates.sort((a, b) => b.mtimeMs - a.mtimeMs || a.path.localeCompare(b.path));
+    return candidates[0]?.path ?? defaultPath;
+}
+function resolveZccacheSessionStatsPath(buildCachePath) {
+    return resolveZccacheSessionFilePath(buildCachePath, "last-session-stats.json");
+}
+function resolveZccacheSessionJournalPath(buildCachePath) {
+    return resolveZccacheSessionFilePath(buildCachePath, "last-session.jsonl");
+}
+function collectSessionFileCandidates(root, filename) {
+    let entries;
+    try {
+        if (!fs.statSync(root).isDirectory())
+            return [];
+        entries = fs.readdirSync(root, { withFileTypes: true });
+    }
+    catch {
+        return [];
+    }
+    const out = [];
+    for (const ent of entries) {
+        if (!ent.isDirectory())
+            continue;
+        const candidate = path.join(root, ent.name, "logs", filename);
+        const archiveCandidate = path.join(root, ent.name, filename);
+        for (const filePath of [candidate, archiveCandidate]) {
+            try {
+                const stat = fs.statSync(filePath);
+                if (stat.isFile()) {
+                    out.push({ path: filePath, mtimeMs: stat.mtimeMs });
+                }
+            }
+            catch {
+                // Candidate shape not present; try the next known layout.
+            }
+        }
+    }
+    return out;
+}
+function buildFinalCacheSummary(result, state, saves, passthrough = false) {
+    return {
+        schema_version: 1,
+        setup_cache: cacheLayerSummary({
+            enabled: state.setupCacheEnabled,
+            key: result.setupCache.key,
+            exactHit: state.setupCacheExactHit,
+            matchedKey: state.setupCacheMatchedKey,
+            save: notManagedSave(),
+        }),
+        target_cache: cacheLayerSummary({
+            enabled: state.targetCacheEnabled,
+            key: result.targetCache.key,
+            exactHit: state.targetCacheExactHit,
+            matchedKey: state.targetCacheMatchedKey,
+            save: saves.targetCache,
+        }),
+        build_cache: cacheLayerSummary({
+            enabled: state.buildCacheEnabled,
+            key: result.buildCache.key,
+            exactHit: state.buildCacheExactHit,
+            matchedKey: state.buildCacheMatchedKey,
+            save: saves.buildCache,
+        }),
+        cargo_registry_cache: cacheLayerSummary({
+            enabled: state.cargoRegistryCacheEnabled,
+            key: result.cargoRegistryCache.key,
+            exactHit: state.cargoRegistryCacheExactHit,
+            matchedKey: state.cargoRegistryCacheMatchedKey,
+            save: saves.cargoRegistryCache,
+        }),
+        zccache_session: readZccacheSessionSummary(result.buildCache.path),
+        compile_cache_report: readSoldrCacheReport(process.env["SOLDR_BINARY"]?.trim(), passthrough),
+        // PR4 — walk the per-session archive that soldr#379's
+        // `cache shutdown --archive-logs` populates between cargo invocations
+        // and roll the per-session stats up into a single job-wide aggregate.
+        // Empty archive (no archival happened, or only one session ran) leaves
+        // `sessionCount=0`, which makes the renderer / outputs no-op.
+        multi_session_rollup: (0, compile_cache_stats_js_1.aggregateSessions)((0, compile_cache_stats_js_1.collectArchivedSessionStats)(path.join(result.buildCache.path, "logs", "archive"))),
+    };
+}
+function numberStat(stats, key) {
+    const value = stats?.[key];
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+function zccacheOneLine(summary) {
+    if (!summary.present)
+        return `missing (${summary.stats_path})`;
+    if (summary.status !== "ok") {
+        return summary.error ? `${summary.status} (${summary.error})` : summary.status;
+    }
+    const hits = numberStat(summary.stats, "hits") ?? 0;
+    const misses = numberStat(summary.stats, "misses") ?? 0;
+    const compilations = numberStat(summary.stats, "compilations") ?? hits + misses;
+    const nonCacheable = numberStat(summary.stats, "non_cacheable") ?? 0;
+    const errors = numberStat(summary.stats, "errors") ?? 0;
+    const hitRate = numberStat(summary.stats, "hit_rate");
+    const hitRateText = hitRate === undefined ? "n/a" : `${(hitRate * 100).toFixed(1)}%`;
+    return `hits=${hits} misses=${misses} compilations=${compilations} non_cacheable=${nonCacheable} errors=${errors} hit_rate=${hitRateText}`;
+}
+function restoreText(layer) {
+    if (!layer.enabled)
+        return "disabled";
+    if (layer.restore_status === "exact-hit")
+        return "exact hit";
+    if (layer.restore_status === "restore-key-hit")
+        return "restore-key hit";
+    return "miss";
+}
+function saveText(save) {
+    switch (save.status) {
+        case "saved":
+            return save.cache_id === undefined ? "saved" : `saved id=${save.cache_id}`;
+        case "exact-hit-skip":
+            return "skipped exact hit";
+        case "missing-dir-skip":
+            return "skipped missing dir";
+        case "oversize-skip":
+            return "skipped oversize payload";
+        case "tiny-delta-skip":
+            return save.skip_reason ? `skipped tiny delta (${save.skip_reason})` : "skipped tiny delta";
+        case "failed":
+            return save.error ? `failed: ${save.error}` : "failed";
+        case "disabled":
+            return "disabled";
+        case "not-managed-in-post":
+            return "not managed in post";
+    }
+}
+function markdownCell(value) {
+    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+function tableRow(label, layer) {
+    return [
+        label,
+        restoreText(layer),
+        layer.key,
+        layer.matched_key || "",
+        saveText(layer.save),
+    ]
+        .map(markdownCell)
+        .join(" | ");
+}
+function fmtBytes(n) {
+    if (n >= 1_073_741_824)
+        return `${(n / 1_073_741_824).toFixed(1)} GB`;
+    if (n >= 1_048_576)
+        return `${(n / 1_048_576).toFixed(1)} MB`;
+    if (n >= 1_024)
+        return `${(n / 1_024).toFixed(1)} KB`;
+    return `${n} B`;
+}
+function fmtOptionalBytes(n) {
+    return typeof n === "number" && Number.isFinite(n) ? fmtBytes(n) : "";
+}
+function skipSummaryText(payload) {
+    if (payload.skipped.length === 0)
+        return "none";
+    return payload.skipped.map((entry) => `${entry.reason}: ${entry.count}`).join(", ");
+}
+function payloadEntryLines(entries) {
+    if (entries.length === 0)
+        return ["- none"];
+    return entries.map((entry) => `- \`${entry.path}\` - ${fmtBytes(entry.bytes)}`);
+}
+function payloadSubtreeLines(entries) {
+    if (entries.length === 0)
+        return ["- none"];
+    return entries.map((entry) => `- \`${entry.path}\` - ${fmtBytes(entry.bytes)} across ${entry.files} files`);
+}
+function payloadSkipLines(payload) {
+    if (payload.skipped.length === 0)
+        return ["- none"];
+    const lines = [];
+    for (const skipped of payload.skipped) {
+        const samples = skipped.samples.length > 0 ? `; samples: ${skipped.samples.map((s) => `\`${s}\``).join(", ")}` : "";
+        lines.push(`- ${skipped.reason}: ${skipped.count}${samples}`);
+    }
+    return lines;
+}
+function cachePayloadAuditSection(summary) {
+    const rows = [];
+    for (const [label, save] of [
+        ["target cache", summary.target_cache.save],
+        ["build cache", summary.build_cache.save],
+        ["cargo registry cache", summary.cargo_registry_cache.save],
+    ]) {
+        if (save.payload)
+            rows.push([label, save]);
+    }
+    if (rows.length === 0)
+        return [];
+    const lines = [
+        "",
+        "### cache payload audit",
+        "",
+        "| Layer | Payload | Files | Symlinks | Archive | Skipped |",
+        "| --- | ---: | ---: | ---: | ---: | --- |",
+    ];
+    for (const [label, save] of rows) {
+        const payload = save.payload;
+        if (!payload)
+            continue;
+        lines.push(`| ${markdownCell(label)} | ${fmtBytes(payload.bytes)} | ${payload.files} | ${payload.symlinks} | ` +
+            `${fmtOptionalBytes(save.archiveBytes)} | ${markdownCell(skipSummaryText(payload))} |`);
+    }
+    for (const [label, save] of rows) {
+        const payload = save.payload;
+        if (!payload)
+            continue;
+        lines.push("", `<details><summary>${label} largest payload entries</summary>`, "", "Largest subtrees:", "", ...payloadSubtreeLines(payload.topSubtrees), "", "Largest files:", "", ...payloadEntryLines(payload.topFiles), "", "Largest directories:", "", ...payloadEntryLines(payload.topDirectories), "", "Skipped tar inputs:", "", ...payloadSkipLines(payload), "", "</details>");
+    }
+    return lines;
+}
+function setCompileCacheOutputs(report, mode) {
+    core.setOutput("compile-cache-session-status", report.status);
+    if (report.status !== "ok" || !report.report)
+        return;
+    core.setOutput("compile-cache-summary-json", JSON.stringify(report.report));
+    const lastSession = report.report["last_session"];
+    if (lastSession) {
+        const hits = numberStat(lastSession, "hits") ?? 0;
+        const misses = numberStat(lastSession, "misses") ?? 0;
+        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
+        const hitRate = numberStat(lastSession, "hit_rate");
+        const timeSavedMs = numberStat(lastSession, "time_saved_ms");
+        const bytesRead = numberStat(lastSession, "bytes_read");
+        const bytesWritten = numberStat(lastSession, "bytes_written");
+        core.setOutput("compile-cache-hits", String(hits));
+        core.setOutput("compile-cache-misses", String(misses));
+        core.setOutput("compile-cache-compilations", String(compilations));
+        if (hitRate !== undefined)
+            core.setOutput("compile-cache-hit-rate", String(hitRate));
+        if (timeSavedMs !== undefined)
+            core.setOutput("compile-cache-time-saved-ms", String(timeSavedMs));
+        if (bytesRead !== undefined)
+            core.setOutput("compile-cache-bytes-read", String(bytesRead));
+        if (bytesWritten !== undefined)
+            core.setOutput("compile-cache-bytes-written", String(bytesWritten));
+    }
+    if (mode === "detailed") {
+        const rollups = report.report["rollups"];
+        if (rollups)
+            core.setOutput("compile-cache-rollups-json", JSON.stringify(rollups));
+    }
+}
+function compileCacheReportSection(report, mode) {
+    if (mode === "none")
+        return [];
+    // Insights mode is a superset of summarize — render the per-session table
+    // first so workflows don't lose the baseline metrics, then append the
+    // diagnoses block underneath. The detailed roll-up tables stay
+    // detailed-only (they're already noisy enough on their own).
+    const summaryMode = mode === "insights" ? "summarize" : mode;
+    const lines = ["", "### Compile cache (zccache)", ""];
+    if (report.status !== "ok" || !report.report) {
+        lines.push(`| Status | ${markdownCell(report.status)} |`);
+        if (report.error)
+            lines.push(`| Detail | ${markdownCell(report.error)} |`);
+        return lines;
+    }
+    const body = report.report;
+    const lastSession = body["last_session"] ?? null;
+    const rollups = body["rollups"] ?? null;
+    if (lastSession) {
+        const hits = numberStat(lastSession, "hits") ?? 0;
+        const misses = numberStat(lastSession, "misses") ?? 0;
+        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
+        const rate = numberStat(lastSession, "hit_rate");
+        const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
+        const saved = numberStat(lastSession, "time_saved_ms");
+        const bytesRead = numberStat(lastSession, "bytes_read");
+        const bytesWritten = numberStat(lastSession, "bytes_written");
+        lines.push("| Metric | Value |", "| --- | --- |");
+        lines.push(`| Compilations | ${compilations} |`);
+        lines.push(`| Hits | ${hits} |`);
+        lines.push(`| Misses | ${misses} |`);
+        lines.push(`| Hit rate | ${rateText} |`);
+        if (saved !== undefined)
+            lines.push(`| Time saved (est.) | ${(saved / 1000).toFixed(1)}s |`);
+        if (bytesRead !== undefined)
+            lines.push(`| Bytes read | ${fmtBytes(bytesRead)} |`);
+        if (bytesWritten !== undefined)
+            lines.push(`| Bytes written | ${fmtBytes(bytesWritten)} |`);
+        if (report.soldr_version)
+            lines.push(`| soldr | ${markdownCell(report.soldr_version)} |`);
+        if (report.managed_zccache_version)
+            lines.push(`| zccache | ${markdownCell(report.managed_zccache_version)} |`);
+    }
+    else {
+        lines.push("_(no last\\_session yet — run a cache-enabled build first)_");
+    }
+    if (mode === "detailed" && rollups) {
+        const byExt = rollups["by_extension"];
+        if (byExt && typeof byExt === "object" && !Array.isArray(byExt)) {
+            const rows = Object.entries(byExt);
+            if (rows.length > 0) {
+                lines.push("", "#### By output extension", "");
+                lines.push("| Extension | Hits | Misses | Total ms |", "| --- | --- | --- | --- |");
+                for (const [ext, bucket] of rows) {
+                    const b = bucket ?? {};
+                    const h = numberStat(b, "hits") ?? 0;
+                    const m = numberStat(b, "misses") ?? 0;
+                    const t = numberStat(b, "total_ms") ?? 0;
+                    lines.push(`| ${markdownCell(ext)} | ${h} | ${m} | ${t} |`);
+                }
+            }
+        }
+        const byTool = rollups["by_tool_total_ms"];
+        if (byTool && typeof byTool === "object" && !Array.isArray(byTool)) {
+            const rows = Object.entries(byTool)
+                .map(([tool, ms]) => [tool, typeof ms === "number" ? ms : 0])
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 10);
+            if (rows.length > 0) {
+                lines.push("", "#### By tool (wall-clock)", "");
+                lines.push("| Tool | ms |", "| --- | --- |");
+                for (const [tool, ms] of rows) {
+                    lines.push(`| ${markdownCell(tool)} | ${ms} |`);
+                }
+            }
+        }
+    }
+    // PR3 — insights mode appends per-diagnosis <details> blocks below the
+    // per-session table. Each diagnosis renders its evidence (miss reasons
+    // table + slowest misses list + wasted_ms) plus a blockquoted
+    // suggested_fix line. Annotations are not emitted from this pure
+    // renderer — the run() loop separately forwards them to core.warning /
+    // core.notice so they show up pinned in the PR Files view.
+    if (mode === "insights") {
+        const insights = (0, compile_cache_stats_js_1.renderInsights)(body);
+        if (insights.markdown.length > 0) {
+            lines.push("", "### Compile cache insights", "");
+            lines.push(insights.markdown);
+        }
+    }
+    const notes = body["notes"];
+    if (Array.isArray(notes) && notes.length > 0) {
+        lines.push("", "<details><summary>Notes from soldr</summary>", "");
+        for (const note of notes) {
+            if (typeof note === "string")
+                lines.push(`- ${markdownCell(note)}`);
+        }
+        lines.push("", "</details>");
+    }
+    // Silence the "unused variable" warning — summaryMode is reserved for a
+    // future split where insights includes/excludes the detailed-rollup
+    // tables. Today the rollup gate is still keyed on `mode`.
+    void summaryMode;
+    return lines;
+}
+function formatFinalCacheSummaryMarkdown(summary, compileCacheStats = "summarize") {
+    // PR4 — multi-step roll-up. Renders only when >1 sessions were
+    // archived AND the user didn't opt out via compile-cache-stats=none.
+    // The block sits between the layer table and the per-session compile
+    // cache section so the high-level "what happened across the whole job"
+    // signal lands first, with the per-invocation breakdown beneath.
+    const multiStepBlock = compileCacheStats !== "none"
+        ? (0, compile_cache_stats_js_1.renderMultiSessionRollup)(summary.multi_session_rollup)
+        : "";
+    const multiStepLines = multiStepBlock.length > 0 ? ["", multiStepBlock] : [];
+    const lines = [
+        "## setup-soldr final cache summary",
+        "",
+        "| Layer | Restore | Primary key | Matched key | Save |",
+        "| --- | --- | --- | --- | --- |",
+        `| ${tableRow("setup cache", summary.setup_cache)} |`,
+        `| ${tableRow("target cache", summary.target_cache)} |`,
+        `| ${tableRow("build cache", summary.build_cache)} |`,
+        `| ${tableRow("cargo registry cache", summary.cargo_registry_cache)} |`,
+        ...cachePayloadAuditSection(summary),
+        ...multiStepLines,
+        "",
+        "### zccache session",
+        "",
+        `- Stats: ${zccacheOneLine(summary.zccache_session)}`,
+        `- Stats file: ${summary.zccache_session.stats_path}`,
+        ...compileCacheReportSection(summary.compile_cache_report, compileCacheStats),
+        "",
+        "<details><summary>Final cache summary JSON</summary>",
+        "",
+        "```json",
+        JSON.stringify(summary, null, 2),
+        "```",
+        "",
+        "</details>",
+        "",
+    ];
+    return `${lines.join("\n")}\n`;
+}
+/**
+ * PR4 — emit the multi-step roll-up's scalar outputs. Skipped when
+ * `sessionCount <= 1` so single-session jobs don't surface a misleading
+ * roll-up to downstream workflow steps. Exported so the post-step `run()`
+ * function and the contract tests can drive it the same way.
+ */
+function setMultiSessionOutputs(rollup) {
+    if (rollup.sessionCount <= 1)
+        return;
+    core.setOutput("compile-cache-sessions-total", String(rollup.sessionCount));
+    if (rollup.overallHitRate !== null && Number.isFinite(rollup.overallHitRate)) {
+        core.setOutput("compile-cache-overall-hit-rate", String(rollup.overallHitRate));
+    }
+}
+function logFinalCacheSummary(summary, log) {
+    log(`final cache summary: setup=${restoreText(summary.setup_cache)} target=${restoreText(summary.target_cache)} ` +
+        `build=${restoreText(summary.build_cache)}/${saveText(summary.build_cache.save)} ` +
+        `cargo-registry=${restoreText(summary.cargo_registry_cache)}/${saveText(summary.cargo_registry_cache.save)}`);
+    log(`final zccache session stats: ${zccacheOneLine(summary.zccache_session)}`);
+    log(`compile cache report: ${compileCacheReportOneLine(summary.compile_cache_report)}`);
+}
+function compileCacheReportOneLine(report) {
+    if (report.status !== "ok" || !report.report) {
+        return report.error ? `${report.status} (${report.error})` : report.status;
+    }
+    const lastSession = report.report["last_session"];
+    if (!lastSession) {
+        return `ok (no last_session yet, soldr ${report.soldr_version ?? "?"})`;
+    }
+    const hits = numberStat(lastSession, "hits") ?? 0;
+    const misses = numberStat(lastSession, "misses") ?? 0;
+    const rate = numberStat(lastSession, "hit_rate");
+    const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
+    return `ok hits=${hits} misses=${misses} hit_rate=${rateText} soldr=${report.soldr_version ?? "?"}`;
+}
+function writeCompileCacheReportFile(report, runnerTemp, log) {
+    if (!runnerTemp)
+        return undefined;
+    const outPath = path.join(runnerTemp, "setup-soldr-compile-cache-report.json");
+    try {
+        fs.writeFileSync(outPath, JSON.stringify(report, null, 2), "utf8");
+        return outPath;
+    }
+    catch (err) {
+        log(`post: failed to write compile-cache-report.json: ${err instanceof Error ? err.message : String(err)}`);
+        return undefined;
+    }
+}
+function writeStepSummary(markdown, log) {
+    const summaryPath = process.env["GITHUB_STEP_SUMMARY"]?.trim();
+    if (!summaryPath)
+        return;
+    try {
+        fs.appendFileSync(summaryPath, markdown, "utf8");
+    }
+    catch (err) {
+        log(`post: failed to write GitHub step summary: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+/**
+ * PR3 — Emit insights-mode side effects:
+ *   - Forward each `renderInsights` annotation line to core.warning /
+ *     core.notice so it shows up pinned in the PR Files-Changed view.
+ *   - Best-effort: ask soldr to write a chrome-trace JSON (a developer
+ *     debugger trace file consumable by chrome://tracing or Perfetto)
+ *     and upload it as a workflow artifact. Silently skipped when soldr
+ *     doesn't support the `--chrome-trace` flag — keeps the action green
+ *     on older soldr versions that don't have the subcommand yet.
+ */
+async function emitInsightsAnnotationsAndTrace(opts) {
+    const { report, soldrBinary, runnerTemp, log } = opts;
+    if (report.status === "ok" && report.report) {
+        try {
+            const out = (0, compile_cache_stats_js_1.renderInsights)(report.report);
+            for (const line of out.annotations) {
+                // Echo to stdout exactly as GitHub Actions expects — the runner
+                // ingests `::warning::` / `::notice::` workflow-command lines
+                // from stdout regardless of which library wrote them. Avoid the
+                // @actions/core helpers because they re-encode the message and
+                // we want the file= pin we computed in renderInsights to land
+                // verbatim.
+                process.stdout.write(`${line}\n`);
+            }
+            log(`compile-cache-stats: emitted ${out.annotations.length} insights annotations`);
+        }
+        catch (err) {
+            log(`compile-cache-stats: failed to emit insights annotations: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    // Chrome-trace upload. Skipped when no SOLDR_BINARY is on disk, or
+    // when soldr's `cache report --chrome-trace <path>` exits with an
+    // "unknown subcommand"/"unrecognized flag" error (i.e. the user is on
+    // a soldr build that predates the trace flag).
+    if (!soldrBinary || !fileExists(soldrBinary) || !runnerTemp)
+        return;
+    const runId = process.env["GITHUB_RUN_ID"]?.trim() || "local";
+    const tracePath = path.join(runnerTemp, `setup-soldr-trace-${runId}.json`);
+    let traced = false;
+    try {
+        const child = (0, node_child_process_1.spawnSync)(soldrBinary, ["cache", "report", "--chrome-trace", tracePath], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+            windowsHide: true,
+        });
+        if (child.error) {
+            log(`compile-cache-stats: chrome-trace spawn failed: ${child.error.message}`);
+            return;
+        }
+        if (child.status !== 0) {
+            const combined = `${child.stderr || ""}\n${child.stdout || ""}`;
+            if (/unrecognized|unknown|invalid/i.test(combined) && /chrome[-_ ]?trace/i.test(combined)) {
+                log("compile-cache-stats: chrome-trace flag not supported by this soldr — skipping upload");
+                return;
+            }
+            log(`compile-cache-stats: chrome-trace generation failed (exit ${child.status})`);
+            return;
+        }
+        traced = fileExists(tracePath);
+    }
+    catch (err) {
+        log(`compile-cache-stats: chrome-trace generation threw: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+    }
+    if (!traced) {
+        log(`compile-cache-stats: chrome-trace file not present at ${tracePath} — skipping upload`);
+        return;
+    }
+    try {
+        // Lazy require so the action stays loadable even when
+        // @actions/artifact's runtime requirements aren't met (e.g. running
+        // outside of a GitHub-hosted runner, which is the case for every
+        // unit test in this repo). Any failure is logged-not-thrown.
+        const artifact = await __nccwpck_require__.e(/* import() */ 846).then(__nccwpck_require__.t.bind(__nccwpck_require__, 76846, 23));
+        const client = new artifact.DefaultArtifactClient();
+        const artifactName = `setup-soldr-trace-${runId}.json`;
+        await client.uploadArtifact(artifactName, [tracePath], path.dirname(tracePath));
+        log(`compile-cache-stats: uploaded chrome-trace artifact ${artifactName}`);
+    }
+    catch (err) {
+        log(`compile-cache-stats: chrome-trace artifact upload failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+async function run() {
+    const logger = (0, log_utils_js_1.createLogger)(process.env);
+    const log = (msg) => logger.log(msg);
+    const state = core.getState("resolveResult");
+    if (!state) {
+        log("post: no resolve state available, exiting");
+        return;
+    }
+    let result;
+    try {
+        result = JSON.parse(state);
+    }
+    catch (err) {
+        log(`post: failed to parse resolve state: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+    }
+    const buildCacheMatched = core.getState("buildCacheMatchedKey");
+    const registryMatched = core.getState("cargoRegistryCacheMatchedKey");
+    const passthrough = stateBool("setupSoldrPassthrough");
+    const restoreState = readRestoreState();
+    const statsMode = (core.getState("statsMode") || "summarize");
+    const compileCacheStats = (core.getState("compileCacheStats") || "summarize");
+    const runnerTemp = core.getState("runnerTemp") || "";
+    const debugMode = result.debugMode ?? false;
+    const debugLog = debugMode ? log : () => undefined;
+    const postCollector = new stats_collector_js_1.StatsCollector();
+    const rawInputs = (0, raw_inputs_js_1.readRawInputs)(process.env);
+    const payloadPolicy = resolveCachePayloadPolicy(rawInputs, log);
+    // Always stop long-running cache daemons before packing the build
+    // cache so file locks release and the tarball reflects a quiescent
+    // on-disk view. Best-effort; failures are logged, not raised.
+    //
+    // Wire `--archive-logs <build-cache>/logs/archive` through so soldr
+    // (post-#379) stashes the just-ended session's logs into a
+    // per-session subdirectory before we render this post step's roll-up.
+    // The tar payload planner filters the build-cache logs/ subtree out of
+    // cache saves: raw session journals are diagnostics, not reusable cache
+    // content, and can be tens of MB per invocation.
+    const logsArchiveDir = restoreState.buildCacheEnabled
+        ? path.join(result.buildCache.path, "logs", "archive")
+        : undefined;
+    await (0, shutdown_cache_js_1.shutdownCacheDaemons)({
+        soldrPath: process.env["SOLDR_BINARY"]?.trim() || undefined,
+        logsArchiveDir,
+        log,
+    });
+    // Source-mtime snapshot (preserve-source-mtimes opt-in). Walk tracked
+    // sources, capture each (mtime, size, content-hash), and drop the JSON
+    // INSIDE the build-cache directory so it gets bundled into the same
+    // tar.zst the build-cache save will upload. main.ts replays the
+    // mtimes on warm after the build-cache decompresses, gated on each
+    // file's content matching what we snapshotted here.
+    const preserveSourceMtimes = core.getState("preserveSourceMtimes") === "true";
+    if (preserveSourceMtimes && restoreState.buildCacheEnabled) {
+        const t0 = Date.now();
+        // The "project root" — where the Cargo workspace being built actually
+        // lives — is the parent of the resolved target-dir, NOT result.workspace
+        // (which is GITHUB_WORKSPACE — usually the outer checkout containing
+        // the action itself plus one or more sub-repos). For the demo,
+        // result.workspace=/home/runner/work/setup-soldr/setup-soldr but the
+        // zccache project being built is at .../setup-soldr/zccache.
+        const projectRoot = path.dirname(result.targetCache.targetPath);
+        try {
+            const r = await (0, source_mtime_snapshot_js_1.snapshotSourceMtimes)({ workspace: projectRoot, log });
+            const out = path.join(result.buildCache.path, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
+            try {
+                fs.mkdirSync(path.dirname(out), { recursive: true });
+                (0, source_mtime_snapshot_js_1.writeSnapshotFile)(r.snapshot, out);
+                log(`source-mtime-snapshot: wrote ${out} scanned=${r.scanned} hashed=${r.hashed} skipped=${r.skipped} elapsed_ms=${Date.now() - t0}`);
+            }
+            catch (err) {
+                log(`source-mtime-snapshot: failed to write ${out}: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+        catch (err) {
+            log(`source-mtime-snapshot: scan failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    // Build cache. A delta-aware gate (#230/#214) skips the expensive
+    // archive+upload when the session compiled nothing new AND a cache was
+    // already restored — the restored entry already holds everything, so
+    // re-saving under a fallback key just uploads a duplicate multi-GiB payload.
+    const buildSaveStart = Date.now();
+    const buildCacheRestored = buildCacheMatched.trim().length > 0;
+    const buildDeltaMisses = restoreState.buildCacheEnabled
+        ? numberStat(readZccacheSessionSummary(result.buildCache.path).stats, "misses") ?? null
+        : null;
+    const buildSaveGate = (0, compile_cache_stats_js_1.decideBuildCacheSave)({
+        restored: buildCacheRestored,
+        newCompiles: buildDeltaMisses,
+        minCompiles: (0, compile_cache_stats_js_1.parseMinCompiles)(rawInputs.buildCacheSaveMinCompiles),
+    });
+    let buildSave;
+    if (!restoreState.buildCacheEnabled) {
+        buildSave = Object.assign(disabledSave(), {
+            archiveBytes: null,
+            inflatedBytes: null,
+            fileCount: null,
+            payload: null,
+        });
+    }
+    else if (buildSaveGate.skip) {
+        log(`build-cache: skipping save — ${buildSaveGate.reason} (set build-cache-save-min-compiles: 0 to force-save)`);
+        buildSave = Object.assign({
+            status: "tiny-delta-skip",
+            cache_dir: result.buildCache.path,
+            skip_reason: buildSaveGate.reason,
+        }, { archiveBytes: null, inflatedBytes: null, fileCount: null, payload: null });
+    }
+    else {
+        buildSave = await saveOne({
+            cacheDir: result.buildCache.path,
+            codec: result.targetCacheCompress,
+            level: result.targetCacheCompressLevel,
+            key: result.buildCache.key,
+            matchedKey: buildCacheMatched,
+            label: "build-cache",
+            debug: debugMode,
+            log: debugLog,
+            payloadProfile: "zccache-build-cache",
+            payloadPolicy,
+        });
+    }
+    if (buildSave.status === "saved" || buildSave.status === "oversize-skip") {
+        postCollector.record({
+            label: "build-cache", operation: "save", hit: false,
+            key: result.buildCache.key, matchedKey: buildCacheMatched, restoreKeys: [],
+            status: buildSave.status,
+            archiveBytes: buildSave.archiveBytes, inflatedBytes: buildSave.inflatedBytes, fileCount: buildSave.fileCount,
+            payload: buildSave.payload,
+            durationMs: Date.now() - buildSaveStart, timestamp: new Date().toISOString(),
+        });
+    }
+    // Target cache. Previously slotted as `notManagedSave()` in the
+    // finalSummary — i.e. restored in main.ts but never saved here. That
+    // meant every commit cold-rebuilt `target/` (or the rust-plan bundle)
+    // because no entry was ever written for the restore-key prefix to
+    // fall back to. This block fixes the gap.
+    //
+    // Behavior:
+    // - Skip when target-cache layer is disabled (`target-cache: false`
+    //   or umbrella `cache: false`).
+    // - Skip on exact-hit (re-saving the same content under the same key
+    //   wastes time and triggers @actions/cache's "reservation already
+    //   exists" path).
+    // - Use `cache.saveCache` directly with the multi-path array (one
+    //   path in `thin`/`once` modes, two in `full`). @actions/cache will
+    //   tar+compress with its default codec — we don't route through
+    //   compressCache because target-cache may legitimately carry
+    //   multiple roots and compressCache is single-dir-shaped.
+    // - Paths array must match the one passed to restoreCache in main.ts
+    //   (the @actions/cache "version" hash depends on it — same gotcha
+    //   that bit cook-cache in #141).
+    let targetCacheSave = Object.assign(disabledSave(), { archiveBytes: null });
+    if (restoreState.targetCacheEnabled) {
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        const targetKey = result.targetCache.key;
+        const targetMatched = restoreState.targetCacheMatchedKey;
+        if (targetPaths.length === 0) {
+            log("target-cache: no paths configured, skipping save");
+            targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: "(no paths)" }, { archiveBytes: null });
+        }
+        else if (restoreState.targetCacheExactHit) {
+            log(`target-cache: exact cache hit on ${targetKey}, skipping save`);
+            targetCacheSave = Object.assign({ status: "exact-hit-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
+        }
+        else {
+            const existingPaths = targetPaths.filter((p) => fs.existsSync(p));
+            if (existingPaths.length === 0) {
+                log(`target-cache: none of the configured paths exist on disk (${targetPaths.join(", ")}), skipping save`);
+                targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
+            }
+            else {
+                const targetSaveStart = Date.now();
+                try {
+                    const id = await cache.saveCache(existingPaths, targetKey);
+                    if (id <= 0) {
+                        log(`target-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
+                            `job already saved key=${targetKey}`);
+                        targetCacheSave = Object.assign({
+                            status: "failed",
+                            cache_dir: existingPaths.join(","),
+                            saved_paths: existingPaths,
+                            error: `saveCache returned id=${id} (reserve failed; race or quota)`,
+                        }, { archiveBytes: null });
+                    }
+                    else {
+                        log(`target-cache: saved cache id=${id} key=${targetKey} paths=${existingPaths.join(",")}`);
+                        targetCacheSave = Object.assign({
+                            status: "saved",
+                            cache_dir: existingPaths.join(","),
+                            saved_paths: existingPaths,
+                            cache_id: id,
+                        }, { archiveBytes: null });
+                        postCollector.record({
+                            label: "target-cache",
+                            operation: "save",
+                            hit: false,
+                            key: targetKey,
+                            matchedKey: targetMatched,
+                            restoreKeys: [],
+                            archiveBytes: null,
+                            inflatedBytes: null,
+                            fileCount: null,
+                            durationMs: Date.now() - targetSaveStart,
+                            timestamp: new Date().toISOString(),
+                        });
+                    }
+                }
+                catch (err) {
+                    const message = err instanceof Error ? err.message : String(err);
+                    log(`target-cache: save failed: ${message}`);
+                    targetCacheSave = Object.assign({
+                        status: "failed",
+                        cache_dir: existingPaths.join(","),
+                        saved_paths: existingPaths,
+                        error: message,
+                    }, { archiveBytes: null });
+                }
+            }
+        }
+    }
+    // Cargo registry cache (only when enabled).
+    // setup-soldr#102: bundle `.global-cache` (cargo's RFC-3413 GC db) and the
+    // `git/` directory (bare mirrors + checkouts for git-source crate deps)
+    // into the same archive alongside `registry/`. Cache key + archive path
+    // are unchanged — the extras simply ride inside the existing tarball.
+    let cargoRegistrySave = Object.assign(disabledSave(), {
+        archiveBytes: null,
+        inflatedBytes: null,
+        fileCount: null,
+        payload: null,
+    });
+    if (result.cargoRegistryCache.enabled) {
+        const regSaveStart = Date.now();
+        cargoRegistrySave = await saveOne({
+            cacheDir: result.cargoRegistryCache.path,
+            codec: result.targetCacheCompress,
+            level: result.targetCacheCompressLevel,
+            key: result.cargoRegistryCache.key,
+            matchedKey: registryMatched,
+            label: "cargo-registry-cache",
+            debug: debugMode,
+            log: debugLog,
+            extraBasenames: result.cargoRegistryCache.extraBasenames,
+            payloadPolicy,
+        });
+        if (cargoRegistrySave.status === "saved" || cargoRegistrySave.status === "oversize-skip") {
+            postCollector.record({
+                label: "cargo-registry", operation: "save", hit: false,
+                key: result.cargoRegistryCache.key, matchedKey: registryMatched, restoreKeys: [],
+                status: cargoRegistrySave.status,
+                archiveBytes: cargoRegistrySave.archiveBytes,
+                inflatedBytes: cargoRegistrySave.inflatedBytes,
+                fileCount: cargoRegistrySave.fileCount,
+                payload: cargoRegistrySave.payload,
+                durationMs: Date.now() - regSaveStart, timestamp: new Date().toISOString(),
+            });
+        }
+    }
+    // Solo toolchain cache save. Opt-in via the `solo-toolchain-cache`
+    // input. Skip the save when the install delta is empty (the common
+    // case on hosted runners that already provide the requested
+    // toolchain) — per CLAUDE.md "Default-stable workflows should
+    // produce zero cache writes."
+    const soloEnabled = core.getState("soloToolchainEnabled") === "true";
+    if (soloEnabled) {
+        const soloExactKey = core.getState("soloToolchainExactKey");
+        const soloMatchedKey = core.getState("soloToolchainMatchedKey");
+        const soloExactHit = core.getState("soloToolchainExactHit") === "true";
+        const soloIncrementalEmpty = core.getState("soloToolchainIncrementalEmpty") === "true";
+        const soloSaveDiffPath = core.getState("soloToolchainSaveDiffPath");
+        const soloLevel = core.getState("soloToolchainLevel") || "19";
+        log(`solo-toolchain-cache: post-step exactKey=${soloExactKey} matched=${soloMatchedKey} ` +
+            `exactHit=${soloExactHit} incrementalEmpty=${soloIncrementalEmpty} saveDiffPath=${soloSaveDiffPath}`);
+        if (soloExactHit && soloIncrementalEmpty) {
+            log("solo-toolchain-cache: exact hit and no install delta — skipping save");
+        }
+        else if (!soloSaveDiffPath || !fs.existsSync(soloSaveDiffPath)) {
+            log("solo-toolchain-cache: no save-diff manifest available, skipping save");
+        }
+        else {
+            try {
+                const manifest = JSON.parse(fs.readFileSync(soloSaveDiffPath, "utf8"));
+                const added = Array.isArray(manifest.added) ? manifest.added : [];
+                if (added.length === 0) {
+                    log("solo-toolchain-cache: empty save-diff manifest, skipping save");
+                }
+                else {
+                    const soloRootMap = {
+                        "rustup-toolchains": path.join(result.rustupHome, "toolchains"),
+                        "cargo-bin": path.join(result.cargoHome, "bin"),
+                    };
+                    const stagingDir = path.join(runnerTemp, "setup-soldr-solo-stage-save");
+                    const soloSaveStart = Date.now();
+                    const staged = await (0, solo_toolchain_cache_js_1.stageDiffForSave)({ added, removed: [], changed: [] }, soloRootMap, stagingDir);
+                    log(`solo-toolchain-cache: staged ${staged.stagedFiles} files (missing=${staged.missingFiles})`);
+                    const saveResult = await (0, solo_toolchain_cache_js_1.saveSoloCache)({
+                        stagingDir,
+                        key: soloExactKey,
+                        level: soloLevel,
+                        debug: debugMode,
+                        log,
+                    });
+                    if (saveResult.status === "saved") {
+                        postCollector.record({
+                            label: "solo-toolchain-cache",
+                            operation: "save",
+                            hit: false,
+                            key: soloExactKey,
+                            matchedKey: soloMatchedKey,
+                            restoreKeys: [],
+                            archiveBytes: saveResult.archiveBytes ?? null,
+                            inflatedBytes: saveResult.inflatedBytes ?? null,
+                            fileCount: saveResult.fileCount ?? null,
+                            durationMs: Date.now() - soloSaveStart,
+                            timestamp: new Date().toISOString(),
+                        });
+                    }
+                    else {
+                        log(`solo-toolchain-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
+                    }
+                }
+            }
+            catch (err) {
+                log(`solo-toolchain-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    }
+    // Cook cache save. Default-on layer; skipped when cook didn't run
+    // (cache hit, gate disabled, or run failed). zstd-19 + --long=27 per
+    // CLAUDE.md "Compression" + the cook simulation findings.
+    const cookEnabled = core.getState("cookEnabled") === "true";
+    if (cookEnabled) {
+        const cookLayered = core.getState("cookLayered") === "true";
+        const cookHit = core.getState("cookHit") === "true";
+        const cookRan = core.getState("cookRan") === "true";
+        const cookTargetDir = core.getState("cookTargetDir");
+        if (cookLayered) {
+            const cookSaveLayer = core.getState("cookSaveLayer") || "none";
+            const cookProjectRoot = core.getState("cookProjectRoot");
+            const cookBaseKey = core.getState("cookBaseExactKey");
+            const cookDeltaKey = core.getState("cookDeltaExactKey");
+            const cookBaseArchive = core.getState("cookBaseArchive");
+            const cookDeltaArchive = core.getState("cookDeltaArchive");
+            const cookBaseManifest = core.getState("cookBaseManifest");
+            const soldrBinary = core.getState("cookSoldrBinary") || process.env["SOLDR_BINARY"]?.trim() || "soldr";
+            log(`cook-cache: post-step layered save_layer=${cookSaveLayer} hit=${cookHit} ` +
+                `ran=${cookRan} target=${cookTargetDir}`);
+            if (!cookRan || cookSaveLayer === "none") {
+                log("cook-cache: layered cache warm or cook did not run successfully - skipping save");
+            }
+            else if (!cookTargetDir || !fs.existsSync(cookTargetDir)) {
+                log(`cook-cache: target dir ${cookTargetDir} missing - skipping save`);
+            }
+            else if (!cookProjectRoot || !fs.existsSync(cookProjectRoot)) {
+                log(`cook-cache: project root ${cookProjectRoot} missing - skipping save`);
+            }
+            else {
+                const saveKey = cookSaveLayer === "delta" ? cookDeltaKey : cookBaseKey;
+                const archivePath = cookSaveLayer === "delta" ? cookDeltaArchive : cookBaseArchive;
+                const level = cookSaveLayer === "delta"
+                    ? core.getState("cookDeltaCompressLevel") || "3"
+                    : core.getState("cookCompressLevel") || "19";
+                const cookSaveStart = Date.now();
+                try {
+                    const saveResult = await (0, cook_cache_js_1.saveLayeredCookCache)({
+                        soldrBinary,
+                        projectRoot: cookProjectRoot,
+                        targetDir: cookTargetDir,
+                        exactKey: saveKey,
+                        archivePath,
+                        layer: cookSaveLayer === "delta" ? "delta" : "base",
+                        zstdLevel: level,
+                        baseManifestPath: cookBaseManifest,
+                        log,
+                    });
+                    if (saveResult.status === "saved") {
+                        postCollector.record({
+                            label: `cook-cache-${cookSaveLayer}`,
+                            operation: "save",
+                            hit: false,
+                            key: saveKey,
+                            matchedKey: "",
+                            restoreKeys: [],
+                            archiveBytes: saveResult.archiveBytes ?? null,
+                            inflatedBytes: saveResult.inflatedBytes ?? null,
+                            fileCount: saveResult.fileCount ?? null,
+                            durationMs: Date.now() - cookSaveStart,
+                            timestamp: new Date().toISOString(),
+                        });
+                    }
+                    else {
+                        log(`cook-cache-${cookSaveLayer}: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
+                    }
+                }
+                catch (err) {
+                    log(`cook-cache-${cookSaveLayer}: save failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        else {
+            const cookExactKey = core.getState("cookExactKey");
+            const cookLongWindow = parseInt(core.getState("cookLongWindow") || "27", 10);
+            const cookLevel = core.getState("cookCompressLevel") || "19";
+            log(`cook-cache: post-step key=${cookExactKey} hit=${cookHit} ran=${cookRan} target=${cookTargetDir}`);
+            if (cookHit) {
+                log("cook-cache: exact hit - skipping save");
+            }
+            else if (!cookRan) {
+                log("cook-cache: cook did not run successfully - skipping save");
+            }
+            else if (!cookTargetDir || !fs.existsSync(cookTargetDir)) {
+                log(`cook-cache: target dir ${cookTargetDir} missing - skipping save`);
+            }
+            else {
+                const cookSaveStart = Date.now();
+                try {
+                    const saveResult = await (0, cook_cache_js_1.saveCookCache)({
+                        targetDir: cookTargetDir,
+                        exactKey: cookExactKey,
+                        level: cookLevel,
+                        longWindow: cookLongWindow,
+                        debug: debugMode,
+                        log,
+                    });
+                    if (saveResult.status === "saved") {
+                        postCollector.record({
+                            label: "cook-cache",
+                            operation: "save",
+                            hit: false,
+                            key: cookExactKey,
+                            matchedKey: "",
+                            restoreKeys: [],
+                            archiveBytes: saveResult.archiveBytes ?? null,
+                            inflatedBytes: saveResult.inflatedBytes ?? null,
+                            fileCount: saveResult.fileCount ?? null,
+                            durationMs: Date.now() - cookSaveStart,
+                            timestamp: new Date().toISOString(),
+                        });
+                    }
+                    else {
+                        log(`cook-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
+                    }
+                }
+                catch (err) {
+                    log(`cook-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+    }
+    // Soldr-mini-cache save. Default-on; skipped when restore already hit
+    // (binary is byte-identical, no point re-saving), when disabled, or
+    // when running in passthrough mode.
+    const soldrMiniEnabled = core.getState("soldrMiniEnabled") === "true";
+    if (soldrMiniEnabled && !passthrough) {
+        const miniHit = core.getState("soldrMiniHit") === "true";
+        const miniExactKey = core.getState("soldrMiniExactKey");
+        const miniInstallDir = core.getState("soldrMiniInstallDir");
+        const miniArchive = core.getState("soldrMiniArchive");
+        log(`soldr-mini-cache: post-step key=${miniExactKey} hit=${miniHit} installDir=${miniInstallDir}`);
+        if (miniHit) {
+            log("soldr-mini-cache: exact hit — skipping save");
+        }
+        else if (!miniExactKey) {
+            log("soldr-mini-cache: no key (ineligible at main-time) — skipping save");
+        }
+        else if (!miniInstallDir || !fs.existsSync(miniInstallDir)) {
+            log(`soldr-mini-cache: install dir ${miniInstallDir} missing — skipping save`);
+        }
+        else {
+            const miniSaveStart = Date.now();
+            try {
+                const saveResult = await (0, soldr_mini_cache_js_1.saveMiniCache)({
+                    installDir: miniInstallDir,
+                    archivePath: miniArchive,
+                    exactKey: miniExactKey,
+                    level: "19",
+                    longWindow: 27,
+                    debug: debugMode,
+                    log,
+                });
+                if (saveResult.status === "saved") {
+                    postCollector.record({
+                        label: "soldr-mini-cache",
+                        operation: "save",
+                        hit: false,
+                        key: miniExactKey,
+                        matchedKey: "",
+                        restoreKeys: [],
+                        archiveBytes: saveResult.archiveBytes ?? null,
+                        inflatedBytes: saveResult.inflatedBytes ?? null,
+                        fileCount: saveResult.fileCount ?? null,
+                        durationMs: Date.now() - miniSaveStart,
+                        timestamp: new Date().toISOString(),
+                    });
+                }
+                else {
+                    log(`soldr-mini-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
+                }
+            }
+            catch (err) {
+                log(`soldr-mini-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    }
+    // ---- per-(host × target) cross-tool cache save (setup-soldr#106) ----
+    // Wave 2.1 of zackees/soldr#514. Save each lane whose restore missed and
+    // whose `paths` actually exist on disk after executeCrossBootstrap ran.
+    // Skipping exact hits avoids re-uploading identical content; skipping
+    // missing paths avoids cache-API failures on unsupported lanes.
+    try {
+        const lanePlansRaw = core.getState("crossToolCachePlans");
+        const restoresRaw = core.getState("crossToolCacheRestores");
+        if (lanePlansRaw) {
+            const lanePlans = JSON.parse(lanePlansRaw);
+            const restores = restoresRaw
+                ? JSON.parse(restoresRaw)
+                : {};
+            for (const lane of lanePlans) {
+                if (!lane.paths || lane.paths.length === 0) {
+                    continue; // unsupported lane, nothing to save
+                }
+                const restore = restores[lane.target];
+                if (restore?.hit) {
+                    log(`cross-tool-cache: lane=${lane.target} exact hit — skipping save`);
+                    continue;
+                }
+                // Only save when at least one of the lane's paths exists. The cache
+                // API will error on a fully-missing path list, and there's no
+                // point uploading nothing.
+                const existing = lane.paths.filter((p) => {
+                    try {
+                        return fs.existsSync(p);
+                    }
+                    catch {
+                        return false;
+                    }
+                });
+                if (existing.length === 0) {
+                    log(`cross-tool-cache: lane=${lane.target} no paths exist on disk — skipping save`);
+                    continue;
+                }
+                const t0 = Date.now();
+                try {
+                    const id = await cache.saveCache(existing, lane.key);
+                    if (id > 0) {
+                        log(`cross-tool-cache: lane=${lane.target} saved id=${id} key=${lane.key}`);
+                        postCollector.record({
+                            label: `cross-tool-cache:${lane.target}`,
+                            operation: "save",
+                            hit: false,
+                            key: lane.key,
+                            matchedKey: "",
+                            restoreKeys: [],
+                            archiveBytes: null,
+                            inflatedBytes: null,
+                            fileCount: null,
+                            durationMs: Date.now() - t0,
+                            timestamp: new Date().toISOString(),
+                        });
+                    }
+                    else {
+                        log(`cross-tool-cache: lane=${lane.target} save skipped (id=${id}) — likely concurrent save by another job`);
+                    }
+                }
+                catch (err) {
+                    log(`cross-tool-cache: lane=${lane.target} save failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+    }
+    catch (err) {
+        log(`cross-tool-cache: post-step failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    // ---- Dylint tool/driver cache save (setup-soldr#221) ----
+    // Exact-key only and opt-in. Cold jobs keep their existing install/build
+    // steps; warm jobs restore cargo-dylint/dylint-link plus the compatible
+    // driver directory before those steps run.
+    try {
+        if (result.dylintCache.enabled && result.dylintCache.paths.length > 0) {
+            const exactHit = core.getState("dylintCacheExactHit") === "true";
+            if (exactHit) {
+                log("dylint-cache: exact hit - skipping save");
+            }
+            else {
+                const existing = result.dylintCache.paths.some((p) => cachePathExists(p));
+                if (!existing) {
+                    log("dylint-cache: no configured paths exist on disk - skipping save");
+                }
+                else {
+                    const t0 = Date.now();
+                    try {
+                        const id = await cache.saveCache(result.dylintCache.paths, result.dylintCache.key);
+                        if (id > 0) {
+                            log(`dylint-cache: saved id=${id} key=${result.dylintCache.key}`);
+                            postCollector.record({
+                                label: "dylint-cache",
+                                operation: "save",
+                                hit: false,
+                                key: result.dylintCache.key,
+                                matchedKey: "",
+                                restoreKeys: [],
+                                archiveBytes: null,
+                                inflatedBytes: null,
+                                fileCount: null,
+                                durationMs: Date.now() - t0,
+                                timestamp: new Date().toISOString(),
+                            });
+                        }
+                        else {
+                            log(`dylint-cache: save skipped (id=${id}) - likely concurrent save by another job`);
+                        }
+                    }
+                    catch (err) {
+                        log(`dylint-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
+                    }
+                }
+            }
+        }
+    }
+    catch (err) {
+        log(`dylint-cache: post-step failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    const finalSummary = buildFinalCacheSummary(result, restoreState, {
+        buildCache: buildSave,
+        cargoRegistryCache: cargoRegistrySave,
+        targetCache: targetCacheSave,
+    }, passthrough);
+    logFinalCacheSummary(finalSummary, log);
+    if (compileCacheStats !== "none") {
+        setCompileCacheOutputs(finalSummary.compile_cache_report, compileCacheStats);
+        // PR4 — surface the two job-wide scalar outputs alongside the
+        // existing per-session outputs. The setter no-ops when the archive
+        // walker didn't find >1 sessions, so single-session jobs see no
+        // change in behavior.
+        setMultiSessionOutputs(finalSummary.multi_session_rollup);
+    }
+    writeStepSummary(formatFinalCacheSummaryMarkdown(finalSummary, compileCacheStats), log);
+    // Job-wide compile-cache hit/miss counts, read post-hoc from the
+    // multi-session rollup (preferred) or the last-session report. Shared by
+    // the cook reuse-mismatch warning (#235) and the zero-count guard (#227).
+    let jobHits = null;
+    let jobMisses = null;
+    {
+        const rollup = finalSummary.multi_session_rollup;
+        if (rollup && rollup.sessionCount > 0) {
+            jobHits = rollup.totalHits;
+            jobMisses = rollup.totalMisses;
+        }
+        else if (finalSummary.compile_cache_report.status === "ok" &&
+            finalSummary.compile_cache_report.report) {
+            const last = finalSummary.compile_cache_report.report["last_session"];
+            if (last) {
+                jobHits = numberStat(last, "hits") ?? null;
+                jobMisses = numberStat(last, "misses") ?? null;
+            }
+        }
+    }
+    // Cook reuse-mismatch warning (issue #235). Post-hoc only: setup-soldr
+    // can't know the consumer's downstream cargo profile/toolchain at cook
+    // time, so the "cook ran but nothing reused it" fingerprint is only
+    // observable here, after the job's compiles have been recorded.
+    {
+        const cookSignal = (0, compile_cache_stats_js_1.detectCookReuseMismatch)({
+            cookEnabled: core.getState("cookEnabled") === "true",
+            cookProducedDeps: core.getState("cookHit") === "true" || core.getState("cookRan") === "true",
+            hits: jobHits,
+            misses: jobMisses,
+            cookFlags: rawInputs.prebuildDepsFlags,
+        });
+        if (cookSignal.mismatch)
+            core.warning(cookSignal.message);
+    }
+    // Compile-cache activity verification (issue #227). Opt-in via
+    // verify-compile-cache. When a job that is expected to exercise zccache
+    // reports hits+misses==0, the build bypassed the cache (or the measurement
+    // is invalid) — fail or warn instead of laundering it into warm-cache
+    // evidence. Every legitimate bypass (passthrough, build-cache off, no
+    // stats) is reported as a quiet skip.
+    {
+        const verify = (0, compile_cache_stats_js_1.verifyCompileCacheActivity)({
+            mode: (0, compile_cache_stats_js_1.parseVerifyCompileCacheMode)(rawInputs.verifyCompileCache),
+            enabled: !passthrough,
+            buildCacheEnabled: restoreState.buildCacheEnabled,
+            reportStatus: finalSummary.compile_cache_report.status,
+            hits: jobHits,
+            misses: jobMisses,
+            env: {
+                rustcWrapper: process.env["RUSTC_WRAPPER"],
+                soldrCacheDir: process.env["SOLDR_CACHE_DIR"],
+                zccacheCacheDir: process.env["ZCCACHE_CACHE_DIR"],
+                shimsDir: process.env["SETUP_SOLDR_SHIMS_DIR"],
+                statsPath: finalSummary.compile_cache_report.status === "ok"
+                    ? resolveZccacheSessionStatsPath(result.buildCache.path)
+                    : undefined,
+            },
+        });
+        core.setOutput("compile-cache-verification", verify.status);
+        if (verify.fail) {
+            core.setFailed(verify.message);
+        }
+        else if (verify.status === "invalid-measurement") {
+            core.warning(verify.message);
+        }
+        else if (verify.message && (0, diagnostics_js_1.loggingEnabled)(rawInputs.logging)) {
+            log(verify.message);
+        }
+    }
+    // PR3 — insights mode side-effects: emit GH annotations + optional
+    // chrome-trace artifact upload. These run only when the user explicitly
+    // opted into `insights`; the markdown insights block already landed in
+    // the step summary above via formatFinalCacheSummaryMarkdown.
+    if (compileCacheStats === "insights") {
+        await emitInsightsAnnotationsAndTrace({
+            report: finalSummary.compile_cache_report,
+            soldrBinary: process.env["SOLDR_BINARY"]?.trim(),
+            runnerTemp,
+            log,
+        });
+    }
+    const reportPath = writeCompileCacheReportFile(finalSummary.compile_cache_report, runnerTemp, log);
+    if (reportPath) {
+        log(`compile-cache-report.json written to ${reportPath}`);
+    }
+    // Note: setup-soldr-cache-keys.txt is written in main.ts (right after
+    // resolveSetup) so workflow steps that run between main and post —
+    // notably actions/upload-artifact — can read it. Re-write it here
+    // anyway as a safety net in case main.ts crashed before writing.
+    if (runnerTemp) {
+        writeCacheKeysManifestFromSummary(finalSummary, runnerTemp, log);
+    }
+    // Append save ops to detailed session log if requested
+    if (statsMode === "detailed" && runnerTemp) {
+        try {
+            await postCollector.appendSavesToSessionLog(runnerTemp);
+        }
+        catch (err) {
+            log(`post: stats log append failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    // Optional verbose diagnostic dump. Gated on `logging: true` which
+    // main.ts persists into action state.
+    const loggingState = core.getState("logging");
+    if ((0, diagnostics_js_1.loggingEnabled)(loggingState)) {
+        // zccache writes its per-rustc-invocation JSONL journal under the
+        // build-cache directory (which == ZCCACHE_CACHE_DIR per
+        // resolve-setup.ts's env exports). When `logging: true` is on we
+        // surface its contents so the reader can answer "warm reported 0
+        // hits — why did each lookup miss" without another build.
+        // Resolve the journal the same private-dir-aware way as the stats file —
+        // soldr's private daemon sessions write it under
+        // `<cache>/private/<id>/logs/`, not the bare `<cache>/logs/` (#247).
+        const journalPath = resolveZccacheSessionJournalPath(result.buildCache.path);
+        // Forward the verbatim `report` field from `soldr cache report --json`
+        // so dumpDiagnostics can format its `rollups` (per-extension /
+        // per-crate / slowest_entries) breakdown.
+        const cacheReport = finalSummary.compile_cache_report.report;
+        // Capture a process snapshot only when debug mode is on — `ps` /
+        // `tasklist` are cheap but the output is large and only useful when
+        // you're investigating cache-state weirdness (e.g. orphan daemons).
+        const processSnapshot = debugMode ? (0, diagnostics_js_1.captureProcessSnapshot)() ?? undefined : undefined;
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "post",
+            env: process.env,
+            rawInputs,
+            result,
+            cacheOutcomes: postCollector.snapshot(),
+            finalSummary: finalSummary,
+            journalPath,
+            // Raw JSONL stream — one record per rustc invocation, often
+            // thousands of lines / 20-30 MB of stdout per warm build. Default
+            // gate is `debug:true` (backwards compat with #134 era), but a
+            // workflow can explicitly opt out via `journal-print-raw: false`
+            // when it already uploads the JSONL as an artifact and doesn't
+            // want to pay the post-step log-writer cost (~30-50 s on the
+            // hosted ubuntu demo).
+            journalPrintRaw: resolveJournalPrintRaw(rawInputs.journalPrintRaw, debugMode),
+            cacheReport,
+            processSnapshot,
+            logger,
+            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
+        });
+    }
+}
+function writeCacheKeysManifestFromSummary(summary, runnerTemp, log) {
+    const keys = [
+        summary.setup_cache.key,
+        summary.build_cache.key,
+        summary.target_cache.key,
+        summary.cargo_registry_cache.key,
+    ].filter((k) => Boolean(k));
+    if (keys.length === 0)
+        return;
+    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
+    try {
+        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
+        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
+    }
+    catch (err) {
+        log(`post: failed to write cache-keys manifest: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+// See main.ts for the rationale behind the test-import escape hatch.
+if (typeof process !== "undefined" &&
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    run().catch((err) => {
+        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        core.warning(`setup-soldr post-job step failed: ${message}`);
+    });
+}
+
+
+/***/ }),
+
+/***/ 126:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25049,8 +26866,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredentialPolicy = void 0;
 const constants_js_1 = __nccwpck_require__(34);
 const utils_common_js_1 = __nccwpck_require__(454);
-const CredentialPolicy_js_1 = __nccwpck_require__(300);
-const SharedKeyComparator_js_1 = __nccwpck_require__(172);
+const CredentialPolicy_js_1 = __nccwpck_require__(301);
+const SharedKeyComparator_js_1 = __nccwpck_require__(173);
 /**
  * StorageSharedKeyCredentialPolicy is a policy used to sign HTTP request with a shared key.
  */
@@ -25194,7 +27011,7 @@ exports.StorageSharedKeyCredentialPolicy = StorageSharedKeyCredentialPolicy;
 
 /***/ }),
 
-/***/ 126:
+/***/ 127:
 /***/ ((module) => {
 
 "use strict";
@@ -25214,7 +27031,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 127:
+/***/ 128:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25223,7 +27040,7 @@ module.exports = {
 
 
 const assert = __nccwpck_require__(503)
-const { Readable } = __nccwpck_require__(129)
+const { Readable } = __nccwpck_require__(130)
 const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(468)
 const util = __nccwpck_require__(67)
 const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(67)
@@ -25544,7 +27361,7 @@ function consumeFinish (consume, err) {
 
 /***/ }),
 
-/***/ 128:
+/***/ 129:
 /***/ ((module) => {
 
 "use strict";
@@ -25552,7 +27369,7 @@ module.exports = require("querystring");
 
 /***/ }),
 
-/***/ 129:
+/***/ 130:
 /***/ ((module) => {
 
 "use strict";
@@ -25560,7 +27377,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 130:
+/***/ 131:
 /***/ ((module) => {
 
 "use strict";
@@ -25630,7 +27447,7 @@ function range(a, b, str) {
 
 /***/ }),
 
-/***/ 131:
+/***/ 132:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -25667,7 +27484,7 @@ const net = __importStar(__nccwpck_require__(488));
 const tls = __importStar(__nccwpck_require__(485));
 const assert_1 = __importDefault(__nccwpck_require__(503));
 const debug_1 = __importDefault(__nccwpck_require__(493));
-const agent_base_1 = __nccwpck_require__(233);
+const agent_base_1 = __nccwpck_require__(234);
 const url_1 = __nccwpck_require__(82);
 const parse_proxy_response_1 = __nccwpck_require__(400);
 const debug = (0, debug_1.default)('https-proxy-agent');
@@ -25817,7 +27634,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 132:
+/***/ 133:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -25833,7 +27650,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(278);
+const http_client_1 = __nccwpck_require__(279);
 const auth_1 = __nccwpck_require__(25);
 const core_1 = __nccwpck_require__(439);
 class OidcClient {
@@ -25901,16 +27718,16 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 133:
+/***/ 134:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
-const binary_format_contract_1 = __nccwpck_require__(323);
+const binary_format_contract_1 = __nccwpck_require__(324);
 const pb_long_1 = __nccwpck_require__(116);
-const goog_varint_1 = __nccwpck_require__(198);
+const goog_varint_1 = __nccwpck_require__(199);
 const defaultsRead = {
     readUnknownField: true,
     readerFactory: bytes => new BinaryReader(bytes),
@@ -26092,7 +27909,7 @@ exports.BinaryReader = BinaryReader;
 
 /***/ }),
 
-/***/ 134:
+/***/ 135:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26306,7 +28123,7 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 135:
+/***/ 136:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -26404,7 +28221,7 @@ exports.reflectionMergePartial = reflectionMergePartial;
 
 /***/ }),
 
-/***/ 136:
+/***/ 137:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26430,7 +28247,7 @@ __export(xml_exports, {
   stringifyXML: () => stringifyXML
 });
 module.exports = __toCommonJS(xml_exports);
-var import_fast_xml_parser = __nccwpck_require__(312);
+var import_fast_xml_parser = __nccwpck_require__(313);
 var import_xml_common = __nccwpck_require__(19);
 function getCommonOptions(options) {
   return {
@@ -26497,22 +28314,22 @@ async function parseXML(str, opts = {}) {
 
 /***/ }),
 
-/***/ 137:
+/***/ 138:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports.request = __nccwpck_require__(490)
-module.exports.stream = __nccwpck_require__(341)
+module.exports.stream = __nccwpck_require__(342)
 module.exports.pipeline = __nccwpck_require__(104)
 module.exports.upgrade = __nccwpck_require__(412)
-module.exports.connect = __nccwpck_require__(357)
+module.exports.connect = __nccwpck_require__(358)
 
 
 /***/ }),
 
-/***/ 138:
+/***/ 139:
 /***/ ((module) => {
 
 "use strict";
@@ -26560,7 +28377,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 139:
+/***/ 140:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26569,7 +28386,7 @@ module.exports = {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollOperation = exports.initOperation = exports.deserializeState = void 0;
-const logger_js_1 = __nccwpck_require__(186);
+const logger_js_1 = __nccwpck_require__(187);
 const constants_js_1 = __nccwpck_require__(58);
 /**
  * Deserializes the state
@@ -26739,7 +28556,7 @@ exports.pollOperation = pollOperation;
 
 /***/ }),
 
-/***/ 140:
+/***/ 141:
 /***/ ((module) => {
 
 "use strict";
@@ -26747,7 +28564,7 @@ module.exports = require("diagnostics_channel");
 
 /***/ }),
 
-/***/ 141:
+/***/ 142:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -26763,7 +28580,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(358);
+	createDebug.humanize = __nccwpck_require__(359);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -27046,7 +28863,7 @@ module.exports = setup;
 
 /***/ }),
 
-/***/ 142:
+/***/ 143:
 /***/ ((module) => {
 
 "use strict";
@@ -27054,7 +28871,7 @@ module.exports = require("node:events");
 
 /***/ }),
 
-/***/ 143:
+/***/ 144:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -27089,7 +28906,7 @@ function isObject(input) {
 
 /***/ }),
 
-/***/ 144:
+/***/ 145:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -27132,12 +28949,12 @@ __export(internal_exports, {
 module.exports = __toCommonJS(internal_exports);
 var import_delay = __nccwpck_require__(455);
 var import_random = __nccwpck_require__(486);
-var import_object = __nccwpck_require__(143);
-var import_error = __nccwpck_require__(151);
-var import_sha256 = __nccwpck_require__(195);
+var import_object = __nccwpck_require__(144);
+var import_error = __nccwpck_require__(152);
+var import_sha256 = __nccwpck_require__(196);
 var import_uuidUtils = __nccwpck_require__(377);
 var import_checkEnvironment = __nccwpck_require__(418);
-var import_bytesEncoding = __nccwpck_require__(280);
+var import_bytesEncoding = __nccwpck_require__(281);
 var import_sanitizer = __nccwpck_require__(120);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -27146,7 +28963,7 @@ var import_sanitizer = __nccwpck_require__(120);
 
 /***/ }),
 
-/***/ 145:
+/***/ 146:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -27171,7 +28988,7 @@ __export(internal_exports, {
   createLoggerContext: () => import_logger.createLoggerContext
 });
 module.exports = __toCommonJS(internal_exports);
-var import_logger = __nccwpck_require__(239);
+var import_logger = __nccwpck_require__(240);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -27179,7 +28996,7 @@ var import_logger = __nccwpck_require__(239);
 
 /***/ }),
 
-/***/ 146:
+/***/ 147:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -27415,7 +29232,7 @@ exports.PathStylePorts = [
 
 /***/ }),
 
-/***/ 147:
+/***/ 148:
 /***/ ((module) => {
 
 "use strict";
@@ -27423,7 +29240,7 @@ module.exports = require("string_decoder");
 
 /***/ }),
 
-/***/ 148:
+/***/ 149:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -27467,7 +29284,7 @@ function setClientRequestIdPolicy(requestIdHeaderName = "x-ms-client-request-id"
 
 /***/ }),
 
-/***/ 149:
+/***/ 150:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -27492,7 +29309,7 @@ __export(log_exports, {
   logger: () => logger
 });
 module.exports = __toCommonJS(log_exports);
-var import_logger = __nccwpck_require__(239);
+var import_logger = __nccwpck_require__(240);
 const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -27501,7 +29318,7 @@ const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 
 /***/ }),
 
-/***/ 150:
+/***/ 151:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -27527,7 +29344,7 @@ __export(basicAuthenticationPolicy_exports, {
   basicAuthenticationPolicyName: () => basicAuthenticationPolicyName
 });
 module.exports = __toCommonJS(basicAuthenticationPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(280);
+var import_bytesEncoding = __nccwpck_require__(281);
 var import_checkInsecureConnection = __nccwpck_require__(414);
 const basicAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function basicAuthenticationPolicy(options) {
@@ -27558,7 +29375,7 @@ function basicAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 151:
+/***/ 152:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -27583,7 +29400,7 @@ __export(error_exports, {
   isError: () => isError
 });
 module.exports = __toCommonJS(error_exports);
-var import_object = __nccwpck_require__(143);
+var import_object = __nccwpck_require__(144);
 function isError(e) {
   if ((0, import_object.isObject)(e)) {
     const hasName = typeof e.name === "string";
@@ -27599,7 +29416,7 @@ function isError(e) {
 
 /***/ }),
 
-/***/ 152:
+/***/ 153:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -27645,7 +29462,7 @@ exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(12);
-const constants_js_1 = __nccwpck_require__(146);
+const constants_js_1 = __nccwpck_require__(147);
 /**
  * Reserved URL characters must be properly escaped for Storage services like Blob or File.
  *
@@ -28413,7 +30230,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 153:
+/***/ 154:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28443,20 +30260,20 @@ exports.StorageBrowserPolicyFactory = StorageBrowserPolicyFactory;
 
 /***/ }),
 
-/***/ 154:
+/***/ 155:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(190).kConstruct)
+  kConstruct: (__nccwpck_require__(191).kConstruct)
 }
 
 
 /***/ }),
 
-/***/ 155:
+/***/ 156:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28488,7 +30305,7 @@ exports.reflectionLongConvert = reflectionLongConvert;
 
 /***/ }),
 
-/***/ 156:
+/***/ 157:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28545,7 +30362,7 @@ exports.readJournal = readJournal;
 exports.summarize = summarize;
 exports.formatJournalSection = formatJournalSection;
 exports.formatRollupsSection = formatRollupsSection;
-const fs = __importStar(__nccwpck_require__(242));
+const fs = __importStar(__nccwpck_require__(243));
 const diagnostics_js_1 = __nccwpck_require__(438);
 const SLOWEST_TOP_N = 20;
 /**
@@ -28839,7 +30656,7 @@ function formatRollupsSection(report) {
 
 /***/ }),
 
-/***/ 157:
+/***/ 158:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -28873,7 +30690,7 @@ const DEFAULT_RETRY_POLICY_COUNT = 3;
 
 /***/ }),
 
-/***/ 158:
+/***/ 159:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28914,7 +30731,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.uploadCacheArchiveSDK = exports.UploadProgress = void 0;
 const core = __importStar(__nccwpck_require__(439));
 const storage_blob_1 = __nccwpck_require__(427);
-const errors_1 = __nccwpck_require__(295);
+const errors_1 = __nccwpck_require__(296);
 /**
  * Class for tracking the upload state and displaying stats.
  */
@@ -29047,7 +30864,7 @@ exports.uploadCacheArchiveSDK = uploadCacheArchiveSDK;
 
 /***/ }),
 
-/***/ 159:
+/***/ 160:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29077,7 +30894,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.req = exports.json = exports.toBuffer = void 0;
-const http = __importStar(__nccwpck_require__(320));
+const http = __importStar(__nccwpck_require__(321));
 const https = __importStar(__nccwpck_require__(68));
 async function toBuffer(stream) {
     let length = 0;
@@ -29120,7 +30937,7 @@ exports.req = req;
 
 /***/ }),
 
-/***/ 160:
+/***/ 161:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -29258,7 +31075,7 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 
 /***/ }),
 
-/***/ 161:
+/***/ 162:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29267,27 +31084,27 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 const Client = __nccwpck_require__(86)
 const Dispatcher = __nccwpck_require__(458)
 const errors = __nccwpck_require__(468)
-const Pool = __nccwpck_require__(327)
+const Pool = __nccwpck_require__(328)
 const BalancedPool = __nccwpck_require__(366)
 const Agent = __nccwpck_require__(5)
 const util = __nccwpck_require__(67)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(137)
-const buildConnector = __nccwpck_require__(260)
-const MockClient = __nccwpck_require__(194)
+const api = __nccwpck_require__(138)
+const buildConnector = __nccwpck_require__(261)
+const MockClient = __nccwpck_require__(195)
 const MockAgent = __nccwpck_require__(362)
-const MockPool = __nccwpck_require__(336)
-const mockErrors = __nccwpck_require__(225)
-const ProxyAgent = __nccwpck_require__(331)
-const RetryHandler = __nccwpck_require__(267)
+const MockPool = __nccwpck_require__(337)
+const mockErrors = __nccwpck_require__(226)
+const ProxyAgent = __nccwpck_require__(332)
+const RetryHandler = __nccwpck_require__(268)
 const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(361)
 const DecoratorHandler = __nccwpck_require__(456)
 const RedirectHandler = __nccwpck_require__(374)
-const createRedirectInterceptor = __nccwpck_require__(248)
+const createRedirectInterceptor = __nccwpck_require__(249)
 
 let hasCrypto
 try {
-  __nccwpck_require__(283)
+  __nccwpck_require__(284)
   hasCrypto = true
 } catch {
   hasCrypto = false
@@ -29382,17 +31199,17 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   module.exports.Headers = __nccwpck_require__(494).Headers
   module.exports.Response = __nccwpck_require__(40).Response
   module.exports.Request = __nccwpck_require__(81).Request
-  module.exports.FormData = __nccwpck_require__(202).FormData
-  module.exports.File = __nccwpck_require__(349).File
+  module.exports.FormData = __nccwpck_require__(203).FormData
+  module.exports.File = __nccwpck_require__(350).File
   module.exports.FileReader = __nccwpck_require__(93).FileReader
 
-  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(138)
+  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(139)
 
   module.exports.setGlobalOrigin = setGlobalOrigin
   module.exports.getGlobalOrigin = getGlobalOrigin
 
-  const { CacheStorage } = __nccwpck_require__(276)
-  const { kConstruct } = __nccwpck_require__(154)
+  const { CacheStorage } = __nccwpck_require__(277)
+  const { kConstruct } = __nccwpck_require__(155)
 
   // Cache & CacheStorage are tightly coupled with fetch. Even if it may run
   // in an older version of Node, it doesn't have any use without fetch.
@@ -29414,7 +31231,7 @@ if (util.nodeMajor >= 16) {
 }
 
 if (util.nodeMajor >= 18 && hasCrypto) {
-  const { WebSocket } = __nccwpck_require__(291)
+  const { WebSocket } = __nccwpck_require__(292)
 
   module.exports.WebSocket = WebSocket
 }
@@ -29433,7 +31250,7 @@ module.exports.mockErrors = mockErrors
 
 /***/ }),
 
-/***/ 162:
+/***/ 163:
 /***/ ((module) => {
 
 "use strict";
@@ -29441,7 +31258,7 @@ module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 163:
+/***/ 164:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29454,18 +31271,18 @@ module.exports = require("child_process");
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 tslib_1.__exportStar(__nccwpck_require__(117), exports);
-tslib_1.__exportStar(__nccwpck_require__(176), exports);
+tslib_1.__exportStar(__nccwpck_require__(177), exports);
 tslib_1.__exportStar(__nccwpck_require__(121), exports);
-tslib_1.__exportStar(__nccwpck_require__(307), exports);
-tslib_1.__exportStar(__nccwpck_require__(203), exports);
-tslib_1.__exportStar(__nccwpck_require__(264), exports);
+tslib_1.__exportStar(__nccwpck_require__(308), exports);
+tslib_1.__exportStar(__nccwpck_require__(204), exports);
+tslib_1.__exportStar(__nccwpck_require__(265), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 164:
+/***/ 165:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29478,7 +31295,7 @@ exports.storageRetryPolicy = storageRetryPolicy;
 const abort_controller_1 = __nccwpck_require__(475);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(12);
-const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(317);
+const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(318);
 const constants_js_1 = __nccwpck_require__(34);
 const utils_common_js_1 = __nccwpck_require__(454);
 const log_js_1 = __nccwpck_require__(15);
@@ -29640,7 +31457,7 @@ function storageRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 165:
+/***/ 166:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29673,7 +31490,7 @@ exports.create = create;
 
 /***/ }),
 
-/***/ 166:
+/***/ 167:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29682,7 +31499,7 @@ exports.create = create;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.UserDelegationKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(268);
+const node_crypto_1 = __nccwpck_require__(269);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -29727,7 +31544,7 @@ exports.UserDelegationKeyCredential = UserDelegationKeyCredential;
 
 /***/ }),
 
-/***/ 167:
+/***/ 168:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -29753,10 +31570,10 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(280);
+var import_bytesEncoding = __nccwpck_require__(281);
 var import_typeGuards = __nccwpck_require__(477);
 var import_uuidUtils = __nccwpck_require__(377);
-var import_concat = __nccwpck_require__(294);
+var import_concat = __nccwpck_require__(295);
 function generateBoundary() {
   return `----AzSDKFormBoundary${(0, import_uuidUtils.randomUUID)()}`;
 }
@@ -29865,7 +31682,7 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 168:
+/***/ 169:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -29992,7 +31809,7 @@ function requestToOptions(request) {
 
 /***/ }),
 
-/***/ 169:
+/***/ 170:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30004,7 +31821,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 170:
+/***/ 171:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30019,20 +31836,20 @@ var reflection_info_1 = __nccwpck_require__(504);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
 Object.defineProperty(exports, "readMethodOption", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOption; } }));
 Object.defineProperty(exports, "readServiceOption", ({ enumerable: true, get: function () { return reflection_info_1.readServiceOption; } }));
-var rpc_error_1 = __nccwpck_require__(171);
+var rpc_error_1 = __nccwpck_require__(172);
 Object.defineProperty(exports, "RpcError", ({ enumerable: true, get: function () { return rpc_error_1.RpcError; } }));
-var rpc_options_1 = __nccwpck_require__(285);
+var rpc_options_1 = __nccwpck_require__(286);
 Object.defineProperty(exports, "mergeRpcOptions", ({ enumerable: true, get: function () { return rpc_options_1.mergeRpcOptions; } }));
-var rpc_output_stream_1 = __nccwpck_require__(298);
+var rpc_output_stream_1 = __nccwpck_require__(299);
 Object.defineProperty(exports, "RpcOutputStreamController", ({ enumerable: true, get: function () { return rpc_output_stream_1.RpcOutputStreamController; } }));
 var test_transport_1 = __nccwpck_require__(491);
 Object.defineProperty(exports, "TestTransport", ({ enumerable: true, get: function () { return test_transport_1.TestTransport; } }));
 var deferred_1 = __nccwpck_require__(51);
 Object.defineProperty(exports, "Deferred", ({ enumerable: true, get: function () { return deferred_1.Deferred; } }));
 Object.defineProperty(exports, "DeferredState", ({ enumerable: true, get: function () { return deferred_1.DeferredState; } }));
-var duplex_streaming_call_1 = __nccwpck_require__(296);
+var duplex_streaming_call_1 = __nccwpck_require__(297);
 Object.defineProperty(exports, "DuplexStreamingCall", ({ enumerable: true, get: function () { return duplex_streaming_call_1.DuplexStreamingCall; } }));
-var client_streaming_call_1 = __nccwpck_require__(337);
+var client_streaming_call_1 = __nccwpck_require__(338);
 Object.defineProperty(exports, "ClientStreamingCall", ({ enumerable: true, get: function () { return client_streaming_call_1.ClientStreamingCall; } }));
 var server_streaming_call_1 = __nccwpck_require__(431);
 Object.defineProperty(exports, "ServerStreamingCall", ({ enumerable: true, get: function () { return server_streaming_call_1.ServerStreamingCall; } }));
@@ -30050,7 +31867,7 @@ Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: tru
 
 /***/ }),
 
-/***/ 171:
+/***/ 172:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30094,7 +31911,7 @@ exports.RpcError = RpcError;
 
 /***/ }),
 
-/***/ 172:
+/***/ 173:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30177,7 +31994,7 @@ function isLessThan(lhs, rhs) {
 
 /***/ }),
 
-/***/ 173:
+/***/ 174:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30186,10 +32003,10 @@ function isLessThan(lhs, rhs) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-const operation_js_1 = __nccwpck_require__(344);
+const operation_js_1 = __nccwpck_require__(345);
 const constants_js_1 = __nccwpck_require__(58);
 const poller_js_1 = __nccwpck_require__(72);
-const operation_js_2 = __nccwpck_require__(139);
+const operation_js_2 = __nccwpck_require__(140);
 /**
  * The LRO Engine, a class that performs polling.
  */
@@ -30217,7 +32034,7 @@ exports.LroEngine = LroEngine;
 
 /***/ }),
 
-/***/ 174:
+/***/ 175:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -31867,7 +33684,7 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 175:
+/***/ 176:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -40210,7 +42027,7 @@ exports.BlockBlobGetBlockListExceptionHeaders = {
 
 /***/ }),
 
-/***/ 176:
+/***/ 177:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -40227,7 +42044,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 177:
+/***/ 178:
 /***/ ((module) => {
 
 "use strict";
@@ -40235,7 +42052,7 @@ module.exports = require("tty");
 
 /***/ }),
 
-/***/ 178:
+/***/ 179:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -40251,11 +42068,11 @@ exports.getCredentialFromPipeline = getCredentialFromPipeline;
 const core_http_compat_1 = __nccwpck_require__(70);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_client_1 = __nccwpck_require__(419);
-const core_xml_1 = __nccwpck_require__(189);
+const core_xml_1 = __nccwpck_require__(190);
 const core_auth_1 = __nccwpck_require__(492);
 const log_js_1 = __nccwpck_require__(105);
-const storage_common_1 = __nccwpck_require__(270);
-const constants_js_1 = __nccwpck_require__(146);
+const storage_common_1 = __nccwpck_require__(271);
+const constants_js_1 = __nccwpck_require__(147);
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return constants_js_1.StorageOAuthScopes; } }));
 /**
  * A helper to decide if a given argument satisfies the Pipeline contract
@@ -40519,7 +42336,7 @@ function isCoreHttpPolicyFactory(factory) {
 
 /***/ }),
 
-/***/ 179:
+/***/ 180:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -40552,7 +42369,7 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 
 /***/ }),
 
-/***/ 180:
+/***/ 181:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -40566,22 +42383,22 @@ const core_auth_1 = __nccwpck_require__(492);
 const core_util_1 = __nccwpck_require__(12);
 const core_util_2 = __nccwpck_require__(12);
 const BlobDownloadResponse_js_1 = __nccwpck_require__(405);
-const BlobQueryResponse_js_1 = __nccwpck_require__(196);
-const storage_common_1 = __nccwpck_require__(270);
+const BlobQueryResponse_js_1 = __nccwpck_require__(197);
+const storage_common_1 = __nccwpck_require__(271);
 const models_js_1 = __nccwpck_require__(396);
 const PageBlobRangeResponse_js_1 = __nccwpck_require__(27);
-const Pipeline_js_1 = __nccwpck_require__(178);
+const Pipeline_js_1 = __nccwpck_require__(179);
 const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(510);
 const Range_js_1 = __nccwpck_require__(103);
 const StorageClient_js_1 = __nccwpck_require__(434);
 const Batch_js_1 = __nccwpck_require__(89);
-const storage_common_2 = __nccwpck_require__(270);
-const constants_js_1 = __nccwpck_require__(146);
+const storage_common_2 = __nccwpck_require__(271);
+const constants_js_1 = __nccwpck_require__(147);
 const tracing_js_1 = __nccwpck_require__(29);
-const utils_common_js_1 = __nccwpck_require__(152);
-const utils_js_1 = __nccwpck_require__(197);
+const utils_common_js_1 = __nccwpck_require__(153);
+const utils_js_1 = __nccwpck_require__(198);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(66);
-const BlobLeaseClient_js_1 = __nccwpck_require__(199);
+const BlobLeaseClient_js_1 = __nccwpck_require__(200);
 /**
  * A BlobClient represents a URL to an Azure Storage blob; the blob may be a block blob,
  * append blob, or page blob.
@@ -43411,14 +45228,14 @@ exports.PageBlobClient = PageBlobClient;
 
 /***/ }),
 
-/***/ 181:
+/***/ 182:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryWriter = void 0;
-const binary_format_contract_1 = __nccwpck_require__(323);
+const binary_format_contract_1 = __nccwpck_require__(324);
 const reflection_info_1 = __nccwpck_require__(432);
 const assert_1 = __nccwpck_require__(464);
 const pb_long_1 = __nccwpck_require__(116);
@@ -43652,7 +45469,7 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 
 /***/ }),
 
-/***/ 182:
+/***/ 183:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -43663,7 +45480,7 @@ const { maxUnsigned16Bit } = __nccwpck_require__(445)
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(283)
+  crypto = __nccwpck_require__(284)
 } catch {
 
 }
@@ -43733,7 +45550,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 183:
+/***/ 184:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -43780,7 +45597,7 @@ function isApiKeyCredential(credential) {
 
 /***/ }),
 
-/***/ 184:
+/***/ 185:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(503)
@@ -43833,7 +45650,7 @@ module.exports = { getResolveErrorBodyCallback }
 
 /***/ }),
 
-/***/ 185:
+/***/ 186:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -43955,7 +45772,7 @@ exports.getSelectedOneofValue = getSelectedOneofValue;
 
 /***/ }),
 
-/***/ 186:
+/***/ 187:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -43974,14 +45791,14 @@ exports.logger = (0, logger_1.createClientLogger)("core-lro");
 
 /***/ }),
 
-/***/ 187:
+/***/ 188:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 /* eslint-disable object-property-newline */
 
 
-const decodeText = __nccwpck_require__(269)
+const decodeText = __nccwpck_require__(270)
 
 const RE_ENCODED = /%[a-fA-F0-9][a-fA-F0-9]/g
 
@@ -44178,7 +45995,7 @@ module.exports = parseParams
 
 /***/ }),
 
-/***/ 188:
+/***/ 189:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -44204,8 +46021,8 @@ __export(auxiliaryAuthenticationHeaderPolicy_exports, {
   auxiliaryAuthenticationHeaderPolicyName: () => auxiliaryAuthenticationHeaderPolicyName
 });
 module.exports = __toCommonJS(auxiliaryAuthenticationHeaderPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(160);
-var import_log = __nccwpck_require__(179);
+var import_tokenCycler = __nccwpck_require__(161);
+var import_log = __nccwpck_require__(180);
 const auxiliaryAuthenticationHeaderPolicyName = "auxiliaryAuthenticationHeaderPolicy";
 const AUTHORIZATION_AUXILIARY_HEADER = "x-ms-authorization-auxiliary";
 async function sendAuthorizeRequest(options) {
@@ -44271,7 +46088,7 @@ function auxiliaryAuthenticationHeaderPolicy(options) {
 
 /***/ }),
 
-/***/ 189:
+/***/ 190:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -44299,7 +46116,7 @@ __export(src_exports, {
   stringifyXML: () => import_xml.stringifyXML
 });
 module.exports = __toCommonJS(src_exports);
-var import_xml = __nccwpck_require__(136);
+var import_xml = __nccwpck_require__(137);
 var import_xml_common = __nccwpck_require__(19);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -44308,7 +46125,7 @@ var import_xml_common = __nccwpck_require__(19);
 
 /***/ }),
 
-/***/ 190:
+/***/ 191:
 /***/ ((module) => {
 
 module.exports = {
@@ -44378,7 +46195,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 191:
+/***/ 192:
 /***/ ((module) => {
 
 "use strict";
@@ -44503,7 +46320,7 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 192:
+/***/ 193:
 /***/ ((module) => {
 
 "use strict";
@@ -44511,7 +46328,7 @@ module.exports = require("node:child_process");
 
 /***/ }),
 
-/***/ 193:
+/***/ 194:
 /***/ ((module) => {
 
 "use strict";
@@ -44519,7 +46336,7 @@ module.exports = require("util/types");
 
 /***/ }),
 
-/***/ 194:
+/***/ 195:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44537,8 +46354,8 @@ const {
   kOriginalDispatch,
   kConnected
 } = __nccwpck_require__(450)
-const { MockInterceptor } = __nccwpck_require__(134)
-const Symbols = __nccwpck_require__(190)
+const { MockInterceptor } = __nccwpck_require__(135)
+const Symbols = __nccwpck_require__(191)
 const { InvalidArgumentError } = __nccwpck_require__(468)
 
 /**
@@ -44586,7 +46403,7 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 195:
+/***/ 196:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -44612,7 +46429,7 @@ __export(sha256_exports, {
   computeSha256Hmac: () => computeSha256Hmac
 });
 module.exports = __toCommonJS(sha256_exports);
-var import_node_crypto = __nccwpck_require__(268);
+var import_node_crypto = __nccwpck_require__(269);
 async function computeSha256Hmac(key, stringToSign, encoding) {
   const decodedKey = Buffer.from(key, "base64");
   return (0, import_node_crypto.createHmac)("sha256", decodedKey).update(stringToSign).digest(encoding);
@@ -44627,7 +46444,7 @@ async function computeSha256Hash(content, encoding) {
 
 /***/ }),
 
-/***/ 196:
+/***/ 197:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45007,7 +46824,7 @@ exports.BlobQueryResponse = BlobQueryResponse;
 
 /***/ }),
 
-/***/ 197:
+/***/ 198:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45020,10 +46837,10 @@ exports.streamToBuffer = streamToBuffer;
 exports.streamToBuffer2 = streamToBuffer2;
 exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
-const tslib_1 = __nccwpck_require__(210);
-const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(242));
-const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(359));
-const constants_js_1 = __nccwpck_require__(146);
+const tslib_1 = __nccwpck_require__(211);
+const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(243));
+const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(360));
+const constants_js_1 = __nccwpck_require__(147);
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
  *
@@ -45154,7 +46971,7 @@ exports.fsCreateReadStream = node_fs_1.default.createReadStream;
 
 /***/ }),
 
-/***/ 198:
+/***/ 199:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -45436,7 +47253,7 @@ exports.varint32read = varint32read;
 
 /***/ }),
 
-/***/ 199:
+/***/ 200:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45446,9 +47263,9 @@ exports.varint32read = varint32read;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobLeaseClient = void 0;
 const core_util_1 = __nccwpck_require__(12);
-const constants_js_1 = __nccwpck_require__(146);
+const constants_js_1 = __nccwpck_require__(147);
 const tracing_js_1 = __nccwpck_require__(29);
-const utils_common_js_1 = __nccwpck_require__(152);
+const utils_common_js_1 = __nccwpck_require__(153);
 /**
  * A client that manages leases for a {@link ContainerClient} or a {@link BlobClient}.
  */
@@ -45648,7 +47465,7 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 /***/ }),
 
-/***/ 200:
+/***/ 201:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45704,7 +47521,7 @@ exports.reflectionCreate = reflectionCreate;
 
 /***/ }),
 
-/***/ 201:
+/***/ 202:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45746,7 +47563,7 @@ function storageBrowserPolicy() {
 
 /***/ }),
 
-/***/ 202:
+/***/ 203:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -45754,7 +47571,7 @@ function storageBrowserPolicy() {
 
 const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(495)
 const { kState } = __nccwpck_require__(13)
-const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(349)
+const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(350)
 const { webidl } = __nccwpck_require__(436)
 const { Blob, File: NativeFile } = __nccwpck_require__(118)
 
@@ -46019,7 +47836,7 @@ module.exports = { FormData }
 
 /***/ }),
 
-/***/ 203:
+/***/ 204:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -46036,7 +47853,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 204:
+/***/ 205:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -46063,7 +47880,7 @@ __export(getClient_exports, {
 module.exports = __toCommonJS(getClient_exports);
 var import_clientHelpers = __nccwpck_require__(472);
 var import_sendRequest = __nccwpck_require__(429);
-var import_urlHelpers = __nccwpck_require__(315);
+var import_urlHelpers = __nccwpck_require__(316);
 var import_checkEnvironment = __nccwpck_require__(418);
 function getClient(endpoint, clientOptions = {}) {
   const pipeline = clientOptions.pipeline ?? (0, import_clientHelpers.createDefaultPipeline)(clientOptions);
@@ -46219,7 +48036,7 @@ function buildOperation(method, url, pipeline, options, allowInsecureConnection,
 
 /***/ }),
 
-/***/ 205:
+/***/ 206:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -46263,7 +48080,7 @@ function convertHttpClient(requestPolicyClient) {
 
 /***/ }),
 
-/***/ 206:
+/***/ 207:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -46289,8 +48106,8 @@ __export(retryPolicy_exports, {
 });
 module.exports = __toCommonJS(retryPolicy_exports);
 var import_logger = __nccwpck_require__(43);
-var import_constants = __nccwpck_require__(157);
-var import_policies = __nccwpck_require__(279);
+var import_constants = __nccwpck_require__(158);
+var import_policies = __nccwpck_require__(280);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("core-rest-pipeline retryPolicy");
 function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAULT_RETRY_POLICY_COUNT }) {
   return (0, import_policies.retryPolicy)(strategies, {
@@ -46304,7 +48121,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 
 /***/ }),
 
-/***/ 207:
+/***/ 208:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46313,7 +48130,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getErrorMessage = getErrorMessage;
-const util_1 = __nccwpck_require__(144);
+const util_1 = __nccwpck_require__(145);
 /**
  * Given what is thought to be an error object, return the message if possible.
  * If the message is missing, returns a stringified version of the input.
@@ -46344,7 +48161,7 @@ function getErrorMessage(e) {
 
 /***/ }),
 
-/***/ 208:
+/***/ 209:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -46384,13 +48201,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.restoreCache = exports.isFeatureAvailable = exports.FinalizeCacheError = exports.ReserveCacheError = exports.ValidationError = void 0;
 const core = __importStar(__nccwpck_require__(439));
-const path = __importStar(__nccwpck_require__(241));
+const path = __importStar(__nccwpck_require__(242));
 const utils = __importStar(__nccwpck_require__(73));
 const cacheHttpClient = __importStar(__nccwpck_require__(32));
 const cacheTwirpClient = __importStar(__nccwpck_require__(59));
 const config_1 = __nccwpck_require__(35);
 const tar_1 = __nccwpck_require__(420);
-const http_client_1 = __nccwpck_require__(278);
+const http_client_1 = __nccwpck_require__(279);
 class ValidationError extends Error {
     constructor(message) {
         super(message);
@@ -46870,7 +48687,7 @@ function saveCacheV2(paths, key, options, enableCrossOsArchive = false) {
 
 /***/ }),
 
-/***/ 209:
+/***/ 210:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -46947,7 +48764,7 @@ class ExtendedServiceClient extends import_core_client.ServiceClient {
 
 /***/ }),
 
-/***/ 210:
+/***/ 211:
 /***/ ((module) => {
 
 /******************************************************************************
@@ -47405,7 +49222,7 @@ var __rewriteRelativeImportExtension;
 
 /***/ }),
 
-/***/ 211:
+/***/ 212:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47432,9 +49249,9 @@ __export(bearerTokenAuthenticationPolicy_exports, {
   parseChallenges: () => parseChallenges
 });
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(160);
-var import_log = __nccwpck_require__(179);
-var import_restError = __nccwpck_require__(340);
+var import_tokenCycler = __nccwpck_require__(161);
+var import_log = __nccwpck_require__(180);
+var import_restError = __nccwpck_require__(341);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
   try {
@@ -47624,7 +49441,7 @@ function getCaeChallengeClaims(challenges) {
 
 /***/ }),
 
-/***/ 212:
+/***/ 213:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47650,7 +49467,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(280);
 const systemErrorRetryPolicyName = import_policies.systemErrorRetryPolicyName;
 function systemErrorRetryPolicy(options = {}) {
   return (0, import_policies.systemErrorRetryPolicy)(options);
@@ -47661,7 +49478,7 @@ function systemErrorRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 213:
+/***/ 214:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47675,9 +49492,9 @@ function systemErrorRetryPolicy(options = {}) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(419));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(63));
 /** Class containing Container operations. */
 class ContainerImpl {
@@ -48389,7 +50206,7 @@ const getAccountInfoOperationSpec = {
 
 /***/ }),
 
-/***/ 214:
+/***/ 215:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -48434,7 +50251,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 215:
+/***/ 216:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -48463,7 +50280,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.safeTrimTrailingSeparator = exports.normalizeSeparators = exports.hasRoot = exports.hasAbsoluteRoot = exports.ensureAbsoluteRoot = exports.dirname = void 0;
-const path = __importStar(__nccwpck_require__(241));
+const path = __importStar(__nccwpck_require__(242));
 const assert_1 = __importDefault(__nccwpck_require__(503));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -48639,7 +50456,7 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 
 /***/ }),
 
-/***/ 216:
+/***/ 217:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -48717,7 +50534,7 @@ exports.parseVerifyCompileCacheMode = parseVerifyCompileCacheMode;
 exports.verifyCompileCacheActivity = verifyCompileCacheActivity;
 exports.parseMinCompiles = parseMinCompiles;
 exports.decideBuildCacheSave = decideBuildCacheSave;
-const fs = __importStar(__nccwpck_require__(242));
+const fs = __importStar(__nccwpck_require__(243));
 const path = __importStar(__nccwpck_require__(487));
 /** Markdown table cell escaping — keeps the table grid intact. */
 function cell(value) {
@@ -49232,7 +51049,7 @@ function decideBuildCacheSave(input) {
 
 /***/ }),
 
-/***/ 217:
+/***/ 218:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49269,7 +51086,7 @@ const net = __importStar(__nccwpck_require__(488));
 const tls = __importStar(__nccwpck_require__(485));
 const debug_1 = __importDefault(__nccwpck_require__(493));
 const events_1 = __nccwpck_require__(449);
-const agent_base_1 = __nccwpck_require__(233);
+const agent_base_1 = __nccwpck_require__(234);
 const url_1 = __nccwpck_require__(82);
 const debug = (0, debug_1.default)('http-proxy-agent');
 /**
@@ -49387,7 +51204,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 218:
+/***/ 219:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49424,7 +51241,7 @@ var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
 const fs = __importStar(__nccwpck_require__(507));
-const path = __importStar(__nccwpck_require__(241));
+const path = __importStar(__nccwpck_require__(242));
 _a = fs.promises
 // export const {open} = 'fs'
 , exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
@@ -49577,7 +51394,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 219:
+/***/ 220:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49586,8 +51403,8 @@ exports.getCmdPath = getCmdPath;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
-const tslib_1 = __nccwpck_require__(210);
-var poller_js_1 = __nccwpck_require__(310);
+const tslib_1 = __nccwpck_require__(211);
+var poller_js_1 = __nccwpck_require__(311);
 Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: function () { return poller_js_1.createHttpPoller; } }));
 /**
  * This can be uncommented to expose the protocol-agnostic poller
@@ -49601,14 +51418,14 @@ Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: fun
 // } from "./poller/models";
 // export { buildCreatePoller } from "./poller/poller";
 /** legacy */
-tslib_1.__exportStar(__nccwpck_require__(236), exports);
+tslib_1.__exportStar(__nccwpck_require__(237), exports);
 tslib_1.__exportStar(__nccwpck_require__(72), exports);
 tslib_1.__exportStar(__nccwpck_require__(39), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 220:
+/***/ 221:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -49654,7 +51471,7 @@ function apiVersionPolicy(options) {
 
 /***/ }),
 
-/***/ 221:
+/***/ 222:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -49901,7 +51718,7 @@ exports.AbortSignal = AbortSignal;
 
 /***/ }),
 
-/***/ 222:
+/***/ 223:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -49918,7 +51735,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 
 /***/ }),
 
-/***/ 223:
+/***/ 224:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49932,9 +51749,9 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(419));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(63));
 /** Class containing Service operations. */
 class ServiceImpl {
@@ -50254,7 +52071,7 @@ const filterBlobsOperationSpec = {
 
 /***/ }),
 
-/***/ 224:
+/***/ 225:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -50280,7 +52097,7 @@ __export(agentPolicy_exports, {
   agentPolicyName: () => agentPolicyName
 });
 module.exports = __toCommonJS(agentPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(280);
 const agentPolicyName = import_policies.agentPolicyName;
 function agentPolicy(agent) {
   return (0, import_policies.agentPolicy)(agent);
@@ -50291,7 +52108,7 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 225:
+/***/ 226:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50316,13 +52133,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 226:
+/***/ 227:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Transform } = __nccwpck_require__(129)
+const { Transform } = __nccwpck_require__(130)
 const { Console } = __nccwpck_require__(30)
 
 /**
@@ -50364,7 +52181,7 @@ module.exports = class PendingInterceptorsFormatter {
 
 /***/ }),
 
-/***/ 227:
+/***/ 228:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50435,7 +52252,7 @@ exports.CacheMetadata = new CacheMetadata$Type();
 
 /***/ }),
 
-/***/ 228:
+/***/ 229:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -50482,7 +52299,7 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 229:
+/***/ 230:
 /***/ ((module) => {
 
 "use strict";
@@ -50490,7 +52307,7 @@ module.exports = require("node:process");
 
 /***/ }),
 
-/***/ 230:
+/***/ 231:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50734,7 +52551,7 @@ function appendQueryParams(url, queryParams, sequenceParams, noOverwrite = false
 
 /***/ }),
 
-/***/ 231:
+/***/ 232:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -50760,7 +52577,7 @@ __export(decompressResponsePolicy_exports, {
   decompressResponsePolicyName: () => decompressResponsePolicyName
 });
 module.exports = __toCommonJS(decompressResponsePolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(280);
 const decompressResponsePolicyName = import_policies.decompressResponsePolicyName;
 function decompressResponsePolicy() {
   return (0, import_policies.decompressResponsePolicy)();
@@ -50771,7 +52588,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 232:
+/***/ 233:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -50818,7 +52635,7 @@ function ndJsonPolicy() {
 
 /***/ }),
 
-/***/ 233:
+/***/ 234:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -50852,9 +52669,9 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Agent = void 0;
 const net = __importStar(__nccwpck_require__(488));
-const http = __importStar(__nccwpck_require__(320));
+const http = __importStar(__nccwpck_require__(321));
 const https_1 = __nccwpck_require__(68);
-__exportStar(__nccwpck_require__(159), exports);
+__exportStar(__nccwpck_require__(160), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
 class Agent extends http.Agent {
     constructor(opts) {
@@ -51003,7 +52820,7 @@ exports.Agent = Agent;
 
 /***/ }),
 
-/***/ 234:
+/***/ 235:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -51046,7 +52863,7 @@ exports.mergeJsonOptions = mergeJsonOptions;
 
 /***/ }),
 
-/***/ 235:
+/***/ 236:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51081,7 +52898,7 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 236:
+/***/ 237:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51090,13 +52907,13 @@ function createHttpHeaders(rawHeaders) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-var lroEngine_js_1 = __nccwpck_require__(173);
+var lroEngine_js_1 = __nccwpck_require__(174);
 Object.defineProperty(exports, "LroEngine", ({ enumerable: true, get: function () { return lroEngine_js_1.LroEngine; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 237:
+/***/ 238:
 /***/ ((module) => {
 
 "use strict";
@@ -51104,7 +52921,7 @@ module.exports = require("fs/promises");
 
 /***/ }),
 
-/***/ 238:
+/***/ 239:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51139,7 +52956,7 @@ function createEmptyPipeline() {
 
 /***/ }),
 
-/***/ 239:
+/***/ 240:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -51284,7 +53101,7 @@ function createClientLogger(namespace) {
 
 /***/ }),
 
-/***/ 240:
+/***/ 241:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -51331,7 +53148,7 @@ function isTokenCredential(credential) {
 
 /***/ }),
 
-/***/ 241:
+/***/ 242:
 /***/ ((module) => {
 
 "use strict";
@@ -51339,7 +53156,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 242:
+/***/ 243:
 /***/ ((module) => {
 
 "use strict";
@@ -51347,7 +53164,7 @@ module.exports = require("node:fs");
 
 /***/ }),
 
-/***/ 243:
+/***/ 244:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51355,7 +53172,7 @@ module.exports = require("node:fs");
 
 const { webidl } = __nccwpck_require__(436)
 const { kEnumerableProperty } = __nccwpck_require__(67)
-const { MessagePort } = __nccwpck_require__(309)
+const { MessagePort } = __nccwpck_require__(310)
 
 /**
  * @see https://html.spec.whatwg.org/multipage/comms.html#messageevent
@@ -51658,7 +53475,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 244:
+/***/ 245:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51666,7 +53483,7 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryWriter = exports.binaryWriteOptions = void 0;
 const pb_long_1 = __nccwpck_require__(116);
-const goog_varint_1 = __nccwpck_require__(198);
+const goog_varint_1 = __nccwpck_require__(199);
 const assert_1 = __nccwpck_require__(464);
 const defaultsWrite = {
     writeUnknownFields: true,
@@ -51898,7 +53715,7 @@ exports.BinaryWriter = BinaryWriter;
 
 /***/ }),
 
-/***/ 245:
+/***/ 246:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51995,7 +53812,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 
 /***/ }),
 
-/***/ 246:
+/***/ 247:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52016,7 +53833,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 247:
+/***/ 248:
 /***/ ((module) => {
 
 "use strict";
@@ -52053,7 +53870,7 @@ module.exports = class Pluralizer {
 
 /***/ }),
 
-/***/ 248:
+/***/ 249:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52082,7 +53899,7 @@ module.exports = createRedirectInterceptor
 
 /***/ }),
 
-/***/ 249:
+/***/ 250:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52136,7 +53953,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 250:
+/***/ 251:
 /***/ ((module) => {
 
 "use strict";
@@ -52144,7 +53961,7 @@ module.exports = require("stream/web");
 
 /***/ }),
 
-/***/ 251:
+/***/ 252:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52154,8 +53971,8 @@ module.exports = require("stream/web");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getBodyAsText = getBodyAsText;
 exports.utf8ByteLength = utf8ByteLength;
-const utils_js_1 = __nccwpck_require__(197);
-const constants_js_1 = __nccwpck_require__(146);
+const utils_js_1 = __nccwpck_require__(198);
+const constants_js_1 = __nccwpck_require__(147);
 async function getBodyAsText(batchResponse) {
     let buffer = Buffer.alloc(constants_js_1.BATCH_MAX_PAYLOAD_IN_BYTES);
     const responseLength = await (0, utils_js_1.streamToBuffer2)(batchResponse.readableStreamBody, buffer);
@@ -52170,7 +53987,7 @@ function utf8ByteLength(str) {
 
 /***/ }),
 
-/***/ 252:
+/***/ 253:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52221,7 +54038,7 @@ function wrapAbortSignalLikePolicy() {
 
 /***/ }),
 
-/***/ 253:
+/***/ 254:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52273,7 +54090,7 @@ function createAbortablePromise(buildPromise, options) {
 
 /***/ }),
 
-/***/ 254:
+/***/ 255:
 /***/ ((module) => {
 
 "use strict";
@@ -52281,7 +54098,7 @@ module.exports = require("punycode");
 
 /***/ }),
 
-/***/ 255:
+/***/ 256:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52321,7 +54138,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.retryHttpClientResponse = exports.retryTypedResponse = exports.retry = exports.isRetryableStatusCode = exports.isServerErrorStatusCode = exports.isSuccessStatusCode = void 0;
 const core = __importStar(__nccwpck_require__(439));
-const http_client_1 = __nccwpck_require__(278);
+const http_client_1 = __nccwpck_require__(279);
 const constants_1 = __nccwpck_require__(44);
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
@@ -52425,7 +54242,7 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 
 /***/ }),
 
-/***/ 256:
+/***/ 257:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52434,8 +54251,8 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(268);
-const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(125);
+const node_crypto_1 = __nccwpck_require__(269);
+const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(126);
 const Credential_js_1 = __nccwpck_require__(94);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -52484,7 +54301,7 @@ exports.StorageSharedKeyCredential = StorageSharedKeyCredential;
 
 /***/ }),
 
-/***/ 257:
+/***/ 258:
 /***/ ((module) => {
 
 "use strict";
@@ -52492,7 +54309,7 @@ module.exports = require("node:http");
 
 /***/ }),
 
-/***/ 258:
+/***/ 259:
 /***/ ((module) => {
 
 "use strict";
@@ -52500,7 +54317,7 @@ module.exports = require("node:buffer");
 
 /***/ }),
 
-/***/ 259:
+/***/ 260:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52624,7 +54441,7 @@ exports.getDownloadOptions = getDownloadOptions;
 
 /***/ }),
 
-/***/ 260:
+/***/ 261:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52821,7 +54638,7 @@ module.exports = buildConnector
 
 /***/ }),
 
-/***/ 261:
+/***/ 262:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52830,7 +54647,7 @@ module.exports = buildConnector
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageContextClient = void 0;
-const index_js_1 = __nccwpck_require__(288);
+const index_js_1 = __nccwpck_require__(289);
 /**
  * @internal
  */
@@ -52849,7 +54666,7 @@ exports.StorageContextClient = StorageContextClient;
 
 /***/ }),
 
-/***/ 262:
+/***/ 263:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52875,7 +54692,7 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(280);
 const formDataPolicyName = import_policies.formDataPolicyName;
 function formDataPolicy() {
   return (0, import_policies.formDataPolicy)();
@@ -52886,7 +54703,7 @@ function formDataPolicy() {
 
 /***/ }),
 
-/***/ 263:
+/***/ 264:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52914,7 +54731,7 @@ __export(multipart_exports, {
 module.exports = __toCommonJS(multipart_exports);
 var import_restError = __nccwpck_require__(424);
 var import_httpHeaders = __nccwpck_require__(465);
-var import_bytesEncoding = __nccwpck_require__(280);
+var import_bytesEncoding = __nccwpck_require__(281);
 var import_typeGuards = __nccwpck_require__(477);
 function getHeaderValue(descriptor, headerName) {
   if (descriptor.headers) {
@@ -53024,7 +54841,7 @@ function buildMultipartBody(parts) {
 
 /***/ }),
 
-/***/ 264:
+/***/ 265:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -53041,7 +54858,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 265:
+/***/ 266:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53067,8 +54884,8 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_policies = __nccwpck_require__(279);
-var import_file = __nccwpck_require__(318);
+var import_policies = __nccwpck_require__(280);
+var import_file = __nccwpck_require__(319);
 const multipartPolicyName = import_policies.multipartPolicyName;
 function multipartPolicy() {
   const tspPolicy = (0, import_policies.multipartPolicy)();
@@ -53092,7 +54909,7 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 266:
+/***/ 267:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -53187,12 +55004,12 @@ exports.listEnumNumbers = listEnumNumbers;
 
 /***/ }),
 
-/***/ 267:
+/***/ 268:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(503)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(190)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(191)
 const { RequestRetryError } = __nccwpck_require__(468)
 const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(67)
 
@@ -53530,7 +55347,7 @@ module.exports = RetryHandler
 
 /***/ }),
 
-/***/ 268:
+/***/ 269:
 /***/ ((module) => {
 
 "use strict";
@@ -53538,7 +55355,7 @@ module.exports = require("node:crypto");
 
 /***/ }),
 
-/***/ 269:
+/***/ 270:
 /***/ (function(module) {
 
 "use strict";
@@ -53660,7 +55477,7 @@ module.exports = decodeText
 
 /***/ }),
 
-/***/ 270:
+/***/ 271:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53669,32 +55486,32 @@ module.exports = decodeText
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
-const tslib_1 = __nccwpck_require__(210);
-tslib_1.__exportStar(__nccwpck_require__(348), exports);
-var cache_js_1 = __nccwpck_require__(246);
+const tslib_1 = __nccwpck_require__(211);
+tslib_1.__exportStar(__nccwpck_require__(349), exports);
+var cache_js_1 = __nccwpck_require__(247);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
 tslib_1.__exportStar(__nccwpck_require__(80), exports);
-tslib_1.__exportStar(__nccwpck_require__(153), exports);
+tslib_1.__exportStar(__nccwpck_require__(154), exports);
 tslib_1.__exportStar(__nccwpck_require__(381), exports);
 tslib_1.__exportStar(__nccwpck_require__(94), exports);
-tslib_1.__exportStar(__nccwpck_require__(256), exports);
-tslib_1.__exportStar(__nccwpck_require__(317), exports);
+tslib_1.__exportStar(__nccwpck_require__(257), exports);
+tslib_1.__exportStar(__nccwpck_require__(318), exports);
 var RequestPolicy_js_1 = __nccwpck_require__(45);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
 tslib_1.__exportStar(__nccwpck_require__(91), exports);
-tslib_1.__exportStar(__nccwpck_require__(300), exports);
-tslib_1.__exportStar(__nccwpck_require__(201), exports);
+tslib_1.__exportStar(__nccwpck_require__(301), exports);
+tslib_1.__exportStar(__nccwpck_require__(202), exports);
 tslib_1.__exportStar(__nccwpck_require__(443), exports);
-tslib_1.__exportStar(__nccwpck_require__(164), exports);
-tslib_1.__exportStar(__nccwpck_require__(125), exports);
+tslib_1.__exportStar(__nccwpck_require__(165), exports);
+tslib_1.__exportStar(__nccwpck_require__(126), exports);
 tslib_1.__exportStar(__nccwpck_require__(75), exports);
 tslib_1.__exportStar(__nccwpck_require__(406), exports);
-tslib_1.__exportStar(__nccwpck_require__(166), exports);
+tslib_1.__exportStar(__nccwpck_require__(167), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 271:
+/***/ 272:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53707,18 +55524,18 @@ tslib_1.__exportStar(__nccwpck_require__(166), exports);
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(210);
-tslib_1.__exportStar(__nccwpck_require__(223), exports);
-tslib_1.__exportStar(__nccwpck_require__(213), exports);
+const tslib_1 = __nccwpck_require__(211);
+tslib_1.__exportStar(__nccwpck_require__(224), exports);
+tslib_1.__exportStar(__nccwpck_require__(214), exports);
 tslib_1.__exportStar(__nccwpck_require__(46), exports);
-tslib_1.__exportStar(__nccwpck_require__(275), exports);
+tslib_1.__exportStar(__nccwpck_require__(276), exports);
 tslib_1.__exportStar(__nccwpck_require__(24), exports);
-tslib_1.__exportStar(__nccwpck_require__(342), exports);
+tslib_1.__exportStar(__nccwpck_require__(343), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 272:
+/***/ 273:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -53777,7 +55594,7 @@ const os = __importStar(__nccwpck_require__(367));
 const path = __importStar(__nccwpck_require__(487));
 const core = __importStar(__nccwpck_require__(439));
 const exec = __importStar(__nccwpck_require__(16));
-const io = __importStar(__nccwpck_require__(286));
+const io = __importStar(__nccwpck_require__(287));
 /**
  * Recursively walk a directory and sum file sizes.
  */
@@ -54424,7 +56241,7 @@ function parseLevel(value) {
  * Bubbles non-zero exit codes from either side.
  */
 async function runPipe(producer, consumer) {
-    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 192, 23));
+    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 193, 23));
     const [pCmd, pArgs] = producer;
     const [cCmd, cArgs] = consumer;
     await new Promise((resolve, reject) => {
@@ -54464,7 +56281,7 @@ async function runPipe(producer, consumer) {
 
 /***/ }),
 
-/***/ 273:
+/***/ 274:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -54694,7 +56511,7 @@ exports.ContainerSASPermissions = ContainerSASPermissions;
 
 /***/ }),
 
-/***/ 274:
+/***/ 275:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -54720,20 +56537,20 @@ __export(createPipelineFromOptions_exports, {
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(69);
-var import_pipeline = __nccwpck_require__(238);
-var import_redirectPolicy = __nccwpck_require__(330);
+var import_pipeline = __nccwpck_require__(239);
+var import_redirectPolicy = __nccwpck_require__(331);
 var import_userAgentPolicy = __nccwpck_require__(373);
-var import_multipartPolicy = __nccwpck_require__(265);
-var import_decompressResponsePolicy = __nccwpck_require__(231);
+var import_multipartPolicy = __nccwpck_require__(266);
+var import_decompressResponsePolicy = __nccwpck_require__(232);
 var import_defaultRetryPolicy = __nccwpck_require__(53);
-var import_formDataPolicy = __nccwpck_require__(262);
+var import_formDataPolicy = __nccwpck_require__(263);
 var import_core_util = __nccwpck_require__(12);
 var import_proxyPolicy = __nccwpck_require__(452);
-var import_setClientRequestIdPolicy = __nccwpck_require__(148);
-var import_agentPolicy = __nccwpck_require__(224);
+var import_setClientRequestIdPolicy = __nccwpck_require__(149);
+var import_agentPolicy = __nccwpck_require__(225);
 var import_tlsPolicy = __nccwpck_require__(363);
-var import_tracingPolicy = __nccwpck_require__(326);
-var import_wrapAbortSignalLikePolicy = __nccwpck_require__(252);
+var import_tracingPolicy = __nccwpck_require__(327);
+var import_wrapAbortSignalLikePolicy = __nccwpck_require__(253);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_core_util.isNodeLike) {
@@ -54767,7 +56584,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 275:
+/***/ 276:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -54781,9 +56598,9 @@ function createPipelineFromOptions(options) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(419));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(63));
 /** Class containing PageBlob operations. */
 class PageBlobImpl {
@@ -55237,13 +57054,13 @@ const copyIncrementalOperationSpec = {
 
 /***/ }),
 
-/***/ 276:
+/***/ 277:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(154)
+const { kConstruct } = __nccwpck_require__(155)
 const { Cache } = __nccwpck_require__(10)
 const { webidl } = __nccwpck_require__(436)
 const { kEnumerableProperty } = __nccwpck_require__(67)
@@ -55389,7 +57206,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 277:
+/***/ 278:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55425,7 +57242,7 @@ function createClientPipeline(options = {}) {
 
 /***/ }),
 
-/***/ 278:
+/***/ 279:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -55465,11 +57282,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
-const http = __importStar(__nccwpck_require__(320));
+const http = __importStar(__nccwpck_require__(321));
 const https = __importStar(__nccwpck_require__(68));
-const pm = __importStar(__nccwpck_require__(302));
+const pm = __importStar(__nccwpck_require__(303));
 const tunnel = __importStar(__nccwpck_require__(498));
-const undici_1 = __nccwpck_require__(161);
+const undici_1 = __nccwpck_require__(162);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -56084,7 +57901,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 279:
+/***/ 280:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -56137,19 +57954,19 @@ __export(internal_exports, {
 });
 module.exports = __toCommonJS(internal_exports);
 var import_agentPolicy = __nccwpck_require__(444);
-var import_decompressResponsePolicy = __nccwpck_require__(343);
-var import_defaultRetryPolicy = __nccwpck_require__(316);
+var import_decompressResponsePolicy = __nccwpck_require__(344);
+var import_defaultRetryPolicy = __nccwpck_require__(317);
 var import_exponentialRetryPolicy = __nccwpck_require__(500);
 var import_retryPolicy = __nccwpck_require__(14);
 var import_systemErrorRetryPolicy = __nccwpck_require__(26);
 var import_throttlingRetryPolicy = __nccwpck_require__(499);
-var import_formDataPolicy = __nccwpck_require__(329);
+var import_formDataPolicy = __nccwpck_require__(330);
 var import_logPolicy = __nccwpck_require__(101);
-var import_multipartPolicy = __nccwpck_require__(167);
+var import_multipartPolicy = __nccwpck_require__(168);
 var import_proxyPolicy = __nccwpck_require__(37);
-var import_redirectPolicy = __nccwpck_require__(308);
-var import_tlsPolicy = __nccwpck_require__(214);
-var import_userAgentPolicy = __nccwpck_require__(346);
+var import_redirectPolicy = __nccwpck_require__(309);
+var import_tlsPolicy = __nccwpck_require__(215);
+var import_userAgentPolicy = __nccwpck_require__(347);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -56157,7 +57974,7 @@ var import_userAgentPolicy = __nccwpck_require__(346);
 
 /***/ }),
 
-/***/ 280:
+/***/ 281:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -56196,7 +58013,7 @@ function stringToUint8Array(value, format) {
 
 /***/ }),
 
-/***/ 281:
+/***/ 282:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56209,10 +58026,10 @@ exports.generateAccountSASQueryParametersInternal = generateAccountSASQueryParam
 const AccountSASPermissions_js_1 = __nccwpck_require__(56);
 const AccountSASResourceTypes_js_1 = __nccwpck_require__(2);
 const AccountSASServices_js_1 = __nccwpck_require__(364);
-const SasIPRange_js_1 = __nccwpck_require__(345);
+const SasIPRange_js_1 = __nccwpck_require__(346);
 const SASQueryParameters_js_1 = __nccwpck_require__(502);
-const constants_js_1 = __nccwpck_require__(146);
-const utils_common_js_1 = __nccwpck_require__(152);
+const constants_js_1 = __nccwpck_require__(147);
+const utils_common_js_1 = __nccwpck_require__(153);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -56307,7 +58124,7 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 
 /***/ }),
 
-/***/ 282:
+/***/ 283:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56315,7 +58132,7 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
 const reflection_info_1 = __nccwpck_require__(432);
-const oneof_1 = __nccwpck_require__(185);
+const oneof_1 = __nccwpck_require__(186);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
     constructor(info) {
@@ -56545,7 +58362,7 @@ exports.ReflectionTypeCheck = ReflectionTypeCheck;
 
 /***/ }),
 
-/***/ 283:
+/***/ 284:
 /***/ ((module) => {
 
 "use strict";
@@ -56553,7 +58370,7 @@ module.exports = require("crypto");
 
 /***/ }),
 
-/***/ 284:
+/***/ 285:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -56580,7 +58397,7 @@ __export(userAgent_exports, {
 });
 module.exports = __toCommonJS(userAgent_exports);
 var import_userAgentPlatform = __nccwpck_require__(115);
-var import_constants = __nccwpck_require__(157);
+var import_constants = __nccwpck_require__(158);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
   for (const [key, value] of telemetryInfo) {
@@ -56606,7 +58423,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 285:
+/***/ 286:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56680,7 +58497,7 @@ function copy(a, into) {
 
 /***/ }),
 
-/***/ 286:
+/***/ 287:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -56716,8 +58533,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
 const assert_1 = __nccwpck_require__(503);
-const path = __importStar(__nccwpck_require__(241));
-const ioUtil = __importStar(__nccwpck_require__(218));
+const path = __importStar(__nccwpck_require__(242));
+const ioUtil = __importStar(__nccwpck_require__(219));
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -56986,7 +58803,7 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 287:
+/***/ 288:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57067,7 +58884,7 @@ exports.maskSecretUrls = maskSecretUrls;
 
 /***/ }),
 
-/***/ 288:
+/***/ 289:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57081,16 +58898,16 @@ exports.maskSecretUrls = maskSecretUrls;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 tslib_1.__exportStar(__nccwpck_require__(451), exports);
 var storageClient_js_1 = __nccwpck_require__(426);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(163), exports);
+tslib_1.__exportStar(__nccwpck_require__(164), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 289:
+/***/ 290:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -57140,7 +58957,7 @@ exports.AzureKeyCredential = AzureKeyCredential;
 
 /***/ }),
 
-/***/ 290:
+/***/ 291:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57151,7 +58968,7 @@ const {
   NotSupportedError
 } = __nccwpck_require__(468)
 const assert = __nccwpck_require__(503)
-const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(190)
+const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(191)
 const util = __nccwpck_require__(67)
 
 // tokenRegExp and headerCharRegex have been lifted from
@@ -57182,7 +58999,7 @@ const channels = {}
 let extractBody
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(140)
+  const diagnosticsChannel = __nccwpck_require__(141)
   channels.create = diagnosticsChannel.channel('undici:request:create')
   channels.bodySent = diagnosticsChannel.channel('undici:request:bodySent')
   channels.headers = diagnosticsChannel.channel('undici:request:headers')
@@ -57647,7 +59464,7 @@ module.exports = Request
 
 /***/ }),
 
-/***/ 291:
+/***/ 292:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57656,7 +59473,7 @@ module.exports = Request
 const { webidl } = __nccwpck_require__(436)
 const { DOMException } = __nccwpck_require__(28)
 const { URLSerializer } = __nccwpck_require__(23)
-const { getGlobalOrigin } = __nccwpck_require__(138)
+const { getGlobalOrigin } = __nccwpck_require__(139)
 const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(445)
 const {
   kWebSocketURL,
@@ -57668,8 +59485,8 @@ const {
   kByteParser
 } = __nccwpck_require__(97)
 const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(55)
-const { establishWebSocketConnection } = __nccwpck_require__(350)
-const { WebsocketFrameSend } = __nccwpck_require__(182)
+const { establishWebSocketConnection } = __nccwpck_require__(351)
+const { WebsocketFrameSend } = __nccwpck_require__(183)
 const { ByteParser } = __nccwpck_require__(462)
 const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(67)
 const { getGlobalDispatcher } = __nccwpck_require__(361)
@@ -58296,7 +60113,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 292:
+/***/ 293:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58631,7 +60448,7 @@ class AvroRecordType extends AvroType {
 
 /***/ }),
 
-/***/ 293:
+/***/ 294:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58757,7 +60574,7 @@ exports.base64encode = base64encode;
 
 /***/ }),
 
-/***/ 294:
+/***/ 295:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -58782,7 +60599,7 @@ __export(concat_exports, {
   concat: () => concat
 });
 module.exports = __toCommonJS(concat_exports);
-var import_stream = __nccwpck_require__(129);
+var import_stream = __nccwpck_require__(130);
 var import_typeGuards = __nccwpck_require__(477);
 async function* streamAsyncIterator() {
   const reader = this.getReader();
@@ -58844,7 +60661,7 @@ async function concat(sources) {
 
 /***/ }),
 
-/***/ 295:
+/***/ 296:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58921,7 +60738,7 @@ UsageError.isUsageErrorMessage = (msg) => {
 
 /***/ }),
 
-/***/ 296:
+/***/ 297:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -58978,7 +60795,7 @@ exports.DuplexStreamingCall = DuplexStreamingCall;
 
 /***/ }),
 
-/***/ 297:
+/***/ 298:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -59042,7 +60859,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.shutdownCacheDaemons = shutdownCacheDaemons;
 const exec = __importStar(__nccwpck_require__(16));
-const io = __importStar(__nccwpck_require__(286));
+const io = __importStar(__nccwpck_require__(287));
 async function exists(cmd) {
     try {
         await io.which(cmd, true);
@@ -59162,7 +60979,7 @@ async function shutdownCacheDaemons(opts) {
 
 /***/ }),
 
-/***/ 298:
+/***/ 299:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59340,7 +61157,7 @@ exports.RpcOutputStreamController = RpcOutputStreamController;
 
 /***/ }),
 
-/***/ 299:
+/***/ 300:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59362,7 +61179,7 @@ exports.enumToMap = enumToMap;
 
 /***/ }),
 
-/***/ 300:
+/***/ 301:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59402,7 +61219,7 @@ exports.CredentialPolicy = CredentialPolicy;
 
 /***/ }),
 
-/***/ 301:
+/***/ 302:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59413,8 +61230,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BatchResponseParser = void 0;
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_http_compat_1 = __nccwpck_require__(70);
-const constants_js_1 = __nccwpck_require__(146);
-const BatchUtils_js_1 = __nccwpck_require__(251);
+const constants_js_1 = __nccwpck_require__(147);
+const BatchUtils_js_1 = __nccwpck_require__(252);
 const log_js_1 = __nccwpck_require__(105);
 const HTTP_HEADER_DELIMITER = ": ";
 const SPACE_DELIMITER = " ";
@@ -59555,7 +61372,7 @@ exports.BatchResponseParser = BatchResponseParser;
 
 /***/ }),
 
-/***/ 302:
+/***/ 303:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59657,7 +61474,7 @@ class DecodedURL extends URL {
 
 /***/ }),
 
-/***/ 303:
+/***/ 304:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59798,7 +61615,7 @@ function flattenResponse(fullResponse, responseSpec) {
 
 /***/ }),
 
-/***/ 304:
+/***/ 305:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59807,7 +61624,7 @@ function flattenResponse(fullResponse, responseSpec) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.buildCreatePoller = void 0;
-const operation_js_1 = __nccwpck_require__(139);
+const operation_js_1 = __nccwpck_require__(140);
 const constants_js_1 = __nccwpck_require__(58);
 const core_util_1 = __nccwpck_require__(12);
 const createStateProxy = () => ({
@@ -59979,7 +61796,7 @@ exports.buildCreatePoller = buildCreatePoller;
 
 /***/ }),
 
-/***/ 305:
+/***/ 306:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59989,11 +61806,11 @@ exports.buildCreatePoller = buildCreatePoller;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
 const core_rest_pipeline_1 = __nccwpck_require__(100);
-const pipeline_js_1 = __nccwpck_require__(277);
-const utils_js_1 = __nccwpck_require__(303);
+const pipeline_js_1 = __nccwpck_require__(278);
+const utils_js_1 = __nccwpck_require__(304);
 const httpClientCache_js_1 = __nccwpck_require__(382);
 const operationHelpers_js_1 = __nccwpck_require__(411);
-const urlHelpers_js_1 = __nccwpck_require__(230);
+const urlHelpers_js_1 = __nccwpck_require__(231);
 const interfaceHelpers_js_1 = __nccwpck_require__(383);
 const log_js_1 = __nccwpck_require__(461);
 /**
@@ -60162,7 +61979,7 @@ function getCredentialScopes(options) {
 
 /***/ }),
 
-/***/ 306:
+/***/ 307:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60189,16 +62006,16 @@ __export(createPipelineFromOptions_exports, {
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(101);
 var import_pipeline = __nccwpck_require__(501);
-var import_redirectPolicy = __nccwpck_require__(308);
-var import_userAgentPolicy = __nccwpck_require__(346);
-var import_decompressResponsePolicy = __nccwpck_require__(343);
-var import_defaultRetryPolicy = __nccwpck_require__(316);
-var import_formDataPolicy = __nccwpck_require__(329);
+var import_redirectPolicy = __nccwpck_require__(309);
+var import_userAgentPolicy = __nccwpck_require__(347);
+var import_decompressResponsePolicy = __nccwpck_require__(344);
+var import_defaultRetryPolicy = __nccwpck_require__(317);
+var import_formDataPolicy = __nccwpck_require__(330);
 var import_checkEnvironment = __nccwpck_require__(418);
 var import_proxyPolicy = __nccwpck_require__(37);
 var import_agentPolicy = __nccwpck_require__(444);
-var import_tlsPolicy = __nccwpck_require__(214);
-var import_multipartPolicy = __nccwpck_require__(167);
+var import_tlsPolicy = __nccwpck_require__(215);
+var import_multipartPolicy = __nccwpck_require__(168);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_checkEnvironment.isNodeLike) {
@@ -60228,7 +62045,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 307:
+/***/ 308:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -60245,7 +62062,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 308:
+/***/ 309:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60271,7 +62088,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_log = __nccwpck_require__(149);
+var import_log = __nccwpck_require__(150);
 const redirectPolicyName = "redirectPolicy";
 const allowedRedirect = ["GET", "HEAD"];
 function redirectPolicy(options = {}) {
@@ -60317,7 +62134,7 @@ async function handleRedirect(next, response, maxRetries, allowCrossOriginRedire
 
 /***/ }),
 
-/***/ 309:
+/***/ 310:
 /***/ ((module) => {
 
 "use strict";
@@ -60325,7 +62142,7 @@ module.exports = require("worker_threads");
 
 /***/ }),
 
-/***/ 310:
+/***/ 311:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60335,7 +62152,7 @@ module.exports = require("worker_threads");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
 const operation_js_1 = __nccwpck_require__(50);
-const poller_js_1 = __nccwpck_require__(304);
+const poller_js_1 = __nccwpck_require__(305);
 /**
  * Creates a poller that can be used to poll a long-running operation.
  * @param lro - Description of the long-running operation
@@ -60380,7 +62197,7 @@ exports.createHttpPoller = createHttpPoller;
 
 /***/ }),
 
-/***/ 311:
+/***/ 312:
 /***/ ((module) => {
 
 "use strict";
@@ -60388,14 +62205,14 @@ module.exports = require("perf_hooks");
 
 /***/ }),
 
-/***/ 312:
+/***/ 313:
 /***/ ((module) => {
 
 (()=>{"use strict";var t={d:(e,n)=>{for(var i in n)t.o(n,i)&&!t.o(e,i)&&Object.defineProperty(e,i,{enumerable:!0,get:n[i]})},o:(t,e)=>Object.prototype.hasOwnProperty.call(t,e),r:t=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(t,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(t,"__esModule",{value:!0})}},e={};t.r(e),t.d(e,{XMLBuilder:()=>ie,XMLParser:()=>Lt,XMLValidator:()=>se});const n=":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD",i=new RegExp("^["+n+"]["+n+"\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$");function s(t,e){const n=[];let i=e.exec(t);for(;i;){const s=[];s.startIndex=e.lastIndex-i[0].length;const r=i.length;for(let t=0;t<r;t++)s.push(i[t]);n.push(s),i=e.exec(t)}return n}const r=function(t){return!(null==i.exec(t))},o=["hasOwnProperty","toString","valueOf","__defineGetter__","__defineSetter__","__lookupGetter__","__lookupSetter__"],a=["__proto__","constructor","prototype"],h={allowBooleanAttributes:!1,unpairedTags:[]};function l(t,e){e=Object.assign({},h,e);const n=[];let i=!1,s=!1;"\ufeff"===t[0]&&(t=t.substr(1));for(let r=0;r<t.length;r++)if("<"===t[r]&&"?"===t[r+1]){if(r+=2,r=p(t,r),r.err)return r}else{if("<"!==t[r]){if(u(t[r]))continue;return b("InvalidChar","char '"+t[r]+"' is not expected.",w(t,r))}{let o=r;if(r++,"!"===t[r]){r=c(t,r);continue}{let a=!1;"/"===t[r]&&(a=!0,r++);let h="";for(;r<t.length&&">"!==t[r]&&" "!==t[r]&&"\t"!==t[r]&&"\n"!==t[r]&&"\r"!==t[r];r++)h+=t[r];if(h=h.trim(),"/"===h[h.length-1]&&(h=h.substring(0,h.length-1),r--),!E(h)){let e;return e=0===h.trim().length?"Invalid space after '<'.":"Tag '"+h+"' is an invalid name.",b("InvalidTag",e,w(t,r))}const l=g(t,r);if(!1===l)return b("InvalidAttr","Attributes for '"+h+"' have open quote.",w(t,r));let d=l.value;if(r=l.index,"/"===d[d.length-1]){const n=r-d.length;d=d.substring(0,d.length-1);const s=x(d,e);if(!0!==s)return b(s.err.code,s.err.msg,w(t,n+s.err.line));i=!0}else if(a){if(!l.tagClosed)return b("InvalidTag","Closing tag '"+h+"' doesn't have proper closing.",w(t,r));if(d.trim().length>0)return b("InvalidTag","Closing tag '"+h+"' can't have attributes or invalid starting.",w(t,o));if(0===n.length)return b("InvalidTag","Closing tag '"+h+"' has not been opened.",w(t,o));{const e=n.pop();if(h!==e.tagName){let n=w(t,e.tagStartPos);return b("InvalidTag","Expected closing tag '"+e.tagName+"' (opened in line "+n.line+", col "+n.col+") instead of closing tag '"+h+"'.",w(t,o))}0==n.length&&(s=!0)}}else{const a=x(d,e);if(!0!==a)return b(a.err.code,a.err.msg,w(t,r-d.length+a.err.line));if(!0===s)return b("InvalidXml","Multiple possible root nodes found.",w(t,r));-1!==e.unpairedTags.indexOf(h)||n.push({tagName:h,tagStartPos:o}),i=!0}for(r++;r<t.length;r++)if("<"===t[r]){if("!"===t[r+1]){r++,r=c(t,r);continue}if("?"!==t[r+1])break;if(r=p(t,++r),r.err)return r}else if("&"===t[r]){const e=N(t,r);if(-1==e)return b("InvalidChar","char '&' is not expected.",w(t,r));r=e}else if(!0===s&&!u(t[r]))return b("InvalidXml","Extra text at the end",w(t,r));"<"===t[r]&&r--}}}return i?1==n.length?b("InvalidTag","Unclosed tag '"+n[0].tagName+"'.",w(t,n[0].tagStartPos)):!(n.length>0)||b("InvalidXml","Invalid '"+JSON.stringify(n.map(t=>t.tagName),null,4).replace(/\r?\n/g,"")+"' found.",{line:1,col:1}):b("InvalidXml","Start tag expected.",1)}function u(t){return" "===t||"\t"===t||"\n"===t||"\r"===t}function p(t,e){const n=e;for(;e<t.length;e++)if("?"==t[e]||" "==t[e]){const i=t.substr(n,e-n);if(e>5&&"xml"===i)return b("InvalidXml","XML declaration allowed only at the start of the document.",w(t,e));if("?"==t[e]&&">"==t[e+1]){e++;break}continue}return e}function c(t,e){if(t.length>e+5&&"-"===t[e+1]&&"-"===t[e+2]){for(e+=3;e<t.length;e++)if("-"===t[e]&&"-"===t[e+1]&&">"===t[e+2]){e+=2;break}}else if(t.length>e+8&&"D"===t[e+1]&&"O"===t[e+2]&&"C"===t[e+3]&&"T"===t[e+4]&&"Y"===t[e+5]&&"P"===t[e+6]&&"E"===t[e+7]){let n=1;for(e+=8;e<t.length;e++)if("<"===t[e])n++;else if(">"===t[e]&&(n--,0===n))break}else if(t.length>e+9&&"["===t[e+1]&&"C"===t[e+2]&&"D"===t[e+3]&&"A"===t[e+4]&&"T"===t[e+5]&&"A"===t[e+6]&&"["===t[e+7])for(e+=8;e<t.length;e++)if("]"===t[e]&&"]"===t[e+1]&&">"===t[e+2]){e+=2;break}return e}const d='"',f="'";function g(t,e){let n="",i="",s=!1;for(;e<t.length;e++){if(t[e]===d||t[e]===f)""===i?i=t[e]:i!==t[e]||(i="");else if(">"===t[e]&&""===i){s=!0;break}n+=t[e]}return""===i&&{value:n,index:e,tagClosed:s}}const m=new RegExp("(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['\"])(([\\s\\S])*?)\\5)?","g");function x(t,e){const n=s(t,m),i={};for(let t=0;t<n.length;t++){if(0===n[t][1].length)return b("InvalidAttr","Attribute '"+n[t][2]+"' has no space in starting.",v(n[t]));if(void 0!==n[t][3]&&void 0===n[t][4])return b("InvalidAttr","Attribute '"+n[t][2]+"' is without value.",v(n[t]));if(void 0===n[t][3]&&!e.allowBooleanAttributes)return b("InvalidAttr","boolean attribute '"+n[t][2]+"' is not allowed.",v(n[t]));const s=n[t][2];if(!y(s))return b("InvalidAttr","Attribute '"+s+"' is an invalid name.",v(n[t]));if(Object.prototype.hasOwnProperty.call(i,s))return b("InvalidAttr","Attribute '"+s+"' is repeated.",v(n[t]));i[s]=1}return!0}function N(t,e){if(";"===t[++e])return-1;if("#"===t[e])return function(t,e){let n=/\d/;for("x"===t[e]&&(e++,n=/[\da-fA-F]/);e<t.length;e++){if(";"===t[e])return e;if(!t[e].match(n))break}return-1}(t,++e);let n=0;for(;e<t.length;e++,n++)if(!(t[e].match(/\w/)&&n<20)){if(";"===t[e])break;return-1}return e}function b(t,e,n){return{err:{code:t,msg:e,line:n.line||n,col:n.col}}}function y(t){return r(t)}function E(t){return r(t)}function w(t,e){const n=t.substring(0,e).split(/\r?\n/);return{line:n.length,col:n[n.length-1].length+1}}function v(t){return t.startIndex+t[1].length}const S=t=>o.includes(t)?"__"+t:t,_={preserveOrder:!1,attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,removeNSPrefix:!1,allowBooleanAttributes:!1,parseTagValue:!0,parseAttributeValue:!1,trimValues:!0,cdataPropName:!1,numberParseOptions:{hex:!0,leadingZeros:!0,eNotation:!0},tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},stopNodes:[],alwaysCreateTextNode:!1,isArray:()=>!1,commentPropName:!1,unpairedTags:[],processEntities:!0,htmlEntities:!1,entityDecoder:null,ignoreDeclaration:!1,ignorePiTags:!1,transformTagName:!1,transformAttributeName:!1,updateTag:function(t,e,n){return t},captureMetaData:!1,maxNestedTags:100,strictReservedNames:!0,jPath:!0,onDangerousProperty:S};function A(t,e){if("string"!=typeof t)return;const n=t.toLowerCase();if(o.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);if(a.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`)}function T(t,e){return"boolean"==typeof t?{enabled:t,maxEntitySize:1e4,maxExpansionDepth:1e4,maxTotalExpansions:1/0,maxExpandedLength:1e5,maxEntityCount:1e3,allowedTags:null,tagFilter:null,appliesTo:"all"}:"object"==typeof t&&null!==t?{enabled:!1!==t.enabled,maxEntitySize:Math.max(1,t.maxEntitySize??1e4),maxExpansionDepth:Math.max(1,t.maxExpansionDepth??1e4),maxTotalExpansions:Math.max(1,t.maxTotalExpansions??1/0),maxExpandedLength:Math.max(1,t.maxExpandedLength??1e5),maxEntityCount:Math.max(1,t.maxEntityCount??1e3),allowedTags:t.allowedTags??null,tagFilter:t.tagFilter??null,appliesTo:t.appliesTo??"all"}:T(!0)}const C=function(t){const e=Object.assign({},_,t),n=[{value:e.attributeNamePrefix,name:"attributeNamePrefix"},{value:e.attributesGroupName,name:"attributesGroupName"},{value:e.textNodeName,name:"textNodeName"},{value:e.cdataPropName,name:"cdataPropName"},{value:e.commentPropName,name:"commentPropName"}];for(const{value:t,name:e}of n)t&&A(t,e);return null===e.onDangerousProperty&&(e.onDangerousProperty=S),e.processEntities=T(e.processEntities,e.htmlEntities),e.unpairedTagsSet=new Set(e.unpairedTags),e.stopNodes&&Array.isArray(e.stopNodes)&&(e.stopNodes=e.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),e};let P;P="function"!=typeof Symbol?"@@xmlMetadata":Symbol("XML Node Metadata");class ${constructor(t){this.tagname=t,this.child=[],this[":@"]=Object.create(null)}add(t,e){"__proto__"===t&&(t="#__proto__"),this.child.push({[t]:e})}addChild(t,e){"__proto__"===t.tagname&&(t.tagname="#__proto__"),t[":@"]&&Object.keys(t[":@"]).length>0?this.child.push({[t.tagname]:t.child,":@":t[":@"]}):this.child.push({[t.tagname]:t.child}),void 0!==e&&(this.child[this.child.length-1][P]={startIndex:e})}static getMetaDataSymbol(){return P}}const O=":A-Za-z_À-ÖØ-öø-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�",I=":A-Za-z_À-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�𐀀-󯿿",V=I+"\\-\\.\\d·̀-ͯ҇‿-⁀",D=(t,e,n="")=>{const i=`[${t.replace(":","")}][${e.replace(":","")}]*`;return{name:new RegExp(`^[${t}][${e}]*$`,n),ncName:new RegExp(`^${i}$`,n),qName:new RegExp(`^${i}(?::${i})?$`,n),nmToken:new RegExp(`^[${e}]+$`,n),nmTokens:new RegExp(`^[${e}]+(?:\\s+[${e}]+)*$`,n)}},M=D(O,O+"\\-\\.\\d·̀-ͯ‿-⁀"),j=D(I,V,"u"),L=(t,{xmlVersion:e="1.0"}={})=>((t="1.0")=>"1.1"===t?j:M)(e).qName.test(t);class k{constructor(t,e){this.suppressValidationErr=!t,this.options=t,this.xmlVersion=e||1}setXmlVersion(t=1){this.xmlVersion=t}readDocType(t,e){const n=Object.create(null);let i=0;if("O"!==t[e+3]||"C"!==t[e+4]||"T"!==t[e+5]||"Y"!==t[e+6]||"P"!==t[e+7]||"E"!==t[e+8])throw new Error("Invalid Tag instead of DOCTYPE");{e+=9;let s=1,r=!1,o=!1,a="";for(;e<t.length;e++)if("<"!==t[e]||o)if(">"===t[e]){if(o?"-"===t[e-1]&&"-"===t[e-2]&&(o=!1,s--):s--,0===s)break}else"["===t[e]?r=!0:a+=t[e];else{if(r&&F(t,"!ENTITY",e)){let s,r;if(e+=7,[s,r,e]=this.readEntityExp(t,e+1,this.suppressValidationErr),-1===r.indexOf("&")){if(!1!==this.options.enabled&&null!=this.options.maxEntityCount&&i>=this.options.maxEntityCount)throw new Error(`Entity count (${i+1}) exceeds maximum allowed (${this.options.maxEntityCount})`);n[s]=r,i++}}else if(r&&F(t,"!ELEMENT",e)){e+=8;const{index:n}=this.readElementExp(t,e+1);e=n}else if(r&&F(t,"!ATTLIST",e))e+=8;else if(r&&F(t,"!NOTATION",e)){e+=9;const{index:n}=this.readNotationExp(t,e+1,this.suppressValidationErr);e=n}else{if(!F(t,"!--",e))throw new Error("Invalid DOCTYPE");o=!0}s++,a=""}if(0!==s)throw new Error("Unclosed DOCTYPE")}return{entities:n,i:e}}readEntityExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e])&&'"'!==t[e]&&"'"!==t[e];)e++;let i=t.substring(n,e);if(G(i,{xmlVersion:this.xmlVersion}),e=R(t,e),!this.suppressValidationErr){if("SYSTEM"===t.substring(e,e+6).toUpperCase())throw new Error("External entities are not supported");if("%"===t[e])throw new Error("Parameter entities are not supported")}let s="";if([e,s]=this.readIdentifierVal(t,e,"entity"),!1!==this.options.enabled&&null!=this.options.maxEntitySize&&s.length>this.options.maxEntitySize)throw new Error(`Entity "${i}" size (${s.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`);return[i,s,--e]}readNotationExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);!this.suppressValidationErr&&G(i,{xmlVersion:this.xmlVersion}),e=R(t,e);const s=t.substring(e,e+6).toUpperCase();if(!this.suppressValidationErr&&"SYSTEM"!==s&&"PUBLIC"!==s)throw new Error(`Expected SYSTEM or PUBLIC, found "${s}"`);e+=s.length,e=R(t,e);let r=null,o=null;if("PUBLIC"===s)[e,r]=this.readIdentifierVal(t,e,"publicIdentifier"),'"'!==t[e=R(t,e)]&&"'"!==t[e]||([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"));else if("SYSTEM"===s&&([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"),!this.suppressValidationErr&&!o))throw new Error("Missing mandatory system identifier for SYSTEM notation");return{notationName:i,publicIdentifier:r,systemIdentifier:o,index:--e}}readIdentifierVal(t,e,n){let i="";const s=t[e];if('"'!==s&&"'"!==s)throw new Error(`Expected quoted string, found "${s}"`);const r=++e;for(;e<t.length&&t[e]!==s;)e++;if(i=t.substring(r,e),t[e]!==s)throw new Error(`Unterminated ${n} value`);return[++e,i]}readElementExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);if(!this.suppressValidationErr&&!L(i,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid element name: "${i}"`);let s="";if("E"===t[e=R(t,e)]&&F(t,"MPTY",e))e+=4;else if("A"===t[e]&&F(t,"NY",e))e+=2;else if("("===t[e]){const n=++e;for(;e<t.length&&")"!==t[e];)e++;if(s=t.substring(n,e),")"!==t[e])throw new Error("Unterminated content model")}else if(!this.suppressValidationErr)throw new Error(`Invalid Element Expression, found "${t[e]}"`);return{elementName:i,contentModel:s.trim(),index:e}}readAttlistExp(t,e){let n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);for(G(i,{xmlVersion:this.xmlVersion}),n=e=R(t,e);e<t.length&&!/\s/.test(t[e]);)e++;let s=t.substring(n,e);if(!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid attribute name: "${s}"`);e=R(t,e);let r="";if("NOTATION"===t.substring(e,e+8).toUpperCase()){if(r="NOTATION","("!==t[e=R(t,e+=8)])throw new Error(`Expected '(', found "${t[e]}"`);e++;let n=[];for(;e<t.length&&")"!==t[e];){const i=e;for(;e<t.length&&"|"!==t[e]&&")"!==t[e];)e++;let s=t.substring(i,e);if(s=s.trim(),!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid notation name: "${s}"`);n.push(s),"|"===t[e]&&(e++,e=R(t,e))}if(")"!==t[e])throw new Error("Unterminated list of notations");e++,r+=" ("+n.join("|")+")"}else{const n=e;for(;e<t.length&&!/\s/.test(t[e]);)e++;r+=t.substring(n,e);const i=["CDATA","ID","IDREF","IDREFS","ENTITY","ENTITIES","NMTOKEN","NMTOKENS"];if(!this.suppressValidationErr&&!i.includes(r.toUpperCase()))throw new Error(`Invalid attribute type: "${r}"`)}e=R(t,e);let o="";return"#REQUIRED"===t.substring(e,e+8).toUpperCase()?(o="#REQUIRED",e+=8):"#IMPLIED"===t.substring(e,e+7).toUpperCase()?(o="#IMPLIED",e+=7):[e,o]=this.readIdentifierVal(t,e,"ATTLIST"),{elementName:i,attributeName:s,attributeType:r,defaultValue:o,index:e}}}const R=(t,e)=>{for(;e<t.length&&/\s/.test(t[e]);)e++;return e};function F(t,e,n){for(let i=0;i<e.length;i++)if(e[i]!==t[n+i+1])return!1;return!0}function G(t,e){if(L(t,{xmlVersion:e}))return t;throw new Error(`Invalid entity name ${t}`)}const U=/^[-+]?0x[a-fA-F0-9]+$/,B=/^0b[01]+$/,W=/^0o[0-7]+$/,z=/^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/,X={hex:!0,binary:!1,octal:!1,leadingZeros:!0,decimalPoint:".",eNotation:!0,infinity:"original"};const Y=/^([-+])?(0*)(\d*(\.\d*)?[eE][-\+]?\d+)$/;function q(t,e){const n=t.trim();if(2!==e&&8!==e||(t=n.substring(2)),parseInt)return parseInt(t,e);if(Number.parseInt)return Number.parseInt(t,e);if(window&&window.parseInt)return window.parseInt(t,e);throw new Error("parseInt, Number.parseInt, window.parseInt are not supported")}class Z{constructor(t){this._matcher=t}get separator(){return this._matcher.separator}getCurrentTag(){const t=this._matcher.path;return t.length>0?t[t.length-1].tag:void 0}getCurrentNamespace(){const t=this._matcher.path;return t.length>0?t[t.length-1].namespace:void 0}getAttrValue(t){const e=this._matcher.path;if(0!==e.length)return e[e.length-1].values?.[t]}hasAttr(t){const e=this._matcher.path;if(0===e.length)return!1;const n=e[e.length-1];return void 0!==n.values&&t in n.values}getPosition(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].position??0}getCounter(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this._matcher.path.length}toString(t,e=!0){return this._matcher.toString(t,e)}toArray(){return this._matcher.path.map(t=>t.tag)}matches(t){return this._matcher.matches(t)}matchesAny(t){return t.matchesAny(this._matcher)}}class J{constructor(t={}){this.separator=t.separator||".",this.path=[],this.siblingStacks=[],this._pathStringCache=null,this._view=new Z(this)}push(t,e=null,n=null){this._pathStringCache=null,this.path.length>0&&(this.path[this.path.length-1].values=void 0);const i=this.path.length;this.siblingStacks[i]||(this.siblingStacks[i]=new Map);const s=this.siblingStacks[i],r=n?`${n}:${t}`:t,o=s.get(r)||0;let a=0;for(const t of s.values())a+=t;s.set(r,o+1);const h={tag:t,position:a,counter:o};null!=n&&(h.namespace=n),null!=e&&(h.values=e),this.path.push(h)}pop(){if(0===this.path.length)return;this._pathStringCache=null;const t=this.path.pop();return this.siblingStacks.length>this.path.length+1&&(this.siblingStacks.length=this.path.length+1),t}updateCurrent(t){if(this.path.length>0){const e=this.path[this.path.length-1];null!=t&&(e.values=t)}}getCurrentTag(){return this.path.length>0?this.path[this.path.length-1].tag:void 0}getCurrentNamespace(){return this.path.length>0?this.path[this.path.length-1].namespace:void 0}getAttrValue(t){if(0!==this.path.length)return this.path[this.path.length-1].values?.[t]}hasAttr(t){if(0===this.path.length)return!1;const e=this.path[this.path.length-1];return void 0!==e.values&&t in e.values}getPosition(){return 0===this.path.length?-1:this.path[this.path.length-1].position??0}getCounter(){return 0===this.path.length?-1:this.path[this.path.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this.path.length}toString(t,e=!0){const n=t||this.separator;if(n===this.separator&&!0===e){if(null!==this._pathStringCache)return this._pathStringCache;const t=this.path.map(t=>t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n);return this._pathStringCache=t,t}return this.path.map(t=>e&&t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n)}toArray(){return this.path.map(t=>t.tag)}reset(){this._pathStringCache=null,this.path=[],this.siblingStacks=[]}matches(t){const e=t.segments;return 0!==e.length&&(t.hasDeepWildcard()?this._matchWithDeepWildcard(e):this._matchSimple(e))}_matchSimple(t){if(this.path.length!==t.length)return!1;for(let e=0;e<t.length;e++)if(!this._matchSegment(t[e],this.path[e],e===this.path.length-1))return!1;return!0}_matchWithDeepWildcard(t){let e=this.path.length-1,n=t.length-1;for(;n>=0&&e>=0;){const i=t[n];if("deep-wildcard"===i.type){if(n--,n<0)return!0;const i=t[n];let s=!1;for(let t=e;t>=0;t--)if(this._matchSegment(i,this.path[t],t===this.path.length-1)){e=t-1,n--,s=!0;break}if(!s)return!1}else{if(!this._matchSegment(i,this.path[e],e===this.path.length-1))return!1;e--,n--}}return n<0}_matchSegment(t,e,n){if("*"!==t.tag&&t.tag!==e.tag)return!1;if(void 0!==t.namespace&&"*"!==t.namespace&&t.namespace!==e.namespace)return!1;if(void 0!==t.attrName){if(!n)return!1;if(!e.values||!(t.attrName in e.values))return!1;if(void 0!==t.attrValue&&String(e.values[t.attrName])!==String(t.attrValue))return!1}if(void 0!==t.position){if(!n)return!1;const i=e.counter??0;if("first"===t.position&&0!==i)return!1;if("odd"===t.position&&i%2!=1)return!1;if("even"===t.position&&i%2!=0)return!1;if("nth"===t.position&&i!==t.positionValue)return!1}return!0}matchesAny(t){return t.matchesAny(this)}snapshot(){return{path:this.path.map(t=>({...t})),siblingStacks:this.siblingStacks.map(t=>new Map(t))}}restore(t){this._pathStringCache=null,this.path=t.path.map(t=>({...t})),this.siblingStacks=t.siblingStacks.map(t=>new Map(t))}readOnly(){return this._view}}class K{constructor(t,e={},n){this.pattern=t,this.separator=e.separator||".",this.segments=this._parse(t),this.data=n,this._hasDeepWildcard=this.segments.some(t=>"deep-wildcard"===t.type),this._hasAttributeCondition=this.segments.some(t=>void 0!==t.attrName),this._hasPositionSelector=this.segments.some(t=>void 0!==t.position)}_parse(t){const e=[];let n=0,i="";for(;n<t.length;)t[n]===this.separator?n+1<t.length&&t[n+1]===this.separator?(i.trim()&&(e.push(this._parseSegment(i.trim())),i=""),e.push({type:"deep-wildcard"}),n+=2):(i.trim()&&e.push(this._parseSegment(i.trim())),i="",n++):(i+=t[n],n++);return i.trim()&&e.push(this._parseSegment(i.trim())),e}_parseSegment(t){const e={type:"tag"};let n=null,i=t;const s=t.match(/^([^\[]+)(\[[^\]]*\])(.*)$/);if(s&&(i=s[1]+s[3],s[2])){const t=s[2].slice(1,-1);t&&(n=t)}let r,o,a=i;if(i.includes("::")){const e=i.indexOf("::");if(r=i.substring(0,e).trim(),a=i.substring(e+2).trim(),!r)throw new Error(`Invalid namespace in pattern: ${t}`)}let h=null;if(a.includes(":")){const t=a.lastIndexOf(":"),e=a.substring(0,t).trim(),n=a.substring(t+1).trim();["first","last","odd","even"].includes(n)||/^nth\(\d+\)$/.test(n)?(o=e,h=n):o=a}else o=a;if(!o)throw new Error(`Invalid segment pattern: ${t}`);if(e.tag=o,r&&(e.namespace=r),n)if(n.includes("=")){const t=n.indexOf("=");e.attrName=n.substring(0,t).trim(),e.attrValue=n.substring(t+1).trim()}else e.attrName=n.trim();if(h){const t=h.match(/^nth\((\d+)\)$/);t?(e.position="nth",e.positionValue=parseInt(t[1],10)):e.position=h}return e}get length(){return this.segments.length}hasDeepWildcard(){return this._hasDeepWildcard}hasAttributeCondition(){return this._hasAttributeCondition}hasPositionSelector(){return this._hasPositionSelector}toString(){return this.pattern}}class Q{constructor(){this._byDepthAndTag=new Map,this._wildcardByDepth=new Map,this._deepWildcards=[],this._patterns=new Set,this._sealed=!1}add(t){if(this._sealed)throw new TypeError("ExpressionSet is sealed. Create a new ExpressionSet to add more expressions.");if(this._patterns.has(t.pattern))return this;if(this._patterns.add(t.pattern),t.hasDeepWildcard())return this._deepWildcards.push(t),this;const e=t.length,n=t.segments[t.segments.length-1],i=n?.tag;if(i&&"*"!==i){const n=`${e}:${i}`;this._byDepthAndTag.has(n)||this._byDepthAndTag.set(n,[]),this._byDepthAndTag.get(n).push(t)}else this._wildcardByDepth.has(e)||this._wildcardByDepth.set(e,[]),this._wildcardByDepth.get(e).push(t);return this}addAll(t){for(const e of t)this.add(e);return this}has(t){return this._patterns.has(t.pattern)}get size(){return this._patterns.size}seal(){return this._sealed=!0,this}get isSealed(){return this._sealed}matchesAny(t){return null!==this.findMatch(t)}findMatch(t){const e=t.getDepth(),n=`${e}:${t.getCurrentTag()}`,i=this._byDepthAndTag.get(n);if(i)for(let e=0;e<i.length;e++)if(t.matches(i[e]))return i[e];const s=this._wildcardByDepth.get(e);if(s)for(let e=0;e<s.length;e++)if(t.matches(s[e]))return s[e];for(let e=0;e<this._deepWildcards.length;e++)if(t.matches(this._deepWildcards[e]))return this._deepWildcards[e];return null}}const H={cent:"¢",pound:"£",curren:"¤",yen:"¥",euro:"€",dollar:"$",euro:"€",fnof:"ƒ",inr:"₹",af:"؋",birr:"ብር",peso:"₱",rub:"₽",won:"₩",yuan:"¥",cedil:"¸"},tt={amp:"&",apos:"'",gt:">",lt:"<",quot:'"'},et={nbsp:" ",copy:"©",reg:"®",trade:"™",mdash:"—",ndash:"–",hellip:"…",laquo:"«",raquo:"»",lsquo:"‘",rsquo:"’",ldquo:"“",rdquo:"”",bull:"•",para:"¶",sect:"§",deg:"°",frac12:"½",frac14:"¼",frac34:"¾"},nt=new Set("!?\\\\/[]$%{}^&*()<>|+");function it(t){if("#"===t[0])throw new Error(`[EntityReplacer] Invalid character '#' in entity name: "${t}"`);for(const e of t)if(nt.has(e))throw new Error(`[EntityReplacer] Invalid character '${e}' in entity name: "${t}"`);return t}function st(...t){const e=Object.create(null);for(const n of t)if(n)for(const t of Object.keys(n)){const i=n[t];if("string"==typeof i)e[t]=i;else if(i&&"object"==typeof i&&void 0!==i.val){const n=i.val;"string"==typeof n&&(e[t]=n)}}return e}const rt="external",ot="base",at="all",ht=Object.freeze({allow:0,leave:1,remove:2,throw:3}),lt=new Set([9,10,13]);class ut{constructor(t={}){var e;this._limit=t.limit||{},this._maxTotalExpansions=this._limit.maxTotalExpansions||0,this._maxExpandedLength=this._limit.maxExpandedLength||0,this._postCheck="function"==typeof t.postCheck?t.postCheck:t=>t,this._limitTiers=(e=this._limit.applyLimitsTo??rt)&&e!==rt?e===at?new Set([at]):e===ot?new Set([ot]):Array.isArray(e)?new Set(e):new Set([rt]):new Set([rt]),this._numericAllowed=t.numericAllowed??!0,this._baseMap=st(tt,t.namedEntities||null),this._externalMap=Object.create(null),this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this._removeSet=new Set(t.remove&&Array.isArray(t.remove)?t.remove:[]),this._leaveSet=new Set(t.leave&&Array.isArray(t.leave)?t.leave:[]);const n=function(t){if(!t)return{xmlVersion:1,onLevel:ht.allow,nullLevel:ht.remove};const e=1.1===t.xmlVersion?1.1:1,n=ht[t.onNCR]??ht.allow,i=ht[t.nullNCR]??ht.remove;return{xmlVersion:e,onLevel:n,nullLevel:Math.max(i,ht.remove)}}(t.ncr);this._ncrXmlVersion=n.xmlVersion,this._ncrOnLevel=n.onLevel,this._ncrNullLevel=n.nullLevel}setExternalEntities(t){if(t)for(const e of Object.keys(t))it(e);this._externalMap=st(t)}addExternalEntity(t,e){it(t),"string"==typeof e&&-1===e.indexOf("&")&&(this._externalMap[t]=e)}addInputEntities(t){this._totalExpansions=0,this._expandedLength=0,this._inputMap=st(t)}reset(){return this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this}setXmlVersion(t){this._ncrXmlVersion=1.1===t?1.1:1}decode(t){if("string"!=typeof t||0===t.length)return t;const e=t,n=[],i=t.length;let s=0,r=0;const o=this._maxTotalExpansions>0,a=this._maxExpandedLength>0,h=o||a;for(;r<i;){if(38!==t.charCodeAt(r)){r++;continue}let e=r+1;for(;e<i&&59!==t.charCodeAt(e)&&e-r<=32;)e++;if(e>=i||59!==t.charCodeAt(e)){r++;continue}const l=t.slice(r+1,e);if(0===l.length){r++;continue}let u,p;if(this._removeSet.has(l))u="",void 0===p&&(p=rt);else{if(this._leaveSet.has(l)){r++;continue}if(35===l.charCodeAt(0)){const t=this._resolveNCR(l);if(void 0===t){r++;continue}u=t,p=ot}else{const t=this._resolveName(l);u=t?.value,p=t?.tier}}if(void 0!==u){if(r>s&&n.push(t.slice(s,r)),n.push(u),s=e+1,r=s,h&&this._tierCounts(p)){if(o&&(this._totalExpansions++,this._totalExpansions>this._maxTotalExpansions))throw new Error(`[EntityReplacer] Entity expansion count limit exceeded: ${this._totalExpansions} > ${this._maxTotalExpansions}`);if(a){const t=u.length-(l.length+2);if(t>0&&(this._expandedLength+=t,this._expandedLength>this._maxExpandedLength))throw new Error(`[EntityReplacer] Expanded content length limit exceeded: ${this._expandedLength} > ${this._maxExpandedLength}`)}}}else r++}s<i&&n.push(t.slice(s));const l=0===n.length?t:n.join("");return this._postCheck(l,e)}_tierCounts(t){return!!this._limitTiers.has(at)||this._limitTiers.has(t)}_resolveName(t){return t in this._inputMap?{value:this._inputMap[t],tier:rt}:t in this._externalMap?{value:this._externalMap[t],tier:rt}:t in this._baseMap?{value:this._baseMap[t],tier:ot}:void 0}_classifyNCR(t){return 0===t?this._ncrNullLevel:t>=55296&&t<=57343||1===this._ncrXmlVersion&&t>=1&&t<=31&&!lt.has(t)?ht.remove:-1}_applyNCRAction(t,e,n){switch(t){case ht.allow:return String.fromCodePoint(n);case ht.remove:return"";case ht.leave:return;case ht.throw:throw new Error(`[EntityDecoder] Prohibited numeric character reference &${e}; (U+${n.toString(16).toUpperCase().padStart(4,"0")})`);default:return String.fromCodePoint(n)}}_resolveNCR(t){const e=t.charCodeAt(1);let n;if(n=120===e||88===e?parseInt(t.slice(2),16):parseInt(t.slice(1),10),Number.isNaN(n)||n<0||n>1114111)return;const i=this._classifyNCR(n);if(!this._numericAllowed&&i<ht.remove)return;const s=-1===i?this._ncrOnLevel:Math.max(this._ncrOnLevel,i);return this._applyNCRAction(s,t,n)}}function pt(t,e){if(!t)return{};const n=e.attributesGroupName?t[e.attributesGroupName]:t;if(!n)return{};const i={};for(const t in n)t.startsWith(e.attributeNamePrefix)?i[t.substring(e.attributeNamePrefix.length)]=n[t]:i[t]=n[t];return i}function ct(t){if(!t||"string"!=typeof t)return;const e=t.indexOf(":");if(-1!==e&&e>0){const n=t.substring(0,e);if("xmlns"!==n)return n}}class dt{constructor(t,e){var n;this.options=t,this.currentNode=null,this.tagsNodeStack=[],this.parseXml=Nt,this.parseTextData=ft,this.resolveNameSpace=gt,this.buildAttributesMap=xt,this.isItStopNode=wt,this.replaceEntitiesValue=yt,this.readStopNodeData=At,this.saveTextToParentTag=Et,this.addChild=bt,this.ignoreAttributesFn="function"==typeof(n=this.options.ignoreAttributes)?n:Array.isArray(n)?t=>{for(const e of n){if("string"==typeof e&&t===e)return!0;if(e instanceof RegExp&&e.test(t))return!0}}:()=>!1,this.entityExpansionCount=0,this.currentExpandedLength=0;let i={...tt};this.options.entityDecoder?this.entityDecoder=this.options.entityDecoder:("object"==typeof this.options.htmlEntities?i=this.options.htmlEntities:!0===this.options.htmlEntities&&(i={...et,...H}),this.entityDecoder=new ut({namedEntities:{...i,...e},numericAllowed:this.options.htmlEntities,limit:{maxTotalExpansions:this.options.processEntities.maxTotalExpansions,maxExpandedLength:this.options.processEntities.maxExpandedLength,applyLimitsTo:this.options.processEntities.appliesTo}})),this.matcher=new J,this.readonlyMatcher=this.matcher.readOnly(),this.isCurrentNodeStopNode=!1,this.stopNodeExpressionsSet=new Q;const s=this.options.stopNodes;if(s&&s.length>0){for(let t=0;t<s.length;t++){const e=s[t];"string"==typeof e?this.stopNodeExpressionsSet.add(new K(e)):e instanceof K&&this.stopNodeExpressionsSet.add(e)}this.stopNodeExpressionsSet.seal()}}}function ft(t,e,n,i,s,r,o){const a=this.options;if(void 0!==t&&(a.trimValues&&!i&&(t=t.trim()),t.length>0)){o||(t=this.replaceEntitiesValue(t,e,n));const i=a.jPath?n.toString():n,h=a.tagValueProcessor(e,t,i,s,r);return null==h?t:typeof h!=typeof t||h!==t?h:a.trimValues||t.trim()===t?Tt(t,a.parseTagValue,a.numberParseOptions):t}}function gt(t){if(this.options.removeNSPrefix){const e=t.split(":"),n="/"===t.charAt(0)?"/":"";if("xmlns"===e[0])return"";2===e.length&&(t=n+e[1])}return t}const mt=new RegExp("([^\\s=]+)\\s*(=\\s*(['\"])([\\s\\S]*?)\\3)?","gm");function xt(t,e,n,i=!1){const r=this.options;if(!0===i||!0!==r.ignoreAttributes&&"string"==typeof t){const i=s(t,mt),o=i.length,a={},h=new Array(o);let l=!1;const u={};for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]),s=i[t][4];if(e.length&&void 0!==s){let i=s;r.trimValues&&(i=i.trim()),i=this.replaceEntitiesValue(i,n,this.readonlyMatcher),h[t]=i,u[e]=i,l=!0}}l&&"object"==typeof e&&e.updateCurrent&&e.updateCurrent(u);const p=r.jPath?e.toString():this.readonlyMatcher;let c=!1;for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]);if(this.ignoreAttributesFn(e,p))continue;let n=r.attributeNamePrefix+e;if(e.length)if(r.transformAttributeName&&(n=r.transformAttributeName(n)),n=Pt(n,r),void 0!==i[t][4]){const i=h[t],s=r.attributeValueProcessor(e,i,p);a[n]=null==s?i:typeof s!=typeof i||s!==i?s:Tt(i,r.parseAttributeValue,r.numberParseOptions),c=!0}else r.allowBooleanAttributes&&(a[n]=!0,c=!0)}if(!c)return;if(r.attributesGroupName&&!r.preserveOrder){const t={};return t[r.attributesGroupName]=a,t}return a}}const Nt=function(t){t=t.replace(/\r\n?/g,"\n");const e=new $("!xml");let n=e,i="";this.matcher.reset(),this.entityDecoder.reset(),this.entityExpansionCount=0,this.currentExpandedLength=0;const s=this.options,r=new k(s.processEntities),o=t.length;for(let a=0;a<o;a++)if("<"===t[a]){const h=t.charCodeAt(a+1);if(47===h){const e=vt(t,">",a,"Closing Tag is not closed.");let r=t.substring(a+2,e).trim();if(s.removeNSPrefix){const t=r.indexOf(":");-1!==t&&(r=r.substr(t+1))}r=Ct(s.transformTagName,r,"",s).tagName,n&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher));const o=this.matcher.getCurrentTag();if(r&&s.unpairedTagsSet.has(r))throw new Error(`Unpaired tag can not be used as closing tag: </${r}>`);o&&s.unpairedTagsSet.has(o)&&(this.matcher.pop(),this.tagsNodeStack.pop()),this.matcher.pop(),this.isCurrentNodeStopNode=!1,n=this.tagsNodeStack.pop(),i="",a=e}else if(63===h){let e=_t(t,a,!1,"?>");if(!e)throw new Error("Pi Tag is not closed.");i=this.saveTextToParentTag(i,n,this.readonlyMatcher);const o=this.buildAttributesMap(e.tagExp,this.matcher,e.tagName,!0);if(o){const t=o[this.options.attributeNamePrefix+"version"];this.entityDecoder.setXmlVersion(Number(t)||1),r.setXmlVersion(Number(t)||1)}if(s.ignoreDeclaration&&"?xml"===e.tagName||s.ignorePiTags);else{const t=new $(e.tagName);t.add(s.textNodeName,""),e.tagName!==e.tagExp&&e.attrExpPresent&&!0!==s.ignoreAttributes&&(t[":@"]=o),this.addChild(n,t,this.readonlyMatcher,a)}a=e.closeIndex+1}else if(33===h&&45===t.charCodeAt(a+2)&&45===t.charCodeAt(a+3)){const e=vt(t,"--\x3e",a+4,"Comment is not closed.");if(s.commentPropName){const r=t.substring(a+4,e-2);i=this.saveTextToParentTag(i,n,this.readonlyMatcher),n.add(s.commentPropName,[{[s.textNodeName]:r}])}a=e}else if(33===h&&68===t.charCodeAt(a+2)){const e=r.readDocType(t,a);this.entityDecoder.addInputEntities(e.entities),a=e.i}else if(33===h&&91===t.charCodeAt(a+2)){const e=vt(t,"]]>",a,"CDATA is not closed.")-2,r=t.substring(a+9,e);i=this.saveTextToParentTag(i,n,this.readonlyMatcher);let o=this.parseTextData(r,n.tagname,this.readonlyMatcher,!0,!1,!0,!0);null==o&&(o=""),s.cdataPropName?n.add(s.cdataPropName,[{[s.textNodeName]:r}]):n.add(s.textNodeName,o),a=e+2}else{let r=_t(t,a,s.removeNSPrefix);if(!r){const e=t.substring(Math.max(0,a-50),Math.min(o,a+50));throw new Error(`readTagExp returned undefined at position ${a}. Context: "${e}"`)}let h=r.tagName;const l=r.rawTagName;let u=r.tagExp,p=r.attrExpPresent,c=r.closeIndex;if(({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s)),s.strictReservedNames&&(h===s.commentPropName||h===s.cdataPropName||h===s.textNodeName||h===s.attributesGroupName))throw new Error(`Invalid tag name: ${h}`);n&&i&&"!xml"!==n.tagname&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher,!1));const d=n;d&&s.unpairedTagsSet.has(d.tagname)&&(n=this.tagsNodeStack.pop(),this.matcher.pop());let f=!1;u.length>0&&u.lastIndexOf("/")===u.length-1&&(f=!0,"/"===h[h.length-1]?(h=h.substr(0,h.length-1),u=h):u=u.substr(0,u.length-1),p=h!==u);let g,m=null,x={};g=ct(l),h!==e.tagname&&this.matcher.push(h,{},g),h!==u&&p&&(m=this.buildAttributesMap(u,this.matcher,h),m&&(x=pt(m,s))),h!==e.tagname&&(this.isCurrentNodeStopNode=this.isItStopNode());const N=a;if(this.isCurrentNodeStopNode){let e="";if(f)a=r.closeIndex;else if(s.unpairedTagsSet.has(h))a=r.closeIndex;else{const n=this.readStopNodeData(t,l,c+1);if(!n)throw new Error(`Unexpected end of ${l}`);a=n.i,e=n.tagContent}const i=new $(h);m&&(i[":@"]=m),i.add(s.textNodeName,e),this.matcher.pop(),this.isCurrentNodeStopNode=!1,this.addChild(n,i,this.readonlyMatcher,N)}else{if(f){({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s));const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1}else{if(s.unpairedTagsSet.has(h)){const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1,a=r.closeIndex;continue}{const t=new $(h);if(this.tagsNodeStack.length>s.maxNestedTags)throw new Error("Maximum nested tags exceeded");this.tagsNodeStack.push(n),m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),n=t}}i="",a=c}}}else i+=t[a];return e.child};function bt(t,e,n,i){this.options.captureMetaData||(i=void 0);const s=this.options.jPath?n.toString():n,r=this.options.updateTag(e.tagname,s,e[":@"]);!1===r||("string"==typeof r?(e.tagname=r,t.addChild(e,i)):t.addChild(e,i))}function yt(t,e,n){const i=this.options.processEntities;if(!i||!i.enabled)return t;if(i.allowedTags){const s=this.options.jPath?n.toString():n;if(!(Array.isArray(i.allowedTags)?i.allowedTags.includes(e):i.allowedTags(e,s)))return t}if(i.tagFilter){const s=this.options.jPath?n.toString():n;if(!i.tagFilter(e,s))return t}return this.entityDecoder.decode(t)}function Et(t,e,n,i){return t&&(void 0===i&&(i=0===e.child.length),void 0!==(t=this.parseTextData(t,e.tagname,n,!1,!!e[":@"]&&0!==Object.keys(e[":@"]).length,i))&&""!==t&&e.add(this.options.textNodeName,t),t=""),t}function wt(){return 0!==this.stopNodeExpressionsSet.size&&this.matcher.matchesAny(this.stopNodeExpressionsSet)}function vt(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s+e.length-1}function St(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s}function _t(t,e,n,i=">"){const s=function(t,e,n=">"){let i=0;const s=t.length,r=n.charCodeAt(0),o=n.length>1?n.charCodeAt(1):-1;let a="",h=e;for(let n=e;n<s;n++){const e=t.charCodeAt(n);if(i)e===i&&(i=0);else if(34===e||39===e)i=e;else if(e===r){if(-1===o)return a+=t.substring(h,n),{data:a,index:n};if(t.charCodeAt(n+1)===o)return a+=t.substring(h,n),{data:a,index:n}}else 9!==e||i||(a+=t.substring(h,n)+" ",h=n+1)}}(t,e+1,i);if(!s)return;let r=s.data;const o=s.index,a=r.search(/\s/);let h=r,l=!0;-1!==a&&(h=r.substring(0,a),r=r.substring(a+1).trimStart());const u=h;if(n){const t=h.indexOf(":");-1!==t&&(h=h.substr(t+1),l=h!==s.data.substr(t+1))}return{tagName:h,tagExp:r,closeIndex:o,attrExpPresent:l,rawTagName:u}}function At(t,e,n){const i=n;let s=1;const r=t.length;for(;n<r;n++)if("<"===t[n]){const r=t.charCodeAt(n+1);if(47===r){const r=St(t,">",n,`${e} is not closed`);if(t.substring(n+2,r).trim()===e&&(s--,0===s))return{tagContent:t.substring(i,n),i:r};n=r}else if(63===r)n=vt(t,"?>",n+1,"StopNode is not closed.");else if(33===r&&45===t.charCodeAt(n+2)&&45===t.charCodeAt(n+3))n=vt(t,"--\x3e",n+3,"StopNode is not closed.");else if(33===r&&91===t.charCodeAt(n+2))n=vt(t,"]]>",n,"StopNode is not closed.")-2;else{const i=_t(t,n,!1);i&&((i&&i.tagName)===e&&"/"!==i.tagExp[i.tagExp.length-1]&&s++,n=i.closeIndex)}}}function Tt(t,e,n){if(e&&"string"==typeof t){const e=t.trim();return"true"===e||"false"!==e&&function(t,e={}){if(e=Object.assign({},X,e),!t||"string"!=typeof t)return t;let n=t.trim();if(0===n.length)return t;if(void 0!==e.skipLike&&e.skipLike.test(n))return t;if("0"===n)return 0;if(e.hex&&U.test(n))return q(n,16);if(e.binary&&B.test(n))return q(n,2);if(e.octal&&W.test(n))return q(n,8);if(isFinite(n)){if(n.includes("e")||n.includes("E"))return function(t,e,n){if(!n.eNotation)return t;const i=e.match(Y);if(i){let s=i[1]||"";const r=-1===i[3].indexOf("e")?"E":"e",o=i[2],a=s?t[o.length+1]===r:t[o.length]===r;return o.length>1&&a?t:(1!==o.length||!i[3].startsWith(`.${r}`)&&i[3][0]!==r)&&o.length>0?n.leadingZeros&&!a?(e=(i[1]||"")+i[3],Number(e)):t:Number(e)}return t}(t,n,e);{const s=z.exec(n);if(s){const r=s[1]||"",o=s[2];let a=(i=s[3])&&-1!==i.indexOf(".")?("."===(i=i.replace(/0+$/,""))?i="0":"."===i[0]?i="0"+i:"."===i[i.length-1]&&(i=i.substring(0,i.length-1)),i):i;const h=r?"."===t[o.length+1]:"."===t[o.length];if(!e.leadingZeros&&(o.length>1||1===o.length&&!h))return t;{const i=Number(n),s=String(i);if(0===i)return i;if(-1!==s.search(/[eE]/))return e.eNotation?i:t;if(-1!==n.indexOf("."))return"0"===s||s===a||s===`${r}${a}`?i:t;let h=o?a:n;return o?h===s||r+h===s?i:t:h===s||h===r+s?i:t}}return t}}var i;return function(t,e,n){const i=e===1/0;switch(n.infinity.toLowerCase()){case"null":return null;case"infinity":return e;case"string":return i?"Infinity":"-Infinity";default:return t}}(t,Number(n),e)}(t,n)}return void 0!==t?t:""}function Ct(t,e,n,i){if(t){const i=t(e);n===e&&(n=i),e=i}return{tagName:e=Pt(e,i),tagExp:n}}function Pt(t,e){if(a.includes(t))throw new Error(`[SECURITY] Invalid name: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);return o.includes(t)?e.onDangerousProperty(t):t}const $t=$.getMetaDataSymbol();function Ot(t,e){if(!t||"object"!=typeof t)return{};if(!e)return t;const n={};for(const i in t)i.startsWith(e)?n[i.substring(e.length)]=t[i]:n[i]=t[i];return n}function It(t,e,n,i){return Vt(t,e,n,i)}function Vt(t,e,n,i){let s;const r={};for(let o=0;o<t.length;o++){const a=t[o],h=Dt(a);if(void 0!==h&&h!==e.textNodeName){const t=Ot(a[":@"]||{},e.attributeNamePrefix);n.push(h,t)}if(h===e.textNodeName)void 0===s?s=a[h]:s+=""+a[h];else{if(void 0===h)continue;if(a[h]){let t=Vt(a[h],e,n,i);const s=jt(t,e);if(0===Object.keys(t).length&&e.alwaysCreateTextNode&&(t[e.textNodeName]=""),a[":@"]?Mt(t,a[":@"],i,e):1!==Object.keys(t).length||void 0===t[e.textNodeName]||e.alwaysCreateTextNode?0===Object.keys(t).length&&(e.alwaysCreateTextNode?t[e.textNodeName]="":t=""):t=t[e.textNodeName],void 0!==a[$t]&&"object"==typeof t&&null!==t&&(t[$t]=a[$t]),void 0!==r[h]&&Object.prototype.hasOwnProperty.call(r,h))Array.isArray(r[h])||(r[h]=[r[h]]),r[h].push(t);else{const n=e.jPath?i.toString():i;e.isArray(h,n,s)?r[h]=[t]:r[h]=t}void 0!==h&&h!==e.textNodeName&&n.pop()}}}return"string"==typeof s?s.length>0&&(r[e.textNodeName]=s):void 0!==s&&(r[e.textNodeName]=s),r}function Dt(t){const e=Object.keys(t);for(let t=0;t<e.length;t++){const n=e[t];if(":@"!==n)return n}}function Mt(t,e,n,i){if(e){const s=Object.keys(e),r=s.length;for(let o=0;o<r;o++){const r=s[o],a=r.startsWith(i.attributeNamePrefix)?r.substring(i.attributeNamePrefix.length):r,h=i.jPath?n.toString()+"."+a:n;i.isArray(r,h,!0,!0)?t[r]=[e[r]]:t[r]=e[r]}}}function jt(t,e){const{textNodeName:n}=e,i=Object.keys(t).length;return 0===i||!(1!==i||!t[n]&&"boolean"!=typeof t[n]&&0!==t[n])}class Lt{constructor(t){this.externalEntities={},this.options=C(t)}parse(t,e){if("string"!=typeof t&&t.toString)t=t.toString();else if("string"!=typeof t)throw new Error("XML data is accepted in String or Bytes[] form.");if(e){!0===e&&(e={});const n=l(t,e);if(!0!==n)throw Error(`${n.err.msg}:${n.err.line}:${n.err.col}`)}const n=new dt(this.options,this.externalEntities),i=n.parseXml(t);return this.options.preserveOrder||void 0===i?i:It(i,this.options,n.matcher,n.readonlyMatcher)}addEntity(t,e){if(-1!==e.indexOf("&"))throw new Error("Entity value can't have '&'");if(-1!==t.indexOf("&")||-1!==t.indexOf(";"))throw new Error("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");if("&"===e)throw new Error("An entity with value '&' is not permitted");this.externalEntities[t]=e}static getMetaDataSymbol(){return $.getMetaDataSymbol()}}function kt(t){return String(t).replace(/--/g,"- -").replace(/--/g,"- -").replace(/-$/,"- ")}function Rt(t){return String(t).replace(/\]\]>/g,"]]]]><![CDATA[>")}function Ft(t){return String(t).replace(/"/g,"&quot;").replace(/'/g,"&apos;")}function Gt(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function Ut(t,e){let n="";e.format&&(n="\n");const i=[];if(e.stopNodes&&Array.isArray(e.stopNodes))for(let t=0;t<e.stopNodes.length;t++){const n=e.stopNodes[t];"string"==typeof n?i.push(new K(n)):n instanceof K&&i.push(n)}const s=function(t,e){if(!Array.isArray(t)||0===t.length)return"1.0";const n=t[0];if("?xml"===Yt(n)){const t=n[":@"];if(t){const n=e.attributeNamePrefix+"version";if(t[n])return t[n]}}return"1.0"}(t,e);return Bt(t,e,n,new J,i,s)}function Bt(t,e,n,i,s,r){let o="",a=!1;if(e.maxNestedTags&&i.getDepth()>e.maxNestedTags)throw new Error("Maximum nested tags exceeded");if(!Array.isArray(t)){if(null!=t){let n=t.toString();return n=Jt(n,e),n}return""}for(let h=0;h<t.length;h++){const l=t[h],u=Yt(l);if(void 0===u)continue;const p=u===e.textNodeName||u===e.cdataPropName||u===e.commentPropName||"?"===u[0]?u:Gt(u,!1,e,i,r),c=Wt(l[":@"],e);i.push(p,c);const d=Zt(i,s);if(p===e.textNodeName){let t=l[u];d||(t=e.tagValueProcessor(p,t),t=Jt(t,e)),a&&(o+=n),o+=t,a=!1,i.pop();continue}if(p===e.cdataPropName){a&&(o+=n),o+=`<![CDATA[${Rt(l[u][0][e.textNodeName])}]]>`,a=!1,i.pop();continue}if(p===e.commentPropName){o+=n+`\x3c!--${kt(l[u][0][e.textNodeName])}--\x3e`,a=!0,i.pop();continue}if("?"===p[0]){o+=("?xml"===p?"":n)+`<${p}${qt(l[":@"],e,d,i,r)}?>`,a=!0,i.pop();continue}let f=n;""!==f&&(f+=e.indentBy);const g=n+`<${p}${qt(l[":@"],e,d,i,r)}`;let m;m=d?zt(l[u],e):Bt(l[u],e,f,i,s,r),-1!==e.unpairedTags.indexOf(p)?e.suppressUnpairedNode?o+=g+">":o+=g+"/>":m&&0!==m.length||!e.suppressEmptyNode?m&&m.endsWith(">")?o+=g+`>${m}${n}</${p}>`:(o+=g+">",m&&""!==n&&(m.includes("/>")||m.includes("</"))?o+=n+e.indentBy+m+n:o+=m,o+=`</${p}>`):o+=g+"/>",a=!0,i.pop()}return o}function Wt(t,e){if(!t||e.ignoreAttributes)return null;const n={};let i=!1;for(let s in t)Object.prototype.hasOwnProperty.call(t,s)&&(n[s.startsWith(e.attributeNamePrefix)?s.substr(e.attributeNamePrefix.length):s]=Ft(t[s]),i=!0);return i?n:null}function zt(t,e){if(!Array.isArray(t))return null!=t?t.toString():"";let n="";for(let i=0;i<t.length;i++){const s=t[i],r=Yt(s);if(r===e.textNodeName)n+=s[r];else if(r===e.cdataPropName)n+=s[r][0][e.textNodeName];else if(r===e.commentPropName)n+=s[r][0][e.textNodeName];else{if(r&&"?"===r[0])continue;if(r){const t=Xt(s[":@"],e),i=zt(s[r],e);i&&0!==i.length?n+=`<${r}${t}>${i}</${r}>`:n+=`<${r}${t}/>`}}}return n}function Xt(t,e){let n="";if(t&&!e.ignoreAttributes)for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;let s=t[i];!0===s&&e.suppressBooleanAttributes?n+=` ${i.substr(e.attributeNamePrefix.length)}`:n+=` ${i.substr(e.attributeNamePrefix.length)}="${Ft(s)}"`}return n}function Yt(t){const e=Object.keys(t);for(let n=0;n<e.length;n++){const i=e[n];if(Object.prototype.hasOwnProperty.call(t,i)&&":@"!==i)return i}}function qt(t,e,n,i,s){let r="";if(t&&!e.ignoreAttributes)for(let o in t){if(!Object.prototype.hasOwnProperty.call(t,o))continue;const a=o.substr(e.attributeNamePrefix.length),h=n?a:Gt(a,!0,e,i,s);let l;n?l=t[o]:(l=e.attributeValueProcessor(o,t[o]),l=Jt(l,e)),!0===l&&e.suppressBooleanAttributes?r+=` ${h}`:r+=` ${h}="${Ft(l)}"`}return r}function Zt(t,e){if(!e||0===e.length)return!1;for(let n=0;n<e.length;n++)if(t.matches(e[n]))return!0;return!1}function Jt(t,e){if(t&&t.length>0&&e.processEntities)for(let n=0;n<e.entities.length;n++){const i=e.entities[n];t=t.replace(i.regex,i.val)}return t}const Kt={attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,cdataPropName:!1,format:!1,indentBy:"  ",suppressEmptyNode:!1,suppressUnpairedNode:!0,suppressBooleanAttributes:!0,tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},preserveOrder:!1,commentPropName:!1,unpairedTags:[],entities:[{regex:new RegExp("&","g"),val:"&amp;"},{regex:new RegExp(">","g"),val:"&gt;"},{regex:new RegExp("<","g"),val:"&lt;"},{regex:new RegExp("'","g"),val:"&apos;"},{regex:new RegExp('"',"g"),val:"&quot;"}],processEntities:!0,stopNodes:[],oneListGroup:!1,maxNestedTags:100,jPath:!0,sanitizeName:!1};function Qt(t){if(this.options=Object.assign({},Kt,t),this.options.stopNodes&&Array.isArray(this.options.stopNodes)&&(this.options.stopNodes=this.options.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),this.stopNodeExpressions=[],this.options.stopNodes&&Array.isArray(this.options.stopNodes))for(let t=0;t<this.options.stopNodes.length;t++){const e=this.options.stopNodes[t];"string"==typeof e?this.stopNodeExpressions.push(new K(e)):e instanceof K&&this.stopNodeExpressions.push(e)}var e;!0===this.options.ignoreAttributes||this.options.attributesGroupName?this.isAttribute=function(){return!1}:(this.ignoreAttributesFn="function"==typeof(e=this.options.ignoreAttributes)?e:Array.isArray(e)?t=>{for(const n of e){if("string"==typeof n&&t===n)return!0;if(n instanceof RegExp&&n.test(t))return!0}}:()=>!1,this.attrPrefixLen=this.options.attributeNamePrefix.length,this.isAttribute=ne),this.processTextOrObjNode=te,this.options.format?(this.indentate=ee,this.tagEndChar=">\n",this.newLine="\n"):(this.indentate=function(){return""},this.tagEndChar=">",this.newLine="")}function Ht(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function te(t,e,n,i,s){const r=this.extractAttributes(t);if(i.push(e,r),this.checkStopNode(i)){const s=this.buildRawContent(t),r=this.buildAttributesForStopNode(t);return i.pop(),this.buildObjectNode(s,e,r,n)}const o=this.j2x(t,n+1,i,s);return i.pop(),"?"===e[0]?this.buildTextValNode("",e,o.attrStr,n,i):void 0!==t[this.options.textNodeName]&&1===Object.keys(t).length?this.buildTextValNode(t[this.options.textNodeName],e,o.attrStr,n,i):this.buildObjectNode(o.val,e,o.attrStr,n)}function ee(t){return this.options.indentBy.repeat(t)}function ne(t){return!(!t.startsWith(this.options.attributeNamePrefix)||t===this.options.textNodeName)&&t.substr(this.attrPrefixLen)}Qt.prototype.build=function(t){if(this.options.preserveOrder)return Ut(t,this.options);{Array.isArray(t)&&this.options.arrayNodeName&&this.options.arrayNodeName.length>1&&(t={[this.options.arrayNodeName]:t});const e=new J,n=function(t,e){const n=t["?xml"];if(n&&"object"==typeof n){if(e.attributesGroupName&&n[e.attributesGroupName]){const t=n[e.attributesGroupName][e.attributeNamePrefix+"version"];if(t)return t}const t=n[e.attributeNamePrefix+"version"];if(t)return t}return"1.0"}(t,this.options);return this.j2x(t,0,e,n).val}},Qt.prototype.j2x=function(t,e,n,i){let s="",r="";if(this.options.maxNestedTags&&n.getDepth()>=this.options.maxNestedTags)throw new Error("Maximum nested tags exceeded");const o=this.options.jPath?n.toString():n,a=this.checkStopNode(n);for(let h in t){if(!Object.prototype.hasOwnProperty.call(t,h))continue;const l=h===this.options.textNodeName||h===this.options.cdataPropName||h===this.options.commentPropName||this.options.attributesGroupName&&h===this.options.attributesGroupName||this.isAttribute(h)||"?"===h[0]?h:Ht(h,!1,this.options,n,i);if(void 0===t[h])this.isAttribute(h)&&(r+="");else if(null===t[h])this.isAttribute(h)||l===this.options.cdataPropName||l===this.options.commentPropName?r+="":"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if(t[h]instanceof Date)r+=this.buildTextValNode(t[h],l,"",e,n);else if("object"!=typeof t[h]){const u=this.isAttribute(h);if(u&&!this.ignoreAttributesFn(u,o)){const e=Ht(u,!0,this.options,n,i);s+=this.buildAttrPairStr(e,""+t[h],a)}else if(!u)if(h===this.options.textNodeName){let e=this.options.tagValueProcessor(h,""+t[h]);r+=this.replaceEntitiesValue(e)}else{n.push(l);const i=this.checkStopNode(n);if(n.pop(),i){const n=""+t[h];r+=""===n?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+n+"</"+l+this.tagEndChar}else r+=this.buildTextValNode(t[h],l,"",e,n)}}else if(Array.isArray(t[h])){const s=t[h].length;let o="",a="";for(let u=0;u<s;u++){const s=t[h][u];if(void 0===s);else if(null===s)"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if("object"==typeof s)if(this.options.oneListGroup){n.push(l);const t=this.j2x(s,e+1,n,i);n.pop(),o+=t.val,this.options.attributesGroupName&&s.hasOwnProperty(this.options.attributesGroupName)&&(a+=t.attrStr)}else o+=this.processTextOrObjNode(s,l,e,n,i);else if(this.options.oneListGroup){let t=this.options.tagValueProcessor(l,s);t=this.replaceEntitiesValue(t),o+=t}else{n.push(l);const t=this.checkStopNode(n);if(n.pop(),t){const t=""+s;o+=""===t?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+t+"</"+l+this.tagEndChar}else o+=this.buildTextValNode(s,l,"",e,n)}}this.options.oneListGroup&&(o=this.buildObjectNode(o,l,a,e)),r+=o}else if(this.options.attributesGroupName&&h===this.options.attributesGroupName){const e=Object.keys(t[h]),r=e.length;for(let o=0;o<r;o++){const r=Ht(e[o],!0,this.options,n,i);s+=this.buildAttrPairStr(r,""+t[h][e[o]],a)}}else r+=this.processTextOrObjNode(t[h],l,e,n,i)}return{attrStr:s,val:r}},Qt.prototype.buildAttrPairStr=function(t,e,n){return n||(e=this.options.attributeValueProcessor(t,""+e),e=this.replaceEntitiesValue(e)),this.options.suppressBooleanAttributes&&"true"===e?" "+t:" "+t+'="'+Ft(e)+'"'},Qt.prototype.extractAttributes=function(t){if(!t||"object"!=typeof t)return null;const e={};let n=!1;if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const i=t[this.options.attributesGroupName];for(let t in i)Object.prototype.hasOwnProperty.call(i,t)&&(e[t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t]=Ft(i[t]),n=!0)}else for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;const s=this.isAttribute(i);s&&(e[s]=Ft(t[i]),n=!0)}return n?e:null},Qt.prototype.buildRawContent=function(t){if("string"==typeof t)return t;if("object"!=typeof t||null===t)return String(t);if(void 0!==t[this.options.textNodeName])return t[this.options.textNodeName];let e="";for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;if(this.isAttribute(n))continue;if(this.options.attributesGroupName&&n===this.options.attributesGroupName)continue;const i=t[n];if(n===this.options.textNodeName)e+=i;else if(Array.isArray(i)){for(let t of i)if("string"==typeof t||"number"==typeof t)e+=`<${n}>${t}</${n}>`;else if("object"==typeof t&&null!==t){const i=this.buildRawContent(t),s=this.buildAttributesForStopNode(t);e+=""===i?`<${n}${s}/>`:`<${n}${s}>${i}</${n}>`}}else if("object"==typeof i&&null!==i){const t=this.buildRawContent(i),s=this.buildAttributesForStopNode(i);e+=""===t?`<${n}${s}/>`:`<${n}${s}>${t}</${n}>`}else e+=`<${n}>${i}</${n}>`}return e},Qt.prototype.buildAttributesForStopNode=function(t){if(!t||"object"!=typeof t)return"";let e="";if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const n=t[this.options.attributesGroupName];for(let t in n){if(!Object.prototype.hasOwnProperty.call(n,t))continue;const i=t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t,s=n[t];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}else for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;const i=this.isAttribute(n);if(i){const s=t[n];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}return e},Qt.prototype.buildObjectNode=function(t,e,n,i){if(""===t)return"?"===e[0]?this.indentate(i)+"<"+e+n+"?"+this.tagEndChar:this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar;if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s="</"+e+this.tagEndChar,r="";return"?"===e[0]&&(r="?",s=""),!n&&""!==n||-1!==t.indexOf("<")?!1!==this.options.commentPropName&&e===this.options.commentPropName&&0===r.length?this.indentate(i)+`\x3c!--${t}--\x3e`+this.newLine:this.indentate(i)+"<"+e+n+r+this.tagEndChar+t+this.indentate(i)+s:this.indentate(i)+"<"+e+n+r+">"+t+s}},Qt.prototype.closeTag=function(t){let e="";return-1!==this.options.unpairedTags.indexOf(t)?this.options.suppressUnpairedNode||(e="/"):e=this.options.suppressEmptyNode?"/":`></${t}`,e},Qt.prototype.checkStopNode=function(t){if(!this.stopNodeExpressions||0===this.stopNodeExpressions.length)return!1;for(let e=0;e<this.stopNodeExpressions.length;e++)if(t.matches(this.stopNodeExpressions[e]))return!0;return!1},Qt.prototype.buildTextValNode=function(t,e,n,i,s){if(!1!==this.options.cdataPropName&&e===this.options.cdataPropName){const e=Rt(t);return this.indentate(i)+`<![CDATA[${e}]]>`+this.newLine}if(!1!==this.options.commentPropName&&e===this.options.commentPropName){const e=kt(t);return this.indentate(i)+`\x3c!--${e}--\x3e`+this.newLine}if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s=this.options.tagValueProcessor(e,t);return s=this.replaceEntitiesValue(s),""===s?this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar:this.indentate(i)+"<"+e+n+">"+s+"</"+e+this.tagEndChar}},Qt.prototype.replaceEntitiesValue=function(t){if(t&&t.length>0&&this.options.processEntities)for(let e=0;e<this.options.entities.length;e++){const n=this.options.entities[e];t=t.replace(n.regex,n.val)}return t};const ie=Qt,se={validate:l};module.exports=e})();
 
 /***/ }),
 
-/***/ 313:
+/***/ 314:
 /***/ ((module) => {
 
 "use strict";
@@ -60403,7 +62220,7 @@ module.exports = require("node:string_decoder");
 
 /***/ }),
 
-/***/ 314:
+/***/ 315:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -60421,7 +62238,7 @@ var KnownEncryptionAlgorithmType;
 
 /***/ }),
 
-/***/ 315:
+/***/ 316:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -60650,7 +62467,7 @@ function replaceAll(value, searchValue, replaceValue) {
 
 /***/ }),
 
-/***/ 316:
+/***/ 317:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60696,7 +62513,7 @@ function defaultRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 317:
+/***/ 318:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60737,7 +62554,7 @@ exports.StorageRetryPolicyFactory = StorageRetryPolicyFactory;
 
 /***/ }),
 
-/***/ 318:
+/***/ 319:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60843,7 +62660,7 @@ function toArrayBuffer(source) {
 
 /***/ }),
 
-/***/ 319:
+/***/ 320:
 /***/ ((module) => {
 
 "use strict";
@@ -60948,7 +62765,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 320:
+/***/ 321:
 /***/ ((module) => {
 
 "use strict";
@@ -60956,7 +62773,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 321:
+/***/ 322:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -60975,7 +62792,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 322:
+/***/ 323:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61005,7 +62822,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-const path = __importStar(__nccwpck_require__(241));
+const path = __importStar(__nccwpck_require__(242));
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
  * replaced with /.
@@ -61044,7 +62861,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 323:
+/***/ 324:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -61152,7 +62969,7 @@ var WireType;
 
 /***/ }),
 
-/***/ 324:
+/***/ 325:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61165,13 +62982,13 @@ const core_util_1 = __nccwpck_require__(12);
 const core_auth_1 = __nccwpck_require__(492);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_2 = __nccwpck_require__(12);
-const storage_common_1 = __nccwpck_require__(270);
-const Clients_js_1 = __nccwpck_require__(180);
+const storage_common_1 = __nccwpck_require__(271);
+const Clients_js_1 = __nccwpck_require__(181);
 const Mutex_js_1 = __nccwpck_require__(496);
-const Pipeline_js_1 = __nccwpck_require__(178);
-const utils_common_js_1 = __nccwpck_require__(152);
-const core_xml_1 = __nccwpck_require__(189);
-const constants_js_1 = __nccwpck_require__(146);
+const Pipeline_js_1 = __nccwpck_require__(179);
+const utils_common_js_1 = __nccwpck_require__(153);
+const core_xml_1 = __nccwpck_require__(190);
+const constants_js_1 = __nccwpck_require__(147);
 const tracing_js_1 = __nccwpck_require__(29);
 const core_client_1 = __nccwpck_require__(419);
 /**
@@ -61437,7 +63254,7 @@ function batchHeaderFilterPolicy() {
 
 /***/ }),
 
-/***/ 325:
+/***/ 326:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61450,13 +63267,13 @@ var AvroReader_js_1 = __nccwpck_require__(401);
 Object.defineProperty(exports, "AvroReader", ({ enumerable: true, get: function () { return AvroReader_js_1.AvroReader; } }));
 var AvroReadable_js_1 = __nccwpck_require__(371);
 Object.defineProperty(exports, "AvroReadable", ({ enumerable: true, get: function () { return AvroReadable_js_1.AvroReadable; } }));
-var AvroReadableFromStream_js_1 = __nccwpck_require__(245);
+var AvroReadableFromStream_js_1 = __nccwpck_require__(246);
 Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, get: function () { return AvroReadableFromStream_js_1.AvroReadableFromStream; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 326:
+/***/ 327:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61483,12 +63300,12 @@ __export(tracingPolicy_exports, {
 });
 module.exports = __toCommonJS(tracingPolicy_exports);
 var import_core_tracing = __nccwpck_require__(79);
-var import_constants = __nccwpck_require__(157);
-var import_userAgent = __nccwpck_require__(284);
-var import_log = __nccwpck_require__(179);
+var import_constants = __nccwpck_require__(158);
+var import_userAgent = __nccwpck_require__(285);
+var import_log = __nccwpck_require__(180);
 var import_core_util = __nccwpck_require__(12);
-var import_restError = __nccwpck_require__(340);
-var import_util = __nccwpck_require__(144);
+var import_restError = __nccwpck_require__(341);
+var import_util = __nccwpck_require__(145);
 const tracingPolicyName = "tracingPolicy";
 function tracingPolicy(options = {}) {
   const userAgentPromise = (0, import_userAgent.getUserAgentValue)(options.userAgentPrefix);
@@ -61602,7 +63419,7 @@ function tryProcessResponse(span, response) {
 
 /***/ }),
 
-/***/ 327:
+/***/ 328:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61614,14 +63431,14 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher
-} = __nccwpck_require__(353)
+} = __nccwpck_require__(354)
 const Client = __nccwpck_require__(86)
 const {
   InvalidArgumentError
 } = __nccwpck_require__(468)
 const util = __nccwpck_require__(67)
-const { kUrl, kInterceptors } = __nccwpck_require__(190)
-const buildConnector = __nccwpck_require__(260)
+const { kUrl, kInterceptors } = __nccwpck_require__(191)
+const buildConnector = __nccwpck_require__(261)
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -61718,7 +63535,7 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 328:
+/***/ 329:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61770,7 +63587,7 @@ function oauth2AuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 329:
+/***/ 330:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61796,7 +63613,7 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(280);
+var import_bytesEncoding = __nccwpck_require__(281);
 var import_checkEnvironment = __nccwpck_require__(418);
 var import_httpHeaders = __nccwpck_require__(465);
 const formDataPolicyName = "formDataPolicy";
@@ -61886,7 +63703,7 @@ async function prepareFormData(formData, request) {
 
 /***/ }),
 
-/***/ 330:
+/***/ 331:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61912,7 +63729,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(280);
 const redirectPolicyName = import_policies.redirectPolicyName;
 function redirectPolicy(options = {}) {
   return (0, import_policies.redirectPolicy)(options);
@@ -61923,19 +63740,19 @@ function redirectPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 331:
+/***/ 332:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(190)
+const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(191)
 const { URL } = __nccwpck_require__(82)
 const Agent = __nccwpck_require__(5)
-const Pool = __nccwpck_require__(327)
+const Pool = __nccwpck_require__(328)
 const DispatcherBase = __nccwpck_require__(60)
 const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(468)
-const buildConnector = __nccwpck_require__(260)
+const buildConnector = __nccwpck_require__(261)
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -62120,7 +63937,7 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 332:
+/***/ 333:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62128,11 +63945,11 @@ module.exports = ProxyAgent
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonReader = void 0;
 const json_typings_1 = __nccwpck_require__(378);
-const base64_1 = __nccwpck_require__(293);
+const base64_1 = __nccwpck_require__(294);
 const reflection_info_1 = __nccwpck_require__(432);
 const pb_long_1 = __nccwpck_require__(116);
 const assert_1 = __nccwpck_require__(464);
-const reflection_long_convert_1 = __nccwpck_require__(155);
+const reflection_long_convert_1 = __nccwpck_require__(156);
 /**
  * Reads proto3 messages in canonical JSON format using reflection information.
  *
@@ -62445,7 +64262,7 @@ exports.ReflectionJsonReader = ReflectionJsonReader;
 
 /***/ }),
 
-/***/ 333:
+/***/ 334:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -62735,7 +64552,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 334:
+/***/ 335:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -62818,7 +64635,7 @@ exports.utf8read = utf8read;
 
 /***/ }),
 
-/***/ 335:
+/***/ 336:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62828,7 +64645,7 @@ exports.utf8read = utf8read;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = createTracingClient;
 const instrumenter_js_1 = __nccwpck_require__(388);
-const tracingContext_js_1 = __nccwpck_require__(354);
+const tracingContext_js_1 = __nccwpck_require__(355);
 /**
  * Creates a new tracing client.
  *
@@ -62906,14 +64723,14 @@ function createTracingClient(options) {
 
 /***/ }),
 
-/***/ 336:
+/***/ 337:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { promisify } = __nccwpck_require__(122)
-const Pool = __nccwpck_require__(327)
+const Pool = __nccwpck_require__(328)
 const { buildMockDispatch } = __nccwpck_require__(7)
 const {
   kDispatches,
@@ -62924,8 +64741,8 @@ const {
   kOriginalDispatch,
   kConnected
 } = __nccwpck_require__(450)
-const { MockInterceptor } = __nccwpck_require__(134)
-const Symbols = __nccwpck_require__(190)
+const { MockInterceptor } = __nccwpck_require__(135)
+const Symbols = __nccwpck_require__(191)
 const { InvalidArgumentError } = __nccwpck_require__(468)
 
 /**
@@ -62973,7 +64790,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 337:
+/***/ 338:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -63031,7 +64848,7 @@ exports.ClientStreamingCall = ClientStreamingCall;
 
 /***/ }),
 
-/***/ 338:
+/***/ 339:
 /***/ ((module) => {
 
 module.exports = function (xs, fn) {
@@ -63051,7 +64868,7 @@ var isArray = Array.isArray || function (xs) {
 
 /***/ }),
 
-/***/ 339:
+/***/ 340:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -63100,7 +64917,7 @@ exports.colorForceEnvironment = colorForceEnvironment;
 exports.formatLogLine = formatLogLine;
 exports.isTimestampsEnabled = isTimestampsEnabled;
 const core = __importStar(__nccwpck_require__(439));
-const fs = __importStar(__nccwpck_require__(242));
+const fs = __importStar(__nccwpck_require__(243));
 function makeFileLogger(env) {
     const logPath = (env["SETUP_SOLDR_LOG"] ?? "").trim();
     if (!logPath)
@@ -63222,7 +65039,7 @@ function isTimestampsEnabled(env) {
 
 /***/ }),
 
-/***/ 340:
+/***/ 341:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -63259,20 +65076,20 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 341:
+/***/ 342:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { finished, PassThrough } = __nccwpck_require__(129)
+const { finished, PassThrough } = __nccwpck_require__(130)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
 } = __nccwpck_require__(468)
 const util = __nccwpck_require__(67)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(184)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(185)
 const { AsyncResource } = __nccwpck_require__(408)
 const { addSignal, removeSignal } = __nccwpck_require__(102)
 
@@ -63487,7 +65304,7 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 342:
+/***/ 343:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -63501,9 +65318,9 @@ module.exports = stream
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(419));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(175));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(176));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(63));
 /** Class containing BlockBlob operations. */
 class BlockBlobImpl {
@@ -63867,7 +65684,7 @@ const getBlockListOperationSpec = {
 
 /***/ }),
 
-/***/ 343:
+/***/ 344:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -63912,7 +65729,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 344:
+/***/ 345:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -63922,7 +65739,7 @@ function decompressResponsePolicy() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GenericPollOperation = void 0;
 const operation_js_1 = __nccwpck_require__(50);
-const logger_js_1 = __nccwpck_require__(186);
+const logger_js_1 = __nccwpck_require__(187);
 const createStateProxy = () => ({
     initState: (config) => ({ config, isStarted: true }),
     setCanceled: (state) => (state.isCancelled = true),
@@ -64007,7 +65824,7 @@ exports.GenericPollOperation = GenericPollOperation;
 
 /***/ }),
 
-/***/ 345:
+/***/ 346:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -64030,7 +65847,7 @@ function ipRangeToString(ipRange) {
 
 /***/ }),
 
-/***/ 346:
+/***/ 347:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -64056,7 +65873,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(249);
+var import_userAgent = __nccwpck_require__(250);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -64078,7 +65895,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 347:
+/***/ 348:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -64098,7 +65915,7 @@ exports.getUserAgentString = getUserAgentString;
 
 /***/ }),
 
-/***/ 348:
+/***/ 349:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -64108,7 +65925,7 @@ exports.getUserAgentString = getUserAgentString;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BufferScheduler = void 0;
 const events_1 = __nccwpck_require__(449);
-const PooledBuffer_js_1 = __nccwpck_require__(355);
+const PooledBuffer_js_1 = __nccwpck_require__(356);
 /**
  * This class accepts a Node.js Readable stream as input, and keeps reading data
  * from the stream into the internal buffer structure, until it reaches maxBuffers.
@@ -64387,7 +66204,7 @@ exports.BufferScheduler = BufferScheduler;
 
 /***/ }),
 
-/***/ 349:
+/***/ 350:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -64739,13 +66556,13 @@ module.exports = { File, FileLike, isFileLike }
 
 /***/ }),
 
-/***/ 350:
+/***/ 351:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const diagnosticsChannel = __nccwpck_require__(140)
+const diagnosticsChannel = __nccwpck_require__(141)
 const { uid, states } = __nccwpck_require__(445)
 const {
   kReadyState,
@@ -64754,12 +66571,12 @@ const {
   kReceivedClose
 } = __nccwpck_require__(97)
 const { fireEvent, failWebsocketConnection } = __nccwpck_require__(55)
-const { CloseEvent } = __nccwpck_require__(243)
+const { CloseEvent } = __nccwpck_require__(244)
 const { makeRequest } = __nccwpck_require__(81)
 const { fetching } = __nccwpck_require__(430)
 const { Headers } = __nccwpck_require__(494)
 const { getGlobalDispatcher } = __nccwpck_require__(361)
-const { kHeadersList } = __nccwpck_require__(190)
+const { kHeadersList } = __nccwpck_require__(191)
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -64769,7 +66586,7 @@ channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(283)
+  crypto = __nccwpck_require__(284)
 } catch {
 
 }
@@ -65038,7 +66855,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 351:
+/***/ 352:
 /***/ ((module) => {
 
 "use strict";
@@ -65054,7 +66871,7 @@ module.exports = (flag, argv = process.argv) => {
 
 /***/ }),
 
-/***/ 352:
+/***/ 353:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65110,15 +66927,15 @@ function statusCodeToNumber(statusCode) {
 
 /***/ }),
 
-/***/ 353:
+/***/ 354:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const DispatcherBase = __nccwpck_require__(60)
-const FixedQueue = __nccwpck_require__(191)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(190)
+const FixedQueue = __nccwpck_require__(192)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(191)
 const PoolStats = __nccwpck_require__(20)
 
 const kClients = Symbol('clients')
@@ -65312,7 +67129,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 354:
+/***/ 355:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65372,7 +67189,7 @@ exports.TracingContextImpl = TracingContextImpl;
 
 /***/ }),
 
-/***/ 355:
+/***/ 356:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65381,9 +67198,9 @@ exports.TracingContextImpl = TracingContextImpl;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 const BuffersStream_js_1 = __nccwpck_require__(369);
-const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(258));
+const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(259));
 /**
  * maxBufferLength is max size of each buffer in the pooled buffers.
  */
@@ -65479,7 +67296,7 @@ exports.PooledBuffer = PooledBuffer;
 
 /***/ }),
 
-/***/ 356:
+/***/ 357:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65515,7 +67332,7 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 357:
+/***/ 358:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65627,7 +67444,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 358:
+/***/ 359:
 /***/ ((module) => {
 
 /**
@@ -65796,1807 +67613,11 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 359:
+/***/ 360:
 /***/ ((module) => {
 
 "use strict";
 module.exports = require("node:util");
-
-/***/ }),
-
-/***/ 360:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// setup-soldr post-job entry point. Owned by Agent 2.
-//
-// Runs in the post-job phase via action.yml's `post: dist/post.js`. This is
-// the architectural fix for zackees/setup-soldr#70 — it lets us tar+zstd
-// the build-cache (and optionally cargo-registry) directories BEFORE
-// @actions/cache's post-save uploads them, so the wire format is zstd on
-// every platform (including Windows-x64 where actions/cache@v5 still
-// falls back to gzip).
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.resolveJournalPrintRaw = resolveJournalPrintRaw;
-exports.buildFinalCacheSummary = buildFinalCacheSummary;
-exports.formatFinalCacheSummaryMarkdown = formatFinalCacheSummaryMarkdown;
-exports.setMultiSessionOutputs = setMultiSessionOutputs;
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(242));
-const path = __importStar(__nccwpck_require__(487));
-const node_child_process_1 = __nccwpck_require__(192);
-const core = __importStar(__nccwpck_require__(439));
-const cache = __importStar(__nccwpck_require__(208));
-const cache_compress_js_1 = __nccwpck_require__(272);
-const solo_toolchain_cache_js_1 = __nccwpck_require__(471);
-const cook_cache_js_1 = __nccwpck_require__(38);
-const soldr_mini_cache_js_1 = __nccwpck_require__(84);
-const log_utils_js_1 = __nccwpck_require__(339);
-const shutdown_cache_js_1 = __nccwpck_require__(297);
-const stats_collector_js_1 = __nccwpck_require__(453);
-const compile_cache_stats_js_1 = __nccwpck_require__(216);
-const diagnostics_js_1 = __nccwpck_require__(438);
-const raw_inputs_js_1 = __nccwpck_require__(92);
-const source_mtime_snapshot_js_1 = __nccwpck_require__(389);
-function dirExists(p) {
-    try {
-        return fs.statSync(p).isDirectory();
-    }
-    catch {
-        return false;
-    }
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
-    }
-}
-function cachePathExists(p) {
-    try {
-        if (!p.includes("*"))
-            return fs.existsSync(p);
-        const firstStar = p.indexOf("*");
-        const slash = Math.max(p.lastIndexOf(path.sep, firstStar), p.lastIndexOf("/", firstStar), p.lastIndexOf("\\", firstStar));
-        const dir = slash >= 0 ? p.slice(0, slash) : ".";
-        const prefix = p.slice(slash + 1, firstStar);
-        return fs.readdirSync(dir).some((entry) => entry.startsWith(prefix));
-    }
-    catch {
-        return false;
-    }
-}
-function stateBool(name, fallback = false) {
-    const value = core.getState(name).trim().toLowerCase();
-    if (value === "true")
-        return true;
-    if (value === "false")
-        return false;
-    return fallback;
-}
-/**
- * Decide whether the post-phase diagnostic dump includes the verbatim
- * per-rustc-invocation JSONL stream. The raw stream is large (thousands
- * of records / 20-30 MB on the demo warm build) and dominates Post Setup
- * Soldr wall-clock when emitted. Default: mirror debug mode (preserves
- * pre-existing behavior for workflows that already opted into debug).
- * Explicit values "true"/"false"/"on"/"off"/"yes"/"no"/"1"/"0" override.
- */
-function resolveJournalPrintRaw(rawValue, debugMode) {
-    const v = (rawValue ?? "").trim().toLowerCase();
-    if (v === "")
-        return debugMode;
-    if (v === "true" || v === "1" || v === "yes" || v === "on")
-        return true;
-    if (v === "false" || v === "0" || v === "no" || v === "off")
-        return false;
-    return debugMode;
-}
-function readRestoreState() {
-    return {
-        setupCacheEnabled: stateBool("setupCacheEnabled"),
-        setupCacheExactHit: stateBool("setupCacheExactHit"),
-        setupCacheMatchedKey: core.getState("setupCacheMatchedKey"),
-        targetCacheEnabled: stateBool("targetCacheEnabled"),
-        targetCacheExactHit: stateBool("targetCacheExactHit"),
-        targetCacheMatchedKey: core.getState("targetCacheMatchedKey"),
-        buildCacheEnabled: stateBool("buildCacheEnabled"),
-        buildCacheExactHit: stateBool("buildCacheExactHit"),
-        buildCacheMatchedKey: core.getState("buildCacheMatchedKey"),
-        cargoRegistryCacheEnabled: stateBool("cargoRegistryCacheEnabled"),
-        cargoRegistryCacheExactHit: stateBool("cargoRegistryCacheExactHit"),
-        cargoRegistryCacheMatchedKey: core.getState("cargoRegistryCacheMatchedKey"),
-    };
-}
-function disabledSave() {
-    return { status: "disabled" };
-}
-// setup-cache is intentionally restore-only. Its restore is kept so the
-// action's `cache-hit` output (wired from setupCacheExactHit in main.ts)
-// retains its public contract for downstream workflows, but the save path
-// is permanently inert: the soldr binary moved to soldr-mini-cache (#142)
-// and the rustup toolchain state moved to solo-toolchain-cache (#139),
-// both of which are content-addressable and coarser-keyed. Wiring a save
-// here would re-introduce a duplicate path and defeat those layers' LRU
-// access pattern. See setup-soldr#151 for the full decision rationale.
-function notManagedSave() {
-    return { status: "not-managed-in-post" };
-}
-function restoreStatus(enabled, exactHit, matchedKey) {
-    if (!enabled)
-        return "disabled";
-    if (exactHit)
-        return "exact-hit";
-    if (matchedKey.trim())
-        return "restore-key-hit";
-    return "miss";
-}
-function parseByteCount(raw, inputName, log) {
-    const value = (raw ?? "").trim();
-    if (!value || value === "0")
-        return null;
-    const match = /^(\d+(?:\.\d+)?)\s*([kmgt]?i?b?|b)?$/i.exec(value);
-    if (!match) {
-        core.warning(`setup-soldr: ignoring invalid ${inputName} value '${value}'`);
-        return null;
-    }
-    const amountText = match[1];
-    if (amountText === undefined)
-        return null;
-    const amount = Number(amountText);
-    if (!Number.isFinite(amount) || amount < 0) {
-        core.warning(`setup-soldr: ignoring invalid ${inputName} value '${value}'`);
-        return null;
-    }
-    const unit = (match[2] ?? "b").toLowerCase();
-    const multiplier = unit === "k" || unit === "kb" || unit === "kib"
-        ? 1024
-        : unit === "m" || unit === "mb" || unit === "mib"
-            ? 1024 ** 2
-            : unit === "g" || unit === "gb" || unit === "gib"
-                ? 1024 ** 3
-                : unit === "t" || unit === "tb" || unit === "tib"
-                    ? 1024 ** 4
-                    : 1;
-    const parsed = Math.floor(amount * multiplier);
-    if (parsed <= 0)
-        return null;
-    log(`cache-payload-policy: ${inputName}=${parsed} bytes`);
-    return parsed;
-}
-function parseTopN(raw, log) {
-    const value = (raw ?? "").trim();
-    if (!value)
-        return 10;
-    const parsed = Number(value);
-    if (!Number.isFinite(parsed)) {
-        core.warning(`setup-soldr: ignoring invalid cache-payload-top-n value '${value}'`);
-        return 10;
-    }
-    const topN = Math.max(0, Math.min(50, Math.floor(parsed)));
-    log(`cache-payload-policy: cache-payload-top-n=${topN}`);
-    return topN;
-}
-function resolveCachePayloadPolicy(inputs, log) {
-    const action = (inputs.cachePayloadOversizeAction || "skip").trim().toLowerCase();
-    let oversizeAction = "skip";
-    if (action === "fail") {
-        oversizeAction = "fail";
-    }
-    else if (action && action !== "skip") {
-        core.warning(`setup-soldr: ignoring invalid cache-payload-oversize-action value '${inputs.cachePayloadOversizeAction}'`);
-    }
-    return {
-        warnBytes: parseByteCount(inputs.cachePayloadWarnBytes || "512MiB", "cache-payload-warn-bytes", log),
-        maxBytes: parseByteCount(inputs.cachePayloadMaxBytes, "cache-payload-max-bytes", log),
-        oversizeAction,
-        topN: parseTopN(inputs.cachePayloadTopN, log),
-    };
-}
-async function saveOne(opts) {
-    const { cacheDir, codec, level, key, matchedKey, label, debug, log, extraBasenames, payloadProfile, payloadPolicy } = opts;
-    const withStats = (r) => Object.assign(r, {
-        archiveBytes: null,
-        inflatedBytes: null,
-        fileCount: null,
-        payload: null,
-    });
-    if (!dirExists(cacheDir)) {
-        log(`${label}: cache dir ${cacheDir} does not exist, skipping save`);
-        return withStats({ status: "missing-dir-skip", cache_dir: cacheDir });
-    }
-    if (matchedKey === key) {
-        log(`${label}: exact cache hit on ${key}, skipping save`);
-        return withStats({ status: "exact-hit-skip", cache_dir: cacheDir });
-    }
-    let archiveBytes = null;
-    let archivePath = null;
-    let inflatedBytes = null;
-    let fileCount = null;
-    let payload = null;
-    // Per-phase save timing (#214): separate the archive+compress phase from the
-    // cache reservation+upload phase so a slow Windows post step is diagnosable.
-    let compressMs = 0;
-    let uploadMs = 0;
-    const compressStart = Date.now();
-    try {
-        const result = await (0, cache_compress_js_1.compressCache)({
-            cacheDir,
-            codec,
-            level,
-            debug,
-            log,
-            extraBasenames,
-            payloadWarnBytes: payloadPolicy.warnBytes,
-            payloadMaxBytes: payloadPolicy.maxBytes,
-            payloadOversizeAction: payloadPolicy.oversizeAction,
-            payloadTopN: payloadPolicy.topN,
-            payloadProfile,
-            label,
-        });
-        archivePath = result.archivePath;
-        archiveBytes = result.archiveBytes || null;
-        inflatedBytes = result.inflatedBytes;
-        fileCount = result.fileCount;
-        payload = result.payload;
-        compressMs = Date.now() - compressStart;
-        if (result.skippedReason === "payload-too-large") {
-            log(`${label}: payload exceeded cache-payload-max-bytes, skipping save`);
-            return {
-                status: "oversize-skip",
-                cache_dir: cacheDir,
-                archiveBytes,
-                inflatedBytes,
-                fileCount,
-                payload,
-                phaseTimings: { compressMs },
-            };
-        }
-    }
-    catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        log(`${label}: compression failed: ${message}`);
-        return withStats({ status: "failed", cache_dir: cacheDir, error: message });
-    }
-    const pathsToSave = archivePath ? [archivePath] : [cacheDir];
-    try {
-        const uploadStart = Date.now();
-        const id = await cache.saveCache(pathsToSave, key);
-        uploadMs = Date.now() - uploadStart;
-        log(`${label}: saved cache id=${id} key=${key} via ${archivePath ? "tar.zst" : "default"} ` +
-            `(compress=${compressMs}ms upload=${uploadMs}ms)`);
-        return {
-            status: "saved",
-            cache_dir: cacheDir,
-            archive_path: archivePath ?? undefined,
-            saved_paths: pathsToSave,
-            cache_id: id,
-            archiveBytes,
-            inflatedBytes,
-            fileCount,
-            payload,
-            phaseTimings: { compressMs, uploadMs },
-        };
-    }
-    catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        log(`${label}: save failed: ${message}`);
-        return {
-            status: "failed",
-            cache_dir: cacheDir,
-            archive_path: archivePath ?? undefined,
-            saved_paths: pathsToSave,
-            error: message,
-            archiveBytes,
-            inflatedBytes,
-            fileCount,
-            payload,
-            phaseTimings: { compressMs, uploadMs },
-        };
-    }
-}
-function cacheLayerSummary(opts) {
-    const matchedKey = opts.matchedKey.trim();
-    return {
-        enabled: opts.enabled,
-        key: opts.key,
-        matched_key: matchedKey,
-        exact_hit: opts.enabled ? opts.exactHit : false,
-        restore_status: restoreStatus(opts.enabled, opts.exactHit, matchedKey),
-        save: opts.save,
-    };
-}
-function readSoldrCacheReport(soldrBinary, passthrough) {
-    if (passthrough) {
-        // Short-circuit when the main step installed a passthrough stub
-        // (enable=false). Skips spawning a .cmd on Windows (where
-        // child_process.spawnSync can't launch shell scripts directly) and
-        // documents the passthrough state in the post-step summary.
-        return {
-            status: "ok",
-            soldr_version: "passthrough",
-            report: {
-                notes: ["setup-soldr enable=false: soldr passthrough stub"],
-                last_session: null,
-                rollups: null,
-            },
-        };
-    }
-    if (!soldrBinary || !fileExists(soldrBinary)) {
-        return {
-            status: "missing-binary",
-            error: soldrBinary === undefined
-                ? "SOLDR_BINARY env var not set"
-                : `soldr binary at ${soldrBinary} does not exist`,
-        };
-    }
-    // Use spawnSync so the post step has no async dependencies. The
-    // report subcommand is fast (sub-100ms) — never worth pulling in
-    // @actions/exec just for one shell-out.
-    const child = (0, node_child_process_1.spawnSync)(soldrBinary, ["cache", "report", "--json"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-        windowsHide: true,
-    });
-    if (child.error) {
-        return {
-            status: "error",
-            error: `failed to spawn soldr: ${child.error.message}`,
-        };
-    }
-    const stdout = (child.stdout || "").trim();
-    const stderr = (child.stderr || "").trim();
-    if (child.status !== 0) {
-        const combined = `${stderr}\n${stdout}`;
-        if (/unrecognized subcommand|invalid value for|unknown sub[- ]?command/i.test(combined) &&
-            /\breport\b/.test(combined)) {
-            return {
-                status: "unsupported",
-                error: stderr || stdout || `soldr exited ${child.status}`,
-            };
-        }
-        return {
-            status: "error",
-            error: stderr || stdout || `soldr exited ${child.status}`,
-        };
-    }
-    let report;
-    try {
-        const parsed = JSON.parse(stdout);
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-            return {
-                status: "error",
-                error: "soldr cache report --json returned a non-object payload",
-            };
-        }
-        report = parsed;
-    }
-    catch (err) {
-        return {
-            status: "error",
-            error: `failed to parse soldr cache report JSON: ${err instanceof Error ? err.message : String(err)}`,
-        };
-    }
-    const soldrVersion = typeof report["soldr_version"] === "string" ? report["soldr_version"] : undefined;
-    const zccacheVersion = typeof report["managed_zccache_version"] === "string"
-        ? report["managed_zccache_version"]
-        : undefined;
-    return {
-        status: "ok",
-        soldr_version: soldrVersion,
-        managed_zccache_version: zccacheVersion,
-        report,
-    };
-}
-function readZccacheSessionSummary(buildCachePath) {
-    const statsPath = resolveZccacheSessionStatsPath(buildCachePath);
-    if (!fileExists(statsPath)) {
-        return { stats_path: statsPath, present: false, status: "missing" };
-    }
-    try {
-        const parsed = JSON.parse(fs.readFileSync(statsPath, "utf8"));
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-            return {
-                stats_path: statsPath,
-                present: true,
-                status: "invalid",
-                error: "stats JSON was not an object",
-            };
-        }
-        const stats = parsed;
-        const status = typeof stats["status"] === "string" ? stats["status"] : "unknown";
-        return { stats_path: statsPath, present: true, status, stats };
-    }
-    catch (err) {
-        return {
-            stats_path: statsPath,
-            present: true,
-            status: "invalid",
-            error: err instanceof Error ? err.message : String(err),
-        };
-    }
-}
-function resolveZccacheSessionStatsPath(buildCachePath) {
-    const defaultPath = path.join(buildCachePath, "logs", "last-session-stats.json");
-    if (fileExists(defaultPath))
-        return defaultPath;
-    const candidates = [
-        ...collectSessionStatsCandidates(path.join(buildCachePath, "private")),
-        ...collectSessionStatsCandidates(path.join(buildCachePath, "logs", "archive")),
-    ];
-    candidates.sort((a, b) => b.mtimeMs - a.mtimeMs || a.path.localeCompare(b.path));
-    return candidates[0]?.path ?? defaultPath;
-}
-function collectSessionStatsCandidates(root) {
-    let entries;
-    try {
-        if (!fs.statSync(root).isDirectory())
-            return [];
-        entries = fs.readdirSync(root, { withFileTypes: true });
-    }
-    catch {
-        return [];
-    }
-    const out = [];
-    for (const ent of entries) {
-        if (!ent.isDirectory())
-            continue;
-        const candidate = path.join(root, ent.name, "logs", "last-session-stats.json");
-        const archiveCandidate = path.join(root, ent.name, "last-session-stats.json");
-        for (const statsPath of [candidate, archiveCandidate]) {
-            try {
-                const stat = fs.statSync(statsPath);
-                if (stat.isFile()) {
-                    out.push({ path: statsPath, mtimeMs: stat.mtimeMs });
-                }
-            }
-            catch {
-                // Candidate shape not present; try the next known layout.
-            }
-        }
-    }
-    return out;
-}
-function buildFinalCacheSummary(result, state, saves, passthrough = false) {
-    return {
-        schema_version: 1,
-        setup_cache: cacheLayerSummary({
-            enabled: state.setupCacheEnabled,
-            key: result.setupCache.key,
-            exactHit: state.setupCacheExactHit,
-            matchedKey: state.setupCacheMatchedKey,
-            save: notManagedSave(),
-        }),
-        target_cache: cacheLayerSummary({
-            enabled: state.targetCacheEnabled,
-            key: result.targetCache.key,
-            exactHit: state.targetCacheExactHit,
-            matchedKey: state.targetCacheMatchedKey,
-            save: saves.targetCache,
-        }),
-        build_cache: cacheLayerSummary({
-            enabled: state.buildCacheEnabled,
-            key: result.buildCache.key,
-            exactHit: state.buildCacheExactHit,
-            matchedKey: state.buildCacheMatchedKey,
-            save: saves.buildCache,
-        }),
-        cargo_registry_cache: cacheLayerSummary({
-            enabled: state.cargoRegistryCacheEnabled,
-            key: result.cargoRegistryCache.key,
-            exactHit: state.cargoRegistryCacheExactHit,
-            matchedKey: state.cargoRegistryCacheMatchedKey,
-            save: saves.cargoRegistryCache,
-        }),
-        zccache_session: readZccacheSessionSummary(result.buildCache.path),
-        compile_cache_report: readSoldrCacheReport(process.env["SOLDR_BINARY"]?.trim(), passthrough),
-        // PR4 — walk the per-session archive that soldr#379's
-        // `cache shutdown --archive-logs` populates between cargo invocations
-        // and roll the per-session stats up into a single job-wide aggregate.
-        // Empty archive (no archival happened, or only one session ran) leaves
-        // `sessionCount=0`, which makes the renderer / outputs no-op.
-        multi_session_rollup: (0, compile_cache_stats_js_1.aggregateSessions)((0, compile_cache_stats_js_1.collectArchivedSessionStats)(path.join(result.buildCache.path, "logs", "archive"))),
-    };
-}
-function numberStat(stats, key) {
-    const value = stats?.[key];
-    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-function zccacheOneLine(summary) {
-    if (!summary.present)
-        return `missing (${summary.stats_path})`;
-    if (summary.status !== "ok") {
-        return summary.error ? `${summary.status} (${summary.error})` : summary.status;
-    }
-    const hits = numberStat(summary.stats, "hits") ?? 0;
-    const misses = numberStat(summary.stats, "misses") ?? 0;
-    const compilations = numberStat(summary.stats, "compilations") ?? hits + misses;
-    const nonCacheable = numberStat(summary.stats, "non_cacheable") ?? 0;
-    const errors = numberStat(summary.stats, "errors") ?? 0;
-    const hitRate = numberStat(summary.stats, "hit_rate");
-    const hitRateText = hitRate === undefined ? "n/a" : `${(hitRate * 100).toFixed(1)}%`;
-    return `hits=${hits} misses=${misses} compilations=${compilations} non_cacheable=${nonCacheable} errors=${errors} hit_rate=${hitRateText}`;
-}
-function restoreText(layer) {
-    if (!layer.enabled)
-        return "disabled";
-    if (layer.restore_status === "exact-hit")
-        return "exact hit";
-    if (layer.restore_status === "restore-key-hit")
-        return "restore-key hit";
-    return "miss";
-}
-function saveText(save) {
-    switch (save.status) {
-        case "saved":
-            return save.cache_id === undefined ? "saved" : `saved id=${save.cache_id}`;
-        case "exact-hit-skip":
-            return "skipped exact hit";
-        case "missing-dir-skip":
-            return "skipped missing dir";
-        case "oversize-skip":
-            return "skipped oversize payload";
-        case "tiny-delta-skip":
-            return save.skip_reason ? `skipped tiny delta (${save.skip_reason})` : "skipped tiny delta";
-        case "failed":
-            return save.error ? `failed: ${save.error}` : "failed";
-        case "disabled":
-            return "disabled";
-        case "not-managed-in-post":
-            return "not managed in post";
-    }
-}
-function markdownCell(value) {
-    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
-}
-function tableRow(label, layer) {
-    return [
-        label,
-        restoreText(layer),
-        layer.key,
-        layer.matched_key || "",
-        saveText(layer.save),
-    ]
-        .map(markdownCell)
-        .join(" | ");
-}
-function fmtBytes(n) {
-    if (n >= 1_073_741_824)
-        return `${(n / 1_073_741_824).toFixed(1)} GB`;
-    if (n >= 1_048_576)
-        return `${(n / 1_048_576).toFixed(1)} MB`;
-    if (n >= 1_024)
-        return `${(n / 1_024).toFixed(1)} KB`;
-    return `${n} B`;
-}
-function fmtOptionalBytes(n) {
-    return typeof n === "number" && Number.isFinite(n) ? fmtBytes(n) : "";
-}
-function skipSummaryText(payload) {
-    if (payload.skipped.length === 0)
-        return "none";
-    return payload.skipped.map((entry) => `${entry.reason}: ${entry.count}`).join(", ");
-}
-function payloadEntryLines(entries) {
-    if (entries.length === 0)
-        return ["- none"];
-    return entries.map((entry) => `- \`${entry.path}\` - ${fmtBytes(entry.bytes)}`);
-}
-function payloadSubtreeLines(entries) {
-    if (entries.length === 0)
-        return ["- none"];
-    return entries.map((entry) => `- \`${entry.path}\` - ${fmtBytes(entry.bytes)} across ${entry.files} files`);
-}
-function payloadSkipLines(payload) {
-    if (payload.skipped.length === 0)
-        return ["- none"];
-    const lines = [];
-    for (const skipped of payload.skipped) {
-        const samples = skipped.samples.length > 0 ? `; samples: ${skipped.samples.map((s) => `\`${s}\``).join(", ")}` : "";
-        lines.push(`- ${skipped.reason}: ${skipped.count}${samples}`);
-    }
-    return lines;
-}
-function cachePayloadAuditSection(summary) {
-    const rows = [];
-    for (const [label, save] of [
-        ["target cache", summary.target_cache.save],
-        ["build cache", summary.build_cache.save],
-        ["cargo registry cache", summary.cargo_registry_cache.save],
-    ]) {
-        if (save.payload)
-            rows.push([label, save]);
-    }
-    if (rows.length === 0)
-        return [];
-    const lines = [
-        "",
-        "### cache payload audit",
-        "",
-        "| Layer | Payload | Files | Symlinks | Archive | Skipped |",
-        "| --- | ---: | ---: | ---: | ---: | --- |",
-    ];
-    for (const [label, save] of rows) {
-        const payload = save.payload;
-        if (!payload)
-            continue;
-        lines.push(`| ${markdownCell(label)} | ${fmtBytes(payload.bytes)} | ${payload.files} | ${payload.symlinks} | ` +
-            `${fmtOptionalBytes(save.archiveBytes)} | ${markdownCell(skipSummaryText(payload))} |`);
-    }
-    for (const [label, save] of rows) {
-        const payload = save.payload;
-        if (!payload)
-            continue;
-        lines.push("", `<details><summary>${label} largest payload entries</summary>`, "", "Largest subtrees:", "", ...payloadSubtreeLines(payload.topSubtrees), "", "Largest files:", "", ...payloadEntryLines(payload.topFiles), "", "Largest directories:", "", ...payloadEntryLines(payload.topDirectories), "", "Skipped tar inputs:", "", ...payloadSkipLines(payload), "", "</details>");
-    }
-    return lines;
-}
-function setCompileCacheOutputs(report, mode) {
-    core.setOutput("compile-cache-session-status", report.status);
-    if (report.status !== "ok" || !report.report)
-        return;
-    core.setOutput("compile-cache-summary-json", JSON.stringify(report.report));
-    const lastSession = report.report["last_session"];
-    if (lastSession) {
-        const hits = numberStat(lastSession, "hits") ?? 0;
-        const misses = numberStat(lastSession, "misses") ?? 0;
-        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
-        const hitRate = numberStat(lastSession, "hit_rate");
-        const timeSavedMs = numberStat(lastSession, "time_saved_ms");
-        const bytesRead = numberStat(lastSession, "bytes_read");
-        const bytesWritten = numberStat(lastSession, "bytes_written");
-        core.setOutput("compile-cache-hits", String(hits));
-        core.setOutput("compile-cache-misses", String(misses));
-        core.setOutput("compile-cache-compilations", String(compilations));
-        if (hitRate !== undefined)
-            core.setOutput("compile-cache-hit-rate", String(hitRate));
-        if (timeSavedMs !== undefined)
-            core.setOutput("compile-cache-time-saved-ms", String(timeSavedMs));
-        if (bytesRead !== undefined)
-            core.setOutput("compile-cache-bytes-read", String(bytesRead));
-        if (bytesWritten !== undefined)
-            core.setOutput("compile-cache-bytes-written", String(bytesWritten));
-    }
-    if (mode === "detailed") {
-        const rollups = report.report["rollups"];
-        if (rollups)
-            core.setOutput("compile-cache-rollups-json", JSON.stringify(rollups));
-    }
-}
-function compileCacheReportSection(report, mode) {
-    if (mode === "none")
-        return [];
-    // Insights mode is a superset of summarize — render the per-session table
-    // first so workflows don't lose the baseline metrics, then append the
-    // diagnoses block underneath. The detailed roll-up tables stay
-    // detailed-only (they're already noisy enough on their own).
-    const summaryMode = mode === "insights" ? "summarize" : mode;
-    const lines = ["", "### Compile cache (zccache)", ""];
-    if (report.status !== "ok" || !report.report) {
-        lines.push(`| Status | ${markdownCell(report.status)} |`);
-        if (report.error)
-            lines.push(`| Detail | ${markdownCell(report.error)} |`);
-        return lines;
-    }
-    const body = report.report;
-    const lastSession = body["last_session"] ?? null;
-    const rollups = body["rollups"] ?? null;
-    if (lastSession) {
-        const hits = numberStat(lastSession, "hits") ?? 0;
-        const misses = numberStat(lastSession, "misses") ?? 0;
-        const compilations = numberStat(lastSession, "compilations") ?? hits + misses;
-        const rate = numberStat(lastSession, "hit_rate");
-        const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
-        const saved = numberStat(lastSession, "time_saved_ms");
-        const bytesRead = numberStat(lastSession, "bytes_read");
-        const bytesWritten = numberStat(lastSession, "bytes_written");
-        lines.push("| Metric | Value |", "| --- | --- |");
-        lines.push(`| Compilations | ${compilations} |`);
-        lines.push(`| Hits | ${hits} |`);
-        lines.push(`| Misses | ${misses} |`);
-        lines.push(`| Hit rate | ${rateText} |`);
-        if (saved !== undefined)
-            lines.push(`| Time saved (est.) | ${(saved / 1000).toFixed(1)}s |`);
-        if (bytesRead !== undefined)
-            lines.push(`| Bytes read | ${fmtBytes(bytesRead)} |`);
-        if (bytesWritten !== undefined)
-            lines.push(`| Bytes written | ${fmtBytes(bytesWritten)} |`);
-        if (report.soldr_version)
-            lines.push(`| soldr | ${markdownCell(report.soldr_version)} |`);
-        if (report.managed_zccache_version)
-            lines.push(`| zccache | ${markdownCell(report.managed_zccache_version)} |`);
-    }
-    else {
-        lines.push("_(no last\\_session yet — run a cache-enabled build first)_");
-    }
-    if (mode === "detailed" && rollups) {
-        const byExt = rollups["by_extension"];
-        if (byExt && typeof byExt === "object" && !Array.isArray(byExt)) {
-            const rows = Object.entries(byExt);
-            if (rows.length > 0) {
-                lines.push("", "#### By output extension", "");
-                lines.push("| Extension | Hits | Misses | Total ms |", "| --- | --- | --- | --- |");
-                for (const [ext, bucket] of rows) {
-                    const b = bucket ?? {};
-                    const h = numberStat(b, "hits") ?? 0;
-                    const m = numberStat(b, "misses") ?? 0;
-                    const t = numberStat(b, "total_ms") ?? 0;
-                    lines.push(`| ${markdownCell(ext)} | ${h} | ${m} | ${t} |`);
-                }
-            }
-        }
-        const byTool = rollups["by_tool_total_ms"];
-        if (byTool && typeof byTool === "object" && !Array.isArray(byTool)) {
-            const rows = Object.entries(byTool)
-                .map(([tool, ms]) => [tool, typeof ms === "number" ? ms : 0])
-                .sort((a, b) => b[1] - a[1])
-                .slice(0, 10);
-            if (rows.length > 0) {
-                lines.push("", "#### By tool (wall-clock)", "");
-                lines.push("| Tool | ms |", "| --- | --- |");
-                for (const [tool, ms] of rows) {
-                    lines.push(`| ${markdownCell(tool)} | ${ms} |`);
-                }
-            }
-        }
-    }
-    // PR3 — insights mode appends per-diagnosis <details> blocks below the
-    // per-session table. Each diagnosis renders its evidence (miss reasons
-    // table + slowest misses list + wasted_ms) plus a blockquoted
-    // suggested_fix line. Annotations are not emitted from this pure
-    // renderer — the run() loop separately forwards them to core.warning /
-    // core.notice so they show up pinned in the PR Files view.
-    if (mode === "insights") {
-        const insights = (0, compile_cache_stats_js_1.renderInsights)(body);
-        if (insights.markdown.length > 0) {
-            lines.push("", "### Compile cache insights", "");
-            lines.push(insights.markdown);
-        }
-    }
-    const notes = body["notes"];
-    if (Array.isArray(notes) && notes.length > 0) {
-        lines.push("", "<details><summary>Notes from soldr</summary>", "");
-        for (const note of notes) {
-            if (typeof note === "string")
-                lines.push(`- ${markdownCell(note)}`);
-        }
-        lines.push("", "</details>");
-    }
-    // Silence the "unused variable" warning — summaryMode is reserved for a
-    // future split where insights includes/excludes the detailed-rollup
-    // tables. Today the rollup gate is still keyed on `mode`.
-    void summaryMode;
-    return lines;
-}
-function formatFinalCacheSummaryMarkdown(summary, compileCacheStats = "summarize") {
-    // PR4 — multi-step roll-up. Renders only when >1 sessions were
-    // archived AND the user didn't opt out via compile-cache-stats=none.
-    // The block sits between the layer table and the per-session compile
-    // cache section so the high-level "what happened across the whole job"
-    // signal lands first, with the per-invocation breakdown beneath.
-    const multiStepBlock = compileCacheStats !== "none"
-        ? (0, compile_cache_stats_js_1.renderMultiSessionRollup)(summary.multi_session_rollup)
-        : "";
-    const multiStepLines = multiStepBlock.length > 0 ? ["", multiStepBlock] : [];
-    const lines = [
-        "## setup-soldr final cache summary",
-        "",
-        "| Layer | Restore | Primary key | Matched key | Save |",
-        "| --- | --- | --- | --- | --- |",
-        `| ${tableRow("setup cache", summary.setup_cache)} |`,
-        `| ${tableRow("target cache", summary.target_cache)} |`,
-        `| ${tableRow("build cache", summary.build_cache)} |`,
-        `| ${tableRow("cargo registry cache", summary.cargo_registry_cache)} |`,
-        ...cachePayloadAuditSection(summary),
-        ...multiStepLines,
-        "",
-        "### zccache session",
-        "",
-        `- Stats: ${zccacheOneLine(summary.zccache_session)}`,
-        `- Stats file: ${summary.zccache_session.stats_path}`,
-        ...compileCacheReportSection(summary.compile_cache_report, compileCacheStats),
-        "",
-        "<details><summary>Final cache summary JSON</summary>",
-        "",
-        "```json",
-        JSON.stringify(summary, null, 2),
-        "```",
-        "",
-        "</details>",
-        "",
-    ];
-    return `${lines.join("\n")}\n`;
-}
-/**
- * PR4 — emit the multi-step roll-up's scalar outputs. Skipped when
- * `sessionCount <= 1` so single-session jobs don't surface a misleading
- * roll-up to downstream workflow steps. Exported so the post-step `run()`
- * function and the contract tests can drive it the same way.
- */
-function setMultiSessionOutputs(rollup) {
-    if (rollup.sessionCount <= 1)
-        return;
-    core.setOutput("compile-cache-sessions-total", String(rollup.sessionCount));
-    if (rollup.overallHitRate !== null && Number.isFinite(rollup.overallHitRate)) {
-        core.setOutput("compile-cache-overall-hit-rate", String(rollup.overallHitRate));
-    }
-}
-function logFinalCacheSummary(summary, log) {
-    log(`final cache summary: setup=${restoreText(summary.setup_cache)} target=${restoreText(summary.target_cache)} ` +
-        `build=${restoreText(summary.build_cache)}/${saveText(summary.build_cache.save)} ` +
-        `cargo-registry=${restoreText(summary.cargo_registry_cache)}/${saveText(summary.cargo_registry_cache.save)}`);
-    log(`final zccache session stats: ${zccacheOneLine(summary.zccache_session)}`);
-    log(`compile cache report: ${compileCacheReportOneLine(summary.compile_cache_report)}`);
-}
-function compileCacheReportOneLine(report) {
-    if (report.status !== "ok" || !report.report) {
-        return report.error ? `${report.status} (${report.error})` : report.status;
-    }
-    const lastSession = report.report["last_session"];
-    if (!lastSession) {
-        return `ok (no last_session yet, soldr ${report.soldr_version ?? "?"})`;
-    }
-    const hits = numberStat(lastSession, "hits") ?? 0;
-    const misses = numberStat(lastSession, "misses") ?? 0;
-    const rate = numberStat(lastSession, "hit_rate");
-    const rateText = rate === undefined ? "n/a" : `${(rate * 100).toFixed(1)}%`;
-    return `ok hits=${hits} misses=${misses} hit_rate=${rateText} soldr=${report.soldr_version ?? "?"}`;
-}
-function writeCompileCacheReportFile(report, runnerTemp, log) {
-    if (!runnerTemp)
-        return undefined;
-    const outPath = path.join(runnerTemp, "setup-soldr-compile-cache-report.json");
-    try {
-        fs.writeFileSync(outPath, JSON.stringify(report, null, 2), "utf8");
-        return outPath;
-    }
-    catch (err) {
-        log(`post: failed to write compile-cache-report.json: ${err instanceof Error ? err.message : String(err)}`);
-        return undefined;
-    }
-}
-function writeStepSummary(markdown, log) {
-    const summaryPath = process.env["GITHUB_STEP_SUMMARY"]?.trim();
-    if (!summaryPath)
-        return;
-    try {
-        fs.appendFileSync(summaryPath, markdown, "utf8");
-    }
-    catch (err) {
-        log(`post: failed to write GitHub step summary: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-/**
- * PR3 — Emit insights-mode side effects:
- *   - Forward each `renderInsights` annotation line to core.warning /
- *     core.notice so it shows up pinned in the PR Files-Changed view.
- *   - Best-effort: ask soldr to write a chrome-trace JSON (a developer
- *     debugger trace file consumable by chrome://tracing or Perfetto)
- *     and upload it as a workflow artifact. Silently skipped when soldr
- *     doesn't support the `--chrome-trace` flag — keeps the action green
- *     on older soldr versions that don't have the subcommand yet.
- */
-async function emitInsightsAnnotationsAndTrace(opts) {
-    const { report, soldrBinary, runnerTemp, log } = opts;
-    if (report.status === "ok" && report.report) {
-        try {
-            const out = (0, compile_cache_stats_js_1.renderInsights)(report.report);
-            for (const line of out.annotations) {
-                // Echo to stdout exactly as GitHub Actions expects — the runner
-                // ingests `::warning::` / `::notice::` workflow-command lines
-                // from stdout regardless of which library wrote them. Avoid the
-                // @actions/core helpers because they re-encode the message and
-                // we want the file= pin we computed in renderInsights to land
-                // verbatim.
-                process.stdout.write(`${line}\n`);
-            }
-            log(`compile-cache-stats: emitted ${out.annotations.length} insights annotations`);
-        }
-        catch (err) {
-            log(`compile-cache-stats: failed to emit insights annotations: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    // Chrome-trace upload. Skipped when no SOLDR_BINARY is on disk, or
-    // when soldr's `cache report --chrome-trace <path>` exits with an
-    // "unknown subcommand"/"unrecognized flag" error (i.e. the user is on
-    // a soldr build that predates the trace flag).
-    if (!soldrBinary || !fileExists(soldrBinary) || !runnerTemp)
-        return;
-    const runId = process.env["GITHUB_RUN_ID"]?.trim() || "local";
-    const tracePath = path.join(runnerTemp, `setup-soldr-trace-${runId}.json`);
-    let traced = false;
-    try {
-        const child = (0, node_child_process_1.spawnSync)(soldrBinary, ["cache", "report", "--chrome-trace", tracePath], {
-            encoding: "utf8",
-            stdio: ["ignore", "pipe", "pipe"],
-            windowsHide: true,
-        });
-        if (child.error) {
-            log(`compile-cache-stats: chrome-trace spawn failed: ${child.error.message}`);
-            return;
-        }
-        if (child.status !== 0) {
-            const combined = `${child.stderr || ""}\n${child.stdout || ""}`;
-            if (/unrecognized|unknown|invalid/i.test(combined) && /chrome[-_ ]?trace/i.test(combined)) {
-                log("compile-cache-stats: chrome-trace flag not supported by this soldr — skipping upload");
-                return;
-            }
-            log(`compile-cache-stats: chrome-trace generation failed (exit ${child.status})`);
-            return;
-        }
-        traced = fileExists(tracePath);
-    }
-    catch (err) {
-        log(`compile-cache-stats: chrome-trace generation threw: ${err instanceof Error ? err.message : String(err)}`);
-        return;
-    }
-    if (!traced) {
-        log(`compile-cache-stats: chrome-trace file not present at ${tracePath} — skipping upload`);
-        return;
-    }
-    try {
-        // Lazy require so the action stays loadable even when
-        // @actions/artifact's runtime requirements aren't met (e.g. running
-        // outside of a GitHub-hosted runner, which is the case for every
-        // unit test in this repo). Any failure is logged-not-thrown.
-        const artifact = await __nccwpck_require__.e(/* import() */ 846).then(__nccwpck_require__.t.bind(__nccwpck_require__, 76846, 23));
-        const client = new artifact.DefaultArtifactClient();
-        const artifactName = `setup-soldr-trace-${runId}.json`;
-        await client.uploadArtifact(artifactName, [tracePath], path.dirname(tracePath));
-        log(`compile-cache-stats: uploaded chrome-trace artifact ${artifactName}`);
-    }
-    catch (err) {
-        log(`compile-cache-stats: chrome-trace artifact upload failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-async function run() {
-    const logger = (0, log_utils_js_1.createLogger)(process.env);
-    const log = (msg) => logger.log(msg);
-    const state = core.getState("resolveResult");
-    if (!state) {
-        log("post: no resolve state available, exiting");
-        return;
-    }
-    let result;
-    try {
-        result = JSON.parse(state);
-    }
-    catch (err) {
-        log(`post: failed to parse resolve state: ${err instanceof Error ? err.message : String(err)}`);
-        return;
-    }
-    const buildCacheMatched = core.getState("buildCacheMatchedKey");
-    const registryMatched = core.getState("cargoRegistryCacheMatchedKey");
-    const passthrough = stateBool("setupSoldrPassthrough");
-    const restoreState = readRestoreState();
-    const statsMode = (core.getState("statsMode") || "summarize");
-    const compileCacheStats = (core.getState("compileCacheStats") || "summarize");
-    const runnerTemp = core.getState("runnerTemp") || "";
-    const debugMode = result.debugMode ?? false;
-    const debugLog = debugMode ? log : () => undefined;
-    const postCollector = new stats_collector_js_1.StatsCollector();
-    const rawInputs = (0, raw_inputs_js_1.readRawInputs)(process.env);
-    const payloadPolicy = resolveCachePayloadPolicy(rawInputs, log);
-    // Always stop long-running cache daemons before packing the build
-    // cache so file locks release and the tarball reflects a quiescent
-    // on-disk view. Best-effort; failures are logged, not raised.
-    //
-    // Wire `--archive-logs <build-cache>/logs/archive` through so soldr
-    // (post-#379) stashes the just-ended session's logs into a
-    // per-session subdirectory before we render this post step's roll-up.
-    // The tar payload planner filters the build-cache logs/ subtree out of
-    // cache saves: raw session journals are diagnostics, not reusable cache
-    // content, and can be tens of MB per invocation.
-    const logsArchiveDir = restoreState.buildCacheEnabled
-        ? path.join(result.buildCache.path, "logs", "archive")
-        : undefined;
-    await (0, shutdown_cache_js_1.shutdownCacheDaemons)({
-        soldrPath: process.env["SOLDR_BINARY"]?.trim() || undefined,
-        logsArchiveDir,
-        log,
-    });
-    // Source-mtime snapshot (preserve-source-mtimes opt-in). Walk tracked
-    // sources, capture each (mtime, size, content-hash), and drop the JSON
-    // INSIDE the build-cache directory so it gets bundled into the same
-    // tar.zst the build-cache save will upload. main.ts replays the
-    // mtimes on warm after the build-cache decompresses, gated on each
-    // file's content matching what we snapshotted here.
-    const preserveSourceMtimes = core.getState("preserveSourceMtimes") === "true";
-    if (preserveSourceMtimes && restoreState.buildCacheEnabled) {
-        const t0 = Date.now();
-        // The "project root" — where the Cargo workspace being built actually
-        // lives — is the parent of the resolved target-dir, NOT result.workspace
-        // (which is GITHUB_WORKSPACE — usually the outer checkout containing
-        // the action itself plus one or more sub-repos). For the demo,
-        // result.workspace=/home/runner/work/setup-soldr/setup-soldr but the
-        // zccache project being built is at .../setup-soldr/zccache.
-        const projectRoot = path.dirname(result.targetCache.targetPath);
-        try {
-            const r = await (0, source_mtime_snapshot_js_1.snapshotSourceMtimes)({ workspace: projectRoot, log });
-            const out = path.join(result.buildCache.path, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
-            try {
-                fs.mkdirSync(path.dirname(out), { recursive: true });
-                (0, source_mtime_snapshot_js_1.writeSnapshotFile)(r.snapshot, out);
-                log(`source-mtime-snapshot: wrote ${out} scanned=${r.scanned} hashed=${r.hashed} skipped=${r.skipped} elapsed_ms=${Date.now() - t0}`);
-            }
-            catch (err) {
-                log(`source-mtime-snapshot: failed to write ${out}: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-        catch (err) {
-            log(`source-mtime-snapshot: scan failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    // Build cache. A delta-aware gate (#230/#214) skips the expensive
-    // archive+upload when the session compiled nothing new AND a cache was
-    // already restored — the restored entry already holds everything, so
-    // re-saving under a fallback key just uploads a duplicate multi-GiB payload.
-    const buildSaveStart = Date.now();
-    const buildCacheRestored = buildCacheMatched.trim().length > 0;
-    const buildDeltaMisses = restoreState.buildCacheEnabled
-        ? numberStat(readZccacheSessionSummary(result.buildCache.path).stats, "misses") ?? null
-        : null;
-    const buildSaveGate = (0, compile_cache_stats_js_1.decideBuildCacheSave)({
-        restored: buildCacheRestored,
-        newCompiles: buildDeltaMisses,
-        minCompiles: (0, compile_cache_stats_js_1.parseMinCompiles)(rawInputs.buildCacheSaveMinCompiles),
-    });
-    let buildSave;
-    if (!restoreState.buildCacheEnabled) {
-        buildSave = Object.assign(disabledSave(), {
-            archiveBytes: null,
-            inflatedBytes: null,
-            fileCount: null,
-            payload: null,
-        });
-    }
-    else if (buildSaveGate.skip) {
-        log(`build-cache: skipping save — ${buildSaveGate.reason} (set build-cache-save-min-compiles: 0 to force-save)`);
-        buildSave = Object.assign({
-            status: "tiny-delta-skip",
-            cache_dir: result.buildCache.path,
-            skip_reason: buildSaveGate.reason,
-        }, { archiveBytes: null, inflatedBytes: null, fileCount: null, payload: null });
-    }
-    else {
-        buildSave = await saveOne({
-            cacheDir: result.buildCache.path,
-            codec: result.targetCacheCompress,
-            level: result.targetCacheCompressLevel,
-            key: result.buildCache.key,
-            matchedKey: buildCacheMatched,
-            label: "build-cache",
-            debug: debugMode,
-            log: debugLog,
-            payloadProfile: "zccache-build-cache",
-            payloadPolicy,
-        });
-    }
-    if (buildSave.status === "saved" || buildSave.status === "oversize-skip") {
-        postCollector.record({
-            label: "build-cache", operation: "save", hit: false,
-            key: result.buildCache.key, matchedKey: buildCacheMatched, restoreKeys: [],
-            status: buildSave.status,
-            archiveBytes: buildSave.archiveBytes, inflatedBytes: buildSave.inflatedBytes, fileCount: buildSave.fileCount,
-            payload: buildSave.payload,
-            durationMs: Date.now() - buildSaveStart, timestamp: new Date().toISOString(),
-        });
-    }
-    // Target cache. Previously slotted as `notManagedSave()` in the
-    // finalSummary — i.e. restored in main.ts but never saved here. That
-    // meant every commit cold-rebuilt `target/` (or the rust-plan bundle)
-    // because no entry was ever written for the restore-key prefix to
-    // fall back to. This block fixes the gap.
-    //
-    // Behavior:
-    // - Skip when target-cache layer is disabled (`target-cache: false`
-    //   or umbrella `cache: false`).
-    // - Skip on exact-hit (re-saving the same content under the same key
-    //   wastes time and triggers @actions/cache's "reservation already
-    //   exists" path).
-    // - Use `cache.saveCache` directly with the multi-path array (one
-    //   path in `thin`/`once` modes, two in `full`). @actions/cache will
-    //   tar+compress with its default codec — we don't route through
-    //   compressCache because target-cache may legitimately carry
-    //   multiple roots and compressCache is single-dir-shaped.
-    // - Paths array must match the one passed to restoreCache in main.ts
-    //   (the @actions/cache "version" hash depends on it — same gotcha
-    //   that bit cook-cache in #141).
-    let targetCacheSave = Object.assign(disabledSave(), { archiveBytes: null });
-    if (restoreState.targetCacheEnabled) {
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        const targetKey = result.targetCache.key;
-        const targetMatched = restoreState.targetCacheMatchedKey;
-        if (targetPaths.length === 0) {
-            log("target-cache: no paths configured, skipping save");
-            targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: "(no paths)" }, { archiveBytes: null });
-        }
-        else if (restoreState.targetCacheExactHit) {
-            log(`target-cache: exact cache hit on ${targetKey}, skipping save`);
-            targetCacheSave = Object.assign({ status: "exact-hit-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
-        }
-        else {
-            const existingPaths = targetPaths.filter((p) => fs.existsSync(p));
-            if (existingPaths.length === 0) {
-                log(`target-cache: none of the configured paths exist on disk (${targetPaths.join(", ")}), skipping save`);
-                targetCacheSave = Object.assign({ status: "missing-dir-skip", cache_dir: targetPaths.join(",") }, { archiveBytes: null });
-            }
-            else {
-                const targetSaveStart = Date.now();
-                try {
-                    const id = await cache.saveCache(existingPaths, targetKey);
-                    if (id <= 0) {
-                        log(`target-cache: save did not reserve a new entry (id=${id}) — likely a parallel ` +
-                            `job already saved key=${targetKey}`);
-                        targetCacheSave = Object.assign({
-                            status: "failed",
-                            cache_dir: existingPaths.join(","),
-                            saved_paths: existingPaths,
-                            error: `saveCache returned id=${id} (reserve failed; race or quota)`,
-                        }, { archiveBytes: null });
-                    }
-                    else {
-                        log(`target-cache: saved cache id=${id} key=${targetKey} paths=${existingPaths.join(",")}`);
-                        targetCacheSave = Object.assign({
-                            status: "saved",
-                            cache_dir: existingPaths.join(","),
-                            saved_paths: existingPaths,
-                            cache_id: id,
-                        }, { archiveBytes: null });
-                        postCollector.record({
-                            label: "target-cache",
-                            operation: "save",
-                            hit: false,
-                            key: targetKey,
-                            matchedKey: targetMatched,
-                            restoreKeys: [],
-                            archiveBytes: null,
-                            inflatedBytes: null,
-                            fileCount: null,
-                            durationMs: Date.now() - targetSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                }
-                catch (err) {
-                    const message = err instanceof Error ? err.message : String(err);
-                    log(`target-cache: save failed: ${message}`);
-                    targetCacheSave = Object.assign({
-                        status: "failed",
-                        cache_dir: existingPaths.join(","),
-                        saved_paths: existingPaths,
-                        error: message,
-                    }, { archiveBytes: null });
-                }
-            }
-        }
-    }
-    // Cargo registry cache (only when enabled).
-    // setup-soldr#102: bundle `.global-cache` (cargo's RFC-3413 GC db) and the
-    // `git/` directory (bare mirrors + checkouts for git-source crate deps)
-    // into the same archive alongside `registry/`. Cache key + archive path
-    // are unchanged — the extras simply ride inside the existing tarball.
-    let cargoRegistrySave = Object.assign(disabledSave(), {
-        archiveBytes: null,
-        inflatedBytes: null,
-        fileCount: null,
-        payload: null,
-    });
-    if (result.cargoRegistryCache.enabled) {
-        const regSaveStart = Date.now();
-        cargoRegistrySave = await saveOne({
-            cacheDir: result.cargoRegistryCache.path,
-            codec: result.targetCacheCompress,
-            level: result.targetCacheCompressLevel,
-            key: result.cargoRegistryCache.key,
-            matchedKey: registryMatched,
-            label: "cargo-registry-cache",
-            debug: debugMode,
-            log: debugLog,
-            extraBasenames: result.cargoRegistryCache.extraBasenames,
-            payloadPolicy,
-        });
-        if (cargoRegistrySave.status === "saved" || cargoRegistrySave.status === "oversize-skip") {
-            postCollector.record({
-                label: "cargo-registry", operation: "save", hit: false,
-                key: result.cargoRegistryCache.key, matchedKey: registryMatched, restoreKeys: [],
-                status: cargoRegistrySave.status,
-                archiveBytes: cargoRegistrySave.archiveBytes,
-                inflatedBytes: cargoRegistrySave.inflatedBytes,
-                fileCount: cargoRegistrySave.fileCount,
-                payload: cargoRegistrySave.payload,
-                durationMs: Date.now() - regSaveStart, timestamp: new Date().toISOString(),
-            });
-        }
-    }
-    // Solo toolchain cache save. Opt-in via the `solo-toolchain-cache`
-    // input. Skip the save when the install delta is empty (the common
-    // case on hosted runners that already provide the requested
-    // toolchain) — per CLAUDE.md "Default-stable workflows should
-    // produce zero cache writes."
-    const soloEnabled = core.getState("soloToolchainEnabled") === "true";
-    if (soloEnabled) {
-        const soloExactKey = core.getState("soloToolchainExactKey");
-        const soloMatchedKey = core.getState("soloToolchainMatchedKey");
-        const soloExactHit = core.getState("soloToolchainExactHit") === "true";
-        const soloIncrementalEmpty = core.getState("soloToolchainIncrementalEmpty") === "true";
-        const soloSaveDiffPath = core.getState("soloToolchainSaveDiffPath");
-        const soloLevel = core.getState("soloToolchainLevel") || "19";
-        log(`solo-toolchain-cache: post-step exactKey=${soloExactKey} matched=${soloMatchedKey} ` +
-            `exactHit=${soloExactHit} incrementalEmpty=${soloIncrementalEmpty} saveDiffPath=${soloSaveDiffPath}`);
-        if (soloExactHit && soloIncrementalEmpty) {
-            log("solo-toolchain-cache: exact hit and no install delta — skipping save");
-        }
-        else if (!soloSaveDiffPath || !fs.existsSync(soloSaveDiffPath)) {
-            log("solo-toolchain-cache: no save-diff manifest available, skipping save");
-        }
-        else {
-            try {
-                const manifest = JSON.parse(fs.readFileSync(soloSaveDiffPath, "utf8"));
-                const added = Array.isArray(manifest.added) ? manifest.added : [];
-                if (added.length === 0) {
-                    log("solo-toolchain-cache: empty save-diff manifest, skipping save");
-                }
-                else {
-                    const soloRootMap = {
-                        "rustup-toolchains": path.join(result.rustupHome, "toolchains"),
-                        "cargo-bin": path.join(result.cargoHome, "bin"),
-                    };
-                    const stagingDir = path.join(runnerTemp, "setup-soldr-solo-stage-save");
-                    const soloSaveStart = Date.now();
-                    const staged = await (0, solo_toolchain_cache_js_1.stageDiffForSave)({ added, removed: [], changed: [] }, soloRootMap, stagingDir);
-                    log(`solo-toolchain-cache: staged ${staged.stagedFiles} files (missing=${staged.missingFiles})`);
-                    const saveResult = await (0, solo_toolchain_cache_js_1.saveSoloCache)({
-                        stagingDir,
-                        key: soloExactKey,
-                        level: soloLevel,
-                        debug: debugMode,
-                        log,
-                    });
-                    if (saveResult.status === "saved") {
-                        postCollector.record({
-                            label: "solo-toolchain-cache",
-                            operation: "save",
-                            hit: false,
-                            key: soloExactKey,
-                            matchedKey: soloMatchedKey,
-                            restoreKeys: [],
-                            archiveBytes: saveResult.archiveBytes ?? null,
-                            inflatedBytes: saveResult.inflatedBytes ?? null,
-                            fileCount: saveResult.fileCount ?? null,
-                            durationMs: Date.now() - soloSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                    else {
-                        log(`solo-toolchain-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
-                    }
-                }
-            }
-            catch (err) {
-                log(`solo-toolchain-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    }
-    // Cook cache save. Default-on layer; skipped when cook didn't run
-    // (cache hit, gate disabled, or run failed). zstd-19 + --long=27 per
-    // CLAUDE.md "Compression" + the cook simulation findings.
-    const cookEnabled = core.getState("cookEnabled") === "true";
-    if (cookEnabled) {
-        const cookLayered = core.getState("cookLayered") === "true";
-        const cookHit = core.getState("cookHit") === "true";
-        const cookRan = core.getState("cookRan") === "true";
-        const cookTargetDir = core.getState("cookTargetDir");
-        if (cookLayered) {
-            const cookSaveLayer = core.getState("cookSaveLayer") || "none";
-            const cookProjectRoot = core.getState("cookProjectRoot");
-            const cookBaseKey = core.getState("cookBaseExactKey");
-            const cookDeltaKey = core.getState("cookDeltaExactKey");
-            const cookBaseArchive = core.getState("cookBaseArchive");
-            const cookDeltaArchive = core.getState("cookDeltaArchive");
-            const cookBaseManifest = core.getState("cookBaseManifest");
-            const soldrBinary = core.getState("cookSoldrBinary") || process.env["SOLDR_BINARY"]?.trim() || "soldr";
-            log(`cook-cache: post-step layered save_layer=${cookSaveLayer} hit=${cookHit} ` +
-                `ran=${cookRan} target=${cookTargetDir}`);
-            if (!cookRan || cookSaveLayer === "none") {
-                log("cook-cache: layered cache warm or cook did not run successfully - skipping save");
-            }
-            else if (!cookTargetDir || !fs.existsSync(cookTargetDir)) {
-                log(`cook-cache: target dir ${cookTargetDir} missing - skipping save`);
-            }
-            else if (!cookProjectRoot || !fs.existsSync(cookProjectRoot)) {
-                log(`cook-cache: project root ${cookProjectRoot} missing - skipping save`);
-            }
-            else {
-                const saveKey = cookSaveLayer === "delta" ? cookDeltaKey : cookBaseKey;
-                const archivePath = cookSaveLayer === "delta" ? cookDeltaArchive : cookBaseArchive;
-                const level = cookSaveLayer === "delta"
-                    ? core.getState("cookDeltaCompressLevel") || "3"
-                    : core.getState("cookCompressLevel") || "19";
-                const cookSaveStart = Date.now();
-                try {
-                    const saveResult = await (0, cook_cache_js_1.saveLayeredCookCache)({
-                        soldrBinary,
-                        projectRoot: cookProjectRoot,
-                        targetDir: cookTargetDir,
-                        exactKey: saveKey,
-                        archivePath,
-                        layer: cookSaveLayer === "delta" ? "delta" : "base",
-                        zstdLevel: level,
-                        baseManifestPath: cookBaseManifest,
-                        log,
-                    });
-                    if (saveResult.status === "saved") {
-                        postCollector.record({
-                            label: `cook-cache-${cookSaveLayer}`,
-                            operation: "save",
-                            hit: false,
-                            key: saveKey,
-                            matchedKey: "",
-                            restoreKeys: [],
-                            archiveBytes: saveResult.archiveBytes ?? null,
-                            inflatedBytes: saveResult.inflatedBytes ?? null,
-                            fileCount: saveResult.fileCount ?? null,
-                            durationMs: Date.now() - cookSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                    else {
-                        log(`cook-cache-${cookSaveLayer}: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
-                    }
-                }
-                catch (err) {
-                    log(`cook-cache-${cookSaveLayer}: save failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        else {
-            const cookExactKey = core.getState("cookExactKey");
-            const cookLongWindow = parseInt(core.getState("cookLongWindow") || "27", 10);
-            const cookLevel = core.getState("cookCompressLevel") || "19";
-            log(`cook-cache: post-step key=${cookExactKey} hit=${cookHit} ran=${cookRan} target=${cookTargetDir}`);
-            if (cookHit) {
-                log("cook-cache: exact hit - skipping save");
-            }
-            else if (!cookRan) {
-                log("cook-cache: cook did not run successfully - skipping save");
-            }
-            else if (!cookTargetDir || !fs.existsSync(cookTargetDir)) {
-                log(`cook-cache: target dir ${cookTargetDir} missing - skipping save`);
-            }
-            else {
-                const cookSaveStart = Date.now();
-                try {
-                    const saveResult = await (0, cook_cache_js_1.saveCookCache)({
-                        targetDir: cookTargetDir,
-                        exactKey: cookExactKey,
-                        level: cookLevel,
-                        longWindow: cookLongWindow,
-                        debug: debugMode,
-                        log,
-                    });
-                    if (saveResult.status === "saved") {
-                        postCollector.record({
-                            label: "cook-cache",
-                            operation: "save",
-                            hit: false,
-                            key: cookExactKey,
-                            matchedKey: "",
-                            restoreKeys: [],
-                            archiveBytes: saveResult.archiveBytes ?? null,
-                            inflatedBytes: saveResult.inflatedBytes ?? null,
-                            fileCount: saveResult.fileCount ?? null,
-                            durationMs: Date.now() - cookSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                    else {
-                        log(`cook-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
-                    }
-                }
-                catch (err) {
-                    log(`cook-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-    }
-    // Soldr-mini-cache save. Default-on; skipped when restore already hit
-    // (binary is byte-identical, no point re-saving), when disabled, or
-    // when running in passthrough mode.
-    const soldrMiniEnabled = core.getState("soldrMiniEnabled") === "true";
-    if (soldrMiniEnabled && !passthrough) {
-        const miniHit = core.getState("soldrMiniHit") === "true";
-        const miniExactKey = core.getState("soldrMiniExactKey");
-        const miniInstallDir = core.getState("soldrMiniInstallDir");
-        const miniArchive = core.getState("soldrMiniArchive");
-        log(`soldr-mini-cache: post-step key=${miniExactKey} hit=${miniHit} installDir=${miniInstallDir}`);
-        if (miniHit) {
-            log("soldr-mini-cache: exact hit — skipping save");
-        }
-        else if (!miniExactKey) {
-            log("soldr-mini-cache: no key (ineligible at main-time) — skipping save");
-        }
-        else if (!miniInstallDir || !fs.existsSync(miniInstallDir)) {
-            log(`soldr-mini-cache: install dir ${miniInstallDir} missing — skipping save`);
-        }
-        else {
-            const miniSaveStart = Date.now();
-            try {
-                const saveResult = await (0, soldr_mini_cache_js_1.saveMiniCache)({
-                    installDir: miniInstallDir,
-                    archivePath: miniArchive,
-                    exactKey: miniExactKey,
-                    level: "19",
-                    longWindow: 27,
-                    debug: debugMode,
-                    log,
-                });
-                if (saveResult.status === "saved") {
-                    postCollector.record({
-                        label: "soldr-mini-cache",
-                        operation: "save",
-                        hit: false,
-                        key: miniExactKey,
-                        matchedKey: "",
-                        restoreKeys: [],
-                        archiveBytes: saveResult.archiveBytes ?? null,
-                        inflatedBytes: saveResult.inflatedBytes ?? null,
-                        fileCount: saveResult.fileCount ?? null,
-                        durationMs: Date.now() - miniSaveStart,
-                        timestamp: new Date().toISOString(),
-                    });
-                }
-                else {
-                    log(`soldr-mini-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
-                }
-            }
-            catch (err) {
-                log(`soldr-mini-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    }
-    // ---- per-(host × target) cross-tool cache save (setup-soldr#106) ----
-    // Wave 2.1 of zackees/soldr#514. Save each lane whose restore missed and
-    // whose `paths` actually exist on disk after executeCrossBootstrap ran.
-    // Skipping exact hits avoids re-uploading identical content; skipping
-    // missing paths avoids cache-API failures on unsupported lanes.
-    try {
-        const lanePlansRaw = core.getState("crossToolCachePlans");
-        const restoresRaw = core.getState("crossToolCacheRestores");
-        if (lanePlansRaw) {
-            const lanePlans = JSON.parse(lanePlansRaw);
-            const restores = restoresRaw
-                ? JSON.parse(restoresRaw)
-                : {};
-            for (const lane of lanePlans) {
-                if (!lane.paths || lane.paths.length === 0) {
-                    continue; // unsupported lane, nothing to save
-                }
-                const restore = restores[lane.target];
-                if (restore?.hit) {
-                    log(`cross-tool-cache: lane=${lane.target} exact hit — skipping save`);
-                    continue;
-                }
-                // Only save when at least one of the lane's paths exists. The cache
-                // API will error on a fully-missing path list, and there's no
-                // point uploading nothing.
-                const existing = lane.paths.filter((p) => {
-                    try {
-                        return fs.existsSync(p);
-                    }
-                    catch {
-                        return false;
-                    }
-                });
-                if (existing.length === 0) {
-                    log(`cross-tool-cache: lane=${lane.target} no paths exist on disk — skipping save`);
-                    continue;
-                }
-                const t0 = Date.now();
-                try {
-                    const id = await cache.saveCache(existing, lane.key);
-                    if (id > 0) {
-                        log(`cross-tool-cache: lane=${lane.target} saved id=${id} key=${lane.key}`);
-                        postCollector.record({
-                            label: `cross-tool-cache:${lane.target}`,
-                            operation: "save",
-                            hit: false,
-                            key: lane.key,
-                            matchedKey: "",
-                            restoreKeys: [],
-                            archiveBytes: null,
-                            inflatedBytes: null,
-                            fileCount: null,
-                            durationMs: Date.now() - t0,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                    else {
-                        log(`cross-tool-cache: lane=${lane.target} save skipped (id=${id}) — likely concurrent save by another job`);
-                    }
-                }
-                catch (err) {
-                    log(`cross-tool-cache: lane=${lane.target} save failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-    }
-    catch (err) {
-        log(`cross-tool-cache: post-step failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-    // ---- Dylint tool/driver cache save (setup-soldr#221) ----
-    // Exact-key only and opt-in. Cold jobs keep their existing install/build
-    // steps; warm jobs restore cargo-dylint/dylint-link plus the compatible
-    // driver directory before those steps run.
-    try {
-        if (result.dylintCache.enabled && result.dylintCache.paths.length > 0) {
-            const exactHit = core.getState("dylintCacheExactHit") === "true";
-            if (exactHit) {
-                log("dylint-cache: exact hit - skipping save");
-            }
-            else {
-                const existing = result.dylintCache.paths.some((p) => cachePathExists(p));
-                if (!existing) {
-                    log("dylint-cache: no configured paths exist on disk - skipping save");
-                }
-                else {
-                    const t0 = Date.now();
-                    try {
-                        const id = await cache.saveCache(result.dylintCache.paths, result.dylintCache.key);
-                        if (id > 0) {
-                            log(`dylint-cache: saved id=${id} key=${result.dylintCache.key}`);
-                            postCollector.record({
-                                label: "dylint-cache",
-                                operation: "save",
-                                hit: false,
-                                key: result.dylintCache.key,
-                                matchedKey: "",
-                                restoreKeys: [],
-                                archiveBytes: null,
-                                inflatedBytes: null,
-                                fileCount: null,
-                                durationMs: Date.now() - t0,
-                                timestamp: new Date().toISOString(),
-                            });
-                        }
-                        else {
-                            log(`dylint-cache: save skipped (id=${id}) - likely concurrent save by another job`);
-                        }
-                    }
-                    catch (err) {
-                        log(`dylint-cache: save failed: ${err instanceof Error ? err.message : String(err)}`);
-                    }
-                }
-            }
-        }
-    }
-    catch (err) {
-        log(`dylint-cache: post-step failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-    const finalSummary = buildFinalCacheSummary(result, restoreState, {
-        buildCache: buildSave,
-        cargoRegistryCache: cargoRegistrySave,
-        targetCache: targetCacheSave,
-    }, passthrough);
-    logFinalCacheSummary(finalSummary, log);
-    if (compileCacheStats !== "none") {
-        setCompileCacheOutputs(finalSummary.compile_cache_report, compileCacheStats);
-        // PR4 — surface the two job-wide scalar outputs alongside the
-        // existing per-session outputs. The setter no-ops when the archive
-        // walker didn't find >1 sessions, so single-session jobs see no
-        // change in behavior.
-        setMultiSessionOutputs(finalSummary.multi_session_rollup);
-    }
-    writeStepSummary(formatFinalCacheSummaryMarkdown(finalSummary, compileCacheStats), log);
-    // Job-wide compile-cache hit/miss counts, read post-hoc from the
-    // multi-session rollup (preferred) or the last-session report. Shared by
-    // the cook reuse-mismatch warning (#235) and the zero-count guard (#227).
-    let jobHits = null;
-    let jobMisses = null;
-    {
-        const rollup = finalSummary.multi_session_rollup;
-        if (rollup && rollup.sessionCount > 0) {
-            jobHits = rollup.totalHits;
-            jobMisses = rollup.totalMisses;
-        }
-        else if (finalSummary.compile_cache_report.status === "ok" &&
-            finalSummary.compile_cache_report.report) {
-            const last = finalSummary.compile_cache_report.report["last_session"];
-            if (last) {
-                jobHits = numberStat(last, "hits") ?? null;
-                jobMisses = numberStat(last, "misses") ?? null;
-            }
-        }
-    }
-    // Cook reuse-mismatch warning (issue #235). Post-hoc only: setup-soldr
-    // can't know the consumer's downstream cargo profile/toolchain at cook
-    // time, so the "cook ran but nothing reused it" fingerprint is only
-    // observable here, after the job's compiles have been recorded.
-    {
-        const cookSignal = (0, compile_cache_stats_js_1.detectCookReuseMismatch)({
-            cookEnabled: core.getState("cookEnabled") === "true",
-            cookProducedDeps: core.getState("cookHit") === "true" || core.getState("cookRan") === "true",
-            hits: jobHits,
-            misses: jobMisses,
-            cookFlags: rawInputs.prebuildDepsFlags,
-        });
-        if (cookSignal.mismatch)
-            core.warning(cookSignal.message);
-    }
-    // Compile-cache activity verification (issue #227). Opt-in via
-    // verify-compile-cache. When a job that is expected to exercise zccache
-    // reports hits+misses==0, the build bypassed the cache (or the measurement
-    // is invalid) — fail or warn instead of laundering it into warm-cache
-    // evidence. Every legitimate bypass (passthrough, build-cache off, no
-    // stats) is reported as a quiet skip.
-    {
-        const verify = (0, compile_cache_stats_js_1.verifyCompileCacheActivity)({
-            mode: (0, compile_cache_stats_js_1.parseVerifyCompileCacheMode)(rawInputs.verifyCompileCache),
-            enabled: !passthrough,
-            buildCacheEnabled: restoreState.buildCacheEnabled,
-            reportStatus: finalSummary.compile_cache_report.status,
-            hits: jobHits,
-            misses: jobMisses,
-            env: {
-                rustcWrapper: process.env["RUSTC_WRAPPER"],
-                soldrCacheDir: process.env["SOLDR_CACHE_DIR"],
-                zccacheCacheDir: process.env["ZCCACHE_CACHE_DIR"],
-                shimsDir: process.env["SETUP_SOLDR_SHIMS_DIR"],
-                statsPath: finalSummary.compile_cache_report.status === "ok"
-                    ? resolveZccacheSessionStatsPath(result.buildCache.path)
-                    : undefined,
-            },
-        });
-        core.setOutput("compile-cache-verification", verify.status);
-        if (verify.fail) {
-            core.setFailed(verify.message);
-        }
-        else if (verify.status === "invalid-measurement") {
-            core.warning(verify.message);
-        }
-        else if (verify.message && (0, diagnostics_js_1.loggingEnabled)(rawInputs.logging)) {
-            log(verify.message);
-        }
-    }
-    // PR3 — insights mode side-effects: emit GH annotations + optional
-    // chrome-trace artifact upload. These run only when the user explicitly
-    // opted into `insights`; the markdown insights block already landed in
-    // the step summary above via formatFinalCacheSummaryMarkdown.
-    if (compileCacheStats === "insights") {
-        await emitInsightsAnnotationsAndTrace({
-            report: finalSummary.compile_cache_report,
-            soldrBinary: process.env["SOLDR_BINARY"]?.trim(),
-            runnerTemp,
-            log,
-        });
-    }
-    const reportPath = writeCompileCacheReportFile(finalSummary.compile_cache_report, runnerTemp, log);
-    if (reportPath) {
-        log(`compile-cache-report.json written to ${reportPath}`);
-    }
-    // Note: setup-soldr-cache-keys.txt is written in main.ts (right after
-    // resolveSetup) so workflow steps that run between main and post —
-    // notably actions/upload-artifact — can read it. Re-write it here
-    // anyway as a safety net in case main.ts crashed before writing.
-    if (runnerTemp) {
-        writeCacheKeysManifestFromSummary(finalSummary, runnerTemp, log);
-    }
-    // Append save ops to detailed session log if requested
-    if (statsMode === "detailed" && runnerTemp) {
-        try {
-            await postCollector.appendSavesToSessionLog(runnerTemp);
-        }
-        catch (err) {
-            log(`post: stats log append failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    // Optional verbose diagnostic dump. Gated on `logging: true` which
-    // main.ts persists into action state.
-    const loggingState = core.getState("logging");
-    if ((0, diagnostics_js_1.loggingEnabled)(loggingState)) {
-        // zccache writes its per-rustc-invocation JSONL journal under the
-        // build-cache directory (which == ZCCACHE_CACHE_DIR per
-        // resolve-setup.ts's env exports). When `logging: true` is on we
-        // surface its contents so the reader can answer "warm reported 0
-        // hits — why did each lookup miss" without another build.
-        const journalPath = path.join(result.buildCache.path, "logs", "last-session.jsonl");
-        // Forward the verbatim `report` field from `soldr cache report --json`
-        // so dumpDiagnostics can format its `rollups` (per-extension /
-        // per-crate / slowest_entries) breakdown.
-        const cacheReport = finalSummary.compile_cache_report.report;
-        // Capture a process snapshot only when debug mode is on — `ps` /
-        // `tasklist` are cheap but the output is large and only useful when
-        // you're investigating cache-state weirdness (e.g. orphan daemons).
-        const processSnapshot = debugMode ? (0, diagnostics_js_1.captureProcessSnapshot)() ?? undefined : undefined;
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "post",
-            env: process.env,
-            rawInputs,
-            result,
-            cacheOutcomes: postCollector.snapshot(),
-            finalSummary: finalSummary,
-            journalPath,
-            // Raw JSONL stream — one record per rustc invocation, often
-            // thousands of lines / 20-30 MB of stdout per warm build. Default
-            // gate is `debug:true` (backwards compat with #134 era), but a
-            // workflow can explicitly opt out via `journal-print-raw: false`
-            // when it already uploads the JSONL as an artifact and doesn't
-            // want to pay the post-step log-writer cost (~30-50 s on the
-            // hosted ubuntu demo).
-            journalPrintRaw: resolveJournalPrintRaw(rawInputs.journalPrintRaw, debugMode),
-            cacheReport,
-            processSnapshot,
-            logger,
-            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
-        });
-    }
-}
-function writeCacheKeysManifestFromSummary(summary, runnerTemp, log) {
-    const keys = [
-        summary.setup_cache.key,
-        summary.build_cache.key,
-        summary.target_cache.key,
-        summary.cargo_registry_cache.key,
-    ].filter((k) => Boolean(k));
-    if (keys.length === 0)
-        return;
-    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
-    try {
-        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
-        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
-    }
-    catch (err) {
-        log(`post: failed to write cache-keys manifest: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-// See main.ts for the rationale behind the test-import escape hatch.
-if (typeof process !== "undefined" &&
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.warning(`setup-soldr post-job step failed: ${message}`);
-    });
-}
-
 
 /***/ }),
 
@@ -67646,7 +67667,7 @@ module.exports = {
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(190)
+const { kClients } = __nccwpck_require__(191)
 const Agent = __nccwpck_require__(5)
 const {
   kAgent,
@@ -67659,13 +67680,13 @@ const {
   kOptions,
   kFactory
 } = __nccwpck_require__(450)
-const MockClient = __nccwpck_require__(194)
-const MockPool = __nccwpck_require__(336)
+const MockClient = __nccwpck_require__(195)
+const MockPool = __nccwpck_require__(337)
 const { matchValue, buildMockOptions } = __nccwpck_require__(7)
 const { InvalidArgumentError, UndiciError } = __nccwpck_require__(468)
 const Dispatcher = __nccwpck_require__(458)
-const Pluralizer = __nccwpck_require__(247)
-const PendingInterceptorsFormatter = __nccwpck_require__(226)
+const Pluralizer = __nccwpck_require__(248)
+const PendingInterceptorsFormatter = __nccwpck_require__(227)
 
 class FakeWeakRef {
   constructor (value) {
@@ -67845,7 +67866,7 @@ __export(tlsPolicy_exports, {
   tlsPolicyName: () => tlsPolicyName
 });
 module.exports = __toCommonJS(tlsPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(280);
 const tlsPolicyName = import_policies.tlsPolicyName;
 function tlsPolicy(tlsSettings) {
   return (0, import_policies.tlsPolicy)(tlsSettings);
@@ -68016,9 +68037,9 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(353)
-const Pool = __nccwpck_require__(327)
-const { kUrl, kInterceptors } = __nccwpck_require__(190)
+} = __nccwpck_require__(354)
+const Pool = __nccwpck_require__(328)
+const { kUrl, kInterceptors } = __nccwpck_require__(191)
 const { parseOrigin } = __nccwpck_require__(67)
 const kFactory = Symbol('factory')
 
@@ -68598,7 +68619,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(284);
+var import_userAgent = __nccwpck_require__(285);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -68626,7 +68647,7 @@ function userAgentPolicy(options = {}) {
 
 
 const util = __nccwpck_require__(67)
-const { kBodyUsed } = __nccwpck_require__(190)
+const { kBodyUsed } = __nccwpck_require__(191)
 const assert = __nccwpck_require__(503)
 const { InvalidArgumentError } = __nccwpck_require__(468)
 const EE = __nccwpck_require__(449)
@@ -68900,7 +68921,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(280);
 const exponentialRetryPolicyName = import_policies.exponentialRetryPolicyName;
 function exponentialRetryPolicy(options = {}) {
   return (0, import_policies.exponentialRetryPolicy)(options);
@@ -69236,16 +69257,16 @@ exports.BlobServiceClient = void 0;
 const core_auth_1 = __nccwpck_require__(492);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 const core_util_1 = __nccwpck_require__(12);
-const Pipeline_js_1 = __nccwpck_require__(178);
+const Pipeline_js_1 = __nccwpck_require__(179);
 const ContainerClient_js_1 = __nccwpck_require__(62);
-const utils_common_js_1 = __nccwpck_require__(152);
-const storage_common_1 = __nccwpck_require__(270);
-const utils_common_js_2 = __nccwpck_require__(152);
+const utils_common_js_1 = __nccwpck_require__(153);
+const storage_common_1 = __nccwpck_require__(271);
+const utils_common_js_2 = __nccwpck_require__(153);
 const tracing_js_1 = __nccwpck_require__(29);
 const BlobBatchClient_js_1 = __nccwpck_require__(385);
 const StorageClient_js_1 = __nccwpck_require__(434);
 const AccountSASPermissions_js_1 = __nccwpck_require__(56);
-const AccountSASSignatureValues_js_1 = __nccwpck_require__(281);
+const AccountSASSignatureValues_js_1 = __nccwpck_require__(282);
 const AccountSASServices_js_1 = __nccwpck_require__(364);
 /**
  * A BlobServiceClient represents a Client to the Azure Storage Blob service allowing you
@@ -69948,14 +69969,14 @@ exports.BlobServiceClient = BlobServiceClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatchClient = void 0;
-const BatchResponseParser_js_1 = __nccwpck_require__(301);
-const BatchUtils_js_1 = __nccwpck_require__(251);
-const BlobBatch_js_1 = __nccwpck_require__(324);
+const BatchResponseParser_js_1 = __nccwpck_require__(302);
+const BatchUtils_js_1 = __nccwpck_require__(252);
+const BlobBatch_js_1 = __nccwpck_require__(325);
 const tracing_js_1 = __nccwpck_require__(29);
-const storage_common_1 = __nccwpck_require__(270);
-const StorageContextClient_js_1 = __nccwpck_require__(261);
-const Pipeline_js_1 = __nccwpck_require__(178);
-const utils_common_js_1 = __nccwpck_require__(152);
+const storage_common_1 = __nccwpck_require__(271);
+const StorageContextClient_js_1 = __nccwpck_require__(262);
+const Pipeline_js_1 = __nccwpck_require__(179);
+const utils_common_js_1 = __nccwpck_require__(153);
 /**
  * A BlobBatchClient allows you to make batched requests to the Azure Storage Blob service.
  *
@@ -70129,7 +70150,7 @@ exports.BlobBatchClient = BlobBatchClient;
 
 
 const Decoder = __nccwpck_require__(41)
-const decodeText = __nccwpck_require__(269)
+const decodeText = __nccwpck_require__(270)
 const getLimit = __nccwpck_require__(463)
 
 const RE_CHARSET = /^charset$/i
@@ -70350,7 +70371,7 @@ exports.createDefaultTracingSpan = createDefaultTracingSpan;
 exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
-const tracingContext_js_1 = __nccwpck_require__(354);
+const tracingContext_js_1 = __nccwpck_require__(355);
 const state_js_1 = __nccwpck_require__(95);
 function createDefaultTracingSpan() {
     return {
@@ -70479,9 +70500,9 @@ exports.snapshotSourceMtimes = snapshotSourceMtimes;
 exports.replaySourceMtimes = replaySourceMtimes;
 exports.writeSnapshotFile = writeSnapshotFile;
 exports.readSnapshotFile = readSnapshotFile;
-const fs = __importStar(__nccwpck_require__(242));
+const fs = __importStar(__nccwpck_require__(243));
 const path = __importStar(__nccwpck_require__(487));
-const node_crypto_1 = __nccwpck_require__(268);
+const node_crypto_1 = __nccwpck_require__(269);
 const normalize_source_mtime_js_1 = __nccwpck_require__(76);
 exports.SNAPSHOT_FILENAME = "setup-soldr-source-mtimes.json";
 async function hashFile(absolute) {
@@ -70658,9 +70679,9 @@ function readSnapshotFile(filePath) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
-const binary_format_contract_1 = __nccwpck_require__(323);
+const binary_format_contract_1 = __nccwpck_require__(324);
 const reflection_info_1 = __nccwpck_require__(432);
-const reflection_long_convert_1 = __nccwpck_require__(155);
+const reflection_long_convert_1 = __nccwpck_require__(156);
 const reflection_scalar_default_1 = __nccwpck_require__(442);
 /**
  * Reads proto3 messages in binary format using reflection information.
@@ -71280,7 +71301,7 @@ exports.getOptions = getOptions;
 
 /* istanbul ignore file: only for Node 12 */
 
-const { kConnected, kSize } = __nccwpck_require__(190)
+const { kConnected, kSize } = __nccwpck_require__(191)
 
 class CompatWeakRef {
   constructor (value) {
@@ -71340,7 +71361,7 @@ exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTie
 exports.toAccessTier = toAccessTier;
 exports.ensureCpkIfSpecified = ensureCpkIfSpecified;
 exports.getBlobServiceAccountAudience = getBlobServiceAccountAudience;
-const constants_js_1 = __nccwpck_require__(146);
+const constants_js_1 = __nccwpck_require__(147);
 /**
  * Represents the access tier on a blob.
  * For detailed information about block blob level tiering see {@link https://learn.microsoft.com/azure/storage/blobs/storage-blob-storage-tiers|Hot, cool and archive storage tiers.}
@@ -71463,12 +71484,12 @@ function getBlobServiceAccountAudience(storageAccountName) {
 
 
 const WritableStream = (__nccwpck_require__(409).Writable)
-const { inherits } = __nccwpck_require__(359)
+const { inherits } = __nccwpck_require__(360)
 const Dicer = __nccwpck_require__(11)
 
 const MultipartParser = __nccwpck_require__(0)
 const UrlencodedParser = __nccwpck_require__(386)
-const parseParams = __nccwpck_require__(187)
+const parseParams = __nccwpck_require__(188)
 
 function Busboy (opts) {
   if (!(this instanceof Busboy)) { return new Busboy(opts) }
@@ -71796,8 +71817,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReader = void 0;
 // TODO: Do a review of non-interfaces
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
-const AvroConstants_js_1 = __nccwpck_require__(222);
-const AvroParser_js_1 = __nccwpck_require__(292);
+const AvroConstants_js_1 = __nccwpck_require__(223);
+const AvroParser_js_1 = __nccwpck_require__(293);
 const utils_common_js_1 = __nccwpck_require__(375);
 class AvroReader {
     _dataStream;
@@ -71922,13 +71943,13 @@ exports.CacheService = exports.GetCacheEntryDownloadURLResponse = exports.GetCac
 // @generated by protobuf-ts 2.9.1 with parameter long_type_string,client_none,generate_dependencies
 // @generated from protobuf file "results/api/v1/cache.proto" (package "github.actions.results.api.v1", syntax proto3)
 // tslint:disable
-const runtime_rpc_1 = __nccwpck_require__(170);
+const runtime_rpc_1 = __nccwpck_require__(171);
 const runtime_1 = __nccwpck_require__(17);
 const runtime_2 = __nccwpck_require__(17);
 const runtime_3 = __nccwpck_require__(17);
 const runtime_4 = __nccwpck_require__(17);
 const runtime_5 = __nccwpck_require__(17);
-const cachemetadata_1 = __nccwpck_require__(227);
+const cachemetadata_1 = __nccwpck_require__(228);
 // @generated message type with reflection information, may provide speed optimized methods
 class CreateCacheEntryRequest$Type extends runtime_5.MessageType {
     constructor() {
@@ -72327,7 +72348,7 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(126)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(127)
 const { isCTLExcludingHtab } = __nccwpck_require__(391)
 const { collectASequenceOfCodePointsFast } = __nccwpck_require__(23)
 const assert = __nccwpck_require__(503)
@@ -73272,7 +73293,7 @@ __export(userAgentPlatform_exports, {
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
 var import_node_os = __toESM(__nccwpck_require__(367));
-var import_node_process = __toESM(__nccwpck_require__(229));
+var import_node_process = __toESM(__nccwpck_require__(230));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -73368,7 +73389,7 @@ exports.DefaultGlobber = void 0;
 const core = __importStar(__nccwpck_require__(439));
 const fs = __importStar(__nccwpck_require__(507));
 const globOptionsHelper = __importStar(__nccwpck_require__(394));
-const path = __importStar(__nccwpck_require__(241));
+const path = __importStar(__nccwpck_require__(242));
 const patternHelper = __importStar(__nccwpck_require__(42));
 const internal_match_kind_1 = __nccwpck_require__(505);
 const internal_pattern_1 = __nccwpck_require__(482);
@@ -73563,7 +73584,7 @@ exports.DefaultGlobber = DefaultGlobber;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOperationArgumentValueFromParameter = getOperationArgumentValueFromParameter;
 exports.getOperationRequestInfo = getOperationRequestInfo;
-const state_js_1 = __nccwpck_require__(321);
+const state_js_1 = __nccwpck_require__(322);
 /**
  * @internal
  * Retrieves the value to use for a given operation argument
@@ -73777,8 +73798,8 @@ module.exports = upgrade
 "use strict";
 
 const os = __nccwpck_require__(90);
-const tty = __nccwpck_require__(177);
-const hasFlag = __nccwpck_require__(351);
+const tty = __nccwpck_require__(178);
+const hasFlag = __nccwpck_require__(352);
 
 const {env} = process;
 
@@ -73939,7 +73960,7 @@ __export(checkInsecureConnection_exports, {
   ensureSecureConnection: () => ensureSecureConnection
 });
 module.exports = __toCommonJS(checkInsecureConnection_exports);
-var import_log = __nccwpck_require__(149);
+var import_log = __nccwpck_require__(150);
 let insecureConnectionWarningEmmitted = false;
 function allowInsecureConnection(request, options) {
   if (options.allowInsecureConnection && request.allowInsecureConnection) {
@@ -74165,9 +74186,9 @@ exports.authorizeRequestOnTenantChallenge = exports.authorizeRequestOnClaimChall
 var serializer_js_1 = __nccwpck_require__(460);
 Object.defineProperty(exports, "createSerializer", ({ enumerable: true, get: function () { return serializer_js_1.createSerializer; } }));
 Object.defineProperty(exports, "MapperTypeNames", ({ enumerable: true, get: function () { return serializer_js_1.MapperTypeNames; } }));
-var serviceClient_js_1 = __nccwpck_require__(305);
+var serviceClient_js_1 = __nccwpck_require__(306);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
-var pipeline_js_1 = __nccwpck_require__(277);
+var pipeline_js_1 = __nccwpck_require__(278);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
 var interfaces_js_1 = __nccwpck_require__(98);
 Object.defineProperty(exports, "XML_ATTRKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_ATTRKEY; } }));
@@ -74180,7 +74201,7 @@ Object.defineProperty(exports, "serializationPolicy", ({ enumerable: true, get: 
 Object.defineProperty(exports, "serializationPolicyName", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicyName; } }));
 var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(111);
 Object.defineProperty(exports, "authorizeRequestOnClaimChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnClaimChallenge_js_1.authorizeRequestOnClaimChallenge; } }));
-var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(168);
+var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(169);
 Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnTenantChallenge_js_1.authorizeRequestOnTenantChallenge; } }));
 //# sourceMappingURL=index.js.map
 
@@ -74226,9 +74247,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTar = exports.extractTar = exports.listTar = void 0;
 const exec_1 = __nccwpck_require__(16);
-const io = __importStar(__nccwpck_require__(286));
+const io = __importStar(__nccwpck_require__(287));
 const fs_1 = __nccwpck_require__(507);
-const path = __importStar(__nccwpck_require__(241));
+const path = __importStar(__nccwpck_require__(242));
 const utils = __importStar(__nccwpck_require__(73));
 const constants_1 = __nccwpck_require__(44);
 const IS_WINDOWS = process.platform === 'win32';
@@ -74501,14 +74522,14 @@ __export(nodeHttpClient_exports, {
   getBodyLength: () => getBodyLength
 });
 module.exports = __toCommonJS(nodeHttpClient_exports);
-var import_node_http = __toESM(__nccwpck_require__(257));
+var import_node_http = __toESM(__nccwpck_require__(258));
 var import_node_https = __toESM(__nccwpck_require__(372));
 var import_node_zlib = __toESM(__nccwpck_require__(497));
 var import_node_stream = __nccwpck_require__(409);
 var import_AbortError = __nccwpck_require__(9);
 var import_httpHeaders = __nccwpck_require__(465);
 var import_restError = __nccwpck_require__(424);
-var import_log = __nccwpck_require__(149);
+var import_log = __nccwpck_require__(150);
 var import_sanitizer = __nccwpck_require__(120);
 const DEFAULT_TLS_SETTINGS = {};
 function isReadableStream(body) {
@@ -74933,7 +74954,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const crypto = __importStar(__nccwpck_require__(283));
+const crypto = __importStar(__nccwpck_require__(284));
 const fs = __importStar(__nccwpck_require__(507));
 const os = __importStar(__nccwpck_require__(90));
 const utils_1 = __nccwpck_require__(484);
@@ -74995,7 +75016,7 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_error = __nccwpck_require__(151);
+var import_error = __nccwpck_require__(152);
 var import_inspect = __nccwpck_require__(1);
 var import_sanitizer = __nccwpck_require__(120);
 const errorSanitizer = new import_sanitizer.Sanitizer();
@@ -75138,9 +75159,9 @@ function wrapAbortSignalLike(abortSignalLike) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 const coreHttpCompat = tslib_1.__importStar(__nccwpck_require__(70));
-const index_js_1 = __nccwpck_require__(271);
+const index_js_1 = __nccwpck_require__(272);
 class StorageClient extends coreHttpCompat.ExtendedServiceClient {
     url;
     version;
@@ -75206,36 +75227,36 @@ exports.StorageClient = StorageClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = exports.StorageSharedKeyCredentialPolicy = exports.StorageSharedKeyCredential = exports.StorageRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = exports.Credential = exports.CredentialPolicy = exports.BaseRequestPolicy = exports.AnonymousCredentialPolicy = exports.AnonymousCredential = exports.StorageOAuthScopes = exports.newPipeline = exports.isPipelineLike = exports.Pipeline = exports.getBlobServiceAccountAudience = exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTier = exports.generateBlobSASQueryParameters = exports.generateAccountSASQueryParameters = void 0;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 const core_rest_pipeline_1 = __nccwpck_require__(100);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
 tslib_1.__exportStar(__nccwpck_require__(384), exports);
-tslib_1.__exportStar(__nccwpck_require__(180), exports);
+tslib_1.__exportStar(__nccwpck_require__(181), exports);
 tslib_1.__exportStar(__nccwpck_require__(62), exports);
-tslib_1.__exportStar(__nccwpck_require__(199), exports);
+tslib_1.__exportStar(__nccwpck_require__(200), exports);
 tslib_1.__exportStar(__nccwpck_require__(56), exports);
 tslib_1.__exportStar(__nccwpck_require__(2), exports);
 tslib_1.__exportStar(__nccwpck_require__(364), exports);
-var AccountSASSignatureValues_js_1 = __nccwpck_require__(281);
+var AccountSASSignatureValues_js_1 = __nccwpck_require__(282);
 Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(324), exports);
+tslib_1.__exportStar(__nccwpck_require__(325), exports);
 tslib_1.__exportStar(__nccwpck_require__(385), exports);
-tslib_1.__exportStar(__nccwpck_require__(169), exports);
+tslib_1.__exportStar(__nccwpck_require__(170), exports);
 tslib_1.__exportStar(__nccwpck_require__(483), exports);
 var BlobSASSignatureValues_js_1 = __nccwpck_require__(66);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(273), exports);
+tslib_1.__exportStar(__nccwpck_require__(274), exports);
 var models_js_1 = __nccwpck_require__(396);
 Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: function () { return models_js_1.BlockBlobTier; } }));
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
 Object.defineProperty(exports, "getBlobServiceAccountAudience", ({ enumerable: true, get: function () { return models_js_1.getBlobServiceAccountAudience; } }));
-var Pipeline_js_1 = __nccwpck_require__(178);
+var Pipeline_js_1 = __nccwpck_require__(179);
 Object.defineProperty(exports, "Pipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.Pipeline; } }));
 Object.defineProperty(exports, "isPipelineLike", ({ enumerable: true, get: function () { return Pipeline_js_1.isPipelineLike; } }));
 Object.defineProperty(exports, "newPipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.newPipeline; } }));
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return Pipeline_js_1.StorageOAuthScopes; } }));
-var storage_common_1 = __nccwpck_require__(270);
+var storage_common_1 = __nccwpck_require__(271);
 Object.defineProperty(exports, "AnonymousCredential", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredential; } }));
 Object.defineProperty(exports, "AnonymousCredentialPolicy", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredentialPolicy; } }));
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return storage_common_1.BaseRequestPolicy; } }));
@@ -75249,7 +75270,7 @@ Object.defineProperty(exports, "StorageSharedKeyCredentialPolicy", ({ enumerable
 Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
 tslib_1.__exportStar(__nccwpck_require__(502), exports);
-tslib_1.__exportStar(__nccwpck_require__(314), exports);
+tslib_1.__exportStar(__nccwpck_require__(315), exports);
 var log_js_1 = __nccwpck_require__(105);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
@@ -75263,7 +75284,7 @@ Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SPECIAL_HEADERS = exports.HEADER_STATE = exports.MINOR = exports.MAJOR = exports.CONNECTION_TOKEN_CHARS = exports.HEADER_CHARS = exports.TOKEN = exports.STRICT_TOKEN = exports.HEX = exports.URL_CHAR = exports.STRICT_URL_CHAR = exports.USERINFO_CHARS = exports.MARK = exports.ALPHANUM = exports.NUM = exports.HEX_MAP = exports.NUM_MAP = exports.ALPHA = exports.FINISH = exports.H_METHOD_MAP = exports.METHOD_MAP = exports.METHODS_RTSP = exports.METHODS_ICE = exports.METHODS_HTTP = exports.METHODS = exports.LENIENT_FLAGS = exports.FLAGS = exports.TYPE = exports.ERROR = void 0;
-const utils_1 = __nccwpck_require__(299);
+const utils_1 = __nccwpck_require__(300);
 // C headers
 var ERROR;
 (function (ERROR) {
@@ -75572,7 +75593,7 @@ var import_httpHeaders = __nccwpck_require__(465);
 var import_pipelineRequest = __nccwpck_require__(114);
 var import_clientHelpers = __nccwpck_require__(472);
 var import_typeGuards = __nccwpck_require__(477);
-var import_multipart = __nccwpck_require__(263);
+var import_multipart = __nccwpck_require__(264);
 async function sendRequest(method, url, pipeline, options = {}, customHttpClient) {
   const httpClient = customHttpClient ?? (0, import_clientHelpers.getCachedDefaultHttpsClient)();
   const request = buildPipelineRequest(method, url, options);
@@ -75784,15 +75805,15 @@ const {
   subresourceSet,
   DOMException
 } = __nccwpck_require__(28)
-const { kHeadersList } = __nccwpck_require__(190)
+const { kHeadersList } = __nccwpck_require__(191)
 const EE = __nccwpck_require__(449)
-const { Readable, pipeline } = __nccwpck_require__(129)
+const { Readable, pipeline } = __nccwpck_require__(130)
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(67)
 const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(23)
-const { TransformStream } = __nccwpck_require__(250)
+const { TransformStream } = __nccwpck_require__(251)
 const { getGlobalDispatcher } = __nccwpck_require__(361)
 const { webidl } = __nccwpck_require__(436)
-const { STATUS_CODES } = __nccwpck_require__(320)
+const { STATUS_CODES } = __nccwpck_require__(321)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
 /** @type {import('buffer').resolveObjectURL} */
@@ -77533,7 +77554,7 @@ async function httpNetworkFetch (
   // cancelAlgorithm set to cancelAlgorithm, highWaterMark set to
   // highWaterMark, and sizeAlgorithm set to sizeAlgorithm.
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(250).ReadableStream)
+    ReadableStream = (__nccwpck_require__(251).ReadableStream)
   }
 
   const stream = new ReadableStream(
@@ -78157,9 +78178,9 @@ exports.lowerCamelCase = lowerCamelCase;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const StorageContextClient_js_1 = __nccwpck_require__(261);
-const Pipeline_js_1 = __nccwpck_require__(178);
-const utils_common_js_1 = __nccwpck_require__(152);
+const StorageContextClient_js_1 = __nccwpck_require__(262);
+const Pipeline_js_1 = __nccwpck_require__(179);
+const utils_common_js_1 = __nccwpck_require__(153);
 /**
  * A StorageClient represents a based URL class for {@link BlobServiceClient}, {@link ContainerClient}
  * and etc.
@@ -78947,7 +78968,7 @@ module.exports = {
  * Module dependencies.
  */
 
-const tty = __nccwpck_require__(177);
+const tty = __nccwpck_require__(178);
 const util = __nccwpck_require__(122);
 
 /**
@@ -79182,7 +79203,7 @@ function init(debug) {
 	}
 }
 
-module.exports = __nccwpck_require__(141)(exports);
+module.exports = __nccwpck_require__(142)(exports);
 
 const {formatters} = module.exports;
 
@@ -79266,9 +79287,9 @@ exports.redactValue = redactValue;
 exports.captureProcessSnapshot = captureProcessSnapshot;
 exports.dumpDiagnostics = dumpDiagnostics;
 exports.loggingEnabled = loggingEnabled;
-const fs = __importStar(__nccwpck_require__(242));
-const node_child_process_1 = __nccwpck_require__(192);
-const compile_journal_js_1 = __nccwpck_require__(156);
+const fs = __importStar(__nccwpck_require__(243));
+const node_child_process_1 = __nccwpck_require__(193);
+const compile_journal_js_1 = __nccwpck_require__(157);
 const ENV_KEY_PREFIXES = [
     "INPUT_",
     "SOLDR_",
@@ -79634,8 +79655,8 @@ const command_1 = __nccwpck_require__(509);
 const file_command_1 = __nccwpck_require__(423);
 const utils_1 = __nccwpck_require__(484);
 const os = __importStar(__nccwpck_require__(90));
-const path = __importStar(__nccwpck_require__(241));
-const oidc_utils_1 = __nccwpck_require__(132);
+const path = __importStar(__nccwpck_require__(242));
+const oidc_utils_1 = __nccwpck_require__(133);
 /**
  * The code to exit an action
  */
@@ -79920,17 +79941,17 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(333);
+var summary_1 = __nccwpck_require__(334);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(333);
+var summary_2 = __nccwpck_require__(334);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(322);
+var path_utils_1 = __nccwpck_require__(323);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
@@ -80053,7 +80074,7 @@ function repeatedMsgEq(type, a, b) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
 const reflection_info_1 = __nccwpck_require__(432);
-const reflection_long_convert_1 = __nccwpck_require__(155);
+const reflection_long_convert_1 = __nccwpck_require__(156);
 const pb_long_1 = __nccwpck_require__(116);
 /**
  * Creates the default value for a scalar type.
@@ -80682,7 +80703,7 @@ function localstorage() {
 	}
 }
 
-module.exports = __nccwpck_require__(141)(exports);
+module.exports = __nccwpck_require__(142)(exports);
 
 const {formatters} = module.exports;
 
@@ -81049,7 +81070,7 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_policies = __nccwpck_require__(279);
+var import_policies = __nccwpck_require__(280);
 const proxyPolicyName = import_policies.proxyPolicyName;
 function getDefaultProxySettings(proxyUrl) {
   return (0, import_policies.getDefaultProxySettings)(proxyUrl);
@@ -82008,10 +82029,10 @@ exports.ServiceType = ServiceType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
-const tslib_1 = __nccwpck_require__(210);
+const tslib_1 = __nccwpck_require__(211);
 const base64 = tslib_1.__importStar(__nccwpck_require__(417));
 const interfaces_js_1 = __nccwpck_require__(98);
-const utils_js_1 = __nccwpck_require__(303);
+const utils_js_1 = __nccwpck_require__(304);
 class SerializerImpl {
     modelMappers;
     isXML;
@@ -82952,12 +82973,12 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 "use strict";
 
 
-const { Writable } = __nccwpck_require__(129)
-const diagnosticsChannel = __nccwpck_require__(140)
+const { Writable } = __nccwpck_require__(130)
+const diagnosticsChannel = __nccwpck_require__(141)
 const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(445)
 const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(97)
 const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(55)
-const { WebsocketFrameSend } = __nccwpck_require__(182)
+const { WebsocketFrameSend } = __nccwpck_require__(183)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -83489,8 +83510,8 @@ function createHttpHeaders(rawHeaders) {
 /***/ 466:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __nccwpck_require__(338);
-var balanced = __nccwpck_require__(130);
+var concatMap = __nccwpck_require__(339);
+var balanced = __nccwpck_require__(131);
 
 module.exports = expandTop;
 
@@ -83732,8 +83753,8 @@ __export(log_exports, {
 });
 module.exports = __toCommonJS(log_exports);
 var import_node_os = __nccwpck_require__(367);
-var import_node_util = __toESM(__nccwpck_require__(359));
-var import_node_process = __toESM(__nccwpck_require__(229));
+var import_node_util = __toESM(__nccwpck_require__(360));
+var import_node_process = __toESM(__nccwpck_require__(230));
 function log(message, ...args) {
   import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
 }
@@ -84154,7 +84175,7 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 var net = __nccwpck_require__(488);
 var tls = __nccwpck_require__(485);
-var http = __nccwpck_require__(320);
+var http = __nccwpck_require__(321);
 var https = __nccwpck_require__(68);
 var events = __nccwpck_require__(449);
 var assert = __nccwpck_require__(503);
@@ -84478,13 +84499,13 @@ exports.applyStagedToLiveRoots = applyStagedToLiveRoots;
 exports.saveSoloCache = saveSoloCache;
 exports.restoreSoloCache = restoreSoloCache;
 exports.verifyRestoredToolchain = verifyRestoredToolchain;
-const node_crypto_1 = __nccwpck_require__(268);
-const fs = __importStar(__nccwpck_require__(242));
+const node_crypto_1 = __nccwpck_require__(269);
+const fs = __importStar(__nccwpck_require__(243));
 const fsp = __importStar(__nccwpck_require__(107));
 const path = __importStar(__nccwpck_require__(487));
-const cache = __importStar(__nccwpck_require__(208));
+const cache = __importStar(__nccwpck_require__(209));
 const exec = __importStar(__nccwpck_require__(16));
-const cache_compress_js_1 = __nccwpck_require__(272);
+const cache_compress_js_1 = __nccwpck_require__(273);
 /**
  * The two live roots whose deltas this cache layer tracks. The string keys
  * are also the directory names used inside the tarball staging layout.
@@ -84836,14 +84857,14 @@ __export(clientHelpers_exports, {
   getCachedDefaultHttpsClient: () => getCachedDefaultHttpsClient
 });
 module.exports = __toCommonJS(clientHelpers_exports);
-var import_defaultHttpClient = __nccwpck_require__(356);
-var import_createPipelineFromOptions = __nccwpck_require__(306);
-var import_apiVersionPolicy = __nccwpck_require__(220);
-var import_credentials = __nccwpck_require__(183);
+var import_defaultHttpClient = __nccwpck_require__(357);
+var import_createPipelineFromOptions = __nccwpck_require__(307);
+var import_apiVersionPolicy = __nccwpck_require__(221);
+var import_credentials = __nccwpck_require__(184);
 var import_apiKeyAuthenticationPolicy = __nccwpck_require__(85);
-var import_basicAuthenticationPolicy = __nccwpck_require__(150);
+var import_basicAuthenticationPolicy = __nccwpck_require__(151);
 var import_bearerAuthenticationPolicy = __nccwpck_require__(365);
-var import_oauth2AuthenticationPolicy = __nccwpck_require__(328);
+var import_oauth2AuthenticationPolicy = __nccwpck_require__(329);
 let cachedHttpClient;
 function createDefaultPipeline(options = {}) {
   const pipeline = (0, import_createPipelineFromOptions.createPipelineFromOptions)(options);
@@ -85243,7 +85264,7 @@ exports.AbortError = AbortError;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQuickQueryStream = void 0;
 const node_stream_1 = __nccwpck_require__(409);
-const index_js_1 = __nccwpck_require__(325);
+const index_js_1 = __nccwpck_require__(326);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -85390,8 +85411,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
 const os = __importStar(__nccwpck_require__(90));
-const path = __importStar(__nccwpck_require__(241));
-const pathHelper = __importStar(__nccwpck_require__(215));
+const path = __importStar(__nccwpck_require__(242));
+const pathHelper = __importStar(__nccwpck_require__(216));
 const assert_1 = __importDefault(__nccwpck_require__(503));
 const minimatch_1 = __nccwpck_require__(123);
 const internal_match_kind_1 = __nccwpck_require__(505);
@@ -85949,13 +85970,13 @@ module.exports = require("timers");
 "use strict";
 
 
-const Readable = __nccwpck_require__(127)
+const Readable = __nccwpck_require__(128)
 const {
   InvalidArgumentError,
   RequestAbortedError
 } = __nccwpck_require__(468)
 const util = __nccwpck_require__(67)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(184)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(185)
 const { AsyncResource } = __nccwpck_require__(408)
 const { addSignal, removeSignal } = __nccwpck_require__(102)
 
@@ -86147,14 +86168,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TestTransport = void 0;
-const rpc_error_1 = __nccwpck_require__(171);
+const rpc_error_1 = __nccwpck_require__(172);
 const runtime_1 = __nccwpck_require__(17);
-const rpc_output_stream_1 = __nccwpck_require__(298);
-const rpc_options_1 = __nccwpck_require__(285);
+const rpc_output_stream_1 = __nccwpck_require__(299);
+const rpc_options_1 = __nccwpck_require__(286);
 const unary_call_1 = __nccwpck_require__(54);
 const server_streaming_call_1 = __nccwpck_require__(431);
-const client_streaming_call_1 = __nccwpck_require__(337);
-const duplex_streaming_call_1 = __nccwpck_require__(296);
+const client_streaming_call_1 = __nccwpck_require__(338);
+const duplex_streaming_call_1 = __nccwpck_require__(297);
 /**
  * Transport for testing.
  */
@@ -86467,7 +86488,7 @@ class TestInputStream {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isTokenCredential = exports.isSASCredential = exports.AzureSASCredential = exports.isNamedKeyCredential = exports.AzureNamedKeyCredential = exports.isKeyCredential = exports.AzureKeyCredential = void 0;
-var azureKeyCredential_js_1 = __nccwpck_require__(289);
+var azureKeyCredential_js_1 = __nccwpck_require__(290);
 Object.defineProperty(exports, "AzureKeyCredential", ({ enumerable: true, get: function () { return azureKeyCredential_js_1.AzureKeyCredential; } }));
 var keyCredential_js_1 = __nccwpck_require__(36);
 Object.defineProperty(exports, "isKeyCredential", ({ enumerable: true, get: function () { return keyCredential_js_1.isKeyCredential; } }));
@@ -86477,7 +86498,7 @@ Object.defineProperty(exports, "isNamedKeyCredential", ({ enumerable: true, get:
 var azureSASCredential_js_1 = __nccwpck_require__(31);
 Object.defineProperty(exports, "AzureSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.AzureSASCredential; } }));
 Object.defineProperty(exports, "isSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.isSASCredential; } }));
-var tokenCredential_js_1 = __nccwpck_require__(240);
+var tokenCredential_js_1 = __nccwpck_require__(241);
 Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: function () { return tokenCredential_js_1.isTokenCredential; } }));
 //# sourceMappingURL=index.js.map
 
@@ -86508,7 +86529,7 @@ if (typeof process === 'undefined' || process.type === 'renderer' || process.bro
 
 
 
-const { kHeadersList, kConstruct } = __nccwpck_require__(190)
+const { kHeadersList, kConstruct } = __nccwpck_require__(191)
 const { kGuard } = __nccwpck_require__(13)
 const { kEnumerableProperty } = __nccwpck_require__(67)
 const {
@@ -87108,11 +87129,11 @@ module.exports = {
 
 
 const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(28)
-const { getGlobalOrigin } = __nccwpck_require__(138)
-const { performance } = __nccwpck_require__(311)
+const { getGlobalOrigin } = __nccwpck_require__(139)
+const { performance } = __nccwpck_require__(312)
 const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(67)
 const assert = __nccwpck_require__(503)
-const { isUint8Array } = __nccwpck_require__(193)
+const { isUint8Array } = __nccwpck_require__(194)
 
 let supportedHashes = []
 
@@ -87121,7 +87142,7 @@ let supportedHashes = []
 let crypto
 
 try {
-  crypto = __nccwpck_require__(283)
+  crypto = __nccwpck_require__(284)
   const possibleRelevantHashes = ['sha256', 'sha384', 'sha512']
   supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
 /* c8 ignore next 3 */
@@ -88074,7 +88095,7 @@ let ReadableStream = globalThis.ReadableStream
 
 function isReadableStreamLike (stream) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(250).ReadableStream)
+    ReadableStream = (__nccwpck_require__(251).ReadableStream)
   }
 
   return stream instanceof ReadableStream || (
@@ -88663,8 +88684,8 @@ function createEmptyPipeline() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SASQueryParameters = exports.SASProtocol = void 0;
-const SasIPRange_js_1 = __nccwpck_require__(345);
-const utils_common_js_1 = __nccwpck_require__(152);
+const SasIPRange_js_1 = __nccwpck_require__(346);
+const utils_common_js_1 = __nccwpck_require__(153);
 /**
  * Protocols for generated SAS.
  */
@@ -89135,18 +89156,18 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MessageType = void 0;
 const message_type_contract_1 = __nccwpck_require__(387);
 const reflection_info_1 = __nccwpck_require__(432);
-const reflection_type_check_1 = __nccwpck_require__(282);
-const reflection_json_reader_1 = __nccwpck_require__(332);
+const reflection_type_check_1 = __nccwpck_require__(283);
+const reflection_json_reader_1 = __nccwpck_require__(333);
 const reflection_json_writer_1 = __nccwpck_require__(88);
 const reflection_binary_reader_1 = __nccwpck_require__(390);
-const reflection_binary_writer_1 = __nccwpck_require__(181);
-const reflection_create_1 = __nccwpck_require__(200);
-const reflection_merge_partial_1 = __nccwpck_require__(135);
+const reflection_binary_writer_1 = __nccwpck_require__(182);
+const reflection_create_1 = __nccwpck_require__(201);
+const reflection_merge_partial_1 = __nccwpck_require__(136);
 const json_typings_1 = __nccwpck_require__(378);
-const json_format_contract_1 = __nccwpck_require__(234);
+const json_format_contract_1 = __nccwpck_require__(235);
 const reflection_equals_1 = __nccwpck_require__(441);
-const binary_writer_1 = __nccwpck_require__(244);
-const binary_reader_1 = __nccwpck_require__(133);
+const binary_writer_1 = __nccwpck_require__(245);
+const binary_reader_1 = __nccwpck_require__(134);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
 const messageTypeDescriptor = baseDescriptors[message_type_contract_1.MESSAGE_TYPE] = {};
 /**
@@ -89514,7 +89535,7 @@ function escapeProperty(s) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBeginCopyFromUrlPoller = void 0;
 const core_util_1 = __nccwpck_require__(12);
-const core_lro_1 = __nccwpck_require__(219);
+const core_lro_1 = __nccwpck_require__(220);
 /**
  * This is the poller returned by {@link BlobClient.beginCopyFromURL}.
  * This can not be instantiated directly outside of this package.
@@ -89828,7 +89849,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(360);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(125);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/src/post.ts
+++ b/src/post.ts
@@ -579,19 +579,41 @@ function readZccacheSessionSummary(buildCachePath: string): ZccacheSessionSummar
   }
 }
 
-function resolveZccacheSessionStatsPath(buildCachePath: string): string {
-  const defaultPath = path.join(buildCachePath, "logs", "last-session-stats.json");
+/**
+ * Resolve a per-session zccache log file (e.g. `last-session-stats.json` or
+ * `last-session.jsonl`) across the layouts soldr may use. soldr's private
+ * daemon sessions write under `<cache>/private/<session-id>/logs/`, NOT the
+ * bare `<cache>/logs/` — so a path built with just `<cache>/logs/<file>` is
+ * silently empty under the default layout (setup-soldr#247). Probe, in order:
+ *   1. `<cache>/logs/<file>` (legacy / non-private layout)
+ *   2. `<cache>/private/<id>/logs/<file>` and `<cache>/private/<id>/<file>`
+ *   3. `<cache>/logs/archive/<session>/logs/<file>` and `.../<file>`
+ * most-recent-mtime wins; falls back to the legacy default path.
+ */
+function resolveZccacheSessionFilePath(buildCachePath: string, filename: string): string {
+  const defaultPath = path.join(buildCachePath, "logs", filename);
   if (fileExists(defaultPath)) return defaultPath;
 
   const candidates = [
-    ...collectSessionStatsCandidates(path.join(buildCachePath, "private")),
-    ...collectSessionStatsCandidates(path.join(buildCachePath, "logs", "archive")),
+    ...collectSessionFileCandidates(path.join(buildCachePath, "private"), filename),
+    ...collectSessionFileCandidates(path.join(buildCachePath, "logs", "archive"), filename),
   ];
   candidates.sort((a, b) => b.mtimeMs - a.mtimeMs || a.path.localeCompare(b.path));
   return candidates[0]?.path ?? defaultPath;
 }
 
-function collectSessionStatsCandidates(root: string): Array<{ path: string; mtimeMs: number }> {
+function resolveZccacheSessionStatsPath(buildCachePath: string): string {
+  return resolveZccacheSessionFilePath(buildCachePath, "last-session-stats.json");
+}
+
+export function resolveZccacheSessionJournalPath(buildCachePath: string): string {
+  return resolveZccacheSessionFilePath(buildCachePath, "last-session.jsonl");
+}
+
+function collectSessionFileCandidates(
+  root: string,
+  filename: string,
+): Array<{ path: string; mtimeMs: number }> {
   let entries: fs.Dirent[];
   try {
     if (!fs.statSync(root).isDirectory()) return [];
@@ -603,13 +625,13 @@ function collectSessionStatsCandidates(root: string): Array<{ path: string; mtim
   const out: Array<{ path: string; mtimeMs: number }> = [];
   for (const ent of entries) {
     if (!ent.isDirectory()) continue;
-    const candidate = path.join(root, ent.name, "logs", "last-session-stats.json");
-    const archiveCandidate = path.join(root, ent.name, "last-session-stats.json");
-    for (const statsPath of [candidate, archiveCandidate]) {
+    const candidate = path.join(root, ent.name, "logs", filename);
+    const archiveCandidate = path.join(root, ent.name, filename);
+    for (const filePath of [candidate, archiveCandidate]) {
       try {
-        const stat = fs.statSync(statsPath);
+        const stat = fs.statSync(filePath);
         if (stat.isFile()) {
-          out.push({ path: statsPath, mtimeMs: stat.mtimeMs });
+          out.push({ path: filePath, mtimeMs: stat.mtimeMs });
         }
       } catch {
         // Candidate shape not present; try the next known layout.
@@ -1962,7 +1984,10 @@ export async function run(): Promise<void> {
     // resolve-setup.ts's env exports). When `logging: true` is on we
     // surface its contents so the reader can answer "warm reported 0
     // hits — why did each lookup miss" without another build.
-    const journalPath = path.join(result.buildCache.path, "logs", "last-session.jsonl");
+    // Resolve the journal the same private-dir-aware way as the stats file —
+    // soldr's private daemon sessions write it under
+    // `<cache>/private/<id>/logs/`, not the bare `<cache>/logs/` (#247).
+    const journalPath = resolveZccacheSessionJournalPath(result.buildCache.path);
     // Forward the verbatim `report` field from `soldr cache report --json`
     // so dumpDiagnostics can format its `rollups` (per-extension /
     // per-crate / slowest_entries) breakdown.


### PR DESCRIPTION
Fixes #247.

## Problem
The `[compile_journal]` diagnostic (emitted with `logging: true`) built its path as `<cache>/logs/last-session.jsonl`, but soldr's private daemon sessions write the journal under `<cache>/private/<id>/logs/`. So the warm-miss dump (miss-reason histogram, slowest_misses, rollups) was **silently empty** under the default layout — `(journal file not found …)` — exactly when it's most needed.

## Fix
Generalize the already-private-dir-aware stats-path resolver into `resolveZccacheSessionFilePath(cacheDir, filename)` and add `resolveZccacheSessionJournalPath`. The journal dump (`src/post.ts`) now resolves `last-session.jsonl` the same way `last-session-stats.json` is resolved: `<cache>/logs/` → `<cache>/private/<id>/logs/` (and `/<id>/`) → `logs/archive/<session>/`, most-recent-mtime wins, legacy default as fallback.

## Tests
`__tests__/post.test.ts`: private-daemon layout resolves to `private/<id>/logs/last-session.jsonl`; missing → bare-logs fallback; legacy bare-logs path preferred when present. Full suite green (539 pass / 0 fail), typecheck clean, dist rebuilt.

## Verification
Discovered while enumerating MSRV/Docs warm misses for #236: a real warm CI run logged `(journal file not found at …/cache/zccache/logs/last-session.jsonl)` while the journal existed at `…/cache/zccache/private/<id>/logs/last-session.jsonl` (confirmed by downloading the dir as an artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)