### PR TITLE
chore(release): prepare setup-soldr v0.9.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.17 - 2026-05-29
+
 - Add the `cache-preset` umbrella input (`minimal` | `foundation` | `full`)
   that fills any cache-affecting input the consumer leaves unset; explicit
   fine-grained inputs always win over the preset. `foundation` matches the


### PR DESCRIPTION
Roll the `Unreleased` CHANGELOG entries into a dated **v0.9.17** section. Sole content is the [#251](https://github.com/zackees/setup-soldr/issues/251) cache-policy refinement (`cache-preset` umbrella + `build-cache-mode: thin` resolved default when `target-cache` is opted in), already merged in [#252](https://github.com/zackees/setup-soldr/pull/252).

Once this merges, I'll tag `v0.9.17` on the merge commit and move the floating `v0` tag to point at it so `@v0` consumers pick up the new feature.

## Test plan

- [x] CHANGELOG-only change; no code/dist touched.
- [ ] After merge: `git tag v0.9.17 <merge-sha>` + `git push origin v0.9.17`; move `v0` to the same commit and force-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)