### PR TITLE
perf(post-step): pre-save lookupOnly probe skips wasted solo-cache uploads (#313)

### DIFF
--- a/dist/post.js
+++ b/dist/post.js
@@ -46745,7 +46745,45 @@ async function run() {
         const soloLevel = core.getState("soloToolchainLevel") || "9"; // #310
         log(`solo-toolchain-cache: post-step exactKey=${soloExactKey} matched=${soloMatchedKey} ` +
             `exactHit=${soloExactHit} incrementalEmpty=${soloIncrementalEmpty} saveDiffPath=${soloSaveDiffPath}`);
-        if (soloExactHit && soloIncrementalEmpty) {
+        // #313: pre-save lookupOnly probe. When several parallel jobs in
+        // the same workflow all enable solo-toolchain-cache with the SAME
+        // key (rustc × components × targets × soldr-version), each one
+        // compresses + uploads ~140-175 MB only for GitHub Actions Cache
+        // to reject all-but-one with id=-1. The wasted uploads dominate
+        // the post-step (~100 s × N parallel jobs).
+        let raceSkipped = false;
+        if (!(soloExactHit && soloIncrementalEmpty) && soloSaveDiffPath && fs.existsSync(soloSaveDiffPath)) {
+            try {
+                const probeStart = Date.now();
+                const existing = await cache.restoreCache([], soloExactKey, [], { lookupOnly: true });
+                if (existing) {
+                    raceSkipped = true;
+                    log(`solo-toolchain-cache: pre-save lookupOnly probe found existing key=${existing} ` +
+                        `(probe ${Date.now() - probeStart}ms) — skipping stage+compress+upload (#313)`);
+                    postCollector.record({
+                        label: "solo-toolchain-cache",
+                        operation: "save",
+                        status: "race-precheck-skipped",
+                        hit: false,
+                        key: soloExactKey,
+                        matchedKey: soloMatchedKey,
+                        restoreKeys: [],
+                        archiveBytes: null,
+                        inflatedBytes: null,
+                        fileCount: null,
+                        durationMs: Date.now() - probeStart,
+                        timestamp: new Date().toISOString(),
+                    });
+                }
+            }
+            catch (err) {
+                log(`solo-toolchain-cache: lookupOnly probe failed (will attempt save anyway): ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+        if (raceSkipped) {
+            // probe found an existing entry; nothing more to do for this layer
+        }
+        else if (soloExactHit && soloIncrementalEmpty) {
             log("solo-toolchain-cache: exact hit and no install delta — skipping save");
         }
         else if (!soloSaveDiffPath || !fs.existsSync(soloSaveDiffPath)) {

--- a/src/post.ts
+++ b/src/post.ts
@@ -1578,7 +1578,47 @@ export async function run(): Promise<void> {
       `solo-toolchain-cache: post-step exactKey=${soloExactKey} matched=${soloMatchedKey} ` +
         `exactHit=${soloExactHit} incrementalEmpty=${soloIncrementalEmpty} saveDiffPath=${soloSaveDiffPath}`,
     );
-    if (soloExactHit && soloIncrementalEmpty) {
+    // #313: pre-save lookupOnly probe. When several parallel jobs in
+    // the same workflow all enable solo-toolchain-cache with the SAME
+    // key (rustc × components × targets × soldr-version), each one
+    // compresses + uploads ~140-175 MB only for GitHub Actions Cache
+    // to reject all-but-one with id=-1. The wasted uploads dominate
+    // the post-step (~100 s × N parallel jobs).
+    let raceSkipped = false;
+    if (!(soloExactHit && soloIncrementalEmpty) && soloSaveDiffPath && fs.existsSync(soloSaveDiffPath)) {
+      try {
+        const probeStart = Date.now();
+        const existing = await cache.restoreCache([], soloExactKey, [], { lookupOnly: true });
+        if (existing) {
+          raceSkipped = true;
+          log(
+            `solo-toolchain-cache: pre-save lookupOnly probe found existing key=${existing} ` +
+              `(probe ${Date.now() - probeStart}ms) — skipping stage+compress+upload (#313)`,
+          );
+          postCollector.record({
+            label: "solo-toolchain-cache",
+            operation: "save",
+            status: "race-precheck-skipped",
+            hit: false,
+            key: soloExactKey,
+            matchedKey: soloMatchedKey,
+            restoreKeys: [],
+            archiveBytes: null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - probeStart,
+            timestamp: new Date().toISOString(),
+          });
+        }
+      } catch (err) {
+        log(
+          `solo-toolchain-cache: lookupOnly probe failed (will attempt save anyway): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    if (raceSkipped) {
+      // probe found an existing entry; nothing more to do for this layer
+    } else if (soloExactHit && soloIncrementalEmpty) {
       log("solo-toolchain-cache: exact hit and no install delta — skipping save");
     } else if (!soloSaveDiffPath || !fs.existsSync(soloSaveDiffPath)) {
       log("solo-toolchain-cache: no save-diff manifest available, skipping save");


### PR DESCRIPTION
## Summary
Probe \`cache.restoreCache([], soloKey, [], { lookupOnly: true })\` BEFORE staging+compressing+uploading the solo-toolchain-cache. If the key already exists (saved by a sibling job in this workflow or a prior commit on the same branch), skip the entire stage+compress+upload chain.

## Motivation
Real data from zccache CI v0.9.35 (PR #508 enabled solo-cache on 5 parallel jobs):

\`\`\`
Formatting:    saved id=-1   (104s post-step)
MSRV:          saved id=-1   (~95s)
Documentation: saved id=-1   (~93s)
Dylint:        save skipped (id=-1) - likely concurrent save by another job
\`\`\`

All N parallel jobs uploaded the same 140-175 MB archive; GitHub Actions Cache accepted ONE and rejected the rest with id=-1. The wasted uploads dominated post-step wall clock (~300-400 s on a 5-job workflow).

## Behavior
- Probe is a single HEAD-style call (~50-200 ms).
- On hit: log \`race-precheck-skipped\`, record into post-collector summary, return immediately.
- On miss: proceed to the existing stage+compress+upload+saveCache path.
- On probe error: log and fall through to the save (graceful degradation).

Race window: two jobs probing at exactly the same millisecond both proceed. Worst case: 2 wasted uploads instead of N. On a 5-job workflow: ~3-4 min saved per cold-save cycle.

## Files
- \`src/post.ts\`: probe + new \`race-precheck-skipped\` status row.
- \`dist/post.js\`: rebuilt via Docker node:24 (dist/main.js untouched).

## Test plan
- [x] \`npx tsc --noEmit\` clean.
- [x] \`npm test\` 580 pass / 0 fail.
- [ ] After merge + cascade: confirm next zccache cold-save cycle shows only 1-2 \`solo-toolchain-cache saved\` rows; rest show \`race-precheck-skipped\`.

Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)