### PR TITLE
chore(release): prepare setup-soldr v0.9.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.18 - 2026-05-30
+
 - Add `target-cache-save-min-compiles` (default `1`) — delta-aware save gate
   for the Rust target/ artifact cache, mirroring `build-cache-save-min-compiles`.
   When `target-cache` is opted in and the cache was restored from a fallback


### PR DESCRIPTION
Roll Unreleased → v0.9.18 dated. Sole content: [#255](https://github.com/zackees/setup-soldr/issues/255) (PR [#256](https://github.com/zackees/setup-soldr/pull/256)) — `target-cache-save-min-compiles` delta gate. After merge: tag v0.9.18 + move v0.