### PR TITLE
ci(bench): split native-sqlite into 2N matrix — linux x86 cross-build + target-native test

### DIFF
--- a/.github/workflows/comparison-cluster.yml
+++ b/.github/workflows/comparison-cluster.yml
@@ -124,13 +124,18 @@ jobs:
           cross-targets: ${{ matrix.target }}
 
       - name: Provision cross-toolchain via soldr prepare
-        # setup-soldr's `cross-targets` cross-bootstrap covers
-        # linux-musl, apple-darwin, and windows-gnu lanes natively.
-        # For the other lanes (linux-gnu cross to aarch64, windows-msvc),
-        # soldr 0.7.59's `prepare --target` fills in cargo-xwin /
-        # clang-cl / cross-cc. Idempotent on supported lanes.
+        # `--github-env $GITHUB_ENV` is critical: it tells soldr to
+        # persist the env mutations (SDKROOT for darwin lanes, linker
+        # config for aarch64 cross, xwin cache path for msvc, etc.)
+        # into GITHUB_ENV so the subsequent `Cross-build` step inherits
+        # them. Without it, soldr writes the vars only to its own
+        # subprocess env and the next step sees nothing — the symptom
+        # is `ld.lld: incompatible with elf_x86_64` (host linker
+        # invoked) on aarch64 lanes and `dsymutil: No such file or
+        # directory` on darwin lanes. This mirrors soldr's own
+        # `.github/actions/prepare-cross-toolchain/action.yml`.
         shell: bash
-        run: soldr prepare --target "${{ matrix.target }}"
+        run: soldr prepare --target "${{ matrix.target }}" --github-env "$GITHUB_ENV"
 
       - name: Cross-build zccache binaries
         shell: bash

--- a/.github/workflows/comparison-cluster.yml
+++ b/.github/workflows/comparison-cluster.yml
@@ -184,20 +184,24 @@ jobs:
         #
         # Subcommand selection per target:
         #   *-pc-windows-msvc -> `cargo xwin build` (clang-cl + xwin's
-        #     MSVC CRT). Plain `cargo build --target` here fails at
-        #     `failed to find tool "lib.exe"`.
-        #   anything else  -> `cargo zigbuild` (zig cc as the C compiler,
-        #     understands -arch / -mmacosx-version-min for darwin and
-        #     produces aarch64-linux objects from x86_64 hosts).
+        #     MSVC CRT).
+        #   anything else     -> `cargo zigbuild` (zig cc as C compiler
+        #     + linker; understands -arch / -mmacosx-version-min for
+        #     darwin, links aarch64 objects from an x86_64 host).
         #
-        # `soldr cargo zigbuild` and `soldr cargo xwin build`
-        # auto-bootstrap zig + cargo-zigbuild and cargo-xwin respectively
-        # on first invocation (soldr#841, soldr#834), so no extra
-        # install step is needed.
+        # Invoked directly (not via `soldr cargo`) because run 27956361315
+        # showed `soldr cargo zigbuild` doesn't reliably propagate
+        # cargo-zigbuild's per-target LINKER override to the inner
+        # cargo/rustc invocation for cross-arch targets — symptom is
+        # `ld.lld: incompatible with elf_x86_64` (host linker invoked
+        # despite cargo-zigbuild being on PATH). Plain `cargo zigbuild`
+        # works because cargo-zigbuild then owns the entire invocation
+        # chain and its env mutations stay intact.
         run: |
           set -euo pipefail
+          which cargo-zigbuild cargo-xwin 2>/dev/null || true
           if [[ "$TGT" == *-pc-windows-msvc ]]; then
-            soldr cargo xwin build \
+            cargo xwin build \
               --release \
               --locked \
               --target "$TGT" \
@@ -205,7 +209,7 @@ jobs:
               --bin zccache \
               --bin zccache-daemon
           else
-            soldr cargo zigbuild \
+            cargo zigbuild \
               --release \
               --locked \
               --target "$TGT" \

--- a/.github/workflows/comparison-cluster.yml
+++ b/.github/workflows/comparison-cluster.yml
@@ -123,17 +123,48 @@ jobs:
         with:
           cross-targets: ${{ matrix.target }}
 
+      - name: Pre-install cargo-zigbuild or cargo-xwin onto PATH
+        # Matches soldr's own cross-compile-all-targets.yml pattern:
+        # cargo-zigbuild / cargo-xwin must be on PATH **before** the
+        # `cargo … --target X` invocation so they can set per-target
+        # CC / CXX / LINKER env vars. Run 27955618767 proved that
+        # `soldr cargo zigbuild`'s auto-bootstrap downloads the binary
+        # into an internal soldr cache dir that doesn't get exported
+        # to PATH — symptom: the build "succeeds" partially but the
+        # final link uses host clang (`ld.lld: incompatible with
+        # elf_x86_64` for aarch64, `dsymutil: No such file` for
+        # darwin). Pre-installing via `cargo install --locked` is the
+        # simplest portable shape; soldr's own CI uses a manifest
+        # pre-fetch but that needs soldr-internal tool_query.py.
+        shell: bash
+        env:
+          TGT: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TGT" == *-pc-windows-msvc ]]; then
+            cargo install --locked cargo-xwin
+          else
+            cargo install --locked cargo-zigbuild
+            python3 -m pip install --user ziglang
+            # ziglang ships zig as `python -m ziglang`; expose it as a
+            # `zig` command on PATH so cargo-zigbuild's binary lookup
+            # finds it.
+            mkdir -p "$HOME/.zig-bin"
+            cat > "$HOME/.zig-bin/zig" <<'SHIM'
+          #!/bin/bash
+          exec python3 -m ziglang "$@"
+          SHIM
+            chmod +x "$HOME/.zig-bin/zig"
+            echo "$HOME/.zig-bin" >> "$GITHUB_PATH"
+            export PATH="$HOME/.zig-bin:$PATH"
+            zig version
+          fi
+
       - name: Provision cross-toolchain via soldr prepare
-        # `--github-env $GITHUB_ENV` is critical: it tells soldr to
-        # persist the env mutations (SDKROOT for darwin lanes, linker
-        # config for aarch64 cross, xwin cache path for msvc, etc.)
-        # into GITHUB_ENV so the subsequent `Cross-build` step inherits
-        # them. Without it, soldr writes the vars only to its own
-        # subprocess env and the next step sees nothing — the symptom
-        # is `ld.lld: incompatible with elf_x86_64` (host linker
-        # invoked) on aarch64 lanes and `dsymutil: No such file or
-        # directory` on darwin lanes. This mirrors soldr's own
-        # `.github/actions/prepare-cross-toolchain/action.yml`.
+        # `--github-env $GITHUB_ENV` persists soldr's env mutations
+        # (SDKROOT for darwin, xwin cache path for msvc, etc.) into
+        # GITHUB_ENV so subsequent steps inherit them. Mirrors
+        # soldr's own prepare-cross-toolchain composite.
         shell: bash
         run: soldr prepare --target "${{ matrix.target }}" --github-env "$GITHUB_ENV"
 
@@ -142,6 +173,11 @@ jobs:
         working-directory: zccache-src
         env:
           TGT: ${{ matrix.target }}
+          # Override soldr's SOLDR_TARGET_CACHE_DIR redirection so the
+          # build product lands at the documented path
+          # zccache-src/target/<triple>/release/. Without this, soldr's
+          # target-cache integration writes to its own managed dir.
+          CARGO_TARGET_DIR: target
         # zccache and zccache-daemon are [[bin]] entries inside the
         # `zccache` package (crates/zccache/Cargo.toml). The `zccache-cli`
         # package is a PyO3 cdylib that doesn't ship binaries.

--- a/.github/workflows/comparison-cluster.yml
+++ b/.github/workflows/comparison-cluster.yml
@@ -182,26 +182,27 @@ jobs:
         # `zccache` package (crates/zccache/Cargo.toml). The `zccache-cli`
         # package is a PyO3 cdylib that doesn't ship binaries.
         #
-        # Subcommand selection per target:
-        #   *-pc-windows-msvc -> `cargo xwin build` (clang-cl + xwin's
-        #     MSVC CRT).
-        #   anything else     -> `cargo zigbuild` (zig cc as C compiler
-        #     + linker; understands -arch / -mmacosx-version-min for
-        #     darwin, links aarch64 objects from an x86_64 host).
-        #
-        # Invoked directly (not via `soldr cargo`) because run 27956361315
-        # showed `soldr cargo zigbuild` doesn't reliably propagate
-        # cargo-zigbuild's per-target LINKER override to the inner
-        # cargo/rustc invocation for cross-arch targets — symptom is
-        # `ld.lld: incompatible with elf_x86_64` (host linker invoked
-        # despite cargo-zigbuild being on PATH). Plain `cargo zigbuild`
-        # works because cargo-zigbuild then owns the entire invocation
-        # chain and its env mutations stay intact.
+        # Subcommand selection per target (filed as soldr#928):
+        #   *-pc-windows-msvc -> `soldr cargo xwin build` (soldr's
+        #     wrapper injects LLVM toolchain + xwin env via
+        #     prepare_xwin_env / compute_subcommand_env_overrides;
+        #     dropping to plain `cargo xwin build` loses the LLVM
+        #     bootstrap → `failed to find tool llvm-lib`).
+        #   *-apple-darwin -> `cargo zigbuild` direct, with
+        #     CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=off so rustc
+        #     doesn't invoke dsymutil (a darwin-only tool absent on
+        #     linux hosts; cross-compiling debug split is brittle
+        #     either way).
+        #   other (linux-gnu / linux-musl) -> `cargo zigbuild` direct.
+        #     Going through `soldr cargo zigbuild` drops
+        #     cargo-zigbuild's per-target LINKER override for
+        #     cross-arch targets (host clang ends up as linker —
+        #     soldr#928).
         run: |
           set -euo pipefail
           which cargo-zigbuild cargo-xwin 2>/dev/null || true
           if [[ "$TGT" == *-pc-windows-msvc ]]; then
-            cargo xwin build \
+            soldr cargo xwin build \
               --release \
               --locked \
               --target "$TGT" \
@@ -209,6 +210,9 @@ jobs:
               --bin zccache \
               --bin zccache-daemon
           else
+            if [[ "$TGT" == *-apple-darwin ]]; then
+              export CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=off
+            fi
             cargo zigbuild \
               --release \
               --locked \

--- a/.github/workflows/comparison-cluster.yml
+++ b/.github/workflows/comparison-cluster.yml
@@ -77,8 +77,94 @@ jobs:
   # the hard gate lives in .github/workflows/perf-matrix.yml's
   # `sqlite-link/cold-tar-untar-warm` cell. See
   # docs/NATIVE_SQLITE_BENCHMARK.md for how to read the results.
-  native-sqlite:
+  #
+  # The benchmark runs in two stages so the work doubles up correctly
+  # against the runner pool (2N instead of N):
+  #
+  #   `native-sqlite-build` (N=8 cells on linux x86): cross-compile
+  #     zccache for each target using setup-soldr's `cross-targets`
+  #     input (v0.9.63) + soldr 0.7.59's `prepare --target` composite.
+  #     Dogfoods both features and gets the expensive build work onto
+  #     fast ubuntu runners instead of slow ARM/macOS/Windows ones.
+  #
+  #   `native-sqlite-test` (N=8 cells on target-native runners): pull
+  #     the cross-compiled zccache via artifact, then run the actual
+  #     cold-vs-warm compile-time perf measurement on the target's
+  #     native CPU.
+  native-sqlite-build:
+    name: Cross-build zccache for ${{ matrix.target }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+          - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
+    steps:
+      - name: Checkout setup-soldr (action under test)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Checkout zackees/zccache (source to cross-compile)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: zackees/zccache
+          path: zccache-src
+          persist-credentials: false
+
+      - id: setup
+        name: Setup Soldr with cross-target ${{ matrix.target }}
+        uses: ./
+        with:
+          cross-targets: ${{ matrix.target }}
+
+      - name: Provision cross-toolchain via soldr prepare
+        # setup-soldr's `cross-targets` cross-bootstrap covers
+        # linux-musl, apple-darwin, and windows-gnu lanes natively.
+        # For the other lanes (linux-gnu cross to aarch64, windows-msvc),
+        # soldr 0.7.59's `prepare --target` fills in cargo-xwin /
+        # clang-cl / cross-cc. Idempotent on supported lanes.
+        shell: bash
+        run: soldr prepare --target "${{ matrix.target }}"
+
+      - name: Cross-build zccache-cli
+        shell: bash
+        working-directory: zccache-src
+        run: |
+          soldr cargo build --release --locked --target "${{ matrix.target }}" --package zccache-cli
+
+      - name: Stage zccache binaries
+        shell: bash
+        env:
+          TGT: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          mkdir -p staging
+          if [[ "$TGT" == *-pc-windows-* ]]; then
+            cp "zccache-src/target/${TGT}/release/zccache.exe" staging/
+            cp "zccache-src/target/${TGT}/release/zccache-daemon.exe" staging/
+          else
+            cp "zccache-src/target/${TGT}/release/zccache" staging/
+            cp "zccache-src/target/${TGT}/release/zccache-daemon" staging/
+          fi
+          ls -la staging/
+
+      - name: Upload cross-compiled zccache binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: zccache-cross-${{ matrix.target }}
+          path: staging/
+          if-no-files-found: error
+          retention-days: 7
+
+  native-sqlite-test:
     name: Native SQLite (${{ matrix.target }})
+    needs: native-sqlite-build
     runs-on: ${{ matrix.runner }}
     env:
       # Bypass rust-toolchain.toml's `components = ["rustfmt", "clippy"]` so
@@ -156,14 +242,25 @@ jobs:
           done
           dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
 
-      - name: Prepare zccache tool
-        uses: ./.github/actions/comparison-zccache
+      - name: Download cross-compiled zccache
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          cache-cargo-registry: "false"
-          cache-compilation: "false"
-          cache-target: "false"
-          save-cache: "false"
-          zccache-source-ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.zccache_source_ref || '' }}
+          name: zccache-cross-${{ matrix.target }}
+          path: ${{ runner.temp }}/zccache-bin
+
+      - name: Add cross-compiled zccache to PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN_DIR="$RUNNER_TEMP/zccache-bin"
+          if [[ "${{ runner.os }}" != "Windows" ]]; then
+            chmod +x "$BIN_DIR/zccache" "$BIN_DIR/zccache-daemon" 2>/dev/null || true
+          fi
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
+          ls -la "$BIN_DIR"
+          # Sanity check that the cross-built binary runs natively here.
+          # Failure here means the cross-compile target/host mismatch is wrong.
+          (export PATH="$BIN_DIR:$PATH" && zccache --version)
 
       - name: Run native SQLite benchmark
         shell: bash
@@ -436,7 +533,7 @@ jobs:
   benchmark:
     name: Config-driven benchmark
     needs:
-      - native-sqlite
+      - native-sqlite-test
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/comparison-cluster.yml
+++ b/.github/workflows/comparison-cluster.yml
@@ -132,11 +132,24 @@ jobs:
         shell: bash
         run: soldr prepare --target "${{ matrix.target }}"
 
-      - name: Cross-build zccache-cli
+      - name: Cross-build zccache binaries
         shell: bash
         working-directory: zccache-src
+        # zccache and zccache-daemon are [[bin]] entries inside the
+        # `zccache` package (crates/zccache/Cargo.toml). The `zccache-cli`
+        # package is a PyO3 cdylib that doesn't ship binaries — building
+        # just `zccache` and `zccache-daemon` from the `zccache` package
+        # avoids the wasted compile time on the cdylib + the dozen other
+        # workspace bins (echo_shim, exec_test_tool, crash-trigger, …)
+        # the benchmark doesn't need.
         run: |
-          soldr cargo build --release --locked --target "${{ matrix.target }}" --package zccache-cli
+          soldr cargo build \
+            --release \
+            --locked \
+            --target "${{ matrix.target }}" \
+            --package zccache \
+            --bin zccache \
+            --bin zccache-daemon
 
       - name: Stage zccache binaries
         shell: bash
@@ -145,12 +158,21 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p staging
+          REL_DIR="zccache-src/target/${TGT}/release"
+          if [ ! -d "$REL_DIR" ]; then
+            echo "::error::Expected release dir not found: $REL_DIR" >&2
+            echo "Showing zccache-src/target/ contents for diagnosis:" >&2
+            ls -la zccache-src/target/ 2>&1 | head -20 >&2 || true
+            exit 1
+          fi
+          echo "Contents of $REL_DIR (top of listing):"
+          ls -la "$REL_DIR" | head -30
           if [[ "$TGT" == *-pc-windows-* ]]; then
-            cp "zccache-src/target/${TGT}/release/zccache.exe" staging/
-            cp "zccache-src/target/${TGT}/release/zccache-daemon.exe" staging/
+            cp "$REL_DIR/zccache.exe" staging/
+            cp "$REL_DIR/zccache-daemon.exe" staging/
           else
-            cp "zccache-src/target/${TGT}/release/zccache" staging/
-            cp "zccache-src/target/${TGT}/release/zccache-daemon" staging/
+            cp "$REL_DIR/zccache" staging/
+            cp "$REL_DIR/zccache-daemon" staging/
           fi
           ls -la staging/
 

--- a/.github/workflows/comparison-cluster.yml
+++ b/.github/workflows/comparison-cluster.yml
@@ -135,21 +135,43 @@ jobs:
       - name: Cross-build zccache binaries
         shell: bash
         working-directory: zccache-src
+        env:
+          TGT: ${{ matrix.target }}
         # zccache and zccache-daemon are [[bin]] entries inside the
         # `zccache` package (crates/zccache/Cargo.toml). The `zccache-cli`
-        # package is a PyO3 cdylib that doesn't ship binaries — building
-        # just `zccache` and `zccache-daemon` from the `zccache` package
-        # avoids the wasted compile time on the cdylib + the dozen other
-        # workspace bins (echo_shim, exec_test_tool, crash-trigger, …)
-        # the benchmark doesn't need.
+        # package is a PyO3 cdylib that doesn't ship binaries.
+        #
+        # Subcommand selection per target:
+        #   *-pc-windows-msvc -> `cargo xwin build` (clang-cl + xwin's
+        #     MSVC CRT). Plain `cargo build --target` here fails at
+        #     `failed to find tool "lib.exe"`.
+        #   anything else  -> `cargo zigbuild` (zig cc as the C compiler,
+        #     understands -arch / -mmacosx-version-min for darwin and
+        #     produces aarch64-linux objects from x86_64 hosts).
+        #
+        # `soldr cargo zigbuild` and `soldr cargo xwin build`
+        # auto-bootstrap zig + cargo-zigbuild and cargo-xwin respectively
+        # on first invocation (soldr#841, soldr#834), so no extra
+        # install step is needed.
         run: |
-          soldr cargo build \
-            --release \
-            --locked \
-            --target "${{ matrix.target }}" \
-            --package zccache \
-            --bin zccache \
-            --bin zccache-daemon
+          set -euo pipefail
+          if [[ "$TGT" == *-pc-windows-msvc ]]; then
+            soldr cargo xwin build \
+              --release \
+              --locked \
+              --target "$TGT" \
+              --package zccache \
+              --bin zccache \
+              --bin zccache-daemon
+          else
+            soldr cargo zigbuild \
+              --release \
+              --locked \
+              --target "$TGT" \
+              --package zccache \
+              --bin zccache \
+              --bin zccache-daemon
+          fi
 
       - name: Stage zccache binaries
         shell: bash


### PR DESCRIPTION
## Summary

Refactors `comparison-cluster.yml`'s `native-sqlite` job into a two-stage pipeline that dogfoods the new cross-compile features:

- **setup-soldr v0.9.63's `cross-targets`** input (linux → linux-musl / apple-darwin / windows-gnu lanes natively supported via cross-bootstrap)
- **soldr 0.7.59's `prepare --target` composite** (fills in linux-gnu cross to aarch64, windows-msvc via cargo-xwin / clang-cl)

## Layout

```
native-sqlite-build (N=8 cells, all on ubuntu-24.04)
  ├─ checkout setup-soldr (action under test)
  ├─ checkout zackees/zccache (source to cross-compile)
  ├─ ./ with cross-targets: <triple>           [exercises new feature]
  ├─ soldr prepare --target <triple>           [exercises new feature]
  ├─ soldr cargo build --release --target <triple> --package zccache-cli
  └─ upload zccache-cross-<triple> artifact

native-sqlite-test (N=8 cells, target-native runners; needs: native-sqlite-build)
  ├─ download zccache-cross-<triple> artifact
  ├─ chmod + prepend PATH; sanity-check via zccache --version
  └─ run native SQLite benchmark python (unchanged from before)

benchmark (needs: native-sqlite-test)         [unchanged otherwise]
```

## Why this shape

The expensive cross-build work runs on fast linux x86 runners — previously each slow ARM/macOS/Windows runner either had to install a pre-built zccache release (limited platform coverage in `install.sh`) or `cargo install` from source on its native CPU. The cold-vs-warm compile-time perf measurement still happens on each target's native CPU, where it matters.

Total dispatch: 18 runner-jobs (was 10): 8 build + 8 test + 1 benchmark + 1 deploy-pages.

## Test plan

- [x] YAML structure validated (`yaml.safe_load` parses; `needs:` chain `build → test → benchmark` is correct; both matrices have 8 entries)
- [x] Vendor-prose lint passes
- [ ] Workflow dispatched on this branch as an integration smoke (8 build cells exercise the new cross-compile feature for all 8 targets)
- [ ] Cold/warm wall-time numbers on the target runners look sensible (regression vs. prior runs is informational only; benchmark is `mode = "report-only"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)