### PR TITLE
fix: format rust-ci demo fixture

### DIFF
--- a/scripts/bench-workloads/demo-small/src/main.rs
+++ b/scripts/bench-workloads/demo-small/src/main.rs
@@ -21,7 +21,10 @@ struct Greeting {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let g = Greeting { message: args.message, count: 1 };
+    let g = Greeting {
+        message: args.message,
+        count: 1,
+    };
     println!("{}", serde_json::to_string(&g)?);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- format the manual rust-ci dispatch demo fixture so the default `fmt` job passes

Refs #407

## Tests
- `soldr cargo fmt --all -- --check` in `scripts/bench-workloads/demo-small`
- `python -m pytest tests/test_rust_ci_workflow.py`