### PR TITLE
chore: default to soldr 0.7.87 (darwin cross-build lane end-to-end)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## Unreleased
 
+- Default to soldr `0.7.87` (was `0.7.59`). Headline upstream changes
+  carried by this bump span the 0.7.60 → 0.7.87 series and are
+  dominated by the darwin cross-compile lane landing end-to-end:
+  - Darwin cross-build overhaul: migrate `*-apple-darwin` release
+    builds from native runners to `ubuntu-24.04` + `cargo zigbuild`
+    (soldr#917 / #1054), then swap to a blessed-env darwin path
+    that no longer routes through `cargo zigbuild` (soldr#1085),
+    add `-fuse-ld=lld` to the darwin CFLAGS wire (soldr#1098),
+    and inline the per-target toolchain-prep fetch with a fixed
+    upstream URL (soldr#1096 / #1097). `aarch64-apple-darwin`
+    release rows moved to a native `macos-15` runner (soldr#1076
+    / #1077).
+  - `soldr build --target <triple>` auto-dispatch to
+    `zigbuild` / `xwin` (soldr#882 / #1056), plus a
+    `zccache-soldr` `RUSTC_WRAPPER` shim binary with a shared
+    compile-dispatch path (soldr#1082, refs #1081).
+  - Native MSVC cflags + link-args injection into the blessed
+    build (soldr#1036 / #1037), pre-staged xwin SDK splat in the
+    docker-msvc harness (soldr#1055), and `*-sys` catalogue
+    overrides scaffold (soldr#1064 phase B / #1065).
+  - Cook hydration wired into cross-build lanes and the
+    release-auto build job (soldr#1061 phase A: #1062 / #1063).
+  - Daemon UX: cancel inflight compiles instantly when the
+    wrapper disconnects (soldr#1078), and auto-discover the
+    Windows Visual Studio install so MSVC hosts don't need
+    explicit config (soldr#1080, closes soldr#1079).
+  - Fetch smoke-tests: extracted binaries are exercised with
+    `--version` before install (soldr#936 / #1058), plus a
+    manifest-first fetch path with sha256 pinning (already
+    threaded through in 0.7.59, extended here).
+  - Test infra: `tests/common::soldr_bin()` helper for
+    `SOLDR_BIN` override (soldr#1039 / #1045) and
+    `SOLDR_TEST_SKIP_SOURCE_TREE` marker + `fixtures_dir`
+    helper (soldr#1040 / #1046).
+  - CI plumbing: consolidated `_ci-cross-build-linux.yml`
+    (soldr#1041 / #1047) and `_ci-target-run.yml` (soldr#1042 /
+    #1048), wired into `ci.yml` (soldr#1051 / #1052), with the
+    superseded per-platform build workflows deleted
+    (soldr#1044 / #1050). Darwin nextest archive blocker
+    resolved (soldr#1043 / #1049). `soldr-clang-shim`
+    documentation for ring + aarch64-msvc (soldr#886 / #1057).
 - Default to soldr `0.7.59` (was `0.7.56`). Headline upstream changes
   carried by this bump:
   - `soldr prepare --target <triple>` composite-action surface that

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.59`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.87`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -456,7 +456,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.59`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.87`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -554,7 +554,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.59`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.87`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.59.
+    description: Soldr version or tag to install. Defaults to 0.7.87.
     required: false
-    default: "0.7.59"
+    default: "0.7.87"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary

Bumps the `soldr-version` input default from `0.7.59` → `0.7.87` (latest release, published 2026-06-30).

The 0.7.60..0.7.66 window was internal/release-plumbing (no public tags); `0.7.67` was the first tagged release after `0.7.59`.

## What lands with this bump

The 0.7.60 → 0.7.87 series is dominated by the darwin cross-compile lane landing end-to-end:

- **Darwin cross-build overhaul** — `*-apple-darwin` release builds moved from native macOS runners to `ubuntu-24.04` + `cargo zigbuild` (soldr#917 / #1054), then swapped to a blessed-env darwin path that no longer routes through `cargo zigbuild` (soldr#1085); `-fuse-ld=lld` wired into darwin CFLAGS (soldr#1098); per-target toolchain-prep fetch inlined with a fixed upstream URL (soldr#1096 / #1097). `aarch64-apple-darwin` release rows moved to a native `macos-15` runner (soldr#1076 / #1077).
- **`soldr build --target <triple>` auto-dispatch** to `zigbuild`/`xwin` (soldr#882 / #1056), plus a `zccache-soldr` `RUSTC_WRAPPER` shim binary sharing the compile-dispatch path (soldr#1082, refs #1081).
- **Native MSVC** cflags + link-args injection into the blessed build (soldr#1036 / #1037), pre-staged xwin SDK splat in the docker-msvc harness (soldr#1055), `*-sys` catalogue overrides scaffold (soldr#1064 / #1065).
- **Cook hydration** wired into cross-build lanes and the release-auto build job (soldr#1061 phase A).
- **Daemon UX** — cancel inflight compiles instantly when the wrapper disconnects (soldr#1078); auto-discover Windows Visual Studio install for MSVC hosts (soldr#1080, closes soldr#1079).
- **Fetch smoke-tests** — extracted binaries exercised with `--version` before install (soldr#936 / #1058).
- **CI plumbing** — consolidated `_ci-cross-build-linux.yml` (soldr#1041 / #1047) + `_ci-target-run.yml` (soldr#1042 / #1048) wired into `ci.yml` (soldr#1051 / #1052); superseded per-platform build workflows deleted (soldr#1044 / #1050).

## Touches

- `action.yml` — `soldr-version` input default + description
- `README.md` — 3 places (intro, input table, notes)
- `CHANGELOG.md` — new Unreleased entry summarizing the span

`dist/` untouched: none of the changes affect bundled TypeScript source; the version pin is consumed at runtime from `action.yml`.

## Test plan

- [x] `npm test` — 637 pass, 12 skipped, 0 failed
- [x] `npm run typecheck` — clean
- [x] `npm run lint:vendor-prose` — clean (initial draft caught two `Apple SDK` phrasings and I reworded them to the required per-target toolchain-prep framing)
- [ ] Wait for CI on the PR before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)