### PR TITLE
chore(release): default to soldr 0.8.7

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.8.6.
+    description: Soldr version or tag to install. Defaults to 0.8.7.
     required: false
-    default: "0.8.6"
+    default: "0.8.7"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -146,7 +146,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.6"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.7"
 
 
 def _load_action() -> dict:


### PR DESCRIPTION
Closes #420\n\nPromotes setup-soldr's default soldr version from 0.8.6 to 0.8.7 for the v0.9.69 patch release.