### PR TITLE
perf(cache-eviction): add cook-base-v2- to FOUNDATION_PREFIXES (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## v0.9.57 - 2026-06-02
+
+- Add `cook-base-v2-` to `FOUNDATION_PREFIXES` so our controlled
+  eviction skips cook-cache-base entries (closes #368). Production
+  observation on zccache: a base entry that HIT at 08:17 was GONE
+  by 08:38 on a 20-minute child commit cycle — graduated age floor
+  (0.5h danger / 2h moderate / 6h baseline) doesn't protect entries
+  older than 6h, and cook-base saves typically live for many hours.
+  Cost of MISS = ~200s of cold cook; size = ~300 MB / platform
+  after v0.9.53's zstd-9. Ratio comparable to solo-toolchain.
+  GitHub's own LRU still evicts truly-stale cook-base entries that
+  no run accesses for ~7 days, so unbounded growth is bounded.
+
 ## v0.9.56 - 2026-06-02
 
 - Fix v0.9.55's parentSha derivation on shallow checkouts (the

--- a/__tests__/cache-eviction.test.ts
+++ b/__tests__/cache-eviction.test.ts
@@ -116,10 +116,13 @@ test("age floor protects fresh entries from self-eviction (#352)", async () => {
   // ~0.5 GB over trigger (9.5 GB), so the graduated floor stays at 6h
   // and NO eviction should happen — protecting this run's saves.
   const caches = [
-    entry(201, "cook-base-v2-foo", 2000, 0.1), // age 6 minutes
+    // #368: cook-base is now foundation, so we use cook-delta + buildcache
+    // here to exercise the age-floor path (these layers ARE evictable).
+    entry(201, "cook-delta-v2-foo", 2000, 0.1), // age 6 minutes
     entry(202, "setup-soldr-buildcache-v2-bar", 300, 0.1),
     entry(203, "cook-delta-v2-baz", 1500, 1.5), // age 1.5h still < 6h
-    entry(204, "solo-toolchain-v2-foo", 170, 1), // foundation, anyway
+    entry(204, "solo-toolchain-v2-foo", 170, 1), // foundation
+    entry(205, "cook-base-v2-baz", 300, 12), // foundation (#368) — old but protected
   ];
   const { deps, deleted, log } = makeDeps({ caches, usageGb: 10 });
   const result = await evictIfOverBudget("protect-foundations", deps);
@@ -242,6 +245,10 @@ test("entries matching ANY foundation prefix are protected", () => {
     "soldr-mini-linux-x64-glibc-v0.7.51",
     "setup-soldr-v4-linux-unknown-abc-def",
     "setup-soldr-cargoregistry-v1-linux-unknown-abc",
+    // #368: cook-cache-base is foundation. Lockfile-keyed →
+    // serves many CI cycles. Eviction observed within 20 min on
+    // zccache before this was added.
+    "cook-base-v2-linux-x64-glibc-rustc1.94.1-fnone-l92559307b22cc1be-soldrv0.7.51",
   ]) {
     assert.ok(
       FOUNDATION_PREFIXES.some((p) => key.startsWith(p)),
@@ -252,8 +259,8 @@ test("entries matching ANY foundation prefix are protected", () => {
 
 test("entries NOT matching foundation prefix are evictable", () => {
   for (const key of [
+    // cook-delta IS evictable — it's commit-keyed, ages off quickly.
     "cook-delta-v2-linux-x64-glibc-rustc1.94.1-fnone-l...",
-    "cook-base-v2-linux-x64-glibc-rustc1.94.1-...",
     "setup-soldr-buildcache-v2-linux-unknown-abc",
     "zccache-Linux-X64-test-foo",
     "cargo-target-Linux-X64-bench-abc",

--- a/dist/post.js
+++ b/dist/post.js
@@ -45499,6 +45499,17 @@ exports.FOUNDATION_PREFIXES = [
     "soldr-mini-", // ~11 MB, skips soldr binary download
     "setup-soldr-v", // tiny setup-cache
     "setup-soldr-cargoregistry-v", // ~50 MB, skips crate-source download
+    // #368: cook-cache-base is lockfile-keyed (not commit-keyed) so a
+    // single save serves many CI cycles. Observed regression on
+    // zccache: base evicted within 20 minutes (run 26807424213 had
+    // base HIT, child commit run 26808445398 had MISS, same lockfile
+    // hash). Cost of MISS = ~200 s of cold cook per affected job;
+    // size on disk = ~300 MB after v0.9.53's zstd-9. Ratio is
+    // comparable to solo-toolchain (~170 MB / 11 s). Foundation
+    // protection lets our controlled eviction skip these, while
+    // GitHub's own LRU still evicts stale entries that no run
+    // accesses for ~7 days.
+    "cook-base-v2-", // ~300 MB per platform, skips ~200 s cold cook
 ];
 /**
  * #356: graduated age-floor tier table.

--- a/src/lib/cache-eviction.ts
+++ b/src/lib/cache-eviction.ts
@@ -33,6 +33,17 @@ export const FOUNDATION_PREFIXES: readonly string[] = [
   "soldr-mini-", // ~11 MB, skips soldr binary download
   "setup-soldr-v", // tiny setup-cache
   "setup-soldr-cargoregistry-v", // ~50 MB, skips crate-source download
+  // #368: cook-cache-base is lockfile-keyed (not commit-keyed) so a
+  // single save serves many CI cycles. Observed regression on
+  // zccache: base evicted within 20 minutes (run 26807424213 had
+  // base HIT, child commit run 26808445398 had MISS, same lockfile
+  // hash). Cost of MISS = ~200 s of cold cook per affected job;
+  // size on disk = ~300 MB after v0.9.53's zstd-9. Ratio is
+  // comparable to solo-toolchain (~170 MB / 11 s). Foundation
+  // protection lets our controlled eviction skip these, while
+  // GitHub's own LRU still evicts stale entries that no run
+  // accesses for ~7 days.
+  "cook-base-v2-", // ~300 MB per platform, skips ~200 s cold cook
 ];
 
 export type CacheEvictionPolicy = "disabled" | "protect-foundations" | "aggressive";


### PR DESCRIPTION
## Summary
Protect cook-cache-base entries from setup-soldr's own controlled eviction by adding \`cook-base-v2-\` to \`FOUNDATION_PREFIXES\`. Closes #368.

## Why
Direct production evidence on zccache (this iteration):
- 08:17 UTC: commit 25ebcf8b's MSRV had cook-cache-base **HIT** (key \`cook-base-v2-linux-x64-glibc-rustc1.94.1-fnone-l92559307b22cc1be-soldrv0.7.51\`)
- 08:38 UTC: commit f26d9d3's Documentation had cook-cache-base **MISS** on the **same** lockfile hash, only 21 minutes later.

The graduated age floor from #356 (0.5h danger / 2h moderate / 6h baseline) only protects "fresh" entries. cook-base saves live for many hours and must survive across CI cycles. Worse: cook-base archives are often the largest evictable entries (~300 MB after v0.9.53), so the oldest-first eviction picks them preferentially.

## Cost analysis
| Layer | Size | Cost of MISS | Sec-per-MB |
|---|---|---|---|
| solo-toolchain (existing foundation) | 170 MB | ~11 s | 0.06 |
| **cook-base** (new foundation) | **~300 MB** | **~200 s** | **0.67** |
| build-cache (evictable) | ~300 MB | ~30 s | 0.10 |

cook-base has the highest protect-value-per-MB after solo-toolchain. Easy decision.

## Why this won't blow the budget
\`FOUNDATION_PREFIXES\` entries are skipped by our controlled eviction, not by GitHub's own LRU. GitHub still evicts truly-stale cook-base entries that no run has accessed for ~7 days, so we don't accumulate unbounded historical bases. Worst case: ~7 platforms × 300 MB = ~2.1 GB foundation footprint, leaving ~8 GB for LRU-managed layers.

## Test plan
- [x] \`npm test\` — 593 pass, 6 skipped, 0 fail
- [x] Foundation-prefix tests updated: cook-base example moved from "NOT foundation" to "IS foundation"
- [x] Age-floor test updated: foundation entry verified not deleted regardless of age
- [x] dist/post.js rebuilt; \`cook-base-v2-\` present in FOUNDATION_PREFIXES symbol
- [ ] After cascade: zccache base HIT rate on successive commits with same lockfile climbs to >50%

🤖 Generated with [Claude Code](https://claude.com/claude-code)