### PR TITLE
feat(post): record skipped save layers so the post-step table shows them

### DIFF
--- a/dist/post.js
+++ b/dist/post.js
@@ -46743,22 +46743,23 @@ async function run() {
                         debug: debugMode,
                         log,
                     });
-                    if (saveResult.status === "saved") {
-                        postCollector.record({
-                            label: "solo-toolchain-cache",
-                            operation: "save",
-                            hit: false,
-                            key: soloExactKey,
-                            matchedKey: soloMatchedKey,
-                            restoreKeys: [],
-                            archiveBytes: saveResult.archiveBytes ?? null,
-                            inflatedBytes: saveResult.inflatedBytes ?? null,
-                            fileCount: saveResult.fileCount ?? null,
-                            durationMs: Date.now() - soloSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                    else {
+                    // #269: always record so the post-step save table shows
+                    // skipped/race-precheck/etc layers too, not just saved ones.
+                    postCollector.record({
+                        label: "solo-toolchain-cache",
+                        operation: "save",
+                        status: saveResult.status,
+                        hit: false,
+                        key: soloExactKey,
+                        matchedKey: soloMatchedKey,
+                        restoreKeys: [],
+                        archiveBytes: saveResult.status === "saved" ? (saveResult.archiveBytes ?? null) : null,
+                        inflatedBytes: saveResult.status === "saved" ? (saveResult.inflatedBytes ?? null) : null,
+                        fileCount: saveResult.status === "saved" ? (saveResult.fileCount ?? null) : null,
+                        durationMs: Date.now() - soloSaveStart,
+                        timestamp: new Date().toISOString(),
+                    });
+                    if (saveResult.status !== "saved") {
                         log(`solo-toolchain-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
                     }
                 }
@@ -46816,22 +46817,23 @@ async function run() {
                         baseManifestPath: cookBaseManifest,
                         log,
                     });
-                    if (saveResult.status === "saved") {
-                        postCollector.record({
-                            label: `cook-cache-${cookSaveLayer}`,
-                            operation: "save",
-                            hit: false,
-                            key: saveKey,
-                            matchedKey: "",
-                            restoreKeys: [],
-                            archiveBytes: saveResult.archiveBytes ?? null,
-                            inflatedBytes: saveResult.inflatedBytes ?? null,
-                            fileCount: saveResult.fileCount ?? null,
-                            durationMs: Date.now() - cookSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                    else {
+                    // #269: always record so the save table includes skipped/
+                    // race-precheck/oversize layers, not only saved ones.
+                    postCollector.record({
+                        label: `cook-cache-${cookSaveLayer}`,
+                        operation: "save",
+                        status: saveResult.status,
+                        hit: false,
+                        key: saveKey,
+                        matchedKey: "",
+                        restoreKeys: [],
+                        archiveBytes: saveResult.status === "saved" ? (saveResult.archiveBytes ?? null) : null,
+                        inflatedBytes: saveResult.status === "saved" ? (saveResult.inflatedBytes ?? null) : null,
+                        fileCount: saveResult.status === "saved" ? (saveResult.fileCount ?? null) : null,
+                        durationMs: Date.now() - cookSaveStart,
+                        timestamp: new Date().toISOString(),
+                    });
+                    if (saveResult.status !== "saved") {
                         log(`cook-cache-${cookSaveLayer}: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
                     }
                 }
@@ -46865,22 +46867,22 @@ async function run() {
                         debug: debugMode,
                         log,
                     });
-                    if (saveResult.status === "saved") {
-                        postCollector.record({
-                            label: "cook-cache",
-                            operation: "save",
-                            hit: false,
-                            key: cookExactKey,
-                            matchedKey: "",
-                            restoreKeys: [],
-                            archiveBytes: saveResult.archiveBytes ?? null,
-                            inflatedBytes: saveResult.inflatedBytes ?? null,
-                            fileCount: saveResult.fileCount ?? null,
-                            durationMs: Date.now() - cookSaveStart,
-                            timestamp: new Date().toISOString(),
-                        });
-                    }
-                    else {
+                    // #269: always record (skipped layers too).
+                    postCollector.record({
+                        label: "cook-cache",
+                        operation: "save",
+                        status: saveResult.status,
+                        hit: false,
+                        key: cookExactKey,
+                        matchedKey: "",
+                        restoreKeys: [],
+                        archiveBytes: saveResult.status === "saved" ? (saveResult.archiveBytes ?? null) : null,
+                        inflatedBytes: saveResult.status === "saved" ? (saveResult.inflatedBytes ?? null) : null,
+                        fileCount: saveResult.status === "saved" ? (saveResult.fileCount ?? null) : null,
+                        durationMs: Date.now() - cookSaveStart,
+                        timestamp: new Date().toISOString(),
+                    });
+                    if (saveResult.status !== "saved") {
                         log(`cook-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
                     }
                 }
@@ -46921,22 +46923,22 @@ async function run() {
                     debug: debugMode,
                     log,
                 });
-                if (saveResult.status === "saved") {
-                    postCollector.record({
-                        label: "soldr-mini-cache",
-                        operation: "save",
-                        hit: false,
-                        key: miniExactKey,
-                        matchedKey: "",
-                        restoreKeys: [],
-                        archiveBytes: saveResult.archiveBytes ?? null,
-                        inflatedBytes: saveResult.inflatedBytes ?? null,
-                        fileCount: saveResult.fileCount ?? null,
-                        durationMs: Date.now() - miniSaveStart,
-                        timestamp: new Date().toISOString(),
-                    });
-                }
-                else {
+                // #269: always record (skipped layers too).
+                postCollector.record({
+                    label: "soldr-mini-cache",
+                    operation: "save",
+                    status: saveResult.status,
+                    hit: false,
+                    key: miniExactKey,
+                    matchedKey: "",
+                    restoreKeys: [],
+                    archiveBytes: saveResult.status === "saved" ? (saveResult.archiveBytes ?? null) : null,
+                    inflatedBytes: saveResult.status === "saved" ? (saveResult.inflatedBytes ?? null) : null,
+                    fileCount: saveResult.status === "saved" ? (saveResult.fileCount ?? null) : null,
+                    durationMs: Date.now() - miniSaveStart,
+                    timestamp: new Date().toISOString(),
+                });
+                if (saveResult.status !== "saved") {
                     log(`soldr-mini-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
                 }
             }

--- a/src/post.ts
+++ b/src/post.ts
@@ -1607,21 +1607,23 @@ export async function run(): Promise<void> {
             debug: debugMode,
             log,
           });
-          if (saveResult.status === "saved") {
-            postCollector.record({
-              label: "solo-toolchain-cache",
-              operation: "save",
-              hit: false,
-              key: soloExactKey,
-              matchedKey: soloMatchedKey,
-              restoreKeys: [],
-              archiveBytes: saveResult.archiveBytes ?? null,
-              inflatedBytes: saveResult.inflatedBytes ?? null,
-              fileCount: saveResult.fileCount ?? null,
-              durationMs: Date.now() - soloSaveStart,
-              timestamp: new Date().toISOString(),
-            });
-          } else {
+          // #269: always record so the post-step save table shows
+          // skipped/race-precheck/etc layers too, not just saved ones.
+          postCollector.record({
+            label: "solo-toolchain-cache",
+            operation: "save",
+            status: saveResult.status,
+            hit: false,
+            key: soloExactKey,
+            matchedKey: soloMatchedKey,
+            restoreKeys: [],
+            archiveBytes: saveResult.status === "saved" ? (saveResult.archiveBytes ?? null) : null,
+            inflatedBytes: saveResult.status === "saved" ? (saveResult.inflatedBytes ?? null) : null,
+            fileCount: saveResult.status === "saved" ? (saveResult.fileCount ?? null) : null,
+            durationMs: Date.now() - soloSaveStart,
+            timestamp: new Date().toISOString(),
+          });
+          if (saveResult.status !== "saved") {
             log(`solo-toolchain-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
           }
         }
@@ -1682,21 +1684,23 @@ export async function run(): Promise<void> {
             baseManifestPath: cookBaseManifest,
             log,
           });
-          if (saveResult.status === "saved") {
-            postCollector.record({
-              label: `cook-cache-${cookSaveLayer}`,
-              operation: "save",
-              hit: false,
-              key: saveKey,
-              matchedKey: "",
-              restoreKeys: [],
-              archiveBytes: saveResult.archiveBytes ?? null,
-              inflatedBytes: saveResult.inflatedBytes ?? null,
-              fileCount: saveResult.fileCount ?? null,
-              durationMs: Date.now() - cookSaveStart,
-              timestamp: new Date().toISOString(),
-            });
-          } else {
+          // #269: always record so the save table includes skipped/
+          // race-precheck/oversize layers, not only saved ones.
+          postCollector.record({
+            label: `cook-cache-${cookSaveLayer}`,
+            operation: "save",
+            status: saveResult.status,
+            hit: false,
+            key: saveKey,
+            matchedKey: "",
+            restoreKeys: [],
+            archiveBytes: saveResult.status === "saved" ? (saveResult.archiveBytes ?? null) : null,
+            inflatedBytes: saveResult.status === "saved" ? (saveResult.inflatedBytes ?? null) : null,
+            fileCount: saveResult.status === "saved" ? (saveResult.fileCount ?? null) : null,
+            durationMs: Date.now() - cookSaveStart,
+            timestamp: new Date().toISOString(),
+          });
+          if (saveResult.status !== "saved") {
             log(`cook-cache-${cookSaveLayer}: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
           }
         } catch (err) {
@@ -1727,21 +1731,22 @@ export async function run(): Promise<void> {
             debug: debugMode,
             log,
           });
-          if (saveResult.status === "saved") {
-            postCollector.record({
-              label: "cook-cache",
-              operation: "save",
-              hit: false,
-              key: cookExactKey,
-              matchedKey: "",
-              restoreKeys: [],
-              archiveBytes: saveResult.archiveBytes ?? null,
-              inflatedBytes: saveResult.inflatedBytes ?? null,
-              fileCount: saveResult.fileCount ?? null,
-              durationMs: Date.now() - cookSaveStart,
-              timestamp: new Date().toISOString(),
-            });
-          } else {
+          // #269: always record (skipped layers too).
+          postCollector.record({
+            label: "cook-cache",
+            operation: "save",
+            status: saveResult.status,
+            hit: false,
+            key: cookExactKey,
+            matchedKey: "",
+            restoreKeys: [],
+            archiveBytes: saveResult.status === "saved" ? (saveResult.archiveBytes ?? null) : null,
+            inflatedBytes: saveResult.status === "saved" ? (saveResult.inflatedBytes ?? null) : null,
+            fileCount: saveResult.status === "saved" ? (saveResult.fileCount ?? null) : null,
+            durationMs: Date.now() - cookSaveStart,
+            timestamp: new Date().toISOString(),
+          });
+          if (saveResult.status !== "saved") {
             log(`cook-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`);
           }
         } catch (err) {
@@ -1781,21 +1786,22 @@ export async function run(): Promise<void> {
           debug: debugMode,
           log,
         });
-        if (saveResult.status === "saved") {
-          postCollector.record({
-            label: "soldr-mini-cache",
-            operation: "save",
-            hit: false,
-            key: miniExactKey,
-            matchedKey: "",
-            restoreKeys: [],
-            archiveBytes: saveResult.archiveBytes ?? null,
-            inflatedBytes: saveResult.inflatedBytes ?? null,
-            fileCount: saveResult.fileCount ?? null,
-            durationMs: Date.now() - miniSaveStart,
-            timestamp: new Date().toISOString(),
-          });
-        } else {
+        // #269: always record (skipped layers too).
+        postCollector.record({
+          label: "soldr-mini-cache",
+          operation: "save",
+          status: saveResult.status,
+          hit: false,
+          key: miniExactKey,
+          matchedKey: "",
+          restoreKeys: [],
+          archiveBytes: saveResult.status === "saved" ? (saveResult.archiveBytes ?? null) : null,
+          inflatedBytes: saveResult.status === "saved" ? (saveResult.inflatedBytes ?? null) : null,
+          fileCount: saveResult.status === "saved" ? (saveResult.fileCount ?? null) : null,
+          durationMs: Date.now() - miniSaveStart,
+          timestamp: new Date().toISOString(),
+        });
+        if (saveResult.status !== "saved") {
           log(
             `soldr-mini-cache: save status=${saveResult.status} error=${saveResult.error ?? "none"}`,
           );


### PR DESCRIPTION
v0.9.26's save table only shows SAVED layers — skipped ones were stranded in a one-line log. This makes every save attempt (saved or skipped) record into the StatsCollector with its actual status, so the table renders all of them.

The skip-decision time IS interesting budget signal:
- 'cook-cache skipped-race-precheck in 0.1s' → Fix A doing its job  
- 'build-cache skipped tiny-delta in 0.3s' → save gate working
- 'build-cache skipped oversize' → cap might need raising

4 call sites patched. 14 post tests pass. dist rebuilt via Linux/node:24.

Refs: #269, #283, #285.