### PR TITLE
chore: default to soldr 0.7.99 (zccache 1.12.12 + cross-lane repairs + darwin-x64 dropped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+- Default to soldr `0.7.99` (was `0.7.92`). Fast follow-up to the
+  0.7.92 bump — three actually-tagged soldr releases shipped in the
+  36 hours after 0.7.92 (0.7.93/0.7.94/0.7.95/0.7.97 were autonomous-
+  release attempts that never got tag assets; 0.7.96/0.7.98/0.7.99
+  landed with the accumulated changes each time). Headline changes:
+  - **Managed zccache pin bumped `1.12.11` → `1.12.12`** with a
+    protocol-v8 test repair, embedded-zccache state checkpoint before
+    archive, and auto-GC at build end (soldr#1286 / #1295 / #1299,
+    released in 0.7.99). First zccache pin bump for setup-soldr
+    after retiring the vendored zccache subproject in #401.
+  - **`x86_64-apple-darwin` dropped from the soldr release matrix**
+    (soldr#1250, released in 0.7.95) — soldr picked the
+    "always-native-runner" branch of the two-way decision in
+    zackees/soldr#1243, and darwin-x64 builds are no longer produced
+    at all. Consumers who pinned `cross-targets: x86_64-apple-darwin`
+    against setup-soldr should switch to `aarch64-apple-darwin` (still
+    published via native `macos-15` runner) or drop the target.
+  - **Cross-lane repairs (soldr#1285 / #1289, released in 0.7.98):**
+    windows-x64 + windows-arm64 `xwin` bundle case aliases and
+    zlib-ng clang-cl ARM toggles; `*-apple-darwin` lanes now find
+    `libobjc` (SDKROOT was being dropped by the wrapper env filter,
+    and `cargo-zigbuild --sysroot -L` was doubling on zig 0.14).
+  - **linux-arm-musl lane fix** (soldr#1284) — wrapper env allowlist
+    was dropping `crgx`'s `cargo:rustc-env` `CRGX_TARGET`.
+  - Release-side: manylinux_2_17 wheels + stable PEP 517 target dir
+    for fbuild ingestion (soldr#1277); degrade tag/release 403s
+    instead of stranding PyPI+npm (soldr#1281); uv-provisioned
+    ninja fallback + concurrent-safe installs (soldr#1273); sweep
+    stale cmake build dirs on generator switch (soldr#1278); use
+    `ci-bootstrap` profile (no LTO, cu=16) for host build
+    (soldr#1282).
+  - CI perf (all in 0.7.96): `Swatinem/rust-cache` added to
+    `_bootstrap-e2e`, `baseline-zero-deps`, Lint, `_build-and-test`
+    (soldr#1232 / #1235 / #1239 / #1241); zig + `cargo-zigbuild`
+    cached in `baseline-zero-deps` (soldr#1244); per-target
+    toolchain-prep cache for the `*-apple-darwin` cross-build lanes
+    (soldr#1246).
 - Default to soldr `0.7.92` (was `0.7.59`). This is the re-attempted
   bump after the 0.7.87 default was rolled back for the
   `soldr version --json` empty-stdout regression (see prior entry).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.92`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.7.99`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -456,7 +456,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.7.92`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.7.99`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -554,7 +554,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.92`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.7.99`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.7.92.
+    description: Soldr version or tag to install. Defaults to 0.7.99.
     required: false
-    default: "0.7.92"
+    default: "0.7.99"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary

Bumps the `soldr-version` input default from `0.7.92` → `0.7.99` (latest published, 2026-07-02T13:35Z).

Three actually-tagged soldr releases shipped in the ~36 hours after `0.7.92` (0.7.93/0.7.94/0.7.95/0.7.97 were autonomous-release attempts that never got tag assets; 0.7.96/0.7.98/0.7.99 landed with the accumulated changes each time).

## Headline changes

- **Managed zccache pin `1.12.11` → `1.12.12`** with a protocol-v8 test repair, embedded-zccache state checkpoint before archive, and auto-GC at build end (soldr#1286 / #1295 / #1299, released in 0.7.99). First zccache pin bump for setup-soldr after retiring the vendored zccache subproject in #401.
- **`x86_64-apple-darwin` dropped from the soldr release matrix** (soldr#1250, released in 0.7.95). Soldr picked the "always native-runner" branch of the two-way decision in soldr#1243; darwin-x64 builds are no longer produced at all. Consumers who pinned `cross-targets: x86_64-apple-darwin` against setup-soldr should switch to `aarch64-apple-darwin` (still published via native `macos-15` runner) or drop the target.
- **Cross-lane repairs** (soldr#1285 / #1289, released in 0.7.98): windows-x64 + windows-arm64 `xwin` bundle case aliases and zlib-ng clang-cl ARM toggles; `*-apple-darwin` lanes now find `libobjc` (SDKROOT was being dropped by the wrapper env filter, and `cargo-zigbuild --sysroot -L` was doubling on zig 0.14).
- **linux-arm-musl lane fix** (soldr#1284) — wrapper env allowlist was dropping `crgx`'s `cargo:rustc-env` `CRGX_TARGET`.
- Release-side: manylinux_2_17 wheels + stable PEP 517 target dir for fbuild ingestion (soldr#1277); degrade tag/release 403s instead of stranding PyPI+npm (soldr#1281); uv-provisioned ninja fallback + concurrent-safe installs (soldr#1273); sweep stale cmake build dirs on generator switch (soldr#1278); use `ci-bootstrap` profile (no LTO, cu=16) for host build (soldr#1282).
- CI perf (all in 0.7.96): `Swatinem/rust-cache` added to `_bootstrap-e2e`, `baseline-zero-deps`, Lint, `_build-and-test` (soldr#1232 / #1235 / #1239 / #1241); zig + `cargo-zigbuild` cached in `baseline-zero-deps` (soldr#1244); per-target toolchain-prep cache for the `*-apple-darwin` cross-build lanes (soldr#1246).

## Touches

- `action.yml` — `soldr-version` input default + description
- `README.md` — 3 places (intro, input table, notes)
- `CHANGELOG.md` — new Unreleased entry
- `dist/` untouched — version pin is consumed from `action.yml` at runtime

## Test plan

- [x] `npm test` — 644 pass, 12 skipped, 0 failed
- [x] `npm run typecheck` — clean
- [x] `npm run lint:vendor-prose` — clean (first draft this time, no darwin/SDK reword needed)
- [x] `pytest tests/test_action_target_cache_wiring.py tests/test_bench_cache_modes_workflow.py tests/test_release_rollout_contract.py` — 10 passed
- [ ] PR-level checks: `JS Build and Tests`, `Contract Tests`, `vendor-prose`, `Install soldr smoke` — all should be green

Not enabling auto-merge — will watch checks and merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)