### PR TITLE
fix(cache-eviction): graduated age floor by overshoot (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+## v0.9.50 - 2026-06-01
+
+- Graduated age floor for `cache-eviction-policy` (closes #356).
+  v0.9.48's fixed 6h age floor became a no-op under heavy CI
+  load — observed on zccache MSRV at 13.63 GB usage where ALL
+  171 evictable entries were < 6h, leaving GitHub's own
+  non-deterministic LRU in charge (which can evict foundation
+  prefixes arbitrarily, defeating `protect-foundations`).
+  New tier table relaxes the floor as overshoot grows:
+  - small overshoot (<1 GB over trigger): baseline 6h —
+    unchanged (#352 fix preserved).
+  - moderate (1–3 GB over): 2h — protect only the current CI
+    wave's saves.
+  - danger (>3 GB over): 0.5h — only this run's just-saved
+    entries protected; controlled eviction wins the race
+    against GitHub's LRU.
+  Post-step log emits `graduated age floor active — overshoot=
+  X GB, floor=Y h` when relaxed. `aggressive` policy gets the
+  same tiering (baseline 2h, danger 0.5h).
+
 ## v0.9.49 - 2026-06-01
 
 - Raise `cache-eviction-policy` thresholds to better utilize

--- a/__tests__/cache-eviction.test.ts
+++ b/__tests__/cache-eviction.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   evictIfOverBudget,
   thresholdsForPolicy,
+  ageFloorForOvershoot,
   FOUNDATION_PREFIXES,
   type CacheEntry,
   type EvictDeps,
@@ -111,10 +112,9 @@ test("evicts oldest non-foundation entries until under target", async () => {
 });
 
 test("age floor protects fresh entries from self-eviction (#352)", async () => {
-  // All non-foundation entries fresh (< 6h). Even though usage is over
-  // trigger, NO eviction should happen because the age floor protects
-  // them. This is the fix for #352 — protect this run's just-saved
-  // cook/build caches from being deleted before the next CI cycle.
+  // All non-foundation entries fresh (< 6h). Usage at 10 GB is only
+  // ~0.5 GB over trigger (9.5 GB), so the graduated floor stays at 6h
+  // and NO eviction should happen — protecting this run's saves.
   const caches = [
     entry(201, "cook-base-v2-foo", 2000, 0.1), // age 6 minutes
     entry(202, "setup-soldr-buildcache-v2-bar", 300, 0.1),
@@ -131,6 +131,57 @@ test("age floor protects fresh entries from self-eviction (#352)", async () => {
   assert.ok(
     log.some((l) => l.includes("protected") && l.includes("younger than 6h")),
     `expected protected-by-age log line, got: ${log.join("\n")}`,
+  );
+});
+
+test("ageFloorForOvershoot tiers (#356)", () => {
+  const t = { triggerGb: 9.5, targetGb: 9, minAgeHoursBeforeDelete: 6 };
+  // small overshoot (<1 GB over) -> baseline 6h
+  assert.equal(ageFloorForOvershoot(9.5, t), 6);
+  assert.equal(ageFloorForOvershoot(10.4, t), 6);
+  // moderate (1–3 GB over) -> 2h
+  assert.equal(ageFloorForOvershoot(10.6, t), 2);
+  assert.equal(ageFloorForOvershoot(12.5, t), 2);
+  // danger (>3 GB over) -> 0.5h
+  assert.equal(ageFloorForOvershoot(12.6, t), 0.5);
+  assert.equal(ageFloorForOvershoot(13.6, t), 0.5);
+  // aggressive policy keeps baseline of 2h at small overshoot
+  const a = { triggerGb: 7, targetGb: 6, minAgeHoursBeforeDelete: 2 };
+  assert.equal(ageFloorForOvershoot(7.5, a), 2);
+  // moderate tier caps at min(2, baseline) — for aggressive baseline=2, tier stays 2h
+  assert.equal(ageFloorForOvershoot(9.5, a), 2);
+  // danger zone for aggressive triggers at 10 GB (>3 over 7 GB trigger)
+  assert.equal(ageFloorForOvershoot(10.5, a), 0.5);
+});
+
+test("graduated age floor evicts in danger zone (#356)", async () => {
+  // Reproduce zccache 13.63 GB observation: trigger 9.5 GB, usage
+  // 13.63 GB (overshoot 4.13 GB, danger zone). All entries are < 6h
+  // but > 0.5h. The graduated floor drops to 0.5h, so most should
+  // become evictable and we should free space toward the 9 GB target.
+  const caches = [
+    entry(301, "cook-delta-v2-foo", 2000, 5), // 5h old — beats 0.5h floor
+    entry(302, "setup-soldr-buildcache-v2-bar", 1500, 4),
+    entry(303, "cook-delta-v2-baz", 1500, 3),
+    entry(304, "solo-toolchain-v2-foo", 170, 1), // foundation, protected anyway
+    entry(305, "cook-delta-v2-fresh", 200, 0.1), // 6 min — still under 0.5h floor
+  ];
+  const { deps, deleted, log } = makeDeps({ caches, usageGb: 13.63 });
+  const result = await evictIfOverBudget("protect-foundations", deps);
+  assert.equal(result.fired, true);
+  // Should delete ≥ 1 entry (graduated floor active) — at usage 13.63
+  // GB target 9 GB, need to free 4.63 GB. Each large entry is 1.5-2 GB.
+  // Expect 301, 302, 303 evicted (5+4+3h, oldest first).
+  assert.ok(result.deletedCount! >= 2, `expected ≥ 2 deletes, got ${result.deletedCount}`);
+  assert.deepEqual(deleted.slice(0, 3).sort(), [301, 302, 303]);
+  // 305 is too fresh (6 min < 0.5h floor) — should NOT be deleted.
+  assert.ok(!deleted.includes(305), "entry 305 (6 min old) should be protected by 0.5h floor");
+  // 304 is foundation — should NOT be deleted.
+  assert.ok(!deleted.includes(304), "entry 304 (solo-toolchain) is foundation, protected");
+  // log mentions graduated floor activation.
+  assert.ok(
+    log.some((l) => l.includes("graduated age floor active")),
+    `expected graduated-floor log, got: ${log.join("\n")}`,
   );
 });
 

--- a/dist/post.js
+++ b/dist/post.js
@@ -45485,6 +45485,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.FOUNDATION_PREFIXES = void 0;
+exports.ageFloorForOvershoot = ageFloorForOvershoot;
 exports.thresholdsForPolicy = thresholdsForPolicy;
 exports.evictIfOverBudget = evictIfOverBudget;
 const github = __importStar(__nccwpck_require__(93228));
@@ -45499,6 +45500,35 @@ exports.FOUNDATION_PREFIXES = [
     "setup-soldr-v", // tiny setup-cache
     "setup-soldr-cargoregistry-v", // ~50 MB, skips crate-source download
 ];
+/**
+ * #356: graduated age-floor tier table.
+ *
+ * When ALL evictable entries are < 6h old (a burst of CI activity
+ * just landed) and usage is far over the trigger, the original
+ * fixed-6h age floor made eviction a no-op — letting GitHub's own
+ * non-deterministic LRU evict foundation entries arbitrarily.
+ *
+ * The tier table relaxes the floor as overshoot grows:
+ *   - small overshoot (<1 GB over trigger): keep baseline floor —
+ *     fresh entries protected, eviction can wait.
+ *   - moderate (1–3 GB over): drop to 2h — let entries from the
+ *     last ~2 hours be evicted, protecting only the current CI
+ *     wave's saves.
+ *   - danger (>3 GB over): drop to 0.5h — only this run's saves
+ *     are protected, everything older is fair game. GitHub's LRU
+ *     is imminent at this point and our controlled eviction must
+ *     win the race to protect foundation prefixes.
+ */
+function ageFloorForOvershoot(usageGb, thresholds) {
+    const overshoot = usageGb - thresholds.triggerGb;
+    if (overshoot <= 1)
+        return thresholds.minAgeHoursBeforeDelete;
+    // moderate: 1/3 of baseline, capped at 2h
+    if (overshoot <= 3)
+        return Math.min(2, thresholds.minAgeHoursBeforeDelete);
+    // danger: 0.5h — protect only this run's just-saved entries
+    return 0.5;
+}
 function thresholdsForPolicy(policy) {
     switch (policy) {
         case "disabled":
@@ -45609,8 +45639,17 @@ async function evictIfOverBudget(policy, deps) {
     // and consumer parallel jobs may still be saving theirs. Without
     // this guard, the eviction can delete the just-saved cook/build
     // caches that the NEXT CI cycle would have hit.
-    const ageFloorMs = thresholds.minAgeHoursBeforeDelete * 3600 * 1000;
+    //
+    // #356: graduated age floor — relax the protection when usage is
+    // significantly over trigger, so eviction can still free space
+    // under heavy CI load (where everything is fresh).
+    const effectiveFloorHours = ageFloorForOvershoot(usageBeforeGb, thresholds);
+    const ageFloorMs = effectiveFloorHours * 3600 * 1000;
     const ageCutoffEpochMs = Date.now() - ageFloorMs;
+    if (effectiveFloorHours < thresholds.minAgeHoursBeforeDelete) {
+        log(`cache-eviction: graduated age floor active — overshoot=${(usageBeforeGb - thresholds.triggerGb).toFixed(2)} GB, ` +
+            `floor=${effectiveFloorHours}h (down from ${thresholds.minAgeHoursBeforeDelete}h, #356)`);
+    }
     let protectedByAge = 0;
     const evictable = caches
         .filter((c) => {
@@ -45628,7 +45667,7 @@ async function evictIfOverBudget(policy, deps) {
         .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
     if (protectedByAge > 0) {
         deps.log(`cache-eviction: protected ${protectedByAge} entries from self-eviction ` +
-            `(younger than ${thresholds.minAgeHoursBeforeDelete}h, #352)`);
+            `(younger than ${effectiveFloorHours}h, #352/#356)`);
     }
     const targetBytes = thresholds.targetGb * 1024 * 1024 * 1024;
     let bytes = usageBytes;

--- a/src/lib/cache-eviction.ts
+++ b/src/lib/cache-eviction.ts
@@ -43,21 +43,52 @@ export interface CacheEvictionThresholds {
   /** Eviction continues until usage is at or below this. GB. */
   targetGb: number;
   /**
-   * #352: minimum age (hours) before a cache entry is eligible for
-   * eviction. Protects "fresh" caches that were just saved by THIS
-   * workflow run (or recent runs) from being self-evicted before
-   * the next CI cycle can use them.
+   * #352: baseline minimum age (hours) before a cache entry is
+   * eligible for eviction. Protects "fresh" caches just saved by
+   * THIS workflow run (or recent runs) from being self-evicted
+   * before the next CI cycle can use them.
    *
-   * The bug we observed: setup-soldr's post-step ran eviction
-   * BEFORE this run's cook-cache save was visible to LIST API, so
-   * the just-saved entries were age=~0.1h and got deleted
-   * immediately. Next CI run then cold-cooked (200s+ instead of 5s).
-   *
-   * 6h gives the typical "current CI run + next CI run" window
-   * generous coverage. Older entries (yesterday, last week) are
+   * 6h on `protect-foundations` covers the typical "current CI run
+   * + next CI run" window. Older entries (yesterday, last week) are
    * still fair game.
+   *
+   * #356: this is the BASELINE only — when usage significantly
+   * exceeds the trigger, the floor is graduated downward by
+   * `ageFloorForOvershoot` so eviction can still free space
+   * instead of becoming a no-op under heavy CI load.
    */
   minAgeHoursBeforeDelete: number;
+}
+
+/**
+ * #356: graduated age-floor tier table.
+ *
+ * When ALL evictable entries are < 6h old (a burst of CI activity
+ * just landed) and usage is far over the trigger, the original
+ * fixed-6h age floor made eviction a no-op — letting GitHub's own
+ * non-deterministic LRU evict foundation entries arbitrarily.
+ *
+ * The tier table relaxes the floor as overshoot grows:
+ *   - small overshoot (<1 GB over trigger): keep baseline floor —
+ *     fresh entries protected, eviction can wait.
+ *   - moderate (1–3 GB over): drop to 2h — let entries from the
+ *     last ~2 hours be evicted, protecting only the current CI
+ *     wave's saves.
+ *   - danger (>3 GB over): drop to 0.5h — only this run's saves
+ *     are protected, everything older is fair game. GitHub's LRU
+ *     is imminent at this point and our controlled eviction must
+ *     win the race to protect foundation prefixes.
+ */
+export function ageFloorForOvershoot(
+  usageGb: number,
+  thresholds: CacheEvictionThresholds,
+): number {
+  const overshoot = usageGb - thresholds.triggerGb;
+  if (overshoot <= 1) return thresholds.minAgeHoursBeforeDelete;
+  // moderate: 1/3 of baseline, capped at 2h
+  if (overshoot <= 3) return Math.min(2, thresholds.minAgeHoursBeforeDelete);
+  // danger: 0.5h — protect only this run's just-saved entries
+  return 0.5;
 }
 
 export function thresholdsForPolicy(policy: CacheEvictionPolicy): CacheEvictionThresholds | null {
@@ -215,8 +246,19 @@ export async function evictIfOverBudget(
   // and consumer parallel jobs may still be saving theirs. Without
   // this guard, the eviction can delete the just-saved cook/build
   // caches that the NEXT CI cycle would have hit.
-  const ageFloorMs = thresholds.minAgeHoursBeforeDelete * 3600 * 1000;
+  //
+  // #356: graduated age floor — relax the protection when usage is
+  // significantly over trigger, so eviction can still free space
+  // under heavy CI load (where everything is fresh).
+  const effectiveFloorHours = ageFloorForOvershoot(usageBeforeGb, thresholds);
+  const ageFloorMs = effectiveFloorHours * 3600 * 1000;
   const ageCutoffEpochMs = Date.now() - ageFloorMs;
+  if (effectiveFloorHours < thresholds.minAgeHoursBeforeDelete) {
+    log(
+      `cache-eviction: graduated age floor active — overshoot=${(usageBeforeGb - thresholds.triggerGb).toFixed(2)} GB, ` +
+        `floor=${effectiveFloorHours}h (down from ${thresholds.minAgeHoursBeforeDelete}h, #356)`,
+    );
+  }
   let protectedByAge = 0;
   const evictable = caches
     .filter((c) => {
@@ -233,7 +275,7 @@ export async function evictIfOverBudget(
   if (protectedByAge > 0) {
     deps.log(
       `cache-eviction: protected ${protectedByAge} entries from self-eviction ` +
-        `(younger than ${thresholds.minAgeHoursBeforeDelete}h, #352)`,
+        `(younger than ${effectiveFloorHours}h, #352/#356)`,
     );
   }
 


### PR DESCRIPTION
## Summary
Replaces the fixed 6h age floor with a tiered floor based on how far over `triggerGb` actual usage is. Closes #356.

## Why
v0.9.48's fixed 6h floor became a no-op under heavy CI load. Direct production evidence from zccache MSRV CI run `26776770904` job `78930315994` at 2026-06-01 19:30 UTC:

\`\`\`
06:13 cache-eviction: 13.63 GB > 9 GB trigger — evicting toward 8 GB target
06:14 cache-eviction: protected 171 entries from self-eviction (younger than 6h, #352)
06:14 cache-eviction: complete — deleted 0 entries (0.00 GB), usage ~13.63 GB → ~13.63 GB
\`\`\`

171 protected, 0 deleted, usage 3.6 GB over the 10 GB soft cap. GitHub's own LRU is what kept usage from runaway, and that LRU has no concept of foundation prefixes — defeating `protect-foundations`.

## New tier table
| Overshoot (usage − trigger) | Floor (protect-foundations) | Floor (aggressive) |
|---|---|---|
| ≤ 1 GB        | 6h (baseline, #352 fix unchanged)  | 2h |
| 1–3 GB        | 2h                                  | 2h |
| > 3 GB        | 0.5h (danger zone)                  | 0.5h |

Post-step now emits `graduated age floor active — overshoot=X GB, floor=Y h` when the tier kicks in.

## Test plan
- [x] `npm test` — 593 pass, 6 skipped (2 new tests + 1 updated #352 test)
- [x] New `ageFloorForOvershoot` tier table test
- [x] New "danger zone evicts ≥1 entry" test with 13.63 GB usage scenario
- [x] dist/post.js rebuilt; contains `ageFloorForOvershoot` symbol
- [ ] CI green
- [ ] After cascade: zccache post-step log should show `deleted N entries` (N≥1) on next over-cap cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)