### PR TITLE
chore: default to soldr 0.7.45 (zccache 1.11.7 depgraph drift fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Default to soldr `0.7.45`, which bundles zccache `1.11.7` carrying the
+  depgraph drift-detection fix (zackees/zccache#449 → PR #450): prevents
+  stale-artifact hits that produced undefined-symbol link errors when
+  transitive `.cpp.hpp` headers were modified in C++ unity builds.
+
 ## v0.9.18 - 2026-05-30
 
 - Add `target-cache-save-min-compiles` (default `1`) — delta-aware save gate

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.44`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.45`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -456,7 +456,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.44`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.45`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -551,7 +551,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.44`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.45`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.44.
+    description: Soldr version or tag to install. Defaults to 0.7.45.
     required: false
-    default: "0.7.44"
+    default: "0.7.45"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
Bump the default Soldr version from `0.7.44` → `0.7.45`. Drop-in (action.yml default + README references + CHANGELOG Unreleased entry — same shape as PR #250).

## Why

soldr `0.7.45` bundles **zccache `1.11.7`**, which carries the depgraph drift-detection fix (zackees/zccache#449 → [PR #450](https://github.com/zackees/zccache/pull/450)). The original symptom was undefined-symbol link errors when transitive `.cpp.hpp` headers were modified in C++ unity builds — zccache returned stale artifacts when the depgraph hash drifted, and the failure surfaced at link time as missing symbols. The fix forces a re-scan on hash drift instead of trusting the stale entry.

All `@v0` consumers (`fastled/fbuild`, `zackees/fastled-wasm`, `zackees/clud`, etc.) will pick this up automatically the moment `v0` floats to the merge commit; the one explicit-pin consumer (`zackees/zccache@v0.9.17`) will pick it up on its next bump PR.

## Test plan

- [ ] CI runs the demo workflow with the new soldr 0.7.45 binary; the warm zccache build still succeeds (existing tests pass; the depgraph fix is correctness-only and shouldn't affect the cache-mode benchmarks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)