### PR TITLE
ci(comparison): rewire stranded comparison workflows post soldr#674 Phase 2

### DIFF
--- a/.github/workflows/comparison-child-branch.yml
+++ b/.github/workflows/comparison-child-branch.yml
@@ -1,38 +1,43 @@
 name: Cache Benchmark Child Branch
 
-# Parent-to-child cache probe for issue #168.
+# Parent-to-child cache probe for soldr#168.
 #
-# Runs the minimal consumer workflow (see examples/ci-minimal.yml) against a
-# selected branch, captures the setup-soldr action outputs and build timings,
-# and emits a markdown report matching the suggested shape in issue #168.
+# Captures setup-soldr's action outputs and build timings against a selected
+# soldr branch, then emits a markdown report matching the shape in soldr#168.
 #
-# This is a workflow-dispatch probe. Re-run it against the same child branch
-# twice back-to-back to distinguish:
+# Layout post soldr#674 Phase 2: this workflow lives in setup-soldr but
+# probes a `zackees/soldr` branch. setup-soldr is checked out at the
+# repo root (so the local `./` composite action is the one under test);
+# `zackees/soldr` is checked out into `./soldr/` at the requested child
+# branch, and cargo invocations run against that workspace.
+#
+# This is a workflow-dispatch probe. Re-run it against the same child
+# branch twice back-to-back to distinguish:
 #   - run 1: parent (main) restore-key fallback
 #   - run 2: same-branch warm restore
 #
-# Acceptance criteria checks this probe supports (issue #168):
+# Acceptance criteria checks this probe supports (soldr#168):
 #   - demonstrates parent-seeded restore of the zccache build cache
 #   - demonstrates same-branch warm restore
 #   - reports cold vs warm wall-clock, speedup ratio, and seconds saved
 #   - reports whether the stretch "sub-second no-op build" target is met
-#   - posts an issue comment with the merged findings and run URLs
+#   - posts an issue comment on `zackees/soldr` with the merged findings
 
 on:
   workflow_dispatch:
     inputs:
       child_branch:
-        description: Child branch to probe. Defaults to the ref this workflow was dispatched on.
+        description: zackees/soldr branch to probe. Defaults to soldr's `main`.
         required: false
         default: ""
         type: string
       post_comment:
-        description: Post the generated report as a comment on the tracking issue.
+        description: Post the generated report as a comment on the tracking issue in zackees/soldr.
         required: false
         default: "true"
         type: string
       issue_number:
-        description: Tracking issue to comment on.
+        description: Tracking issue number in zackees/soldr to comment on.
         required: false
         default: "168"
         type: string
@@ -49,9 +54,12 @@ jobs:
       seconds: ${{ steps.measure.outputs.seconds }}
       result: ${{ steps.measure.outputs.result }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout zackees/soldr at child branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ inputs.child_branch != '' && inputs.child_branch || github.ref }}
+          repository: zackees/soldr
+          ref: ${{ inputs.child_branch != '' && inputs.child_branch || 'main' }}
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
 
@@ -123,9 +131,16 @@ jobs:
       soldr_version: ${{ steps.setup.outputs.soldr-version }}
       toolchain: ${{ steps.setup.outputs.toolchain }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout setup-soldr (composite action under test)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Checkout zackees/soldr at child branch (workspace to build)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ inputs.child_branch != '' && inputs.child_branch || github.ref }}
+          repository: zackees/soldr
+          ref: ${{ inputs.child_branch != '' && inputs.child_branch || 'main' }}
+          path: soldr
+          persist-credentials: false
 
       # Use the repo-local composite action so the probe validates the
       # action.yml under test, not a pinned release. External consumers would
@@ -172,8 +187,13 @@ jobs:
               "--timings",
           ]
           start = time.perf_counter()
+          # cwd=soldr because zackees/soldr is checked out into ./soldr/ —
+          # cargo needs to find its Cargo.toml there. Probe output (the
+          # `probe-results/` dir we write below) stays at the runner root
+          # because pathlib.Path uses Python's own cwd.
           proc = subprocess.run(
               command,
+              cwd="soldr",
               stdout=subprocess.PIPE,
               stderr=subprocess.STDOUT,
               text=True,
@@ -210,7 +230,7 @@ jobs:
         with:
           name: child-branch-probe-warm
           path: |
-            target/cargo-timings
+            soldr/target/cargo-timings
             probe-results
             probe-setup-outputs.txt
           if-no-files-found: warn
@@ -252,11 +272,21 @@ jobs:
           if-no-files-found: error
 
       - name: Comment on tracking issue
-        if: ${{ inputs.post_comment == 'true' && github.repository == 'zackees/soldr' }}
+        # Only fire from canonical setup-soldr (avoid spamming from forks).
+        # Comment posts cross-repo into zackees/soldr; that requires a PAT
+        # with `repo:public_repo` (or `issues: write`) on zackees/soldr,
+        # stored as the SOLDR_CROSS_REPO_TOKEN secret. If the secret is
+        # missing or the post fails, the step warns and uploads the report
+        # as an artifact instead.
+        if: ${{ inputs.post_comment == 'true' && github.repository == 'zackees/setup-soldr' }}
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.SOLDR_CROSS_REPO_TOKEN || github.token }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
         run: |
           set -euo pipefail
-          gh issue comment "$ISSUE_NUMBER" --body-file parent-child-zccache-report.md
+          if gh -R zackees/soldr issue comment "$ISSUE_NUMBER" --body-file parent-child-zccache-report.md; then
+            echo "Posted report to zackees/soldr#$ISSUE_NUMBER"
+          else
+            echo "::warning::Could not post comment to zackees/soldr#$ISSUE_NUMBER — cross-repo write requires SOLDR_CROSS_REPO_TOKEN secret with issues:write on zackees/soldr. Report is uploaded as the child-branch-probe-report artifact."
+          fi

--- a/.github/workflows/comparison-cluster.yml
+++ b/.github/workflows/comparison-cluster.yml
@@ -1,31 +1,25 @@
-name: Comparison cluster (DISABLED — pending soldr#674 Phase 2 rewire)
+name: Comparison cluster
 
-# This workflow is a verbatim move of soldr's `cache-benchmark.yml`,
-# `_cache-benchmark-build.yml`, and `_cache-benchmark-scenario.yml` plus the
-# `comparison_report.py` renderer, the `benchmark.toml` config, and the
-# `benchmarks/workspace-scale/` + `benchmarks/sqlite-native/` fixtures.
+# Third-party comparison (soldr vs Swatinem/rust-cache vs ...) benchmark
+# suite. Origin is soldr's `cache-benchmark.yml` family plus the
+# `comparison_report.py` renderer; per soldr#674 Phase 1 the comparison
+# surface moved to setup-soldr because it belongs with the action, not
+# the binary. The output renders at https://zackees.github.io/setup-soldr/.
 #
-# Per soldr#674 Part 1, these files live in setup-soldr now because the
-# third-party comparison (soldr vs Swatinem/rust-cache vs ...) belongs with
-# the action, not with the binary. The page at https://zackees.github.io/soldr/
-# is being repurposed; the replacement comparison page goes live at
-# https://zackees.github.io/setup-soldr/ once this is rewired.
+# Layout post soldr#674 Phase 2 rewire:
+#   - setup-soldr root: config (`comparison.toml`), fixture
+#     (`benchmarks/sqlite-native/`), composite action
+#     (`.github/actions/comparison-zccache/`), renderer
+#     (`.github/scripts/comparison_report.py`)
+#   - `soldr/` subdir: `zackees/soldr` checked out by `actions/checkout`
+#     so the `cargo build --package soldr-cli` step and the
+#     `crates/soldr-cli/*` mutation paths from `comparison.toml`
+#     resolve correctly.
 #
-# Why triggers are workflow_dispatch-only:
-# The original workflow runs inside soldr's repo root and assumes:
-#   - `crates/soldr-cli/...` paths exist (mutation targets)
-#   - `cargo build` runs against the soldr workspace
-#   - the local `./.github/actions/comparison-zccache/` composite
-# Now living in setup-soldr, the workflow needs an `actions/checkout` of
-# `zackees/soldr` at a known directory, mutation paths reinterpreted relative
-# to that checkout, and the composite action paths renamed
-# (`comparison-zccache` → `comparison-zccache`). That rewire is tracked
-# in a follow-up issue (see PR body for link).
-#
-# Until the rewire ships:
-#   - push + schedule triggers are disabled so accidental runs cannot fail
-#   - workflow_dispatch is allowed so a maintainer can manually exercise
-#     a partially-wired run during the rewire PR's development
+# workflow_dispatch-only by design — the matrix is expensive
+# (8-target native-sqlite + cross-PR / restore-phase opt-ins) and
+# results are published to GitHub Pages, so accidental runs are
+# undesirable.
 on:
   workflow_dispatch:
     inputs:
@@ -79,7 +73,7 @@ jobs:
   # sources via cc-rs — the same workload that drives the sqlite-link
   # perf regression in #491. Each cell measures cold vs warm wall-time
   # with the zccache CC/CXX wrapper enabled and a disabled control row.
-  # `mode = "report-only"` in benchmark.toml: no enforced speedup gate;
+  # `mode = "report-only"` in comparison.toml: no enforced speedup gate;
   # the hard gate lives in .github/workflows/perf-matrix.yml's
   # `sqlite-link/cold-tar-untar-warm` cell. See
   # docs/NATIVE_SQLITE_BENCHMARK.md for how to read the results.
@@ -204,7 +198,7 @@ jobs:
           cache_dir = Path(os.environ["ZCCACHE_CACHE_DIR"])
           target_dir = Path(os.environ["RUNNER_TEMP"]) / f"sqlite-native-target-{target}"
 
-          config = tomllib.loads(Path("benchmark.toml").read_text(encoding="utf-8"))
+          config = tomllib.loads(Path("comparison.toml").read_text(encoding="utf-8"))
           native_config = config["native_sqlite"]
           policies = native_config["policies"]
           manifest = Path(native_config["fixture_manifest"])
@@ -452,13 +446,21 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout setup-soldr (config + scripts + composite action)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Checkout zackees/soldr (workspace for cargo build + mutations)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: zackees/soldr
+          path: soldr
+          persist-credentials: false
 
       - name: Resolve benchmark config
         id: config
         shell: bash
         env:
-          BENCHMARK_CONFIG_PATH: benchmark.toml
+          BENCHMARK_CONFIG_PATH: comparison.toml
           INPUT_THRESHOLD_RATIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '' }}
         run: |
           set -euo pipefail
@@ -488,14 +490,16 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: cache-benchmark-${{ steps.config.outputs.target }}
+          workspaces: soldr -> target
 
       - name: Build soldr
         shell: bash
+        working-directory: soldr
         run: cargo build --package soldr-cli --release --locked --target "${{ steps.config.outputs.target }}"
 
       - name: Add built soldr to PATH
         shell: bash
-        run: echo "$GITHUB_WORKSPACE/target/${{ steps.config.outputs.target }}/release" >> "$GITHUB_PATH"
+        run: echo "$GITHUB_WORKSPACE/soldr/target/${{ steps.config.outputs.target }}/release" >> "$GITHUB_PATH"
 
       - name: Prepare zccache tool
         uses: ./.github/actions/comparison-zccache
@@ -511,7 +515,7 @@ jobs:
         shell: bash
         env:
           BENCHMARK_COMMAND_TARGET: ${{ steps.config.outputs.target }}
-          BENCHMARK_CONFIG_PATH: benchmark.toml
+          BENCHMARK_CONFIG_PATH: comparison.toml
           BENCHMARK_RESULTS_JSON: benchmark-summary/cache-benchmark-results.json
           SCENARIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scenario || 'all' }}
           THRESHOLD_RATIO: ${{ steps.config.outputs.threshold_ratio }}
@@ -553,7 +557,11 @@ jobs:
                   return "{" + key + "}"
 
 
-          repo_root = Path.cwd()
+          # setup-soldr/ contains config + scripts; soldr/ is the cargo workspace
+          # the benchmark mutates (`crates/soldr-cli/*` paths in comparison.toml
+          # resolve under repo_root). See workflow header for the soldr#674
+          # Phase 2 layout.
+          repo_root = Path.cwd() / "soldr"
           config = tomllib.loads(Path(os.environ["BENCHMARK_CONFIG_PATH"]).read_text(encoding="utf-8"))
           target = os.environ["BENCHMARK_COMMAND_TARGET"]
           threshold = float(os.environ["THRESHOLD_RATIO"])
@@ -980,7 +988,7 @@ jobs:
         shell: bash
         env:
           BENCHMARK_COMMAND_TARGET: ${{ steps.config.outputs.target }}
-          BENCHMARK_CONFIG_PATH: benchmark.toml
+          BENCHMARK_CONFIG_PATH: comparison.toml
           BENCHMARK_INPUT_JSON: benchmark-summary/cache-benchmark-results.json
           BENCHMARK_SUMMARY_JSON: benchmark-summary/cache-benchmark-summary.json
           BENCHMARK_SUMMARY_WWW_DIR: benchmark-summary/site


### PR DESCRIPTION
## Summary

Rewires the two comparison workflows ported from soldr in Phase 1 but never wired up for setup-soldr's layout. Both were dispatchable but would fail on the first cargo/rust step.

- `comparison-cluster.yml` had `DISABLED — pending soldr#674 Phase 2 rewire` in its name and read a missing `benchmark.toml`
- `comparison-child-branch.yml` looked runnable but assumed soldr's workspace at root

## What changed

**Both workflows**: add an `actions/checkout` of `zackees/soldr` into a sibling directory and re-target cargo / mutation paths there. setup-soldr stays at the repo root so the local `./` composite action remains the one under test.

**comparison-cluster.yml**:
- Header rewritten (DISABLED tag dropped, post-Phase-2 layout documented)
- `benchmark.toml` → `comparison.toml` (already in repo; same shape) in 3 env vars + 1 inline Python
- `Build soldr` step: `working-directory: soldr`
- `Swatinem/rust-cache`: `workspaces: soldr -> target`
- Inline Python: `repo_root = Path.cwd() / "soldr"` — fixes the catastrophic `git reset --hard` + `git clean -fdx` that previously would have wiped setup-soldr's working tree

**comparison-child-branch.yml**:
- Dual checkout (setup-soldr at root for `uses: ./`, soldr into `./soldr/` at `child_branch`)
- `inputs.child_branch` default fixed (`github.ref` → soldr's `'main'`)
- Python `subprocess.run(..., cwd="soldr")` for the cargo build invocation
- Comment-posting step now correctly gates on `zackees/setup-soldr` and uses `gh -R zackees/soldr` to target the cross-repo tracking issue. Falls back to a warning + artifact path when the default `github.token` lacks cross-repo write (requires optional `SOLDR_CROSS_REPO_TOKEN` secret for full posting)

## Test plan

- [x] YAML syntax passes `yaml.safe_load` on both files
- [ ] Default CI green (workflows are workflow_dispatch only — won't run on PR)
- [ ] Manual dispatch of `comparison-child-branch.yml` on this branch validates the dual-checkout pattern end-to-end. (`comparison-cluster.yml` uses the same checkout architecture; its 8-target native-sqlite matrix is expensive enough to defer to a post-merge dispatch.)
- [ ] Vendor-prose lint passes (no Apple+SDK or Mac+SDK pairings introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)