### PR TITLE
chore(release): prepare setup-soldr v0.9.30 (default soldr 0.7.51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## v0.9.30 - 2026-05-31
+
+- Default to soldr `0.7.51`, which lands `soldr cook` warm-skip
+  (zackees/soldr#622, closes zackees/soldr#621). When the recipe
+  + rustc + soldr version match a previously-written marker file
+  in `target/`, soldr cook short-circuits Phase 2 (the cargo-chef
+  orchestration walk) — saving ~5 min on Coverage-shape workloads
+  and ~2.5 min on Integration-shape ones, with no behavior change
+  for cold runs or any case where the marker doesn't match.
+  Marker is schema-versioned, per-target-dir, and falls through
+  to the normal cook path on any read failure / mismatch / missing
+  file. README + action.yml default version bumped to 0.7.51.
+
 ## v0.9.29 - 2026-05-31
 
 - Post-step save table now includes build-cache + cargo-registry

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.48`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.51`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -456,7 +456,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.48`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.51`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -551,7 +551,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.48`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.51`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.48.
+    description: Soldr version or tag to install. Defaults to 0.7.51.
     required: false
-    default: "0.7.48"
+    default: "0.7.51"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
Picks up zackees/soldr#622 (closes #621) — soldr cook warm-skip saves ~5 min on Coverage-shape workloads.