### PR TITLE
chore: default to soldr 0.7.53 (bundles zccache 1.11.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Default to soldr `0.7.53`, which bumps managed zccache
+  `1.11.14 → 1.11.18` (four upstream patches): NormalizedPath
+  Arc-interning (zackees/zccache#663); daemon `PendingCacheWrite`
+  registry + cold-miss persist wiring (zackees/zccache#664, #665);
+  cold/warm grouped bar charts on benchmark-stats
+  (zackees/zccache#668); **daemon pipe-pool depletion + compile-path
+  wedge recovery (zackees/zccache#669)**; adaptive daemon-spawn wait
+  keyed on lockfile PID (zackees/zccache#674); `ZCCACHE_PATH_REMAP`
+  surfaced in `zccache --help` (zackees/zccache#676); cleaner
+  lost-connection message (zackees/zccache#678).
 - Default to soldr `0.7.52`, which bundles zccache `1.11.14` carrying
   the `meson configure --no-walk` flag (zackees/zccache#660, closes
   zackees/zccache#659). The wrapper now skips its recursive

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.52`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.53`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -456,7 +456,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.52`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.53`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -551,7 +551,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.52`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.53`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.52.
+    description: Soldr version or tag to install. Defaults to 0.7.53.
     required: false
-    default: "0.7.52"
+    default: "0.7.53"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
Bumps the action's default version and the soldr submodule pointer in lockstep with [zackees/soldr#702](https://github.com/zackees/soldr/pull/702) (just merged).

soldr 0.7.53 carries managed zccache **1.11.14 → 1.11.18** (four upstream patches):

- NormalizedPath Arc-interning ([zccache#663](https://github.com/zackees/zccache/pull/663))
- daemon `PendingCacheWrite` registry + cold-miss persist wiring ([zccache#664](https://github.com/zackees/zccache/pull/664), [#665](https://github.com/zackees/zccache/pull/665))
- cold/warm grouped bar charts on benchmark-stats ([zccache#668](https://github.com/zackees/zccache/pull/668))
- **daemon pipe-pool depletion + compile-path wedge recovery ([zccache#669](https://github.com/zackees/zccache/pull/669))** — may also unblock the Windows daemon-stdio-detach hangs worked around in [soldr#696](https://github.com/zackees/soldr/pull/696) / [#701](https://github.com/zackees/soldr/pull/701)
- adaptive daemon-spawn wait keyed on lockfile PID ([zccache#674](https://github.com/zccache/pull/674))
- `ZCCACHE_PATH_REMAP` surfaced in `zccache --help` ([zccache#676](https://github.com/zackees/zccache/pull/676))
- cleaner lost-connection message ([zccache#678](https://github.com/zackees/zccache/pull/678))

## Changes

| File           | What                                           |
|----------------|------------------------------------------------|
| `action.yml`   | `version` input default + description 0.7.52 → 0.7.53 |
| `README.md`    | top-line description + input table + summary 0.7.52 → 0.7.53 |
| `CHANGELOG.md` | prepended `## Unreleased` entry summarising the bump (kept the prior 0.7.52 entry for diff context) |
| `soldr` submodule | 597a52d (v0.7.51 era) → 450f5c9 (v0.7.53 release commit) |

## Test plan

- [x] `npm test` — 593 passed, 0 failed, 6 skipped
- [ ] Setup Soldr Action CI

## Release verification

- [x] soldr v0.7.53 tag exists (created 2026-06-07T15:52:50Z by the autonomous release workflow)
- [x] PyPI `soldr` 0.7.53 published
- [x] npm `@zackees/soldr` 0.7.53 published