### PR TITLE
docs(claude.md): warn about CodeRabbit StatusContext jq pitfall in PR-check polling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,3 +272,28 @@ Or filter explicitly per `__typename`:
 ```
 
 Same trap exists when grouping completed-check counts (`group_by(.conclusion)` misses StatusContext entries entirely). Always coalesce `.conclusion // .state` before grouping.
+
+### Second-order gotcha: jq `//` only replaces `null` / `false`, NOT empty strings
+
+When a CheckRun is still queued/in-progress, `gh pr view --json statusCheckRollup` returns `.conclusion: ""` (empty string), not `null`. The `//` alternative operator in jq treats `""` as **present** (the value is "set" to an empty string), so:
+
+```jq
+(.conclusion // .state // .status)   # returns "" when conclusion=""
+```
+
+…silently bottoms out at the empty string and never falls through to `.state` or `.status`. A polling loop that then does `select(. == "PENDING" or . == "IN_PROGRESS")` will **not** match the empty string and considers the queued job "settled" — exiting too early.
+
+**The robust pattern is explicit, not coalesced**: check the field that actually carries live state. For `CheckRun`, that's `.status == "COMPLETED"`; for `StatusContext`, it's `.state != "PENDING"`. Use a conditional, not `//`:
+
+```bash
+# Wait until every entry is genuinely settled (CheckRun.status=COMPLETED or
+# StatusContext.state in {SUCCESS,FAILURE,ERROR,EXPECTED}).
+until [ "$(gh pr view $PR --json statusCheckRollup --jq '
+  [.statusCheckRollup[] | select(
+    (.__typename == "CheckRun"      and .status != "COMPLETED") or
+    (.__typename == "StatusContext" and .state  == "PENDING")
+  )] | length
+')" = "0" ]; do sleep 30; done
+```
+
+This is the second face of the same family of bugs — the first hit (the original CodeRabbit miss) and this one (empty-string-vs-null) together cost ~10 minutes of stuck polling in one session. **Default to explicit per-typename checks; treat `//` as suspicious for any field that GitHub serializes as `""` when unset.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,3 +236,39 @@ Cache code is famously easy to write and famously hard to validate. Before landi
 2. Measure the **typical pinned case** (specific channel, one extra target). Confirm only the delta lands in the cache, not the runner's pre-existing toolchain.
 3. **Cold restore smoke test**: untar the cache into a clean `$RUSTUP_HOME` and run `rustup show` + `rustc --version`. Catches "the cache restored but rustup can't see it" failures.
 4. **Stat the archive size** before and after `--long=27`, before and after `-19` — cache stats are diagnostic gold. Pipe through `statsCollector` (`src/lib/stats-collector.ts`) so warm runs surface size drift over time.
+
+## Monitoring GitHub PR checks (jq pitfall)
+
+GitHub's PR `statusCheckRollup` returns two distinct GraphQL types and they use **different field names** for their state:
+
+| `__typename`     | Producer                           | State field                      |
+|------------------|------------------------------------|----------------------------------|
+| `CheckRun`       | GitHub Actions, most CI providers  | `.conclusion` (settled) + `.status` (live) |
+| `StatusContext`  | Legacy/external bots (e.g. **CodeRabbit**, some legacy CI) | `.state` (`SUCCESS`/`PENDING`/`FAILURE`/`ERROR`) |
+
+A polling loop that only checks `CheckRun` fields will spin forever on a PR with a `StatusContext` entry, because neither `.conclusion` nor `.status` is ever set on that entry — they're `null`, so a filter like `select(.status != "COMPLETED" and .conclusion == null)` matches it on every poll.
+
+**Wrong** (hung indefinitely on PR #288 against the CodeRabbit entry):
+```bash
+until [ "$(gh pr view $PR --json statusCheckRollup --jq \
+  '[.statusCheckRollup[] | select(.status != "COMPLETED" and .conclusion == null)] | length' \
+)" = "0" ]; do sleep 45; done
+```
+
+**Right** — coalesce all three fields and treat `null` as still pending:
+```bash
+until [ "$(gh pr view $PR --json statusCheckRollup --jq \
+  '[.statusCheckRollup[] | select(((.conclusion // .state // .status) // "PENDING") | IN("PENDING","QUEUED","IN_PROGRESS"))] | length' \
+)" = "0" ]; do sleep 45; done
+```
+
+Or filter explicitly per `__typename`:
+```jq
+[.statusCheckRollup[] | (
+  if .__typename == "CheckRun" then .conclusion
+  elif .__typename == "StatusContext" then .state
+  else null end
+) // "PENDING"] | map(select(. == "PENDING" or . == "IN_PROGRESS"))
+```
+
+Same trap exists when grouping completed-check counts (`group_by(.conclusion)` misses StatusContext entries entirely). Always coalesce `.conclusion // .state` before grouping.


### PR DESCRIPTION
Adds a note to `CLAUDE.md` documenting a real pitfall hit while polling PR check state during the v0.9.17 release / fbuild cache-bump work: a `gh pr view --json statusCheckRollup` polling loop that only checks `.conclusion` / `.status` (CheckRun fields) hangs forever on PRs that include a StatusContext entry (e.g. **CodeRabbit**), because StatusContext uses `.state` instead.

The note shows:
- the broken pattern (which I actually wrote and got stuck on);
- a coalesce-and-treat-null-as-pending fix;
- a per-`__typename` jq variant.

Pure docs; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)