### PR TITLE
fix: ensure rust-ci cross target via soldr toolchain

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -213,11 +213,33 @@ jobs:
           esac
 
       - name: Setup soldr
+        id: setup
         uses: zackees/setup-soldr@v0
         with:
           toolchain: ${{ inputs.toolchain }}
           cache: ${{ inputs.cache }}
           cross-targets: ${{ steps.mode.outputs.cross_targets }}
+
+      - name: Ensure rust-ci toolchain extras
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(toolchain ensure --json)
+          channel="${{ steps.setup.outputs.toolchain }}"
+          if [ -n "$channel" ]; then
+            args+=(--channel "$channel")
+          fi
+          if [ "${{ inputs.fmt }}" = "true" ]; then
+            args+=(--component rustfmt)
+          fi
+          if [ "${{ inputs.clippy }}" = "true" ]; then
+            args+=(--component clippy)
+          fi
+          target="${{ steps.mode.outputs.target }}"
+          if [ -n "$target" ]; then
+            args+=(--target "$target")
+          fi
+          soldr "${args[@]}"
 
       - name: Warm build (workspace, all-targets)
         shell: bash
@@ -246,10 +268,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup soldr
+        id: setup
         uses: zackees/setup-soldr@v0
         with:
           toolchain: ${{ inputs.toolchain }}
           cache: ${{ inputs.cache }}
+
+      - name: Ensure rust-ci toolchain extras
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(toolchain ensure --json)
+          channel="${{ steps.setup.outputs.toolchain }}"
+          if [ -n "$channel" ]; then
+            args+=(--channel "$channel")
+          fi
+          args+=(--component rustfmt)
+          soldr "${args[@]}"
 
       - name: cargo fmt --check
         shell: bash
@@ -266,11 +301,27 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup soldr
+        id: setup
         uses: zackees/setup-soldr@v0
         with:
           toolchain: ${{ inputs.toolchain }}
           cache: ${{ inputs.cache }}
           cross-targets: ${{ needs.warm.outputs.cross_targets }}
+
+      - name: Ensure rust-ci toolchain extras
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(toolchain ensure --json)
+          channel="${{ steps.setup.outputs.toolchain }}"
+          if [ -n "$channel" ]; then
+            args+=(--channel "$channel")
+          fi
+          target="${{ needs.warm.outputs.target }}"
+          if [ -n "$target" ]; then
+            args+=(--target "$target")
+          fi
+          soldr "${args[@]}"
 
       - name: cargo check
         shell: bash
@@ -294,11 +345,27 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup soldr
+        id: setup
         uses: zackees/setup-soldr@v0
         with:
           toolchain: ${{ inputs.toolchain }}
           cache: ${{ inputs.cache }}
           cross-targets: ${{ needs.warm.outputs.cross_targets }}
+
+      - name: Ensure rust-ci toolchain extras
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(toolchain ensure --json --component clippy)
+          channel="${{ steps.setup.outputs.toolchain }}"
+          if [ -n "$channel" ]; then
+            args+=(--channel "$channel")
+          fi
+          target="${{ needs.warm.outputs.target }}"
+          if [ -n "$target" ]; then
+            args+=(--target "$target")
+          fi
+          soldr "${args[@]}"
 
       - name: cargo clippy
         shell: bash
@@ -322,11 +389,27 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup soldr
+        id: setup
         uses: zackees/setup-soldr@v0
         with:
           toolchain: ${{ inputs.toolchain }}
           cache: ${{ inputs.cache }}
           cross-targets: ${{ needs.warm.outputs.cross_targets }}
+
+      - name: Ensure rust-ci toolchain extras
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(toolchain ensure --json)
+          channel="${{ steps.setup.outputs.toolchain }}"
+          if [ -n "$channel" ]; then
+            args+=(--channel "$channel")
+          fi
+          target="${{ needs.warm.outputs.target }}"
+          if [ -n "$target" ]; then
+            args+=(--target "$target")
+          fi
+          soldr "${args[@]}"
 
       - name: cargo test
         shell: bash
@@ -350,6 +433,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup soldr
+        id: setup
         uses: zackees/setup-soldr@v0
         with:
           toolchain: ${{ inputs.toolchain }}

--- a/README.md
+++ b/README.md
@@ -195,9 +195,11 @@ jobs:
 
 That default invocation builds, checks, clippies, and tests
 `x86_64-unknown-linux-musl`. The workflow passes the effective target to
-setup-soldr's `cross-targets` input so target provisioning stays in the
-setup-soldr/soldr-owned path rather than direct workflow-level
-`cargo-zigbuild` or `cargo-xwin` installer steps.
+setup-soldr's `cross-targets` input and then runs
+`soldr toolchain ensure --json --target <target>` before each targeted
+Rust command. Target provisioning stays in the setup-soldr/soldr-owned
+path rather than direct workflow-level `rustup target add`,
+`cargo-zigbuild`, or `cargo-xwin` installer steps.
 
 #### Native opt-in consumer
 

--- a/tests/test_rust_ci_workflow.py
+++ b/tests/test_rust_ci_workflow.py
@@ -66,6 +66,7 @@ def test_targeted_jobs_use_setup_soldr_cross_targets_output() -> None:
     workflow = _load_workflow()
 
     warm_setup = _step_named(workflow["jobs"]["warm"], "Setup soldr")
+    assert warm_setup["id"] == "setup"
     assert warm_setup["with"]["cross-targets"] == "${{ steps.mode.outputs.cross_targets }}"
 
     for job_name, step_name in (
@@ -77,6 +78,7 @@ def test_targeted_jobs_use_setup_soldr_cross_targets_output() -> None:
         job = workflow["jobs"][job_name]
         if job_name != "warm":
             setup = _step_named(job, "Setup soldr")
+            assert setup["id"] == "setup"
             assert setup["with"]["cross-targets"] == "${{ needs.warm.outputs.cross_targets }}"
 
         run_step = _step_named(job, step_name)
@@ -84,6 +86,37 @@ def test_targeted_jobs_use_setup_soldr_cross_targets_output() -> None:
         target_expr = "steps.mode.outputs.target" if job_name == "warm" else "needs.warm.outputs.target"
         assert f'target="${{{{ {target_expr} }}}}"' in run_step["run"]
         assert 'args+=(--target "$target")' in run_step["run"]
+
+
+def test_rust_ci_ensures_targets_through_soldr_toolchain() -> None:
+    workflow = _load_workflow()
+
+    expected_targets = {
+        "warm": "steps.mode.outputs.target",
+        "lint": "needs.warm.outputs.target",
+        "clippy": "needs.warm.outputs.target",
+        "test": "needs.warm.outputs.target",
+    }
+    for job_name, target_expr in expected_targets.items():
+        ensure = _step_named(workflow["jobs"][job_name], "Ensure rust-ci toolchain extras")
+        script = ensure["run"]
+        assert "args=(toolchain ensure --json" in script
+        assert 'channel="${{ steps.setup.outputs.toolchain }}"' in script
+        assert f'target="${{{{ {target_expr} }}}}"' in script
+        assert 'args+=(--target "$target")' in script
+        assert 'soldr "${args[@]}"' in script
+
+    warm_script = _step_named(workflow["jobs"]["warm"], "Ensure rust-ci toolchain extras")["run"]
+    assert "args+=(--component rustfmt)" in warm_script
+    assert "args+=(--component clippy)" in warm_script
+    assert '${{ inputs.fmt }}' in warm_script
+    assert '${{ inputs.clippy }}' in warm_script
+
+    fmt_script = _step_named(workflow["jobs"]["fmt"], "Ensure rust-ci toolchain extras")["run"]
+    assert "args+=(--component rustfmt)" in fmt_script
+
+    clippy_script = _step_named(workflow["jobs"]["clippy"], "Ensure rust-ci toolchain extras")["run"]
+    assert "toolchain ensure --json --component clippy" in clippy_script
 
 
 def test_native_mode_preserves_host_target_behavior() -> None:
@@ -111,4 +144,5 @@ def test_readme_documents_cross_default_native_opt_in_and_manual_trigger() -> No
     assert "`compile-mode: cross`" in readme
     assert "`compile-mode: native`" in readme
     assert "`workflow_dispatch`" in readme
+    assert "`soldr toolchain ensure --json --target <target>`" in readme
     assert DEFAULT_CROSS_TARGET in readme


### PR DESCRIPTION
﻿## Summary

- Add a soldr-owned `soldr toolchain ensure --json` step to the reusable rust-ci workflow so the effective cross target gets its Rust std component before `soldr cargo ... --target` runs.
- Keep target provisioning out of workflow-level `rustup target add` / direct cross-tool installer commands.
- Extend the workflow contract test and README to require the soldr toolchain path.

## Context

#408 merged the cross-first workflow surface and closed #407, but the default `workflow_dispatch` smoke failed on main because setup-soldr logged `Requested Rust targets: none` and the warm build hit `error[E0463]: can't find crate for core` for `x86_64-unknown-linux-musl`.

Refs #407

## Tests

- `python -m pytest tests/test_action_target_cache_wiring.py tests/test_bench_cache_modes_workflow.py tests/test_rust_ci_workflow.py tests/test_release_rollout_contract.py`
- `npm test`
- `npm run typecheck`
