### PR TITLE
chore: default to soldr 0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Default to soldr `0.8.6` (was `0.8.5`). This release restores the managed
+  Windows MSVC cross-build lanes, including ARM64 target provisioning and
+  clang-cl argument-mode handling (soldr#1559), and carries the multicall
+  runtime, embedded-cache, daemon isolation, rust-plan, archive, and wrapper
+  correctness work merged since `0.8.5`.
+
 - Add `zackees/setup-soldr/cook`, a deferred cook-cache sub-action for
   workflows that must run target-specific setup before `soldr cook`. It reuses
   the main action's layered base/delta cook cache helpers, accepts explicit

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.5`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.6`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -524,7 +524,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.8.5`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.8.6`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -622,7 +622,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.5`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.6`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.8.5.
+    description: Soldr version or tag to install. Defaults to 0.8.6.
     required: false
-    default: "0.8.5"
+    default: "0.8.6"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -146,7 +146,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.5"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.6"
 
 
 def _load_action() -> dict:


### PR DESCRIPTION
## Changes

- default the action to the fully published soldr 0.8.6 release
- update the public version documentation and contract expectation
- record the restored managed MSVC cross-build lanes and the post-0.8.5 runtime/cache correctness work

## Upstream release verification

- GitHub release: https://github.com/zackees/soldr/releases/tag/v0.8.6 (15 assets)
- PyPI: 0.8.6
- npm `@zackees/soldr`: 0.8.6
- release workflow: https://github.com/zackees/soldr/actions/runs/29198746343

## Local verification

- `npm run typecheck`
- `npm test` (clean run: 63s)
- `git diff --check`

The standalone Python contract test was not run locally because pytest is not declared or installed in this checkout; the PR contract workflow provides that environment. `dist/` is unchanged because the default version is read from `action.yml` at runtime.