### PR TITLE
fix(#313): lookupOnly probe needs non-empty paths array

### DIFF
--- a/dist/post.js
+++ b/dist/post.js
@@ -46755,7 +46755,17 @@ async function run() {
         if (!(soloExactHit && soloIncrementalEmpty) && soloSaveDiffPath && fs.existsSync(soloSaveDiffPath)) {
             try {
                 const probeStart = Date.now();
-                const existing = await cache.restoreCache([], soloExactKey, [], { lookupOnly: true });
+                // @actions/cache.restoreCache requires a non-empty paths array
+                // even in lookupOnly mode (otherwise: "Path Validation Error:
+                // At least one directory or file path is required"). Pass a
+                // throwaway path; with lookupOnly the directory contents are
+                // never touched.
+                const probePath = path.join(runnerTemp, "setup-soldr-solo-lookup-probe");
+                try {
+                    fs.mkdirSync(probePath, { recursive: true });
+                }
+                catch { }
+                const existing = await cache.restoreCache([probePath], soloExactKey, [], { lookupOnly: true });
                 if (existing) {
                     raceSkipped = true;
                     log(`solo-toolchain-cache: pre-save lookupOnly probe found existing key=${existing} ` +

--- a/src/post.ts
+++ b/src/post.ts
@@ -1588,7 +1588,19 @@ export async function run(): Promise<void> {
     if (!(soloExactHit && soloIncrementalEmpty) && soloSaveDiffPath && fs.existsSync(soloSaveDiffPath)) {
       try {
         const probeStart = Date.now();
-        const existing = await cache.restoreCache([], soloExactKey, [], { lookupOnly: true });
+        // @actions/cache.restoreCache requires a non-empty paths array
+        // even in lookupOnly mode (otherwise: "Path Validation Error:
+        // At least one directory or file path is required"). Pass a
+        // throwaway path; with lookupOnly the directory contents are
+        // never touched.
+        const probePath = path.join(runnerTemp, "setup-soldr-solo-lookup-probe");
+        try { fs.mkdirSync(probePath, { recursive: true }); } catch {}
+        const existing = await cache.restoreCache(
+          [probePath],
+          soloExactKey,
+          [],
+          { lookupOnly: true },
+        );
         if (existing) {
           raceSkipped = true;
           log(


### PR DESCRIPTION
## Summary
Pass a throwaway runner-temp subdir as the paths argument to \`cache.restoreCache(..., { lookupOnly: true })\`. Without it the call fails validation:

\`\`\`
solo-toolchain-cache: lookupOnly probe failed (will attempt save anyway): 
  Path Validation Error: At least one directory or file path is required
\`\`\`

Observed on the first v0.9.37 deployment (zccache d6248c8). The probe ALWAYS errored → fell through to the save attempt → the race-precheck-skipped path never fires in production → #314's intended ~3-4 min/cold-cycle savings are NOT delivered.

## Test plan
- [x] \`npx tsc --noEmit\` clean.
- [x] \`npm test\` 580 pass / 0 fail.
- [ ] After merge + cascade: confirm log line \`solo-toolchain-cache: pre-save lookupOnly probe found existing key=… — skipping stage+compress+upload (#313)\` appears on at least N-1 of N parallel jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)