### PR TITLE
perf(cache-eviction): parallelize deletes with concurrency=10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## v0.9.60 - 2026-06-02
+
+- Parallelize cache-eviction deletes with concurrency=10. Sequential
+  deletes were observed at ~190ms each on the GitHub Actions Cache
+  API; large eviction passes (300+ entries on a busy repo) took ~57s
+  of post-step wall-clock. Worker-pool pattern with N=10 drops that
+  to ~6s. Per-CI-cycle savings: ~50s × matrix-job-count of post-step
+  time on the over-budget path.
+- Pre-compute eviction list before firing deletes (was: decrement
+  byte counter mid-loop). Over-deletion bounded by CONCURRENCY ×
+  largest-entry which is negligible vs the budget target.
+- 401/403 still aborts via shared flag; up to CONCURRENCY failed
+  API calls before the abort propagates (was 1). Acceptable tradeoff
+  for the per-cycle wall-clock savings.
+
 ## v0.9.59 - 2026-06-02
 
 - Drop git SHA from cargo-registry cache key (closes #371). Same

--- a/dist/post.js
+++ b/dist/post.js
@@ -45689,35 +45689,63 @@ async function evictIfOverBudget(policy, deps) {
             `${evictable.length} entries evictable`);
     }
     const targetBytes = thresholds.targetGb * 1024 * 1024 * 1024;
-    let bytes = usageBytes;
+    // Pre-compute the slice of entries we need to delete so we can fire
+    // the delete API calls in parallel. Sequential deletes were observed
+    // at ~190ms each (~57s wall-clock for 300 entries on a busy repo);
+    // parallel deletes drop that to ~6s with concurrency=10. The over-
+    // delete amount is at most CONCURRENCY × largest-entry-size which is
+    // negligible compared to the budget target (we're already aiming
+    // BELOW the trigger, so a few extra GB beyond target is fine).
+    const toDelete = [];
+    let predictedBytes = usageBytes;
+    for (const c of evictable) {
+        if (predictedBytes <= targetBytes)
+            break;
+        toDelete.push(c);
+        predictedBytes -= c.size_in_bytes;
+    }
     let deleted = 0;
     let deletedBytes = 0;
     let permissionDeniedLogged = false;
-    for (const c of evictable) {
-        if (bytes <= targetBytes)
-            break;
-        try {
-            await deleteCacheById(c.id);
-            bytes -= c.size_in_bytes;
-            deleted += 1;
-            deletedBytes += c.size_in_bytes;
-            log(`cache-eviction: deleted ${c.key} (${(c.size_in_bytes / 1024 / 1024).toFixed(0)} MB, ` +
-                `age ${((Date.now() - new Date(c.created_at).getTime()) / 3600000).toFixed(1)}h)`);
-        }
-        catch (err) {
-            const status = err.status;
-            if (status === 404)
-                continue; // raced with another job's delete; fine
-            if (status === 403 || status === 401) {
-                if (!permissionDeniedLogged) {
-                    log(`cache-eviction: permission denied (status=${status}) — workflow needs 'permissions: actions: write'. Skipping further deletes.`);
-                    permissionDeniedLogged = true;
-                }
-                break; // no point trying more deletes
+    let aborted = false;
+    const CONCURRENCY = 10;
+    // Worker-pool pattern: N concurrent workers each pull entries from
+    // the shared queue and delete them. Cleanly handles 401/403 (stop
+    // immediately) and 404 (treat as already-deleted).
+    let queueIndex = 0;
+    const worker = async () => {
+        while (true) {
+            if (aborted)
+                return;
+            const i = queueIndex++;
+            if (i >= toDelete.length)
+                return;
+            const c = toDelete[i];
+            try {
+                await deleteCacheById(c.id);
+                deleted += 1;
+                deletedBytes += c.size_in_bytes;
+                log(`cache-eviction: deleted ${c.key} (${(c.size_in_bytes / 1024 / 1024).toFixed(0)} MB, ` +
+                    `age ${((Date.now() - new Date(c.created_at).getTime()) / 3600000).toFixed(1)}h)`);
             }
-            log(`cache-eviction: delete failed for ${c.key} (status=${status ?? "?"}): ${err instanceof Error ? err.message : String(err)}`);
+            catch (err) {
+                const status = err.status;
+                if (status === 404)
+                    continue;
+                if (status === 403 || status === 401) {
+                    if (!permissionDeniedLogged) {
+                        log(`cache-eviction: permission denied (status=${status}) — workflow needs 'permissions: actions: write'. Skipping further deletes.`);
+                        permissionDeniedLogged = true;
+                    }
+                    aborted = true;
+                    return;
+                }
+                log(`cache-eviction: delete failed for ${c.key} (status=${status ?? "?"}): ${err instanceof Error ? err.message : String(err)}`);
+            }
         }
-    }
+    };
+    await Promise.all(Array.from({ length: Math.min(CONCURRENCY, toDelete.length) }, () => worker()));
+    const bytes = usageBytes - deletedBytes;
     const usageAfterGb = bytes / 1024 / 1024 / 1024;
     log(`cache-eviction: complete — deleted ${deleted} entries (${(deletedBytes / 1024 / 1024 / 1024).toFixed(2)} GB), ` +
         `usage ~${usageBeforeGb.toFixed(2)} GB → ~${usageAfterGb.toFixed(2)} GB`);

--- a/src/lib/cache-eviction.ts
+++ b/src/lib/cache-eviction.ts
@@ -300,38 +300,66 @@ export async function evictIfOverBudget(
   }
 
   const targetBytes = thresholds.targetGb * 1024 * 1024 * 1024;
-  let bytes = usageBytes;
+
+  // Pre-compute the slice of entries we need to delete so we can fire
+  // the delete API calls in parallel. Sequential deletes were observed
+  // at ~190ms each (~57s wall-clock for 300 entries on a busy repo);
+  // parallel deletes drop that to ~6s with concurrency=10. The over-
+  // delete amount is at most CONCURRENCY × largest-entry-size which is
+  // negligible compared to the budget target (we're already aiming
+  // BELOW the trigger, so a few extra GB beyond target is fine).
+  const toDelete: CacheEntry[] = [];
+  let predictedBytes = usageBytes;
+  for (const c of evictable) {
+    if (predictedBytes <= targetBytes) break;
+    toDelete.push(c);
+    predictedBytes -= c.size_in_bytes;
+  }
+
   let deleted = 0;
   let deletedBytes = 0;
   let permissionDeniedLogged = false;
-  for (const c of evictable) {
-    if (bytes <= targetBytes) break;
-    try {
-      await deleteCacheById(c.id);
-      bytes -= c.size_in_bytes;
-      deleted += 1;
-      deletedBytes += c.size_in_bytes;
-      log(
-        `cache-eviction: deleted ${c.key} (${(c.size_in_bytes / 1024 / 1024).toFixed(0)} MB, ` +
-          `age ${((Date.now() - new Date(c.created_at).getTime()) / 3600000).toFixed(1)}h)`,
-      );
-    } catch (err) {
-      const status = (err as { status?: number }).status;
-      if (status === 404) continue; // raced with another job's delete; fine
-      if (status === 403 || status === 401) {
-        if (!permissionDeniedLogged) {
-          log(
-            `cache-eviction: permission denied (status=${status}) — workflow needs 'permissions: actions: write'. Skipping further deletes.`,
-          );
-          permissionDeniedLogged = true;
+  let aborted = false;
+  const CONCURRENCY = 10;
+  // Worker-pool pattern: N concurrent workers each pull entries from
+  // the shared queue and delete them. Cleanly handles 401/403 (stop
+  // immediately) and 404 (treat as already-deleted).
+  let queueIndex = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      if (aborted) return;
+      const i = queueIndex++;
+      if (i >= toDelete.length) return;
+      const c = toDelete[i]!;
+      try {
+        await deleteCacheById(c.id);
+        deleted += 1;
+        deletedBytes += c.size_in_bytes;
+        log(
+          `cache-eviction: deleted ${c.key} (${(c.size_in_bytes / 1024 / 1024).toFixed(0)} MB, ` +
+            `age ${((Date.now() - new Date(c.created_at).getTime()) / 3600000).toFixed(1)}h)`,
+        );
+      } catch (err) {
+        const status = (err as { status?: number }).status;
+        if (status === 404) continue;
+        if (status === 403 || status === 401) {
+          if (!permissionDeniedLogged) {
+            log(
+              `cache-eviction: permission denied (status=${status}) — workflow needs 'permissions: actions: write'. Skipping further deletes.`,
+            );
+            permissionDeniedLogged = true;
+          }
+          aborted = true;
+          return;
         }
-        break; // no point trying more deletes
+        log(
+          `cache-eviction: delete failed for ${c.key} (status=${status ?? "?"}): ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
-      log(
-        `cache-eviction: delete failed for ${c.key} (status=${status ?? "?"}): ${err instanceof Error ? err.message : String(err)}`,
-      );
     }
-  }
+  };
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, toDelete.length) }, () => worker()));
+  const bytes = usageBytes - deletedBytes;
   const usageAfterGb = bytes / 1024 / 1024 / 1024;
   log(
     `cache-eviction: complete — deleted ${deleted} entries (${(deletedBytes / 1024 / 1024 / 1024).toFixed(2)} GB), ` +


### PR DESCRIPTION
## Summary
Worker-pool pattern (N=10) for cache-eviction's delete API calls. Sequential ~190ms/delete × 300 entries = ~57s wall-clock observed on zccache. Parallel = ~6s.

## Production evidence
zccache MSRV run 26817954387 (this iteration's earlier inspection):
\`\`\`
00:17 cache-eviction: 13.63 GB > 9.5 GB trigger ...
01:14 cache-eviction: complete — deleted 300 entries (0.72 GB), usage ~13.63 GB → ~12.91 GB
\`\`\`
57s for 300 deletes = ~190ms/delete. With concurrency=10: ~6s total.

## Implementation
1. Pre-compute the eviction list (loop through sorted evictable entries, accumulate until target reached).
2. Worker-pool: 10 async workers pull from a shared queue, fire deletes in parallel.
3. Over-deletion bound: CONCURRENCY × largest-entry-size. Negligible vs the budget target.
4. 401/403 still aborts via shared flag. Up to CONCURRENCY failed calls before propagation (was 1). Acceptable tradeoff.

## Test plan
- [x] \`npm test\` — 593 pass, 6 skipped, 0 fail
- [x] Existing 403 test still passes (only 1 entry needed deletion so concurrency moot for that case)
- [x] Existing graduated-floor test still passes (uses \`.sort()\` to handle parallel-completion order independence)
- [ ] Next zccache CI cycle: post-step cache-eviction wall-clock drops from ~57s to ~6s when eviction needs to delete many entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)