### PR TITLE
fix: provision rust-ci targets via toolchain file

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -5,8 +5,10 @@
 # build/target/registry caches. Per-tool jobs (`fmt`, `lint`, `clippy`,
 # `test`, `dylint`) then each re-run setup-soldr (same SHA -> same
 # cache key, so the restore is a hot hit) and execute their respective
-# `soldr cargo ...` invocation. Per-tool jobs are individually toggleable
-# via boolean inputs.
+# `soldr cargo ...` invocation. Each Rust job writes a CI-owned
+# rust-toolchain file and passes it to setup-soldr so targets/components are
+# provisioned through setup-soldr's supported toolchain-file path. Per-tool
+# jobs are individually toggleable via boolean inputs.
 #
 # The default compile mode is cross-compilation. On ubuntu-latest this
 # builds and tests x86_64-unknown-linux-musl unless the caller selects
@@ -53,8 +55,8 @@ on:
         default: "."
       toolchain:
         description: >
-          Forwarded to setup-soldr's `toolchain` input. Empty (default) means
-          setup-soldr resolves the toolchain from `rust-toolchain.toml` and
+          Channel written into rust-toolchain.rust-ci.toml. Empty (default)
+          uses the channel from rust-toolchain.toml when present and otherwise
           falls back to stable.
         type: string
         required: false
@@ -128,7 +130,7 @@ on:
         required: false
         default: scripts/bench-workloads/demo-small
       toolchain:
-        description: Toolchain forwarded to setup-soldr.
+        description: Rust channel written into rust-toolchain.rust-ci.toml.
         type: string
         required: false
         default: ""
@@ -179,7 +181,6 @@ jobs:
     runs-on: ${{ inputs.os }}
     outputs:
       target: ${{ steps.mode.outputs.target }}
-      cross_targets: ${{ steps.mode.outputs.cross_targets }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -200,11 +201,9 @@ jobs:
                 target="x86_64-unknown-linux-musl"
               fi
               echo "target=$target" >> "$GITHUB_OUTPUT"
-              echo "cross_targets=$target" >> "$GITHUB_OUTPUT"
               ;;
             native)
               echo "target=" >> "$GITHUB_OUTPUT"
-              echo "cross_targets=" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error title=Invalid compile-mode::compile-mode must be 'cross' or 'native' (got '$mode')"
@@ -212,34 +211,55 @@ jobs:
               ;;
           esac
 
-      - name: Setup soldr
-        id: setup
-        uses: zackees/setup-soldr@v0
-        with:
-          toolchain: ${{ inputs.toolchain }}
-          cache: ${{ inputs.cache }}
-          cross-targets: ${{ steps.mode.outputs.cross_targets }}
-
-      - name: Ensure rust-ci toolchain extras
+      - name: Write rust-ci toolchain spec
+        id: toolchain
         shell: bash
         run: |
           set -euo pipefail
-          args=(toolchain ensure --json)
-          channel="${{ steps.setup.outputs.toolchain }}"
-          if [ -n "$channel" ]; then
-            args+=(--channel "$channel")
-          fi
-          if [ "${{ inputs.fmt }}" = "true" ]; then
-            args+=(--component rustfmt)
-          fi
-          if [ "${{ inputs.clippy }}" = "true" ]; then
-            args+=(--component clippy)
+          path="rust-toolchain.rust-ci.toml"
+          channel="${{ inputs.toolchain }}"
+          if [ -z "$channel" ]; then
+            channel="stable"
+            if [ -f rust-toolchain.toml ]; then
+              parsed="$(sed -n -E 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' rust-toolchain.toml | head -n 1)"
+              if [ -n "$parsed" ]; then
+                channel="$parsed"
+              fi
+            fi
           fi
           target="${{ steps.mode.outputs.target }}"
-          if [ -n "$target" ]; then
-            args+=(--target "$target")
+          components=()
+          if [ "${{ inputs.fmt }}" = "true" ]; then
+            components+=(rustfmt)
           fi
-          soldr "${args[@]}"
+          if [ "${{ inputs.clippy }}" = "true" ]; then
+            components+=(clippy)
+          fi
+          {
+            echo "[toolchain]"
+            printf 'channel = "%s"\n' "$channel"
+            echo 'profile = "minimal"'
+            if [ "${#components[@]}" -gt 0 ]; then
+              printf 'components = ['
+              sep=""
+              for component in "${components[@]}"; do
+                printf '%s"%s"' "$sep" "$component"
+                sep=", "
+              done
+              printf ']\n'
+            fi
+            if [ -n "$target" ]; then
+              printf 'targets = ["%s"]\n' "$target"
+            fi
+          } > "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+          sed 's/^/  /' "$path"
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain-file: ${{ steps.toolchain.outputs.path }}
+          cache: ${{ inputs.cache }}
 
       - name: Warm build (workspace, all-targets)
         shell: bash
@@ -267,24 +287,55 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup soldr
-        id: setup
-        uses: zackees/setup-soldr@v0
-        with:
-          toolchain: ${{ inputs.toolchain }}
-          cache: ${{ inputs.cache }}
-
-      - name: Ensure rust-ci toolchain extras
+      - name: Write rust-ci toolchain spec
+        id: toolchain
         shell: bash
         run: |
           set -euo pipefail
-          args=(toolchain ensure --json)
-          channel="${{ steps.setup.outputs.toolchain }}"
-          if [ -n "$channel" ]; then
-            args+=(--channel "$channel")
+          path="rust-toolchain.rust-ci.toml"
+          channel="${{ inputs.toolchain }}"
+          if [ -z "$channel" ]; then
+            channel="stable"
+            if [ -f rust-toolchain.toml ]; then
+              parsed="$(sed -n -E 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' rust-toolchain.toml | head -n 1)"
+              if [ -n "$parsed" ]; then
+                channel="$parsed"
+              fi
+            fi
           fi
-          args+=(--component rustfmt)
-          soldr "${args[@]}"
+          target="${{ needs.warm.outputs.target }}"
+          components=()
+          if [ "${{ inputs.fmt }}" = "true" ]; then
+            components+=(rustfmt)
+          fi
+          if [ "${{ inputs.clippy }}" = "true" ]; then
+            components+=(clippy)
+          fi
+          {
+            echo "[toolchain]"
+            printf 'channel = "%s"\n' "$channel"
+            echo 'profile = "minimal"'
+            if [ "${#components[@]}" -gt 0 ]; then
+              printf 'components = ['
+              sep=""
+              for component in "${components[@]}"; do
+                printf '%s"%s"' "$sep" "$component"
+                sep=", "
+              done
+              printf ']\n'
+            fi
+            if [ -n "$target" ]; then
+              printf 'targets = ["%s"]\n' "$target"
+            fi
+          } > "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+          sed 's/^/  /' "$path"
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain-file: ${{ steps.toolchain.outputs.path }}
+          cache: ${{ inputs.cache }}
 
       - name: cargo fmt --check
         shell: bash
@@ -300,28 +351,55 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup soldr
-        id: setup
-        uses: zackees/setup-soldr@v0
-        with:
-          toolchain: ${{ inputs.toolchain }}
-          cache: ${{ inputs.cache }}
-          cross-targets: ${{ needs.warm.outputs.cross_targets }}
-
-      - name: Ensure rust-ci toolchain extras
+      - name: Write rust-ci toolchain spec
+        id: toolchain
         shell: bash
         run: |
           set -euo pipefail
-          args=(toolchain ensure --json)
-          channel="${{ steps.setup.outputs.toolchain }}"
-          if [ -n "$channel" ]; then
-            args+=(--channel "$channel")
+          path="rust-toolchain.rust-ci.toml"
+          channel="${{ inputs.toolchain }}"
+          if [ -z "$channel" ]; then
+            channel="stable"
+            if [ -f rust-toolchain.toml ]; then
+              parsed="$(sed -n -E 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' rust-toolchain.toml | head -n 1)"
+              if [ -n "$parsed" ]; then
+                channel="$parsed"
+              fi
+            fi
           fi
           target="${{ needs.warm.outputs.target }}"
-          if [ -n "$target" ]; then
-            args+=(--target "$target")
+          components=()
+          if [ "${{ inputs.fmt }}" = "true" ]; then
+            components+=(rustfmt)
           fi
-          soldr "${args[@]}"
+          if [ "${{ inputs.clippy }}" = "true" ]; then
+            components+=(clippy)
+          fi
+          {
+            echo "[toolchain]"
+            printf 'channel = "%s"\n' "$channel"
+            echo 'profile = "minimal"'
+            if [ "${#components[@]}" -gt 0 ]; then
+              printf 'components = ['
+              sep=""
+              for component in "${components[@]}"; do
+                printf '%s"%s"' "$sep" "$component"
+                sep=", "
+              done
+              printf ']\n'
+            fi
+            if [ -n "$target" ]; then
+              printf 'targets = ["%s"]\n' "$target"
+            fi
+          } > "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+          sed 's/^/  /' "$path"
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain-file: ${{ steps.toolchain.outputs.path }}
+          cache: ${{ inputs.cache }}
 
       - name: cargo check
         shell: bash
@@ -344,28 +422,55 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup soldr
-        id: setup
-        uses: zackees/setup-soldr@v0
-        with:
-          toolchain: ${{ inputs.toolchain }}
-          cache: ${{ inputs.cache }}
-          cross-targets: ${{ needs.warm.outputs.cross_targets }}
-
-      - name: Ensure rust-ci toolchain extras
+      - name: Write rust-ci toolchain spec
+        id: toolchain
         shell: bash
         run: |
           set -euo pipefail
-          args=(toolchain ensure --json --component clippy)
-          channel="${{ steps.setup.outputs.toolchain }}"
-          if [ -n "$channel" ]; then
-            args+=(--channel "$channel")
+          path="rust-toolchain.rust-ci.toml"
+          channel="${{ inputs.toolchain }}"
+          if [ -z "$channel" ]; then
+            channel="stable"
+            if [ -f rust-toolchain.toml ]; then
+              parsed="$(sed -n -E 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' rust-toolchain.toml | head -n 1)"
+              if [ -n "$parsed" ]; then
+                channel="$parsed"
+              fi
+            fi
           fi
           target="${{ needs.warm.outputs.target }}"
-          if [ -n "$target" ]; then
-            args+=(--target "$target")
+          components=()
+          if [ "${{ inputs.fmt }}" = "true" ]; then
+            components+=(rustfmt)
           fi
-          soldr "${args[@]}"
+          if [ "${{ inputs.clippy }}" = "true" ]; then
+            components+=(clippy)
+          fi
+          {
+            echo "[toolchain]"
+            printf 'channel = "%s"\n' "$channel"
+            echo 'profile = "minimal"'
+            if [ "${#components[@]}" -gt 0 ]; then
+              printf 'components = ['
+              sep=""
+              for component in "${components[@]}"; do
+                printf '%s"%s"' "$sep" "$component"
+                sep=", "
+              done
+              printf ']\n'
+            fi
+            if [ -n "$target" ]; then
+              printf 'targets = ["%s"]\n' "$target"
+            fi
+          } > "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+          sed 's/^/  /' "$path"
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain-file: ${{ steps.toolchain.outputs.path }}
+          cache: ${{ inputs.cache }}
 
       - name: cargo clippy
         shell: bash
@@ -388,28 +493,55 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup soldr
-        id: setup
-        uses: zackees/setup-soldr@v0
-        with:
-          toolchain: ${{ inputs.toolchain }}
-          cache: ${{ inputs.cache }}
-          cross-targets: ${{ needs.warm.outputs.cross_targets }}
-
-      - name: Ensure rust-ci toolchain extras
+      - name: Write rust-ci toolchain spec
+        id: toolchain
         shell: bash
         run: |
           set -euo pipefail
-          args=(toolchain ensure --json)
-          channel="${{ steps.setup.outputs.toolchain }}"
-          if [ -n "$channel" ]; then
-            args+=(--channel "$channel")
+          path="rust-toolchain.rust-ci.toml"
+          channel="${{ inputs.toolchain }}"
+          if [ -z "$channel" ]; then
+            channel="stable"
+            if [ -f rust-toolchain.toml ]; then
+              parsed="$(sed -n -E 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' rust-toolchain.toml | head -n 1)"
+              if [ -n "$parsed" ]; then
+                channel="$parsed"
+              fi
+            fi
           fi
           target="${{ needs.warm.outputs.target }}"
-          if [ -n "$target" ]; then
-            args+=(--target "$target")
+          components=()
+          if [ "${{ inputs.fmt }}" = "true" ]; then
+            components+=(rustfmt)
           fi
-          soldr "${args[@]}"
+          if [ "${{ inputs.clippy }}" = "true" ]; then
+            components+=(clippy)
+          fi
+          {
+            echo "[toolchain]"
+            printf 'channel = "%s"\n' "$channel"
+            echo 'profile = "minimal"'
+            if [ "${#components[@]}" -gt 0 ]; then
+              printf 'components = ['
+              sep=""
+              for component in "${components[@]}"; do
+                printf '%s"%s"' "$sep" "$component"
+                sep=", "
+              done
+              printf ']\n'
+            fi
+            if [ -n "$target" ]; then
+              printf 'targets = ["%s"]\n' "$target"
+            fi
+          } > "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+          sed 's/^/  /' "$path"
+
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain-file: ${{ steps.toolchain.outputs.path }}
+          cache: ${{ inputs.cache }}
 
       - name: cargo test
         shell: bash

--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ callers default to `working-directory: .`; manual runs in this repository
 default to `scripts/bench-workloads/demo-small` so the dispatched workflow
 has a small Rust fixture to compile.
 
+For each Rust job, the workflow writes `rust-toolchain.rust-ci.toml` with
+the effective channel, required components, and the cross target when
+`compile-mode: cross` is selected. That file is passed to `setup-soldr`
+through `toolchain-file`, so target/component provisioning stays inside
+setup-soldr's supported toolchain-file path.
+
 Publishing / artifact / release work is intentionally out of scope --
 release flows vary too much across repos to template.
 
@@ -169,10 +175,10 @@ release flows vary too much across repos to template.
 | Name | Type | Default | Purpose |
 | --- | --- | --- | --- |
 | `os` | string | `ubuntu-latest` | Runner label. |
-| `compile-mode` | string | `cross` | Compilation mode. `cross` uses setup-soldr's cross-target provisioning and passes `--target`; `native` builds the runner host target with no `--target`. |
+| `compile-mode` | string | `cross` | Compilation mode. `cross` writes the target into the generated setup-soldr toolchain file and passes `--target`; `native` builds the runner host target with no `--target`. |
 | `target` | string | `x86_64-unknown-linux-musl` | Rust target triple used only when `compile-mode: cross`. Ignored in native mode. |
 | `working-directory` | string | `.` (`workflow_call`), `scripts/bench-workloads/demo-small` (`workflow_dispatch`) | Directory containing the Rust workspace or package to check. |
-| `toolchain` | string | `""` | Forwarded to `setup-soldr`. Empty = `rust-toolchain.toml` or `stable`. |
+| `toolchain` | string | `""` | Channel written into `rust-toolchain.rust-ci.toml`. Empty = channel parsed from `rust-toolchain.toml` when present, otherwise `stable`. |
 | `features` | string | `""` | Forwarded as `--features` to the warm build. |
 | `cargo-args` | string | `""` | Free-form extra args appended to the warm build. |
 | `cache` | boolean | `true` | Forwarded to `setup-soldr`'s umbrella cache switch. |
@@ -194,12 +200,13 @@ jobs:
 ```
 
 That default invocation builds, checks, clippies, and tests
-`x86_64-unknown-linux-musl`. The workflow passes the effective target to
-setup-soldr's `cross-targets` input and then runs
-`soldr toolchain ensure --json --target <target>` before each targeted
-Rust command. Target provisioning stays in the setup-soldr/soldr-owned
-path rather than direct workflow-level `rustup target add`,
-`cargo-zigbuild`, or `cargo-xwin` installer steps.
+`x86_64-unknown-linux-musl`. The workflow writes
+`rust-toolchain.rust-ci.toml` with `targets =
+["x86_64-unknown-linux-musl"]` and passes it to `setup-soldr` through
+`toolchain-file` before each targeted Rust command. Target provisioning
+stays in the setup-soldr/soldr-owned path rather than direct
+workflow-level `rustup target add`, `cargo-zigbuild`, or `cargo-xwin`
+installer steps.
 
 #### Native opt-in consumer
 

--- a/tests/test_rust_ci_workflow.py
+++ b/tests/test_rust_ci_workflow.py
@@ -49,7 +49,6 @@ def test_warm_job_resolves_cross_and_native_modes_once() -> None:
     warm = workflow["jobs"]["warm"]
 
     assert warm["outputs"]["target"] == "${{ steps.mode.outputs.target }}"
-    assert warm["outputs"]["cross_targets"] == "${{ steps.mode.outputs.cross_targets }}"
 
     resolve = _step_named(warm, "Resolve compilation mode")
     script = resolve["run"]
@@ -57,17 +56,24 @@ def test_warm_job_resolves_cross_and_native_modes_once() -> None:
     assert 'target="${{ inputs.target }}"' in script
     assert "mode=\"cross\"" in script
     assert f'target="{DEFAULT_CROSS_TARGET}"' in script
-    assert "cross_targets=$target" in script
     assert "native)" in script
     assert "compile-mode must be 'cross' or 'native'" in script
 
 
-def test_targeted_jobs_use_setup_soldr_cross_targets_output() -> None:
+def test_jobs_pass_generated_toolchain_file_to_setup_soldr() -> None:
     workflow = _load_workflow()
 
-    warm_setup = _step_named(workflow["jobs"]["warm"], "Setup soldr")
-    assert warm_setup["id"] == "setup"
-    assert warm_setup["with"]["cross-targets"] == "${{ steps.mode.outputs.cross_targets }}"
+    for job_name in ("warm", "fmt", "lint", "clippy", "test"):
+        job = workflow["jobs"][job_name]
+        write = _step_named(job, "Write rust-ci toolchain spec")
+        assert write["id"] == "toolchain"
+        assert 'path="rust-toolchain.rust-ci.toml"' in write["run"]
+
+        setup = _step_named(job, "Setup soldr")
+        assert setup["with"]["toolchain-file"] == "${{ steps.toolchain.outputs.path }}"
+        assert "toolchain" not in setup["with"]
+        assert "cross-targets" not in setup["with"]
+        assert "cross-tool" not in setup["with"]
 
     for job_name, step_name in (
         ("warm", "Warm build (workspace, all-targets)"),
@@ -78,8 +84,7 @@ def test_targeted_jobs_use_setup_soldr_cross_targets_output() -> None:
         job = workflow["jobs"][job_name]
         if job_name != "warm":
             setup = _step_named(job, "Setup soldr")
-            assert setup["id"] == "setup"
-            assert setup["with"]["cross-targets"] == "${{ needs.warm.outputs.cross_targets }}"
+            assert setup["with"]["toolchain-file"] == "${{ steps.toolchain.outputs.path }}"
 
         run_step = _step_named(job, step_name)
         assert run_step["working-directory"] == "${{ inputs.working-directory }}"
@@ -88,35 +93,30 @@ def test_targeted_jobs_use_setup_soldr_cross_targets_output() -> None:
         assert 'args+=(--target "$target")' in run_step["run"]
 
 
-def test_rust_ci_ensures_targets_through_soldr_toolchain() -> None:
+def test_rust_ci_toolchain_specs_request_targets_and_components() -> None:
     workflow = _load_workflow()
 
     expected_targets = {
         "warm": "steps.mode.outputs.target",
+        "fmt": "needs.warm.outputs.target",
         "lint": "needs.warm.outputs.target",
         "clippy": "needs.warm.outputs.target",
         "test": "needs.warm.outputs.target",
     }
     for job_name, target_expr in expected_targets.items():
-        ensure = _step_named(workflow["jobs"][job_name], "Ensure rust-ci toolchain extras")
-        script = ensure["run"]
-        assert "args=(toolchain ensure --json" in script
-        assert 'channel="${{ steps.setup.outputs.toolchain }}"' in script
+        write = _step_named(workflow["jobs"][job_name], "Write rust-ci toolchain spec")
+        script = write["run"]
+        assert 'channel="${{ inputs.toolchain }}"' in script
+        assert "channel=\"stable\"" in script
+        assert 'sed -n -E' in script
+        assert 'echo "[toolchain]"' in script
+        assert "profile = \"minimal\"" in script
         assert f'target="${{{{ {target_expr} }}}}"' in script
-        assert 'args+=(--target "$target")' in script
-        assert 'soldr "${args[@]}"' in script
-
-    warm_script = _step_named(workflow["jobs"]["warm"], "Ensure rust-ci toolchain extras")["run"]
-    assert "args+=(--component rustfmt)" in warm_script
-    assert "args+=(--component clippy)" in warm_script
-    assert '${{ inputs.fmt }}' in warm_script
-    assert '${{ inputs.clippy }}' in warm_script
-
-    fmt_script = _step_named(workflow["jobs"]["fmt"], "Ensure rust-ci toolchain extras")["run"]
-    assert "args+=(--component rustfmt)" in fmt_script
-
-    clippy_script = _step_named(workflow["jobs"]["clippy"], "Ensure rust-ci toolchain extras")["run"]
-    assert "toolchain ensure --json --component clippy" in clippy_script
+        assert 'targets = ["%s"]' in script
+        assert "components+=(rustfmt)" in script
+        assert "components+=(clippy)" in script
+        assert '${{ inputs.fmt }}' in script
+        assert '${{ inputs.clippy }}' in script
 
 
 def test_native_mode_preserves_host_target_behavior() -> None:
@@ -125,7 +125,6 @@ def test_native_mode_preserves_host_target_behavior() -> None:
 
     native_branch = resolve_script.split("native)", 1)[1].split(";;", 1)[0]
     assert 'echo "target=" >> "$GITHUB_OUTPUT"' in native_branch
-    assert 'echo "cross_targets=" >> "$GITHUB_OUTPUT"' in native_branch
 
 
 def test_rust_ci_workflow_does_not_directly_install_cross_tooling() -> None:
@@ -133,6 +132,8 @@ def test_rust_ci_workflow_does_not_directly_install_cross_tooling() -> None:
     tool = "car" + "go"
 
     assert "rustup target add" not in text
+    assert "toolchain ensure" not in text
+    assert "cross-targets:" not in text
     assert f"{tool} zigbuild" not in text
     assert f"{tool}-xwin" not in text
 
@@ -144,5 +145,6 @@ def test_readme_documents_cross_default_native_opt_in_and_manual_trigger() -> No
     assert "`compile-mode: cross`" in readme
     assert "`compile-mode: native`" in readme
     assert "`workflow_dispatch`" in readme
-    assert "`soldr toolchain ensure --json --target <target>`" in readme
+    assert "`rust-toolchain.rust-ci.toml`" in readme
+    assert "`toolchain-file`" in readme
     assert DEFAULT_CROSS_TARGET in readme


### PR DESCRIPTION
## Summary
- replace rust-ci's manual `soldr toolchain ensure` calls with generated `rust-toolchain.rust-ci.toml` files passed to setup-soldr via `toolchain-file`
- keep the cross/native target resolution while avoiding the old `cross-targets` bootstrap path in the reusable workflow
- update the rust-ci contract tests and README docs for the generated toolchain-file flow

Refs #407

## Tests
- `python -m pytest tests/test_rust_ci_workflow.py tests/test_action_target_cache_wiring.py tests/test_bench_cache_modes_workflow.py tests/test_release_rollout_contract.py`
- YAML parse smoke for `.github/workflows/rust-ci.yml`
- `npm test`
- `npm run typecheck`
- `npm run build`