### PR TITLE
chore(release): prepare setup-soldr v0.9.20 (default soldr 0.7.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## Unreleased
 
+## v0.9.20 - 2026-05-30
+
+- Default to soldr `0.7.47`, which lands:
+  - zackees/soldr#581 — parallel per-file extraction in `soldr load`
+    (the foundation for the Windows cargo-registry-cache wall-clock
+    fix; bottleneck was Defender's per-CreateFile scan + NTFS MFT/USN
+    overhead serialized on a single tar-extract thread).
+  - zackees/soldr#583 — new `--profile-extract` flag (also
+    `SOLDR_PROFILE_EXTRACT=1`) that emits per-worker job counts +
+    per-file extract latency percentiles for tuning; `--auto-defender-exclude`
+    CLI placeholder on Windows (real `Add-MpPreference` lifecycle is a
+    follow-up that needs an internal module-graph cleanup).
+  - zackees/soldr#591 — fix: per-worker `chmod` restores the Unix +x
+    bit on cache-file restore, so cargo `build-script-build` binaries
+    round-tripped through `soldr save`/`load` are still executable
+    (regression from #581 — `std::fs::write` doesn't carry the tar
+    header's mode the way `entry.unpack()` did).
+- Restore-side wire-in for `soldr load` in the cargo-registry-cache
+  restore path. New `src/lib/soldr-load-shim.ts` detects soldr-format
+  archives (sniffs first tar entry for `SOLDR_MANIFEST.pb`) and
+  branches to `soldr load --archive X --cache-dir Y` when the
+  installed soldr is ≥ `0.7.46` and the archive matches. Otherwise
+  falls through unconditionally to the existing tar+zstd path — no
+  signature churn on `decompressCache`; the other four layers
+  (build, target, cook, mini) keep their existing path. The wire-in
+  is currently dormant for setup-soldr-produced archives (still tar
+  format on the save side); save-side switch tracked at #263 — once
+  that lands, the Windows cargo-registry-cache restore wall-clock
+  drops from ~50 s to a target of < 25 s. (#260, #261, #262)
+
 ## v0.9.19 - 2026-05-30
 
 - Default to soldr `0.7.45`, which bundles zccache `1.11.7` carrying the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.45`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.47`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -456,7 +456,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.45`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.47`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -551,7 +551,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.45`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.47`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.45.
+    description: Soldr version or tag to install. Defaults to 0.7.47.
     required: false
-    default: "0.7.45"
+    default: "0.7.47"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary

Bumps the default soldr binary 0.7.45 → 0.7.47 and prepares the v0.9.20 setup-soldr release.

Soldr 0.7.47 lands the cargo-registry-cache parallel-extract foundation (#575) plus the +x preservation fix that makes the new \`soldr load\` path safe for cargo \`build-script-build\` round-trips:

- zackees/soldr#581 — parallel per-file extraction in \`soldr load\` (Windows wall-clock fix foundation).
- zackees/soldr#583 — \`--profile-extract\` flag (per-worker job counts + p50/p95/p99 latency) + \`--auto-defender-exclude\` CLI placeholder.
- zackees/soldr#591 — fix: per-worker chmod restores Unix +x on cache-file restore.

Setup-soldr's cargo-registry-cache restore-side wire-in (#260, #261) becomes safe to activate against this binary; the save-side switch that actually engages the wire-in is tracked at #263.

## Test plan

- [x] action.yml + README + CHANGELOG bumped consistently.
- [ ] CI: Setup Soldr Action + Setup Soldr Contract + Soldr Cache Speed Demo.

## Follow-up

- #263 — switch cargo-registry-cache \`compressCache\` to \`soldr save\` to activate the load-side wire-in. Required to realize the Windows wall-clock <25 s target from zackees/soldr#575 META.

🤖 Generated with [Claude Code](https://claude.com/claude-code)