### PR TITLE
chore: bump default soldr-version 0.7.51 -> 0.7.52 (closes #379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Default to soldr `0.7.52`, which bundles zccache `1.11.14` carrying
+  the `meson configure --no-walk` flag (zackees/zccache#660, closes
+  zackees/zccache#659). The wrapper now skips its recursive
+  `--source-dir` walk entirely when callers declare every input via
+  `--input-file` — FastLED measured a ~9× cold-with-cache speedup on
+  the hit path (5.6s → 0.62s, see FastLED/FastLED#2761). Closes
+  zackees/setup-soldr#379; meta tracker zackees/zccache#662.
+
 ## v0.9.62 - 2026-06-02
 
 - Drop per-job suffix from cargo-registry cache key (closes #375).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.51`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.52`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -456,7 +456,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.51`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.52`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -551,7 +551,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.51`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.52`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.51.
+    description: Soldr version or tag to install. Defaults to 0.7.52.
     required: false
-    default: "0.7.51"
+    default: "0.7.52"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
Bumps the default `soldr-version` input from `0.7.51` to `0.7.52`. Closes #379.

soldr `0.7.52` is now published (zackees/soldr#678 + #679) and ships zccache `1.11.14`, which lands the `meson configure --no-walk` flag (zackees/zccache#660, closes zackees/zccache#659).

## Impact

FastLED measured the end-to-end speedup in FastLED/FastLED#2761: cold-with-cache reconfigure dropped from ~5.6s (walked hit, 1.11.13) to **0.62s** (no-walk hit, 1.11.14). Any consumer routing through `setup-soldr -> soldr -> managed zccache` inherits the same ~9x speedup automatically once they pin a newer setup-soldr ref (or already use `@main` / `@latest`).

## Scope

- `action.yml`: input `version` default + description`r
- `README.md`: 3 description strings`r
- `CHANGELOG.md`: new entry under `## Unreleased`

Transitive consumers (zackees/clud and similar) automatically pick up the new managed zccache version via `setup-soldr@latest`. No per-consumer follow-up required, which is why `zackees/clud` is not part of the rollout tracker (zackees/zccache#662).

## Related

- Tracker: zackees/zccache#662
- Source change: zackees/zccache#660 (closes zackees/zccache#659)
- Upstream soldr bump: zackees/soldr#678 + #679
- Reference consumer: FastLED/FastLED#2761

🤖 Generated with [Claude Code](https://claude.com/claude-code)