### PR TITLE
chore(release): prepare setup-soldr v0.9.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.19 - 2026-05-30
+
 - Default to soldr `0.7.45`, which bundles zccache `1.11.7` carrying the
   depgraph drift-detection fix (zackees/zccache#449 → PR #450): prevents
   stale-artifact hits that produced undefined-symbol link errors when


### PR DESCRIPTION
Roll Unreleased → v0.9.19 dated. Sole content: PR [#258](https://github.com/zackees/setup-soldr/pull/258) — default soldr 0.7.44 → 0.7.45 (zccache 1.11.7 depgraph drift fix). After merge: tag v0.9.19 + move `v0`.