### PR TITLE
chore: default to soldr 0.7.92 (re-attempt after 0.7.87 revert; verify smoke-test fix confirmed upstream)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## Unreleased
 
+- Default to soldr `0.7.92` (was `0.7.59`). This is the re-attempted
+  bump after the 0.7.87 default was rolled back for the
+  `soldr version --json` empty-stdout regression (see prior entry).
+  Fix and follow-up guards from the upstream:
+  - **soldr#1206** `fix(release): smoke-test soldr version --json
+    across all release lanes` — closes zackees/soldr#1202, the
+    regression report filed from setup-soldr. Every release lane
+    now runs `soldr version --json | jq .soldr_version` on the
+    built binary before the release asset is published, so the
+    empty-stdout mode cannot slip through again.
+  - **soldr#1209** `fix(release): cross-arch size-floor guard for
+    archive soldr bin` — follow-up to soldr#1206 that rejects a
+    release archive whose `soldr` binary falls below a
+    per-triple size floor (catches the "wrong binary got
+    packaged" flavour of the same class of bug).
+  Other upstream changes carried by the 0.7.88 → 0.7.92 span:
+  - `soldr doctor` gains a rustlib-integrity probe for corrupt
+    rustup `rust-std` trees (soldr#884 / #1188).
+  - `soldr logs paths` — discoverable runtime-log API
+    (soldr#820 / #1124).
+  - `soldr exec` + Chocolatey-cargo shadow detection on Windows
+    hosts (soldr#1059 / #1114); auto-inject MSVC env when
+    projects pin `rust-lld` (soldr#1105 / #1109).
+  - `*-sys` catalogue fetcher end-to-end: real download +
+    extract for the syslib catalogue (soldr#1064 / #1111) plus
+    wiring for python / nodelib / openssl / llvm-tools
+    (soldr#1010 / #1127).
+  - Migrate all internal tool queries to the `soldr-toolchain`
+    catalogue (soldr#1125), retire manifest-LFS migration
+    tooling (soldr#993 / #1122).
+  - Release-side robustness: reject stub-wheel releases
+    (soldr#1140 / #1141); `--cargo-profile release` for nextest
+    archive share (soldr#1182 / #1183), then reverted after it
+    regressed archive speed (soldr#1197 / #1198 / #1199).
+  - `*-apple-darwin` cross-compile tail (post 0.7.89): fix
+    per-target toolchain-prep `--github-env FILE` arg
+    (soldr#1220), fix `crgx` / `cargo-chef` darwin-x64 cross
+    (soldr#1223), inject the per-target lib path for zig-cc
+    libiconv (soldr#1226).
+  - `mimalloc` everywhere; drop `jemalloc` (soldr#1112, via
+    zccache#948).
 - Roll back default soldr version from `0.7.87` to `0.7.59` after
   post-merge smoke tests on `main` failed: the bundled
   `soldr version --json` on the linux-x64-glibc release exited 0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.59`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.92`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -456,7 +456,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.59`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.92`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -554,7 +554,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.59`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.92`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.59.
+    description: Soldr version or tag to install. Defaults to 0.7.92.
     required: false
-    default: "0.7.59"
+    default: "0.7.92"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary

Bumps the `soldr-version` input default from `0.7.59` → `0.7.92` (latest release, published 2026-07-01T23:36:16Z).

This is the re-attempt of the 0.7.87 default bump that was reverted in #397. Upstream shipped the fix for the `version --json` regression I filed as zackees/soldr#1202 in the 0.7.88 → 0.7.89 window, then patched additional darwin-cross issues through 0.7.90, 0.7.91, and 0.7.92.

## Fix and follow-up guards for the reverted regression

- **soldr#1206** `fix(release): smoke-test soldr version --json across all release lanes` — closes zackees/soldr#1202. Every release lane now runs `soldr version --json | jq .soldr_version` on the built binary before the release asset is published, so the empty-stdout mode cannot slip through again.
- **soldr#1209** `fix(release): cross-arch size-floor guard for archive soldr bin` — rejects a release archive whose `soldr` binary falls below a per-triple size floor. Catches the "wrong binary got packaged" flavour of the same class of bug.

## Other upstream changes carried by 0.7.88 → 0.7.92

- `soldr doctor` rustlib-integrity probe for corrupt rustup `rust-std` trees (soldr#884 / #1188).
- `soldr logs paths` — discoverable runtime-log API (soldr#820 / #1124).
- `soldr exec` + Chocolatey-cargo shadow detection on Windows hosts (soldr#1059 / #1114); auto-inject MSVC env when projects pin `rust-lld` (soldr#1105 / #1109).
- `*-sys` catalogue fetcher end-to-end: real download + extract (soldr#1064 / #1111) plus wiring for python / nodelib / openssl / llvm-tools (soldr#1010 / #1127).
- Migrate internal tool queries to `soldr-toolchain` catalogue (soldr#1125); retire manifest-LFS migration tooling (soldr#993 / #1122).
- Release-side robustness: reject stub-wheel releases (soldr#1140 / #1141).
- `*-apple-darwin` tail: fix per-target toolchain-prep `--github-env FILE` arg (soldr#1220), fix `crgx` / `cargo-chef` darwin-x64 cross (soldr#1223), inject per-target lib path for zig-cc libiconv (soldr#1226).
- `mimalloc` everywhere; drop `jemalloc` (soldr#1112).

## Touches

- `action.yml` — `soldr-version` input default + description
- `README.md` — 3 places (intro, input table, notes)
- `CHANGELOG.md` — new Unreleased entry summarizing the span + the fix

`dist/` untouched: the version pin is consumed from `action.yml` at runtime, not baked into the ncc bundle.

## ⚠️ Not marking this for auto-merge — please review before merging

Last session, #396 auto-merged on green required checks (JS Build and Tests, vendor-prose, Contract Tests) while the `Setup Soldr Action` and `Soldr Cache Speed Demo` integration workflows silently failed post-merge, briefly pointing `zackees/setup-soldr@v0` at a broken commit. I don't want to repeat that pattern.

**Additionally**: the two integration workflows are currently red on `main` (post-#397) for a *different, pre-existing* reason — `soldr cargo build --locked --package zccache-cli` in the vendored `zccache/` submodule cannot regenerate `zccache/Cargo.lock`. That failure surfaces **after** setup-soldr install + verify succeeds, so this PR still validates that soldr 0.7.92's `version --json` path works end-to-end. The workflow will still exit non-zero at the later build step until the vendored `zccache/` submodule is refreshed (separate task).

**What to look for when reviewing the PR's `Setup Soldr Action` run**:
- ✅ You want to see `Verifying soldr at .../bin/soldr` succeed and log lines from `soldr status --json` (that proves 0.7.92's version subcommand works).
- ⚠️ You will still see `error: cannot update the lock file zccache/Cargo.lock because --locked was passed` at the later `soldr cargo build` step. That's the pre-existing vendored-lockfile issue, not this PR.

## Test plan

- [x] `npm test` — 637 pass, 12 skipped, 0 failed
- [x] `npm run typecheck` — clean
- [x] `npm run lint:vendor-prose` — clean (initial draft caught two `Apple SDK` phrasings and I reworded them to the per-target toolchain-prep framing)
- [ ] PR-level `Setup Soldr Contract` (required check) — should pass
- [ ] PR-level `Setup Soldr Action` — expect setup-soldr install + verify to succeed with 0.7.92; expect the later `soldr cargo build --locked` step to fail on the pre-existing `zccache/Cargo.lock` drift
- [ ] After merge, watch the post-merge `Setup Soldr Action` run on `main` — verify step must pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)