### PR TITLE
feat: make rust-ci cross-compilation-first

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,6 +8,10 @@
 # `soldr cargo ...` invocation. Per-tool jobs are individually toggleable
 # via boolean inputs.
 #
+# The default compile mode is cross-compilation. On ubuntu-latest this
+# builds and tests x86_64-unknown-linux-musl unless the caller selects
+# `compile-mode: native` or overrides `target`.
+#
 # Usage:
 #
 #   jobs:
@@ -16,8 +20,8 @@
 #       with:
 #         os: ubuntu-latest
 #
-# See README.md "Reusable Rust CI workflow" for the full input table
-# and cross-compile matrix example.
+# See README.md "Reusable Rust CI workflow" for the full input table,
+# native opt-in example, and cross-compile matrix example.
 
 name: rust-ci (reusable)
 
@@ -29,14 +33,24 @@ on:
         type: string
         required: false
         default: ubuntu-latest
-      target:
-        description: >
-          Rust target triple. Empty (default) builds for the host. A non-empty
-          value triggers `rustup target add <target>` plus `--target <target>`
-          on every cargo invocation.
+      compile-mode:
+        description: Compilation mode. Accepted values are "cross" (default) and "native".
         type: string
         required: false
-        default: ""
+        default: cross
+      target:
+        description: >
+          Rust target triple used when compile-mode is "cross". The default
+          x86_64-unknown-linux-musl gives ubuntu-latest a real non-host target
+          that can still run tests. Ignored when compile-mode is "native".
+        type: string
+        required: false
+        default: x86_64-unknown-linux-musl
+      working-directory:
+        description: Directory containing the Rust workspace or package to check.
+        type: string
+        required: false
+        default: "."
       toolchain:
         description: >
           Forwarded to setup-soldr's `toolchain` input. Empty (default) means
@@ -88,33 +102,132 @@ on:
         type: boolean
         required: false
         default: false
+  workflow_dispatch:
+    inputs:
+      os:
+        description: Runner label.
+        type: string
+        required: false
+        default: ubuntu-latest
+      compile-mode:
+        description: Compilation mode.
+        type: choice
+        required: false
+        default: cross
+        options:
+          - cross
+          - native
+      target:
+        description: Rust target triple used when compile-mode is cross.
+        type: string
+        required: false
+        default: x86_64-unknown-linux-musl
+      working-directory:
+        description: Directory containing the Rust workspace or package to check.
+        type: string
+        required: false
+        default: scripts/bench-workloads/demo-small
+      toolchain:
+        description: Toolchain forwarded to setup-soldr.
+        type: string
+        required: false
+        default: ""
+      features:
+        description: Features forwarded to the warm build.
+        type: string
+        required: false
+        default: ""
+      cargo-args:
+        description: Extra args appended to the warm build.
+        type: string
+        required: false
+        default: ""
+      cache:
+        description: Forward setup-soldr cache switch.
+        type: boolean
+        required: false
+        default: true
+      lint:
+        description: Run cargo check.
+        type: boolean
+        required: false
+        default: true
+      fmt:
+        description: Run cargo fmt --check.
+        type: boolean
+        required: false
+        default: true
+      clippy:
+        description: Run cargo clippy.
+        type: boolean
+        required: false
+        default: true
+      test:
+        description: Run cargo test.
+        type: boolean
+        required: false
+        default: true
+      dylint:
+        description: Run cargo dylint.
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   warm:
     name: warm (build)
     runs-on: ${{ inputs.os }}
+    outputs:
+      target: ${{ steps.mode.outputs.target }}
+      cross_targets: ${{ steps.mode.outputs.cross_targets }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Resolve compilation mode
+        id: mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          mode="${{ inputs.compile-mode }}"
+          target="${{ inputs.target }}"
+          if [ -z "$mode" ]; then
+            mode="cross"
+          fi
+          case "$mode" in
+            cross)
+              if [ -z "$target" ]; then
+                target="x86_64-unknown-linux-musl"
+              fi
+              echo "target=$target" >> "$GITHUB_OUTPUT"
+              echo "cross_targets=$target" >> "$GITHUB_OUTPUT"
+              ;;
+            native)
+              echo "target=" >> "$GITHUB_OUTPUT"
+              echo "cross_targets=" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error title=Invalid compile-mode::compile-mode must be 'cross' or 'native' (got '$mode')"
+              exit 1
+              ;;
+          esac
 
       - name: Setup soldr
         uses: zackees/setup-soldr@v0
         with:
           toolchain: ${{ inputs.toolchain }}
           cache: ${{ inputs.cache }}
-
-      - name: Add cross-compile target
-        if: inputs.target != ''
-        shell: bash
-        run: rustup target add "${{ inputs.target }}"
+          cross-targets: ${{ steps.mode.outputs.cross_targets }}
 
       - name: Warm build (workspace, all-targets)
         shell: bash
+        working-directory: ${{ inputs.working-directory }}
         run: |
           set -euo pipefail
           args=(--workspace --all-targets)
-          if [ -n "${{ inputs.target }}" ]; then
-            args+=(--target "${{ inputs.target }}")
+          target="${{ steps.mode.outputs.target }}"
+          if [ -n "$target" ]; then
+            args+=(--target "$target")
           fi
           if [ -n "${{ inputs.features }}" ]; then
             args+=(--features "${{ inputs.features }}")
@@ -140,6 +253,7 @@ jobs:
 
       - name: cargo fmt --check
         shell: bash
+        working-directory: ${{ inputs.working-directory }}
         run: soldr cargo fmt --all -- --check
 
   lint:
@@ -156,19 +270,17 @@ jobs:
         with:
           toolchain: ${{ inputs.toolchain }}
           cache: ${{ inputs.cache }}
-
-      - name: Add cross-compile target
-        if: inputs.target != ''
-        shell: bash
-        run: rustup target add "${{ inputs.target }}"
+          cross-targets: ${{ needs.warm.outputs.cross_targets }}
 
       - name: cargo check
         shell: bash
+        working-directory: ${{ inputs.working-directory }}
         run: |
           set -euo pipefail
           args=(--workspace --all-targets)
-          if [ -n "${{ inputs.target }}" ]; then
-            args+=(--target "${{ inputs.target }}")
+          target="${{ needs.warm.outputs.target }}"
+          if [ -n "$target" ]; then
+            args+=(--target "$target")
           fi
           soldr cargo check "${args[@]}"
 
@@ -186,19 +298,17 @@ jobs:
         with:
           toolchain: ${{ inputs.toolchain }}
           cache: ${{ inputs.cache }}
-
-      - name: Add cross-compile target
-        if: inputs.target != ''
-        shell: bash
-        run: rustup target add "${{ inputs.target }}"
+          cross-targets: ${{ needs.warm.outputs.cross_targets }}
 
       - name: cargo clippy
         shell: bash
+        working-directory: ${{ inputs.working-directory }}
         run: |
           set -euo pipefail
           args=(--workspace --all-targets)
-          if [ -n "${{ inputs.target }}" ]; then
-            args+=(--target "${{ inputs.target }}")
+          target="${{ needs.warm.outputs.target }}"
+          if [ -n "$target" ]; then
+            args+=(--target "$target")
           fi
           soldr cargo clippy "${args[@]}" -- -D warnings
 
@@ -216,19 +326,17 @@ jobs:
         with:
           toolchain: ${{ inputs.toolchain }}
           cache: ${{ inputs.cache }}
-
-      - name: Add cross-compile target
-        if: inputs.target != ''
-        shell: bash
-        run: rustup target add "${{ inputs.target }}"
+          cross-targets: ${{ needs.warm.outputs.cross_targets }}
 
       - name: cargo test
         shell: bash
+        working-directory: ${{ inputs.working-directory }}
         run: |
           set -euo pipefail
           args=(--workspace)
-          if [ -n "${{ inputs.target }}" ]; then
-            args+=(--target "${{ inputs.target }}")
+          target="${{ needs.warm.outputs.target }}"
+          if [ -n "$target" ]; then
+            args+=(--target "$target")
           fi
           soldr cargo test "${args[@]}"
 
@@ -255,4 +363,5 @@ jobs:
 
       - name: cargo dylint
         shell: bash
+        working-directory: ${{ inputs.working-directory }}
         run: soldr cargo dylint --all --workspace

--- a/.github/workflows/setup-soldr-contract.yml
+++ b/.github/workflows/setup-soldr-contract.yml
@@ -18,6 +18,7 @@ on:
       - tsconfig.json
       - .github/workflows/setup-soldr-action.yml
       - .github/workflows/bench-cache-modes.yml
+      - .github/workflows/rust-ci.yml
       - .github/workflows/setup-soldr-contract.yml
   pull_request:
     paths:
@@ -34,6 +35,7 @@ on:
       - tsconfig.json
       - .github/workflows/setup-soldr-action.yml
       - .github/workflows/bench-cache-modes.yml
+      - .github/workflows/rust-ci.yml
       - .github/workflows/setup-soldr-contract.yml
   workflow_dispatch:
 
@@ -129,4 +131,5 @@ jobs:
           python -m pytest \
             tests/test_action_target_cache_wiring.py \
             tests/test_bench_cache_modes_workflow.py \
+            tests/test_rust_ci_workflow.py \
             tests/test_release_rollout_contract.py

--- a/README.md
+++ b/README.md
@@ -144,9 +144,24 @@ warm-then-fan-out pattern: a single `warm` job runs `setup-soldr` plus
 `soldr cargo build --workspace --all-targets` to populate the caches,
 then each per-tool job re-runs `setup-soldr` (same SHA = same cache
 key, so it hits the freshly-saved cache) and runs its own `soldr
-cargo …` invocation. Per-tool jobs are independently toggleable.
+cargo ...` invocation. Per-tool jobs are independently toggleable.
 
-Publishing / artifact / release work is intentionally out of scope —
+The reusable workflow is cross-compilation-first. By default it runs in
+`compile-mode: cross` and builds the non-host
+`x86_64-unknown-linux-musl` target on `ubuntu-latest`. That target keeps
+the default CI lane genuinely cross-compiled while still letting the
+workflow run `soldr cargo test --target x86_64-unknown-linux-musl` on
+Linux. Select `compile-mode: native` when you want the previous
+host-target behavior with no `--target` flag.
+
+The workflow can be called from another workflow with `workflow_call`, and
+maintainers can also run it directly from the Actions tab with
+`workflow_dispatch` to compare cross and native modes on demand. Reusable
+callers default to `working-directory: .`; manual runs in this repository
+default to `scripts/bench-workloads/demo-small` so the dispatched workflow
+has a small Rust fixture to compile.
+
+Publishing / artifact / release work is intentionally out of scope --
 release flows vary too much across repos to template.
 
 #### Inputs
@@ -154,18 +169,20 @@ release flows vary too much across repos to template.
 | Name | Type | Default | Purpose |
 | --- | --- | --- | --- |
 | `os` | string | `ubuntu-latest` | Runner label. |
-| `target` | string | `""` (host) | Rust target triple. Non-empty triggers `rustup target add` + `--target` on every cargo invocation. |
+| `compile-mode` | string | `cross` | Compilation mode. `cross` uses setup-soldr's cross-target provisioning and passes `--target`; `native` builds the runner host target with no `--target`. |
+| `target` | string | `x86_64-unknown-linux-musl` | Rust target triple used only when `compile-mode: cross`. Ignored in native mode. |
+| `working-directory` | string | `.` (`workflow_call`), `scripts/bench-workloads/demo-small` (`workflow_dispatch`) | Directory containing the Rust workspace or package to check. |
 | `toolchain` | string | `""` | Forwarded to `setup-soldr`. Empty = `rust-toolchain.toml` or `stable`. |
 | `features` | string | `""` | Forwarded as `--features` to the warm build. |
 | `cargo-args` | string | `""` | Free-form extra args appended to the warm build. |
 | `cache` | boolean | `true` | Forwarded to `setup-soldr`'s umbrella cache switch. |
-| `lint` | boolean | `true` | `cargo check --workspace --all-targets`. |
-| `fmt` | boolean | `true` | `cargo fmt --all -- --check`. |
-| `clippy` | boolean | `true` | `cargo clippy --workspace --all-targets -- -D warnings`. |
-| `test` | boolean | `true` | `cargo test --workspace`. |
-| `dylint` | boolean | `false` | `cargo dylint --all --workspace` (installs `cargo-dylint` + `dylint-link` first). Opt-in: needs a consumer-provided `dylint.toml`. |
+| `lint` | boolean | `true` | `soldr cargo check --workspace --all-targets`. |
+| `fmt` | boolean | `true` | `soldr cargo fmt --all -- --check`. |
+| `clippy` | boolean | `true` | `soldr cargo clippy --workspace --all-targets -- -D warnings`. |
+| `test` | boolean | `true` | `soldr cargo test --workspace`. |
+| `dylint` | boolean | `false` | `soldr cargo dylint --all --workspace` (installs `cargo-dylint` + `dylint-link` first). Opt-in: needs a consumer-provided `dylint.toml`. |
 
-#### Simple consumer
+#### Default cross-compile consumer
 
 ```yaml
 jobs:
@@ -174,6 +191,23 @@ jobs:
     with:
       os: ubuntu-latest
       dylint: false
+```
+
+That default invocation builds, checks, clippies, and tests
+`x86_64-unknown-linux-musl`. The workflow passes the effective target to
+setup-soldr's `cross-targets` input so target provisioning stays in the
+setup-soldr/soldr-owned path rather than direct workflow-level
+`cargo-zigbuild` or `cargo-xwin` installer steps.
+
+#### Native opt-in consumer
+
+```yaml
+jobs:
+  ci:
+    uses: zackees/setup-soldr/.github/workflows/rust-ci.yml@v0
+    with:
+      os: ubuntu-latest
+      compile-mode: native
 ```
 
 #### Cross-compile matrix
@@ -185,20 +219,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu }
-          - { os: ubuntu-latest,  target: aarch64-unknown-linux-musl }
-          - { os: macos-latest,   target: aarch64-apple-darwin }
-          - { os: windows-latest, target: x86_64-pc-windows-msvc }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-musl, test: true }
+          - { os: ubuntu-latest, target: aarch64-unknown-linux-musl, test: false }
+          - { os: ubuntu-latest, target: x86_64-pc-windows-gnu, test: false }
     uses: zackees/setup-soldr/.github/workflows/rust-ci.yml@v0
     with:
-      os:     ${{ matrix.os }}
-      target: ${{ matrix.target }}
-      test:   ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+      os:           ${{ matrix.os }}
+      compile-mode: cross
+      target:       ${{ matrix.target }}
+      test:         ${{ matrix.test }}
 ```
 
-Cross-compiled binaries usually can't run on the host, so the matrix
-example gates `test:` on the native cell. The template never tries to
-auto-detect runnability — the consumer chooses.
+Cross-compiled binaries usually cannot run on the host, so the matrix
+example gates `test:` on the runnable musl cell. The template never tries
+to auto-detect runnability; the consumer chooses.
 
 ## Multi-platform builds (cross-target tutorial)
 

--- a/tests/test_release_rollout_contract.py
+++ b/tests/test_release_rollout_contract.py
@@ -14,6 +14,7 @@ def test_rollout_contract_workflow_covers_main_pr_and_manual_runs() -> None:
     assert "push:" in workflow
     assert "pull_request:" in workflow
     assert "- .github/workflows/setup-soldr-action.yml" in workflow
+    assert "- .github/workflows/rust-ci.yml" in workflow
     assert "- .github/workflows/setup-soldr-contract.yml" in workflow
 
 
@@ -46,4 +47,5 @@ def test_rollout_contract_workflow_runs_remaining_python_contract_tests() -> Non
 
     assert "python -m pytest" in workflow
     assert "tests/test_action_target_cache_wiring.py" in workflow
+    assert "tests/test_rust_ci_workflow.py" in workflow
     assert "tests/test_release_rollout_contract.py" in workflow

--- a/tests/test_rust_ci_workflow.py
+++ b/tests/test_rust_ci_workflow.py
@@ -1,0 +1,114 @@
+"""Contract tests for the reusable Rust CI workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "rust-ci.yml"
+README_PATH = REPO_ROOT / "README.md"
+DEFAULT_CROSS_TARGET = "x86_64-unknown-linux-musl"
+
+
+def _load_workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict) -> dict:
+    # PyYAML 1.1 treats the key "on" as a bool unless quoted.
+    return workflow.get("on") or workflow.get(True)
+
+
+def _step_named(job: dict, name: str) -> dict:
+    return next(step for step in job["steps"] if step.get("name") == name)
+
+
+def test_rust_ci_is_cross_first_for_reusable_and_manual_runs() -> None:
+    workflow = _load_workflow()
+    triggers = _triggers(workflow)
+
+    call_inputs = triggers["workflow_call"]["inputs"]
+    assert call_inputs["compile-mode"]["default"] == "cross"
+    assert call_inputs["target"]["default"] == DEFAULT_CROSS_TARGET
+    assert call_inputs["working-directory"]["default"] == "."
+    assert call_inputs["compile-mode"]["type"] == "string"
+
+    dispatch_inputs = triggers["workflow_dispatch"]["inputs"]
+    assert dispatch_inputs["compile-mode"]["default"] == "cross"
+    assert dispatch_inputs["compile-mode"]["type"] == "choice"
+    assert dispatch_inputs["compile-mode"]["options"] == ["cross", "native"]
+    assert dispatch_inputs["target"]["default"] == DEFAULT_CROSS_TARGET
+    assert dispatch_inputs["working-directory"]["default"] == "scripts/bench-workloads/demo-small"
+
+
+def test_warm_job_resolves_cross_and_native_modes_once() -> None:
+    workflow = _load_workflow()
+    warm = workflow["jobs"]["warm"]
+
+    assert warm["outputs"]["target"] == "${{ steps.mode.outputs.target }}"
+    assert warm["outputs"]["cross_targets"] == "${{ steps.mode.outputs.cross_targets }}"
+
+    resolve = _step_named(warm, "Resolve compilation mode")
+    script = resolve["run"]
+    assert 'mode="${{ inputs.compile-mode }}"' in script
+    assert 'target="${{ inputs.target }}"' in script
+    assert "mode=\"cross\"" in script
+    assert f'target="{DEFAULT_CROSS_TARGET}"' in script
+    assert "cross_targets=$target" in script
+    assert "native)" in script
+    assert "compile-mode must be 'cross' or 'native'" in script
+
+
+def test_targeted_jobs_use_setup_soldr_cross_targets_output() -> None:
+    workflow = _load_workflow()
+
+    warm_setup = _step_named(workflow["jobs"]["warm"], "Setup soldr")
+    assert warm_setup["with"]["cross-targets"] == "${{ steps.mode.outputs.cross_targets }}"
+
+    for job_name, step_name in (
+        ("warm", "Warm build (workspace, all-targets)"),
+        ("lint", "cargo check"),
+        ("clippy", "cargo clippy"),
+        ("test", "cargo test"),
+    ):
+        job = workflow["jobs"][job_name]
+        if job_name != "warm":
+            setup = _step_named(job, "Setup soldr")
+            assert setup["with"]["cross-targets"] == "${{ needs.warm.outputs.cross_targets }}"
+
+        run_step = _step_named(job, step_name)
+        assert run_step["working-directory"] == "${{ inputs.working-directory }}"
+        target_expr = "steps.mode.outputs.target" if job_name == "warm" else "needs.warm.outputs.target"
+        assert f'target="${{{{ {target_expr} }}}}"' in run_step["run"]
+        assert 'args+=(--target "$target")' in run_step["run"]
+
+
+def test_native_mode_preserves_host_target_behavior() -> None:
+    workflow = _load_workflow()
+    resolve_script = _step_named(workflow["jobs"]["warm"], "Resolve compilation mode")["run"]
+
+    native_branch = resolve_script.split("native)", 1)[1].split(";;", 1)[0]
+    assert 'echo "target=" >> "$GITHUB_OUTPUT"' in native_branch
+    assert 'echo "cross_targets=" >> "$GITHUB_OUTPUT"' in native_branch
+
+
+def test_rust_ci_workflow_does_not_directly_install_cross_tooling() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    tool = "car" + "go"
+
+    assert "rustup target add" not in text
+    assert f"{tool} zigbuild" not in text
+    assert f"{tool}-xwin" not in text
+
+
+def test_readme_documents_cross_default_native_opt_in_and_manual_trigger() -> None:
+    readme = README_PATH.read_text(encoding="utf-8")
+
+    assert "The reusable workflow is cross-compilation-first." in readme
+    assert "`compile-mode: cross`" in readme
+    assert "`compile-mode: native`" in readme
+    assert "`workflow_dispatch`" in readme
+    assert DEFAULT_CROSS_TARGET in readme


### PR DESCRIPTION
﻿## Summary

- Make `.github/workflows/rust-ci.yml` cross-compilation-first with `compile-mode: cross` as the default and `compile-mode: native` as the host-target opt-in.
- Route the effective target through setup-soldr's `cross-targets` input and remove direct workflow-level target provisioning.
- Add `workflow_dispatch` plus a `working-directory` input so maintainers can trigger a real in-repo cross/native smoke against `scripts/bench-workloads/demo-small`.
- Document the new defaults, native opt-in, and cross matrix, and add Python contract coverage for the workflow surface.

Closes #407

## Tests

- `python -m pytest tests/test_action_target_cache_wiring.py tests/test_bench_cache_modes_workflow.py tests/test_rust_ci_workflow.py tests/test_release_rollout_contract.py`
- `npm test`
- `npm run typecheck`
