### PR TITLE
chore(release): prepare setup-soldr v0.9.23 (default soldr 0.7.48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## v0.9.23 - 2026-05-31
+
+- Default to soldr `0.7.48`, which bundles zccache `1.11.8` carrying the
+  cross-clone cache-pollution fix (zackees/zccache#474 → PR #478): per-worktree
+  key for PCH + MSVC plus explicit triple prefix-map
+  (`-ffile-prefix-map` + `-fmacro-prefix-map` + `-fdebug-prefix-map`) for
+  clang/gcc. Without 1.11.8, `.obj` artifacts produced in worktree A leaked
+  into worktree B with original-clone absolute paths still embedded,
+  breaking downstream PCH builds with header-redefinition errors.
+- README + `action.yml` default version both bumped to 0.7.48.
+
 ## v0.9.22 - 2026-05-31
 
 - Pre-compress race probe in the cook-cache save path (#268 Fix A,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.47`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.48`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -456,7 +456,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.47`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.48`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -551,7 +551,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.47`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.48`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.47.
+    description: Soldr version or tag to install. Defaults to 0.7.48.
     required: false
-    default: "0.7.47"
+    default: "0.7.48"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary
- Bumps the default soldr binary to **0.7.48** (was 0.7.47).
- Soldr 0.7.48 bundles **zccache 1.11.8** (zackees/zccache#478 → closes zackees/zccache#474): cross-clone cache-pollution fix. Per-worktree key for PCH + MSVC plus explicit triple prefix-map (\`-ffile-prefix-map\` + \`-fmacro-prefix-map\` + \`-fdebug-prefix-map\`) for clang/gcc. Without 1.11.8, \`.obj\` artifacts produced in worktree A leaked into worktree B with the original-clone absolute paths still embedded, breaking downstream PCH builds with header-redefinition errors.
- README + \`action.yml\` default version both bumped to 0.7.48.
- New CHANGELOG entry under v0.9.23.
- \`MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP\` (in \`src/lib/soldr-load-shim.ts\` / compiled \`dist/main.js\`) stays at 0.7.47 — it's a minimum-version capability gate, not the install default.

## Test plan
- [ ] Action self-test CI green on the matrix
- [ ] On a downstream consumer, confirm \`soldr-version\` output matches \`0.7.48\` and \`managed_zccache_version\` is \`1.11.8\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)