### PR TITLE
chore: default to soldr 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,22 +10,29 @@
   `prebuild-deps` in the main action and run cook after `soldr prepare
   --target ... --github-env`.
 
-- Default to soldr `0.8.0` (was `0.7.102`). This ingests the repaired
-  upstream release process after the 0.7.103/0.7.104 rollout issues and
-  makes the complete GitHub binary archive matrix the default install source
-  again. Headline changes:
-  - **Release order repaired:** soldr now builds and verifies GitHub binary
-    archives before the secondary package publishes, so crates.io/PyPI/npm do
-    not advance past a broken binary release (soldr#1395-#1399).
-  - **Cross-release lanes repaired:** native Windows MSVC release builds skip
-    Linux-only xwin prep, use a longer watchdog and a faster MSVC release
-    profile, and bypass the embedded zccache wrapper only for the release
-    cargo build while keeping soldr-owned toolchain/syslib prep
+- Default to soldr `0.8.5` (was `0.7.102`). This ingests the repaired 0.8.0
+  release process together with the 0.8.1–0.8.5 embedded-zccache and daemon
+  hardening series. Headline changes:
+  - **Release order repaired (0.8.0):** soldr builds and verifies GitHub
+    binary archives before the secondary package publishes, so
+    crates.io/PyPI/npm do not advance past a broken binary release
+    (soldr#1395-#1399). Native Windows MSVC release builds skip Linux-only
+    xwin prep and use a faster MSVC release profile
     (soldr#1401/#1402/#1405/#1407).
-  - **soldr-toolchain catalogue validation:** support manifests for
-    cargo-zigbuild, cargo-xwin, xwin-cache, zig, cargo-chef, crgx, and zccache
-    are served from the Pages manifest and descriptor hashes are now linted so
-    root/catalog drift fails before release.
+  - **Embedded zccache coverage widened (0.8.1–0.8.3):** clippy-driver,
+    rustfmt, rustdoc, `cargo miri`, direct `maturin` builds, and
+    rust-analyzer child processes now route through the embedded zccache, and
+    residual bypass gaps are closed (soldr#1411/#1421/#1424/#1426-#1431,
+    #1460). Vendored zccache bumped to `1.12.15` (soldr#1466).
+  - **Standalone-zccache carriers removed (0.8.4):** legacy standalone-zccache
+    shell-out paths are deleted, the trampoline is gated to daemon-free
+    subcommands + `ZCCACHE_NO_SPAWN`, and `soldr doctor` gains a
+    standalone-zccache probe with a no-spawn regression lint
+    (soldr#1467/#1469-#1472). Embedded zccache bumped to `1.12.15`.
+  - **Daemon hardening (0.8.2/0.8.5):** Windows restart hangs are prevented
+    (soldr#1450), and `running-process` is bumped to `4.5.10` so the Windows
+    broker DACL no longer strips child/hardlinked ACLs (soldr#1513/#1518).
+  - **musllinux wheels** are now shipped (soldr#1439).
   - The default still uses soldr's embedded zccache runtime. setup-soldr does
     not fetch or install a standalone zccache for this release.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.0`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.5`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -524,7 +524,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.8.0`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.8.5`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -622,7 +622,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.0`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.5`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.8.0.
+    description: Soldr version or tag to install. Defaults to 0.8.5.
     required: false
-    default: "0.8.0"
+    default: "0.8.5"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -146,7 +146,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.0"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.5"
 
 
 def _load_action() -> dict:


### PR DESCRIPTION
## Changes

- Default `setup-soldr` to soldr `0.8.5` (from `0.8.0`), the newest upstream release with the full GitHub binary archive matrix for this action's installer.
- Ingest the 0.8.1–0.8.5 series: embedded-zccache coverage widened (clippy-driver, rustfmt, rustdoc, `cargo miri`, direct maturin, and IDE toolchain child processes), legacy standalone-zccache shell-out carriers removed with a `soldr doctor` standalone-zccache probe, vendored/embedded zccache bumped to `1.12.15`, Windows daemon restart-hang fix, `running-process` bumped to `4.5.10` (Windows broker DACL no longer strips child/hardlinked ACLs), and musllinux wheels shipped.
- The default still uses soldr's embedded zccache runtime; setup-soldr does not fetch or install a standalone zccache.

## Notes

- No new version gate needed: the `needsEmbeddedZccachePayload` gate (`>= 0.7.103`) is already active at the prior `0.8.0` default, so `0.8.5` inherits it unchanged.
- This release also folds in the prior main commits defaulting to soldr `0.8.0` and the rust-ci cross-compilation-first work, which had not yet been cut into an immutable `setup-soldr` release tag.
- `dist/` is unchanged: the default version is read at runtime from `action.yml` via `core.getInput`, not baked into the bundle.

## Verification

- Local: `npm run typecheck` — clean
- Local: `npm test` — 649 pass, 12 gated skips, 0 fail
- Local: `python -m pytest tests` — 18 passed
- GitHub Actions on this PR: Setup Soldr Action (install smoke), rust-ci, Setup Soldr Contract, Vendor-prose lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
