### PR TITLE
chore: default to soldr 0.7.44 (cook project-restore fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## v0.9.16 - 2026-05-29
+
+- Default to soldr `0.7.44`, which carries the `soldr cook` project-restore fix
+  (zackees/soldr#566): `cargo chef cook` no longer leaves the workspace in its
+  stubbed `0.0.1` skeleton state, so builds after the cook prebuild compile real
+  source at the real version. This stabilizes first-party compile-cache keys
+  across cold→warm runs (the residual first-party warm-miss in #236 / #448 /
+  zccache#448).
+
 ## v0.9.15 - 2026-05-29
 
 - Fix the `[compile_journal]` diagnostic (emitted with `logging: true`) to find

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.43`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.44`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -456,7 +456,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.43`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.44`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -551,7 +551,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.43`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.44`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.43.
+    description: Soldr version or tag to install. Defaults to 0.7.44.
     required: false
-    default: "0.7.43"
+    default: "0.7.44"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
Bumps the default \`version\` input to soldr **0.7.44**, which carries the \`soldr cook\` project-restore fix (zackees/soldr#566, released today).

Before 0.7.44, \`soldr cook\` left the workspace in cargo-chef's stub state (`fn main() {}` + version `0.0.1`), so first-party crates compiled under `0.0.1` and missed the compile-cache on the first warm run (root cause of #236 / #188 / #240 residual + zackees/zccache#448). 0.7.44 restores the project after cook, stabilizing first-party compile-cache keys cold→warm.

Only the default version refs change (action.yml + README); the `0.7.43+` cargo-chef feature gate is unchanged. No src/dist change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)