### PR TITLE
fix: recognize in-process zccache backend

### DIFF
--- a/__tests__/zccache-seed.test.ts
+++ b/__tests__/zccache-seed.test.ts
@@ -126,6 +126,18 @@ test("parseRuntimeStatus recognizes embedded zccache from soldr status", () => {
   assert.equal(parsed?.zccacheSource, "embedded");
 });
 
+test("parseRuntimeStatus recognizes in-process zccache from soldr 0.8.7", () => {
+  const parsed = _internal.parseRuntimeStatus(JSON.stringify({
+    managed_zccache_version: "1.12.13",
+    zccache: {
+      binary_source: "in-process",
+    },
+  }));
+
+  assert.equal(parsed?.embedded, true);
+  assert.equal(parsed?.zccacheSource, "in-process");
+});
+
 test("seedZccache skips legacy install-zccache when soldr reports embedded zccache", async () => {
   const root = mkTmp("zccache-seed-embedded-");
   const calls: Array<{ cmd: string; args: string[] }> = [];

--- a/dist/main.js
+++ b/dist/main.js
@@ -14,15 +14,15 @@
 //  * support limits.fieldNameSize
 //     -- this will require modifications to utils.parseParams
 
-const { Readable } = __nccwpck_require__(442)
-const { inherits } = __nccwpck_require__(383)
+const { Readable } = __nccwpck_require__(443)
+const { inherits } = __nccwpck_require__(384)
 
 const Dicer = __nccwpck_require__(14)
 
-const parseParams = __nccwpck_require__(199)
-const decodeText = __nccwpck_require__(282)
-const basename = __nccwpck_require__(489)
-const getLimit = __nccwpck_require__(495)
+const parseParams = __nccwpck_require__(201)
+const decodeText = __nccwpck_require__(283)
+const basename = __nccwpck_require__(490)
+const getLimit = __nccwpck_require__(496)
 
 const RE_BOUNDARY = /^boundary$/i
 const RE_FIELD = /^form-data$/i
@@ -340,7 +340,7 @@ __export(inspect_exports, {
   custom: () => custom
 });
 module.exports = __toCommonJS(inspect_exports);
-var import_node_util = __nccwpck_require__(383);
+var import_node_util = __nccwpck_require__(384);
 const custom = import_node_util.inspect.custom;
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -503,14 +503,14 @@ exports.saveCookCache = saveCookCache;
 exports.saveLayeredCookCache = saveLayeredCookCache;
 exports.parseCookFlags = parseCookFlags;
 exports.canonicalizeCookFlags = canonicalizeCookFlags;
-const node_crypto_1 = __nccwpck_require__(281);
-const fs = __importStar(__nccwpck_require__(256));
-const fsp = __importStar(__nccwpck_require__(116));
+const node_crypto_1 = __nccwpck_require__(282);
+const fs = __importStar(__nccwpck_require__(257));
+const fsp = __importStar(__nccwpck_require__(118));
 const path = __importStar(__nccwpck_require__(519));
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 const exec = __importStar(__nccwpck_require__(19));
-const cache = __importStar(__nccwpck_require__(222));
-const cache_compress_js_1 = __nccwpck_require__(95);
+const cache = __importStar(__nccwpck_require__(223));
+const cache_compress_js_1 = __nccwpck_require__(97);
 const log_utils_js_1 = __nccwpck_require__(52);
 function layeredCookBaseReady(restore, loaded) {
     return restore.base.hit && loaded.baseLoaded;
@@ -1300,17 +1300,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = exports.downloadCacheHttpClient = exports.DownloadProgress = void 0;
-const core = __importStar(__nccwpck_require__(472));
-const http_client_1 = __nccwpck_require__(293);
-const storage_blob_1 = __nccwpck_require__(460);
-const buffer = __importStar(__nccwpck_require__(126));
+const core = __importStar(__nccwpck_require__(473));
+const http_client_1 = __nccwpck_require__(294);
+const storage_blob_1 = __nccwpck_require__(461);
+const buffer = __importStar(__nccwpck_require__(128));
 const fs = __importStar(__nccwpck_require__(542));
-const stream = __importStar(__nccwpck_require__(138));
-const util = __importStar(__nccwpck_require__(131));
+const stream = __importStar(__nccwpck_require__(140));
+const util = __importStar(__nccwpck_require__(133));
 const utils = __importStar(__nccwpck_require__(82));
 const constants_1 = __nccwpck_require__(49);
-const requestUtils_1 = __nccwpck_require__(268);
-const abort_controller_1 = __nccwpck_require__(235);
+const requestUtils_1 = __nccwpck_require__(269);
+const abort_controller_1 = __nccwpck_require__(236);
 /**
  * Pipes the body of a HTTP response to a stream
  *
@@ -1670,14 +1670,14 @@ exports.SearchState = SearchState;
 "use strict";
 
 
-const { InvalidArgumentError } = __nccwpck_require__(500)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(202)
+const { InvalidArgumentError } = __nccwpck_require__(501)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(204)
 const DispatcherBase = __nccwpck_require__(68)
-const Pool = __nccwpck_require__(348)
-const Client = __nccwpck_require__(96)
+const Pool = __nccwpck_require__(349)
+const Client = __nccwpck_require__(98)
 const util = __nccwpck_require__(75)
-const createRedirectInterceptor = __nccwpck_require__(262)
-const { WeakRef, FinalizationRegistry } = __nccwpck_require__(426)()
+const createRedirectInterceptor = __nccwpck_require__(263)
+const { WeakRef, FinalizationRegistry } = __nccwpck_require__(427)()
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -1902,21 +1902,21 @@ function isNamedKeyCredential(credential) {
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(239)
+const { MockNotMatchedError } = __nccwpck_require__(240)
 const {
   kDispatches,
   kMockAgent,
   kOriginalDispatch,
   kOrigin,
   kGetNetConnect
-} = __nccwpck_require__(483)
+} = __nccwpck_require__(484)
 const { buildURL, nop } = __nccwpck_require__(75)
-const { STATUS_CODES } = __nccwpck_require__(340)
+const { STATUS_CODES } = __nccwpck_require__(341)
 const {
   types: {
     isPromise
   }
-} = __nccwpck_require__(131)
+} = __nccwpck_require__(133)
 
 function matchValue (match, value) {
   if (typeof match === 'string') {
@@ -2341,7 +2341,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetryHelper = void 0;
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 /**
  * Internal class for retries
  */
@@ -2486,18 +2486,18 @@ function formatDefaultJson(value) {
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(164)
-const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(85)
+const { kConstruct } = __nccwpck_require__(166)
+const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(86)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(75)
-const { kHeadersList } = __nccwpck_require__(202)
-const { webidl } = __nccwpck_require__(469)
+const { kHeadersList } = __nccwpck_require__(204)
+const { webidl } = __nccwpck_require__(470)
 const { Response, cloneResponse } = __nccwpck_require__(45)
-const { Request } = __nccwpck_require__(89)
+const { Request } = __nccwpck_require__(90)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(16)
-const { fetching } = __nccwpck_require__(463)
+const { fetching } = __nccwpck_require__(464)
 const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(529)
 const assert = __nccwpck_require__(538)
-const { getGlobalDispatcher } = __nccwpck_require__(384)
+const { getGlobalDispatcher } = __nccwpck_require__(385)
 
 /**
  * @see https://w3c.github.io/ServiceWorker/#dfn-cache-batch-operation
@@ -3332,13 +3332,13 @@ module.exports = {
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(442).Writable)
-const inherits = (__nccwpck_require__(383).inherits)
+const WritableStream = (__nccwpck_require__(443).Writable)
+const inherits = (__nccwpck_require__(384).inherits)
 
-const StreamSearch = __nccwpck_require__(121)
+const StreamSearch = __nccwpck_require__(123)
 
 const PartStream = __nccwpck_require__(72)
-const HeaderParser = __nccwpck_require__(115)
+const HeaderParser = __nccwpck_require__(117)
 
 const DASH = 45
 const B_ONEDASH = Buffer.from('-')
@@ -3565,17 +3565,17 @@ exports.isObject = isObject;
 exports.randomUUID = randomUUID;
 exports.uint8ArrayToString = uint8ArrayToString;
 exports.stringToUint8Array = stringToUint8Array;
-const tslib_1 = __nccwpck_require__(224);
-const tspRuntime = tslib_1.__importStar(__nccwpck_require__(154));
-var aborterUtils_js_1 = __nccwpck_require__(108);
+const tslib_1 = __nccwpck_require__(225);
+const tspRuntime = tslib_1.__importStar(__nccwpck_require__(156));
+var aborterUtils_js_1 = __nccwpck_require__(110);
 Object.defineProperty(exports, "cancelablePromiseRace", ({ enumerable: true, get: function () { return aborterUtils_js_1.cancelablePromiseRace; } }));
-var createAbortablePromise_js_1 = __nccwpck_require__(267);
+var createAbortablePromise_js_1 = __nccwpck_require__(268);
 Object.defineProperty(exports, "createAbortablePromise", ({ enumerable: true, get: function () { return createAbortablePromise_js_1.createAbortablePromise; } }));
-var delay_js_1 = __nccwpck_require__(120);
+var delay_js_1 = __nccwpck_require__(122);
 Object.defineProperty(exports, "delay", ({ enumerable: true, get: function () { return delay_js_1.delay; } }));
-var error_js_1 = __nccwpck_require__(221);
+var error_js_1 = __nccwpck_require__(222);
 Object.defineProperty(exports, "getErrorMessage", ({ enumerable: true, get: function () { return error_js_1.getErrorMessage; } }));
-var typeGuards_js_1 = __nccwpck_require__(118);
+var typeGuards_js_1 = __nccwpck_require__(120);
 Object.defineProperty(exports, "isDefined", ({ enumerable: true, get: function () { return typeGuards_js_1.isDefined; } }));
 Object.defineProperty(exports, "isObjectWithProperties", ({ enumerable: true, get: function () { return typeGuards_js_1.isObjectWithProperties; } }));
 Object.defineProperty(exports, "objectHasProperty", ({ enumerable: true, get: function () { return typeGuards_js_1.objectHasProperty; } }));
@@ -3748,10 +3748,10 @@ __export(retryPolicy_exports, {
   retryPolicy: () => retryPolicy
 });
 module.exports = __toCommonJS(retryPolicy_exports);
-var import_helpers = __nccwpck_require__(468);
-var import_restError = __nccwpck_require__(457);
+var import_helpers = __nccwpck_require__(469);
+var import_restError = __nccwpck_require__(458);
 var import_AbortError = __nccwpck_require__(11);
-var import_logger = __nccwpck_require__(253);
+var import_logger = __nccwpck_require__(254);
 var import_constants = __nccwpck_require__(53);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("ts-http-runtime retryPolicy");
 const retryPolicyName = "retryPolicy";
@@ -3908,8 +3908,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
-const string_decoder_1 = __nccwpck_require__(157);
-const tr = __importStar(__nccwpck_require__(133));
+const string_decoder_1 = __nccwpck_require__(159);
+const tr = __importStar(__nccwpck_require__(135));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -4029,15 +4029,15 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._internal = void 0;
 exports.ensureSoldr = ensureSoldr;
-const fs = __importStar(__nccwpck_require__(256));
-const os = __importStar(__nccwpck_require__(391));
+const fs = __importStar(__nccwpck_require__(257));
+const os = __importStar(__nccwpck_require__(392));
 const path = __importStar(__nccwpck_require__(519));
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 const exec = __importStar(__nccwpck_require__(19));
 const tc = __importStar(__nccwpck_require__(534));
-const fzstd = __importStar(__nccwpck_require__(362));
+const fzstd = __importStar(__nccwpck_require__(363));
 const log_utils_js_1 = __nccwpck_require__(52);
-const verify_soldr_js_1 = __nccwpck_require__(295);
+const verify_soldr_js_1 = __nccwpck_require__(296);
 function detectTarget() {
     const machine = process.arch;
     let arch;
@@ -4607,46 +4607,46 @@ exports._internal = {
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Convenience JSON typings and corresponding type guards
-var json_typings_1 = __nccwpck_require__(406);
+var json_typings_1 = __nccwpck_require__(407);
 Object.defineProperty(exports, "typeofJsonValue", ({ enumerable: true, get: function () { return json_typings_1.typeofJsonValue; } }));
 Object.defineProperty(exports, "isJsonObject", ({ enumerable: true, get: function () { return json_typings_1.isJsonObject; } }));
 // Base 64 encoding
-var base64_1 = __nccwpck_require__(313);
+var base64_1 = __nccwpck_require__(314);
 Object.defineProperty(exports, "base64decode", ({ enumerable: true, get: function () { return base64_1.base64decode; } }));
 Object.defineProperty(exports, "base64encode", ({ enumerable: true, get: function () { return base64_1.base64encode; } }));
 // UTF8 encoding
-var protobufjs_utf8_1 = __nccwpck_require__(355);
+var protobufjs_utf8_1 = __nccwpck_require__(356);
 Object.defineProperty(exports, "utf8read", ({ enumerable: true, get: function () { return protobufjs_utf8_1.utf8read; } }));
 // Binary format contracts, options for reading and writing, for example
-var binary_format_contract_1 = __nccwpck_require__(344);
+var binary_format_contract_1 = __nccwpck_require__(345);
 Object.defineProperty(exports, "WireType", ({ enumerable: true, get: function () { return binary_format_contract_1.WireType; } }));
 Object.defineProperty(exports, "mergeBinaryOptions", ({ enumerable: true, get: function () { return binary_format_contract_1.mergeBinaryOptions; } }));
 Object.defineProperty(exports, "UnknownFieldHandler", ({ enumerable: true, get: function () { return binary_format_contract_1.UnknownFieldHandler; } }));
 // Standard IBinaryReader implementation
-var binary_reader_1 = __nccwpck_require__(142);
+var binary_reader_1 = __nccwpck_require__(144);
 Object.defineProperty(exports, "BinaryReader", ({ enumerable: true, get: function () { return binary_reader_1.BinaryReader; } }));
 Object.defineProperty(exports, "binaryReadOptions", ({ enumerable: true, get: function () { return binary_reader_1.binaryReadOptions; } }));
 // Standard IBinaryWriter implementation
-var binary_writer_1 = __nccwpck_require__(258);
+var binary_writer_1 = __nccwpck_require__(259);
 Object.defineProperty(exports, "BinaryWriter", ({ enumerable: true, get: function () { return binary_writer_1.BinaryWriter; } }));
 Object.defineProperty(exports, "binaryWriteOptions", ({ enumerable: true, get: function () { return binary_writer_1.binaryWriteOptions; } }));
 // Int64 and UInt64 implementations required for the binary format
-var pb_long_1 = __nccwpck_require__(124);
+var pb_long_1 = __nccwpck_require__(126);
 Object.defineProperty(exports, "PbLong", ({ enumerable: true, get: function () { return pb_long_1.PbLong; } }));
 Object.defineProperty(exports, "PbULong", ({ enumerable: true, get: function () { return pb_long_1.PbULong; } }));
 // JSON format contracts, options for reading and writing, for example
-var json_format_contract_1 = __nccwpck_require__(249);
+var json_format_contract_1 = __nccwpck_require__(250);
 Object.defineProperty(exports, "jsonReadOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonReadOptions; } }));
 Object.defineProperty(exports, "jsonWriteOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonWriteOptions; } }));
 Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: function () { return json_format_contract_1.mergeJsonOptions; } }));
 // Message type contract
-var message_type_contract_1 = __nccwpck_require__(418);
+var message_type_contract_1 = __nccwpck_require__(419);
 Object.defineProperty(exports, "MESSAGE_TYPE", ({ enumerable: true, get: function () { return message_type_contract_1.MESSAGE_TYPE; } }));
 // Message type implementation via reflection
 var message_type_1 = __nccwpck_require__(541);
 Object.defineProperty(exports, "MessageType", ({ enumerable: true, get: function () { return message_type_1.MessageType; } }));
 // Reflection info, generated by the plugin, exposed to the user, used by reflection ops
-var reflection_info_1 = __nccwpck_require__(465);
+var reflection_info_1 = __nccwpck_require__(466);
 Object.defineProperty(exports, "ScalarType", ({ enumerable: true, get: function () { return reflection_info_1.ScalarType; } }));
 Object.defineProperty(exports, "LongType", ({ enumerable: true, get: function () { return reflection_info_1.LongType; } }));
 Object.defineProperty(exports, "RepeatType", ({ enumerable: true, get: function () { return reflection_info_1.RepeatType; } }));
@@ -4655,44 +4655,44 @@ Object.defineProperty(exports, "readFieldOptions", ({ enumerable: true, get: fun
 Object.defineProperty(exports, "readFieldOption", ({ enumerable: true, get: function () { return reflection_info_1.readFieldOption; } }));
 Object.defineProperty(exports, "readMessageOption", ({ enumerable: true, get: function () { return reflection_info_1.readMessageOption; } }));
 // Message operations via reflection
-var reflection_type_check_1 = __nccwpck_require__(300);
+var reflection_type_check_1 = __nccwpck_require__(301);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
-var reflection_create_1 = __nccwpck_require__(214);
+var reflection_create_1 = __nccwpck_require__(215);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
-var reflection_scalar_default_1 = __nccwpck_require__(475);
+var reflection_scalar_default_1 = __nccwpck_require__(476);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
-var reflection_merge_partial_1 = __nccwpck_require__(144);
+var reflection_merge_partial_1 = __nccwpck_require__(146);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
-var reflection_equals_1 = __nccwpck_require__(474);
+var reflection_equals_1 = __nccwpck_require__(475);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
-var reflection_binary_reader_1 = __nccwpck_require__(420);
+var reflection_binary_reader_1 = __nccwpck_require__(421);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
-var reflection_binary_writer_1 = __nccwpck_require__(192);
+var reflection_binary_writer_1 = __nccwpck_require__(194);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
-var reflection_json_reader_1 = __nccwpck_require__(353);
+var reflection_json_reader_1 = __nccwpck_require__(354);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
-var reflection_json_writer_1 = __nccwpck_require__(98);
+var reflection_json_writer_1 = __nccwpck_require__(100);
 Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get: function () { return reflection_json_writer_1.ReflectionJsonWriter; } }));
 var reflection_contains_message_type_1 = __nccwpck_require__(56);
 Object.defineProperty(exports, "containsMessageType", ({ enumerable: true, get: function () { return reflection_contains_message_type_1.containsMessageType; } }));
 // Oneof helpers
-var oneof_1 = __nccwpck_require__(197);
+var oneof_1 = __nccwpck_require__(199);
 Object.defineProperty(exports, "isOneofGroup", ({ enumerable: true, get: function () { return oneof_1.isOneofGroup; } }));
 Object.defineProperty(exports, "setOneofValue", ({ enumerable: true, get: function () { return oneof_1.setOneofValue; } }));
 Object.defineProperty(exports, "getOneofValue", ({ enumerable: true, get: function () { return oneof_1.getOneofValue; } }));
 Object.defineProperty(exports, "clearOneofValue", ({ enumerable: true, get: function () { return oneof_1.clearOneofValue; } }));
 Object.defineProperty(exports, "getSelectedOneofValue", ({ enumerable: true, get: function () { return oneof_1.getSelectedOneofValue; } }));
 // Enum object type guard and reflection util, may be interesting to the user.
-var enum_object_1 = __nccwpck_require__(279);
+var enum_object_1 = __nccwpck_require__(280);
 Object.defineProperty(exports, "listEnumValues", ({ enumerable: true, get: function () { return enum_object_1.listEnumValues; } }));
 Object.defineProperty(exports, "listEnumNames", ({ enumerable: true, get: function () { return enum_object_1.listEnumNames; } }));
 Object.defineProperty(exports, "listEnumNumbers", ({ enumerable: true, get: function () { return enum_object_1.listEnumNumbers; } }));
 Object.defineProperty(exports, "isEnumObject", ({ enumerable: true, get: function () { return enum_object_1.isEnumObject; } }));
 // lowerCamelCase() is exported for plugin, rpc-runtime and other rpc packages
-var lower_camel_case_1 = __nccwpck_require__(466);
+var lower_camel_case_1 = __nccwpck_require__(467);
 Object.defineProperty(exports, "lowerCamelCase", ({ enumerable: true, get: function () { return lower_camel_case_1.lowerCamelCase; } }));
 // assertion functions are exported for plugin, may also be useful to user
-var assert_1 = __nccwpck_require__(496);
+var assert_1 = __nccwpck_require__(497);
 Object.defineProperty(exports, "assert", ({ enumerable: true, get: function () { return assert_1.assert; } }));
 Object.defineProperty(exports, "assertNever", ({ enumerable: true, get: function () { return assert_1.assertNever; } }));
 Object.defineProperty(exports, "assertInt32", ({ enumerable: true, get: function () { return assert_1.assertInt32; } }));
@@ -4727,7 +4727,7 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_ts_http_runtime = __nccwpck_require__(97);
+var import_ts_http_runtime = __nccwpck_require__(99);
 function createPipelineRequest(options) {
   return (0, import_ts_http_runtime.createPipelineRequest)(options);
 }
@@ -4775,7 +4775,7 @@ const XML_CHARKEY = "_";
 /***/ 24:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(202)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(204)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -4839,7 +4839,7 @@ __export(throttlingRetryPolicy_exports, {
   throttlingRetryPolicyName: () => throttlingRetryPolicyName
 });
 module.exports = __toCommonJS(throttlingRetryPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(295);
 const throttlingRetryPolicyName = import_policies.throttlingRetryPolicyName;
 function throttlingRetryPolicy(options = {}) {
   return (0, import_policies.throttlingRetryPolicy)(options);
@@ -4856,7 +4856,7 @@ function throttlingRetryPolicy(options = {}) {
 "use strict";
 
 
-const Busboy = __nccwpck_require__(428)
+const Busboy = __nccwpck_require__(429)
 const util = __nccwpck_require__(75)
 const {
   ReadableStreamFrom,
@@ -4866,21 +4866,21 @@ const {
   createDeferredPromise,
   fullyReadBody
 } = __nccwpck_require__(529)
-const { FormData } = __nccwpck_require__(216)
+const { FormData } = __nccwpck_require__(217)
 const { kState } = __nccwpck_require__(16)
-const { webidl } = __nccwpck_require__(469)
+const { webidl } = __nccwpck_require__(470)
 const { DOMException, structuredClone } = __nccwpck_require__(33)
-const { Blob, File: NativeFile } = __nccwpck_require__(126)
-const { kBodyUsed } = __nccwpck_require__(202)
+const { Blob, File: NativeFile } = __nccwpck_require__(128)
+const { kBodyUsed } = __nccwpck_require__(204)
 const assert = __nccwpck_require__(538)
 const { isErrored } = __nccwpck_require__(75)
-const { isUint8Array, isArrayBuffer } = __nccwpck_require__(206)
-const { File: UndiciFile } = __nccwpck_require__(373)
+const { isUint8Array, isArrayBuffer } = __nccwpck_require__(207)
+const { File: UndiciFile } = __nccwpck_require__(374)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(27)
 
 let random
 try {
-  const crypto = __nccwpck_require__(281)
+  const crypto = __nccwpck_require__(282)
   random = (max) => crypto.randomInt(0, max)
 } catch {
   random = (max) => Math.floor(Math.random(max))
@@ -4896,7 +4896,7 @@ const textDecoder = new TextDecoder()
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 function extractBody (object, keepalive = false) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(264).ReadableStream)
+    ReadableStream = (__nccwpck_require__(265).ReadableStream)
   }
 
   // 1. Let stream be null.
@@ -5117,7 +5117,7 @@ function extractBody (object, keepalive = false) {
 function safelyExtractBody (object, keepalive = false) {
   if (!ReadableStream) {
     // istanbul ignore next
-    ReadableStream = (__nccwpck_require__(264).ReadableStream)
+    ReadableStream = (__nccwpck_require__(265).ReadableStream)
   }
 
   // To safely extract a body and a `Content-Type` value from
@@ -5475,7 +5475,7 @@ module.exports = {
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(538)
-const { atob } = __nccwpck_require__(126)
+const { atob } = __nccwpck_require__(128)
 const { isomorphicDecode } = __nccwpck_require__(529)
 
 const encoder = new TextEncoder()
@@ -6119,9 +6119,9 @@ module.exports = {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(224);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(186));
+const tslib_1 = __nccwpck_require__(225);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
 /** Class containing AppendBlob operations. */
 class AppendBlobImpl {
@@ -6454,7 +6454,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(407);
+var import_exponentialRetryStrategy = __nccwpck_require__(408);
 var import_retryPolicy = __nccwpck_require__(17);
 var import_constants = __nccwpck_require__(53);
 const systemErrorRetryPolicyName = "systemErrorRetryPolicy";
@@ -6542,14 +6542,14 @@ exports.applyStagedToLiveRoots = applyStagedToLiveRoots;
 exports.saveSoloCache = saveSoloCache;
 exports.restoreSoloCache = restoreSoloCache;
 exports.verifyRestoredToolchain = verifyRestoredToolchain;
-const node_crypto_1 = __nccwpck_require__(281);
-const fs = __importStar(__nccwpck_require__(256));
-const fsp = __importStar(__nccwpck_require__(116));
-const os = __importStar(__nccwpck_require__(391));
+const node_crypto_1 = __nccwpck_require__(282);
+const fs = __importStar(__nccwpck_require__(257));
+const fsp = __importStar(__nccwpck_require__(118));
+const os = __importStar(__nccwpck_require__(392));
 const path = __importStar(__nccwpck_require__(519));
-const cache = __importStar(__nccwpck_require__(222));
+const cache = __importStar(__nccwpck_require__(223));
 const exec = __importStar(__nccwpck_require__(19));
-const cache_compress_js_1 = __nccwpck_require__(95);
+const cache_compress_js_1 = __nccwpck_require__(97);
 /**
  * The two live roots whose deltas this cache layer tracks. The string keys
  * are also the directory names used inside the tarball staging layout.
@@ -7089,7 +7089,7 @@ function rangeResponseFromModel(response) {
 "use strict";
 
 
-const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(330)
+const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(331)
 
 const corsSafeListedMethods = ['GET', 'HEAD', 'POST']
 const corsSafeListedMethodsSet = new Set(corsSafeListedMethods)
@@ -7302,7 +7302,7 @@ exports.semverGte = semverGte;
 exports.detectSoldrManifest = detectSoldrManifest;
 exports.tryLoadViaSoldr = tryLoadViaSoldr;
 exports.trySaveViaSoldr = trySaveViaSoldr;
-const fs = __importStar(__nccwpck_require__(116));
+const fs = __importStar(__nccwpck_require__(118));
 const exec = __importStar(__nccwpck_require__(19));
 /** Min soldr version with parallel-extract `soldr load`. Released in 0.7.46 alongside zackees/soldr#575. */
 exports.MIN_SOLDR_VERSION_FOR_LOAD = "0.7.46";
@@ -7358,7 +7358,7 @@ function semverGte(value, minimum) {
  * returns (avoiding test-runner timeout from leaked descriptors).
  */
 async function detectSoldrManifest(archivePath) {
-    const { spawnSync } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 205, 23));
+    const { spawnSync } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 206, 23));
     // We invoke tar with `-tf <archive>` directly — bsdtar (Windows) and
     // GNU tar (Linux/macOS) both auto-detect zstd by magic byte on modern
     // versions. Bounded by `timeout: 5000ms`; if tar takes longer than
@@ -7510,8 +7510,8 @@ async function trySaveViaSoldr(opts) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tracingClient = void 0;
-const core_tracing_1 = __nccwpck_require__(87);
-const constants_js_1 = __nccwpck_require__(156);
+const core_tracing_1 = __nccwpck_require__(88);
+const constants_js_1 = __nccwpck_require__(158);
 /**
  * Creates a span using the global tracer.
  * @internal
@@ -7635,18 +7635,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.reserveCache = exports.downloadCache = exports.getCacheEntry = void 0;
-const core = __importStar(__nccwpck_require__(472));
-const http_client_1 = __nccwpck_require__(293);
+const core = __importStar(__nccwpck_require__(473));
+const http_client_1 = __nccwpck_require__(294);
 const auth_1 = __nccwpck_require__(29);
 const fs = __importStar(__nccwpck_require__(542));
-const url_1 = __nccwpck_require__(92);
+const url_1 = __nccwpck_require__(94);
 const utils = __importStar(__nccwpck_require__(82));
-const uploadUtils_1 = __nccwpck_require__(167);
+const uploadUtils_1 = __nccwpck_require__(169);
 const downloadUtils_1 = __nccwpck_require__(4);
-const options_1 = __nccwpck_require__(272);
-const requestUtils_1 = __nccwpck_require__(268);
+const options_1 = __nccwpck_require__(273);
+const requestUtils_1 = __nccwpck_require__(269);
 const config_1 = __nccwpck_require__(41);
-const user_agent_1 = __nccwpck_require__(371);
+const user_agent_1 = __nccwpck_require__(372);
 function getCacheApiUrl(resource) {
     const baseUrl = (0, config_1.getCacheServiceURL)();
     if (!baseUrl) {
@@ -7885,7 +7885,7 @@ __export(throttlingRetryStrategy_exports, {
   throttlingRetryStrategy: () => throttlingRetryStrategy
 });
 module.exports = __toCommonJS(throttlingRetryStrategy_exports);
-var import_helpers = __nccwpck_require__(468);
+var import_helpers = __nccwpck_require__(469);
 const RetryAfterHeader = "Retry-After";
 const AllRetryAfterHeaders = ["retry-after-ms", "x-ms-retry-after-ms", RetryAfterHeader];
 function getRetryAfterInMs(response) {
@@ -8100,9 +8100,9 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_https_proxy_agent = __nccwpck_require__(140);
-var import_http_proxy_agent = __nccwpck_require__(231);
-var import_log = __nccwpck_require__(159);
+var import_https_proxy_agent = __nccwpck_require__(142);
+var import_http_proxy_agent = __nccwpck_require__(232);
+var import_log = __nccwpck_require__(161);
 const HTTPS_PROXY = "HTTPS_PROXY";
 const HTTP_PROXY = "HTTP_PROXY";
 const ALL_PROXY = "ALL_PROXY";
@@ -8294,15 +8294,15 @@ const {
   DOMException
 } = __nccwpck_require__(33)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(16)
-const { webidl } = __nccwpck_require__(469)
-const { FormData } = __nccwpck_require__(216)
-const { getGlobalOrigin } = __nccwpck_require__(147)
+const { webidl } = __nccwpck_require__(470)
+const { FormData } = __nccwpck_require__(217)
+const { getGlobalOrigin } = __nccwpck_require__(149)
 const { URLSerializer } = __nccwpck_require__(27)
-const { kHeadersList, kConstruct } = __nccwpck_require__(202)
+const { kHeadersList, kConstruct } = __nccwpck_require__(204)
 const assert = __nccwpck_require__(538)
-const { types } = __nccwpck_require__(131)
+const { types } = __nccwpck_require__(133)
 
-const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(264).ReadableStream)
+const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(265).ReadableStream)
 const textEncoder = new TextEncoder('utf-8')
 
 // https://fetch.spec.whatwg.org/#response-class
@@ -8936,7 +8936,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
-const pathHelper = __importStar(__nccwpck_require__(229));
+const pathHelper = __importStar(__nccwpck_require__(230));
 const internal_match_kind_1 = __nccwpck_require__(540);
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -9023,7 +9023,7 @@ exports.AzureLogger = void 0;
 exports.setLogLevel = setLogLevel;
 exports.getLogLevel = getLogLevel;
 exports.createClientLogger = createClientLogger;
-const logger_1 = __nccwpck_require__(155);
+const logger_1 = __nccwpck_require__(157);
 const context = (0, logger_1.createLoggerContext)({
     logLevelEnvVarName: "AZURE_LOG_LEVEL",
     namespace: "azure",
@@ -9175,9 +9175,9 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(224);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(186));
+const tslib_1 = __nccwpck_require__(225);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
 /** Class containing Blob operations. */
 class BlobImpl {
@@ -10256,8 +10256,8 @@ exports.formatLogLine = formatLogLine;
 exports.isTimestampsEnabled = isTimestampsEnabled;
 exports.getTimestampFormat = getTimestampFormat;
 exports.streamExec = streamExec;
-const core = __importStar(__nccwpck_require__(472));
-const fs = __importStar(__nccwpck_require__(256));
+const core = __importStar(__nccwpck_require__(473));
+const fs = __importStar(__nccwpck_require__(257));
 function makeFileLogger(env) {
     const logPath = (env["SETUP_SOLDR_LOG"] ?? "").trim();
     if (!logPath)
@@ -10556,9 +10556,9 @@ exports.redactValue = redactValue;
 exports.captureProcessSnapshot = captureProcessSnapshot;
 exports.dumpDiagnostics = dumpDiagnostics;
 exports.loggingEnabled = loggingEnabled;
-const fs = __importStar(__nccwpck_require__(256));
-const node_child_process_1 = __nccwpck_require__(205);
-const compile_journal_js_1 = __nccwpck_require__(283);
+const fs = __importStar(__nccwpck_require__(257));
+const node_child_process_1 = __nccwpck_require__(206);
+const compile_journal_js_1 = __nccwpck_require__(284);
 const ENV_KEY_PREFIXES = [
     "INPUT_",
     "SOLDR_",
@@ -10903,7 +10903,7 @@ exports.StorageBrowserPolicy = void 0;
 const RequestPolicy_js_1 = __nccwpck_require__(50);
 const core_util_1 = __nccwpck_require__(15);
 const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(486);
+const utils_common_js_1 = __nccwpck_require__(487);
 /**
  * StorageBrowserPolicy will handle differences between Node.js and browser runtime, including:
  *
@@ -10956,7 +10956,7 @@ exports.StorageBrowserPolicy = StorageBrowserPolicy;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.containsMessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(418);
+const message_type_contract_1 = __nccwpck_require__(419);
 /**
  * Check if the provided object is a proto message.
  *
@@ -10980,8 +10980,8 @@ exports.containsMessageType = containsMessageType;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollHttpOperation = exports.isOperationError = exports.getResourceLocation = exports.getOperationStatus = exports.getOperationLocation = exports.initHttpOperation = exports.getStatusFromInitialResponse = exports.getErrorFromResponse = exports.parseRetryAfter = exports.inferLroMode = void 0;
-const operation_js_1 = __nccwpck_require__(148);
-const logger_js_1 = __nccwpck_require__(198);
+const operation_js_1 = __nccwpck_require__(150);
+const logger_js_1 = __nccwpck_require__(200);
 function getOperationLocationPollingUrl(inputs) {
     const { azureAsyncOperation, operationLocation } = inputs;
     return operationLocation !== null && operationLocation !== void 0 ? operationLocation : azureAsyncOperation;
@@ -11379,14 +11379,14 @@ const {
   kResult,
   kAborted,
   kLastProgressEventFired
-} = __nccwpck_require__(473)
-const { ProgressEvent } = __nccwpck_require__(455)
-const { getEncoding } = __nccwpck_require__(105)
+} = __nccwpck_require__(474)
+const { ProgressEvent } = __nccwpck_require__(456)
+const { getEncoding } = __nccwpck_require__(107)
 const { DOMException } = __nccwpck_require__(33)
 const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(27)
-const { types } = __nccwpck_require__(131)
-const { StringDecoder } = __nccwpck_require__(157)
-const { btoa } = __nccwpck_require__(126)
+const { types } = __nccwpck_require__(133)
+const { StringDecoder } = __nccwpck_require__(159)
+const { btoa } = __nccwpck_require__(128)
 
 /** @type {PropertyDescriptor} */
 const staticPropertyDescriptors = {
@@ -11772,7 +11772,7 @@ module.exports = {
 
 "use strict";
 
-const f = __nccwpck_require__(416)
+const f = __nccwpck_require__(417)
 const DateTime = global.Date
 
 class Date extends DateTime {
@@ -11824,7 +11824,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(295);
 const defaultRetryPolicyName = import_policies.defaultRetryPolicyName;
 function defaultRetryPolicy(options = {}) {
   return (0, import_policies.defaultRetryPolicy)(options);
@@ -11898,9 +11898,9 @@ exports.UnaryCall = UnaryCall;
 "use strict";
 
 
-const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(106)
-const { states, opcodes } = __nccwpck_require__(478)
-const { MessageEvent, ErrorEvent } = __nccwpck_require__(257)
+const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(108)
+const { states, opcodes } = __nccwpck_require__(479)
+const { MessageEvent, ErrorEvent } = __nccwpck_require__(258)
 
 /* globals Blob */
 
@@ -12381,15 +12381,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.internalCacheTwirpClient = void 0;
-const core_1 = __nccwpck_require__(472);
-const user_agent_1 = __nccwpck_require__(371);
-const errors_1 = __nccwpck_require__(315);
+const core_1 = __nccwpck_require__(473);
+const user_agent_1 = __nccwpck_require__(372);
+const errors_1 = __nccwpck_require__(316);
 const config_1 = __nccwpck_require__(41);
 const cacheUtils_1 = __nccwpck_require__(82);
 const auth_1 = __nccwpck_require__(29);
-const http_client_1 = __nccwpck_require__(293);
-const cache_twirp_client_1 = __nccwpck_require__(448);
-const util_1 = __nccwpck_require__(305);
+const http_client_1 = __nccwpck_require__(294);
+const cache_twirp_client_1 = __nccwpck_require__(449);
+const util_1 = __nccwpck_require__(306);
 /**
  * This class is a wrapper around the CacheServiceClientJSON class generated by Twirp.
  *
@@ -12540,13 +12540,13 @@ exports.internalCacheTwirpClient = internalCacheTwirpClient;
 "use strict";
 
 
-const Dispatcher = __nccwpck_require__(490)
+const Dispatcher = __nccwpck_require__(491)
 const {
   ClientDestroyedError,
   ClientClosedError,
   InvalidArgumentError
-} = __nccwpck_require__(500)
-const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(202)
+} = __nccwpck_require__(501)
+const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(204)
 
 const kDestroyed = Symbol('destroyed')
 const kClosed = Symbol('closed')
@@ -12761,8 +12761,8 @@ __export(requestPolicyFactoryPolicy_exports, {
   requestPolicyFactoryPolicyName: () => requestPolicyFactoryPolicyName
 });
 module.exports = __toCommonJS(requestPolicyFactoryPolicy_exports);
-var import_util = __nccwpck_require__(117);
-var import_response = __nccwpck_require__(424);
+var import_util = __nccwpck_require__(119);
+var import_response = __nccwpck_require__(425);
 var HttpPipelineLogLevel = /* @__PURE__ */ ((HttpPipelineLogLevel2) => {
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["ERROR"] = 1] = "ERROR";
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["INFO"] = 3] = "INFO";
@@ -12812,18 +12812,18 @@ function createRequestPolicyFactoryPolicy(factories) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_1 = __nccwpck_require__(15);
 const core_auth_1 = __nccwpck_require__(525);
-const storage_common_1 = __nccwpck_require__(284);
-const Pipeline_js_1 = __nccwpck_require__(189);
-const StorageClient_js_1 = __nccwpck_require__(467);
+const storage_common_1 = __nccwpck_require__(285);
+const Pipeline_js_1 = __nccwpck_require__(191);
+const StorageClient_js_1 = __nccwpck_require__(468);
 const tracing_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(162);
+const utils_common_js_1 = __nccwpck_require__(164);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(74);
-const BlobLeaseClient_js_1 = __nccwpck_require__(212);
-const Clients_js_1 = __nccwpck_require__(191);
-const BlobBatchClient_js_1 = __nccwpck_require__(414);
+const BlobLeaseClient_js_1 = __nccwpck_require__(213);
+const Clients_js_1 = __nccwpck_require__(193);
+const BlobBatchClient_js_1 = __nccwpck_require__(415);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
  */
@@ -14125,7 +14125,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.action3 = exports.action2 = exports.leaseId1 = exports.action1 = exports.proposedLeaseId = exports.duration = exports.action = exports.comp10 = exports.sourceLeaseId = exports.sourceContainerName = exports.comp9 = exports.deletedContainerVersion = exports.deletedContainerName = exports.comp8 = exports.containerAcl = exports.comp7 = exports.comp6 = exports.ifUnmodifiedSince = exports.ifModifiedSince = exports.leaseId = exports.preventEncryptionScopeOverride = exports.defaultEncryptionScope = exports.access = exports.metadata = exports.restype2 = exports.where = exports.comp5 = exports.multipartContentType = exports.contentLength = exports.comp4 = exports.body = exports.restype1 = exports.comp3 = exports.keyInfo = exports.include = exports.maxPageSize = exports.marker = exports.prefix = exports.comp2 = exports.comp1 = exports.accept1 = exports.requestId = exports.version = exports.timeoutInSeconds = exports.comp = exports.restype = exports.url = exports.accept = exports.blobServiceProperties = exports.contentType = void 0;
 exports.copySourceTags = exports.copySourceAuthorization = exports.sourceContentMD5 = exports.xMsRequiresSync = exports.legalHold1 = exports.sealBlob = exports.blobTagsString = exports.copySource = exports.sourceIfTags = exports.sourceIfNoneMatch = exports.sourceIfMatch = exports.sourceIfUnmodifiedSince = exports.sourceIfModifiedSince = exports.rehydratePriority = exports.tier = exports.comp14 = exports.encryptionScope = exports.legalHold = exports.comp13 = exports.immutabilityPolicyMode = exports.immutabilityPolicyExpiry = exports.comp12 = exports.blobContentDisposition = exports.blobContentLanguage = exports.blobContentEncoding = exports.blobContentMD5 = exports.blobContentType = exports.blobCacheControl = exports.expiresOn = exports.expiryOptions = exports.comp11 = exports.blobDeleteType = exports.deleteSnapshots = exports.ifTags = exports.ifNoneMatch = exports.ifMatch = exports.encryptionAlgorithm = exports.encryptionKeySha256 = exports.encryptionKey = exports.rangeGetContentCRC64 = exports.rangeGetContentMD5 = exports.range = exports.versionId = exports.snapshot = exports.delimiter = exports.startFrom = exports.include1 = exports.proposedLeaseId1 = exports.action4 = exports.breakPeriod = void 0;
 exports.listType = exports.comp25 = exports.blocks = exports.blockId = exports.comp24 = exports.copySourceBlobProperties = exports.blobType2 = exports.comp23 = exports.sourceRange1 = exports.appendPosition = exports.maxSize = exports.comp22 = exports.blobType1 = exports.comp21 = exports.sequenceNumberAction = exports.prevSnapshotUrl = exports.prevsnapshot = exports.comp20 = exports.range1 = exports.sourceContentCrc64 = exports.sourceRange = exports.sourceUrl = exports.pageWrite1 = exports.ifSequenceNumberEqualTo = exports.ifSequenceNumberLessThan = exports.ifSequenceNumberLessThanOrEqualTo = exports.pageWrite = exports.comp19 = exports.accept2 = exports.body1 = exports.contentType1 = exports.blobSequenceNumber = exports.blobContentLength = exports.blobType = exports.transactionalContentCrc64 = exports.transactionalContentMD5 = exports.tags = exports.ifNoneMatch1 = exports.ifMatch1 = exports.ifUnmodifiedSince1 = exports.ifModifiedSince1 = exports.comp18 = exports.comp17 = exports.queryRequest = exports.tier1 = exports.comp16 = exports.copyId = exports.copyActionAbortConstant = exports.comp15 = exports.fileRequestIntent = void 0;
-const mappers_js_1 = __nccwpck_require__(186);
+const mappers_js_1 = __nccwpck_require__(188);
 exports.contentType = {
     parameterPath: ["options", "contentType"],
     mapper: {
@@ -15801,8 +15801,8 @@ exports.listType = {
 "use strict";
 
 
-const inherits = (__nccwpck_require__(383).inherits)
-const ReadableStream = (__nccwpck_require__(442).Readable)
+const inherits = (__nccwpck_require__(384).inherits)
+const ReadableStream = (__nccwpck_require__(443).Readable)
 
 function PartStream (opts) {
   ReadableStream.call(this, opts)
@@ -15835,13 +15835,13 @@ exports.generateBlobSASQueryParametersInternal = generateBlobSASQueryParametersI
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const BlobSASPermissions_js_1 = __nccwpck_require__(515);
-const ContainerSASPermissions_js_1 = __nccwpck_require__(287);
-const storage_common_1 = __nccwpck_require__(284);
-const SasIPRange_js_1 = __nccwpck_require__(369);
+const ContainerSASPermissions_js_1 = __nccwpck_require__(288);
+const storage_common_1 = __nccwpck_require__(285);
+const SasIPRange_js_1 = __nccwpck_require__(370);
 const SASQueryParameters_js_1 = __nccwpck_require__(537);
-const constants_js_1 = __nccwpck_require__(156);
-const utils_common_js_1 = __nccwpck_require__(162);
-const storage_common_2 = __nccwpck_require__(284);
+const constants_js_1 = __nccwpck_require__(158);
+const utils_common_js_1 = __nccwpck_require__(164);
+const storage_common_2 = __nccwpck_require__(285);
 function generateBlobSASQueryParameters(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName) {
     return generateBlobSASQueryParametersInternal(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName).sasQueryParameters;
 }
@@ -16508,14 +16508,14 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 
 
 const assert = __nccwpck_require__(538)
-const { kDestroyed, kBodyUsed } = __nccwpck_require__(202)
-const { IncomingMessage } = __nccwpck_require__(340)
-const stream = __nccwpck_require__(138)
+const { kDestroyed, kBodyUsed } = __nccwpck_require__(204)
+const { IncomingMessage } = __nccwpck_require__(341)
+const stream = __nccwpck_require__(140)
 const net = __nccwpck_require__(520)
-const { InvalidArgumentError } = __nccwpck_require__(500)
-const { Blob } = __nccwpck_require__(126)
-const nodeUtil = __nccwpck_require__(131)
-const { stringify } = __nccwpck_require__(137)
+const { InvalidArgumentError } = __nccwpck_require__(501)
+const { Blob } = __nccwpck_require__(128)
+const nodeUtil = __nccwpck_require__(133)
+const { stringify } = __nccwpck_require__(139)
 const { headerNameLowerCasedRecord } = __nccwpck_require__(80)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
@@ -16885,7 +16885,7 @@ async function * convertIterableToBuffer (iterable) {
 let ReadableStream
 function ReadableStreamFrom (iterable) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(264).ReadableStream)
+    ReadableStream = (__nccwpck_require__(265).ReadableStream)
   }
 
   if (ReadableStream.from) {
@@ -17065,8 +17065,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(190);
-var import_policies = __nccwpck_require__(294);
+var import_log = __nccwpck_require__(192);
+var import_policies = __nccwpck_require__(295);
 const logPolicyName = import_policies.logPolicyName;
 function logPolicy(options = {}) {
   return (0, import_policies.logPolicy)({
@@ -17131,11 +17131,11 @@ exports.targetDirHasCompiledArtifacts = targetDirHasCompiledArtifacts;
 exports.shouldEmitSharedTargetWarning = shouldEmitSharedTargetWarning;
 exports.tryDelegateToSoldrDoctorSharedTargetWarning = tryDelegateToSoldrDoctorSharedTargetWarning;
 exports.detectSharedTargetWarning = detectSharedTargetWarning;
-const fs = __importStar(__nccwpck_require__(256));
+const fs = __importStar(__nccwpck_require__(257));
 const path = __importStar(__nccwpck_require__(519));
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 const log_utils_js_1 = __nccwpck_require__(52);
-const soldr_toolchain_client_js_1 = __nccwpck_require__(179);
+const soldr_toolchain_client_js_1 = __nccwpck_require__(181);
 const WARNING_MESSAGE = "setup-soldr detected a pre-populated shared target directory; a " +
     "subsequent `soldr cargo build` using the same `--target-dir` may fail " +
     "with a missing .rmeta error - see README 'Known limitations'.";
@@ -17356,12 +17356,12 @@ __export(src_exports, {
   toHttpHeadersLike: () => import_util.toHttpHeadersLike
 });
 module.exports = __toCommonJS(src_exports);
-var import_extendedClient = __nccwpck_require__(223);
-var import_response = __nccwpck_require__(424);
+var import_extendedClient = __nccwpck_require__(224);
+var import_response = __nccwpck_require__(425);
 var import_requestPolicyFactoryPolicy = __nccwpck_require__(69);
 var import_disableKeepAlivePolicy = __nccwpck_require__(9);
-var import_httpClientAdapter = __nccwpck_require__(219);
-var import_util = __nccwpck_require__(117);
+var import_httpClientAdapter = __nccwpck_require__(220);
+var import_util = __nccwpck_require__(119);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -17951,15 +17951,15 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 const exec = __importStar(__nccwpck_require__(19));
-const glob = __importStar(__nccwpck_require__(174));
-const io = __importStar(__nccwpck_require__(304));
-const crypto = __importStar(__nccwpck_require__(301));
+const glob = __importStar(__nccwpck_require__(176));
+const io = __importStar(__nccwpck_require__(305));
+const crypto = __importStar(__nccwpck_require__(302));
 const fs = __importStar(__nccwpck_require__(542));
-const path = __importStar(__nccwpck_require__(255));
-const semver = __importStar(__nccwpck_require__(185));
-const util = __importStar(__nccwpck_require__(131));
+const path = __importStar(__nccwpck_require__(256));
+const semver = __importStar(__nccwpck_require__(187));
+const util = __importStar(__nccwpck_require__(133));
 const constants_1 = __nccwpck_require__(49);
 const versionSalt = '1.0';
 // From https://github.com/actions/toolkit/blob/main/packages/tool-cache/src/tool-cache.ts#L23
@@ -18146,10 +18146,10 @@ module.exports = 'AGFzbQEAAAABMAhgAX8Bf2ADf39/AX9gBH9/f38Bf2AAAGADf39/AGABfwBgAn
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageSharedKeyCredentialPolicyName = void 0;
 exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
-const node_crypto_1 = __nccwpck_require__(281);
+const node_crypto_1 = __nccwpck_require__(282);
 const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(486);
-const SharedKeyComparator_js_1 = __nccwpck_require__(183);
+const utils_common_js_1 = __nccwpck_require__(487);
+const SharedKeyComparator_js_1 = __nccwpck_require__(185);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
  */
@@ -18280,6 +18280,1381 @@ function storageSharedKeyCredentialPolicy(options) {
 /***/ }),
 
 /***/ 85:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr entry point. Owned by Agent 2.
+//
+// Replaces the composite action's main-phase steps with a single JS
+// orchestrator. Calls the helpers in src/lib/* in the same order the
+// composite's steps fire.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(257));
+const os = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(519));
+const core = __importStar(__nccwpck_require__(473));
+const cache = __importStar(__nccwpck_require__(223));
+const exec = __importStar(__nccwpck_require__(19));
+const log_utils_js_1 = __nccwpck_require__(52);
+const resolve_setup_js_1 = __nccwpck_require__(416);
+const phase_timing_js_1 = __nccwpck_require__(528);
+const ensure_rust_toolchain_js_1 = __nccwpck_require__(92);
+const ensure_soldr_js_1 = __nccwpck_require__(20);
+const verify_soldr_js_1 = __nccwpck_require__(296);
+const install_passthrough_js_1 = __nccwpck_require__(524);
+const normalize_source_mtime_js_1 = __nccwpck_require__(406);
+const detect_shared_target_warning_js_1 = __nccwpck_require__(78);
+const ensure_shims_js_1 = __nccwpck_require__(198);
+const zccache_seed_js_1 = __nccwpck_require__(93);
+const cache_compress_js_1 = __nccwpck_require__(97);
+const soldr_load_shim_js_1 = __nccwpck_require__(34);
+const seed_isolated_cache_js_1 = __nccwpck_require__(323);
+const stats_collector_js_1 = __nccwpck_require__(450);
+const toolchain_snapshot_js_1 = __nccwpck_require__(472);
+const solo_toolchain_cache_js_1 = __nccwpck_require__(31);
+const cook_cache_js_1 = __nccwpck_require__(3);
+const soldr_mini_cache_js_1 = __nccwpck_require__(129);
+const diagnostics_js_1 = __nccwpck_require__(54);
+const shim_bypass_check_js_1 = __nccwpck_require__(324);
+const cross_bootstrap_js_1 = __nccwpck_require__(289);
+const source_mtime_snapshot_js_1 = __nccwpck_require__(396);
+/**
+ * Map (hit, matchedKey) → workflow-visible restore-status string.
+ * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
+ * for the `<layer>-cache-restore-status` outputs declared in action.yml.
+ */
+function deriveRestoreStatus(hit, matchedKey) {
+    if (hit)
+        return "exact-hit";
+    if (matchedKey.trim())
+        return "restore-key-hit";
+    return "miss";
+}
+function writeCacheKeysManifest(result, runnerTemp, log) {
+    if (!runnerTemp)
+        return;
+    const keys = [
+        result.setupCache.key,
+        result.buildCache.key,
+        result.targetCache.key,
+        result.cargoRegistryCache.key,
+    ].filter((k) => Boolean(k));
+    if (keys.length === 0)
+        return;
+    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
+    try {
+        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
+        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
+    }
+    catch (err) {
+        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+function isTruthy(value) {
+    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
+}
+function isFalsy(value) {
+    return FALSY.has(((value ?? "").trim().toLowerCase()));
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+function dirHasContent(p) {
+    try {
+        return fs.readdirSync(p).length > 0;
+    }
+    catch {
+        return false;
+    }
+}
+async function runGitCapture(workspace, args) {
+    let stdout = "";
+    let stderr = "";
+    const code = await exec.exec("git", ["-C", workspace, ...args], {
+        silent: true,
+        ignoreReturnCode: true,
+        listeners: {
+            stdout: (data) => { stdout += data.toString("utf8"); },
+            stderr: (data) => { stderr += data.toString("utf8"); },
+        },
+    });
+    return { code, stdout, stderr };
+}
+async function deriveParentSha(workspace, githubSha, logger) {
+    // #365: derive parent SHA so cook-cache-delta + target-cache +
+    // cargo-registry can fall back to the prior commit's saved
+    // entry. Returns "" on any error (no regression from prior
+    // behavior — caller treats "" as "no fallback").
+    //
+    // Strategy: try `git log -1 --format=%P HEAD` first. On a
+    // shallow clone (actions/checkout default fetch-depth=1) this
+    // returns empty for grafted root commits — fall back to
+    // `git cat-file -p HEAD` and parse the `parent` header lines
+    // from the raw commit object, which are preserved even when
+    // the parent commit object isn't present in the local repo.
+    // Pass 1: git log %P (works on full-depth checkouts).
+    try {
+        const { code, stdout, stderr } = await runGitCapture(workspace, [
+            "log", "-1", "--format=%P", "HEAD",
+        ]);
+        if (code === 0) {
+            const first = stdout.trim().split(/\s+/)[0] ?? "";
+            if (/^[0-9a-f]{7,40}$/i.test(first)) {
+                if (first === githubSha)
+                    return "";
+                logger.log(`parent-sha: derived ${first.slice(0, 12)} from git log (#365)`);
+                return first;
+            }
+            // empty / unparseable → fall through to cat-file
+        }
+        else {
+            logger.log(`parent-sha: git log exit=${code} stderr=${stderr.trim().slice(0, 120)}; trying cat-file`);
+        }
+    }
+    catch (err) {
+        logger.log(`parent-sha: git log threw (${err instanceof Error ? err.message : String(err)}); trying cat-file`);
+    }
+    // Pass 2: git cat-file -p HEAD (works on shallow clones — the
+    // commit object's `parent` header is preserved even when the
+    // parent commit isn't fetched).
+    try {
+        const { code, stdout, stderr } = await runGitCapture(workspace, [
+            "cat-file", "-p", "HEAD",
+        ]);
+        if (code !== 0) {
+            logger.log(`parent-sha: cat-file exit=${code} stderr=${stderr.trim().slice(0, 120)}; leaving empty`);
+            return "";
+        }
+        // Raw commit object format:
+        //   tree <sha>
+        //   parent <sha>      ← first parent (mainline)
+        //   parent <sha>      ← second parent (only for merges)
+        //   author ...
+        //   committer ...
+        //
+        //   <message>
+        for (const line of stdout.split("\n")) {
+            if (line.startsWith("parent ")) {
+                const sha = line.slice("parent ".length).trim();
+                if (/^[0-9a-f]{7,40}$/i.test(sha) && sha !== githubSha) {
+                    logger.log(`parent-sha: derived ${sha.slice(0, 12)} from cat-file (#365, shallow-safe)`);
+                    return sha;
+                }
+            }
+            if (line === "")
+                break; // header section ended
+        }
+        logger.log(`parent-sha: cat-file produced no usable parent (root commit?); leaving empty`);
+        return "";
+    }
+    catch (err) {
+        logger.log(`parent-sha: cat-file threw (${err instanceof Error ? err.message : String(err)}); leaving empty`);
+        return "";
+    }
+}
+async function buildActionContext() {
+    const env = process.env;
+    const logger = (0, log_utils_js_1.createLogger)(env);
+    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
+    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
+    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
+    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
+    const githubSha = env["GITHUB_SHA"]?.trim() || "";
+    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
+    // #365: parentSha enables cook-cache-delta + target-cache + cargo-
+    // registry to share entries across consecutive commits. The env
+    // override (ACTION_PARENT_SHA) lets a workflow set it explicitly;
+    // otherwise we derive it from `git log -1 --format=%P HEAD` so the
+    // fallback works out of the box for any repo with non-shallow
+    // checkout. Without this, every push-event run had the delta key
+    // mismatch the prior save (0% hit rate observed on zccache).
+    let parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
+    if (!parentSha && githubSha) {
+        parentSha = await deriveParentSha(workspace, githubSha, logger);
+    }
+    return {
+        env: { ...env },
+        workspace,
+        runnerTemp,
+        runnerOs,
+        runnerArch,
+        githubSha,
+        githubToken,
+        parentSha,
+        logger,
+    };
+}
+function actionRoot() {
+    const explicit = process.env["GITHUB_ACTION_PATH"]?.trim() || process.env["SETUP_SOLDR_ACTION_ROOT"]?.trim();
+    if (explicit)
+        return path.resolve(explicit);
+    const moduleDir = typeof __dirname === "string" ? __dirname : process.cwd();
+    return path.resolve(moduleDir, "..");
+}
+async function restoreCacheSafe(paths, key, restoreKeys, logger) {
+    if (paths.length === 0 || !key) {
+        return { hit: false, matchedKey: "" };
+    }
+    try {
+        const matched = await cache.restoreCache(paths, key, restoreKeys);
+        return { hit: matched === key, matchedKey: matched ?? "" };
+    }
+    catch (err) {
+        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "" };
+    }
+}
+async function run() {
+    const ctx = await buildActionContext();
+    const logger = ctx.logger;
+    await (0, phase_timing_js_1.markPhase)("action");
+    // ---- resolve ----
+    await (0, phase_timing_js_1.markPhase)("resolve");
+    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
+    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
+    await (0, resolve_setup_js_1.applyResolveResult)(result);
+    await (0, phase_timing_js_1.finishPhase)("resolve");
+    // Always emit the cache-keys manifest right after resolve so workflow
+    // steps that run between main and post (e.g. actions/upload-artifact)
+    // can read it. The four keys are fully determined by resolveSetup and
+    // never change later in the run.
+    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
+    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            logger,
+            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
+        });
+    }
+    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
+    if (dryRun) {
+        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
+        await (0, phase_timing_js_1.finishPhase)("action");
+        return;
+    }
+    // Persist resolve state for the post-job step.
+    core.saveState("resolveResult", JSON.stringify(result));
+    core.saveState("buildCacheMode", result.buildCache.mode);
+    core.saveState("logging", logging ? "true" : "false");
+    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
+    const statsMode = result.stats;
+    const debugMode = result.debugMode;
+    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
+    const statsCollector = new stats_collector_js_1.StatsCollector();
+    // ---- source-mtime-normalize ----
+    if (isTruthy(inputs.sourceMtimeNormalize)) {
+        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
+    }
+    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
+    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
+    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
+    core.saveState("setupCacheExactHit", "false");
+    core.saveState("setupCacheMatchedKey", "");
+    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
+    core.saveState("targetCacheExactHit", "false");
+    core.saveState("targetCacheMatchedKey", "");
+    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
+    core.saveState("buildCacheExactHit", "false");
+    core.saveState("buildCacheMatchedKey", "");
+    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
+    core.saveState("cargoRegistryCacheExactHit", "false");
+    core.saveState("cargoRegistryCacheMatchedKey", "");
+    core.saveState("dylintCacheEnabled", result.dylintCache.enabled ? "true" : "false");
+    core.saveState("dylintCacheExactHit", "false");
+    core.saveState("dylintCacheMatchedKey", "");
+    // ---- parallel restores ----
+    // setup-cache, target-cache, build-cache, and cargo-registry write to
+    // disjoint paths and have no inter-dependencies, so they run concurrently.
+    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
+    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
+    //
+    // Layers that must stay sequential (wired below): solo-toolchain (writes
+    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
+    // install dir, must precede ensureSoldr), cook (writes target/ and needs
+    // the soldr binary). Cargo-registry was previously after-cook — it's been
+    // moved into this parallel block because nothing the soldr install path
+    // touches depends on its hydrated cargo registry state.
+    await (0, phase_timing_js_1.markPhase)("parallel-restore");
+    let setupCacheExactHit = false;
+    // Capture target-cache match status so we can skip the redundant cook restore.
+    // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
+    // (~2.5 GB inflated) also contains compiled deps. When target-cache matched
+    // at the lockfile/shape/toolchain level (exact OR parent-SHA OR lock-prefix
+    // fallback), we have target/deps/ already populated with identical content —
+    // cook restore would just overwrite. Skipping saves ~5–10 s per warm run.
+    // A looser restoreKeyLockfile-only match (different shape) is NOT enough to
+    // skip cook, since cook output may differ across shapes.
+    let targetCacheMatchedKey = "";
+    const setupRestorePromise = (async () => {
+        if (!(cacheEnabled && result.setupCache.paths.length > 0))
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
+        setupCacheExactHit = restore.hit;
+        core.setOutput("cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("setup_cache_matched_key", restore.matchedKey);
+        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("setupCacheMatchedKey", restore.matchedKey);
+        // Expose for ensure_rust_toolchain to read via env. Must be visible by
+        // the time toolchain phase runs — guaranteed by the Promise.all below.
+        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
+        statsCollector.record({
+            label: "setup-cache", operation: "restore", hit: restore.hit,
+            key: result.setupCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.setupCache.restorePrefix],
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const targetRestorePromise = (async () => {
+        if (!result.targetCache.enabled)
+            return;
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (targetPaths.length === 0)
+            return;
+        const restoreKeys = [];
+        if (result.targetCache.restoreKeyParent)
+            restoreKeys.push(result.targetCache.restoreKeyParent);
+        if (result.targetCache.restoreKeyLock)
+            restoreKeys.push(result.targetCache.restoreKeyLock);
+        if (result.targetCache.restoreKeyLockfile)
+            restoreKeys.push(result.targetCache.restoreKeyLockfile);
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
+        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("target_cache_matched_key", restore.matchedKey);
+        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("targetCacheMatchedKey", restore.matchedKey);
+        targetCacheMatchedKey = restore.matchedKey;
+        statsCollector.record({
+            label: "target-cache", operation: "restore", hit: restore.hit,
+            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const buildRestorePromise = (async () => {
+        if (!buildCacheEnabled)
+            return;
+        const buildCachePath = result.buildCache.path;
+        const archivePath = `${buildCachePath}.tar.zst`;
+        const restoreKeys = [];
+        if (result.buildCache.restoreKeyParent)
+            restoreKeys.push(result.buildCache.restoreKeyParent);
+        if (result.buildCache.restoreKeyToolchain)
+            restoreKeys.push(result.buildCache.restoreKeyToolchain);
+        if (result.buildCache.restoreKeyOsArch)
+            restoreKeys.push(result.buildCache.restoreKeyOsArch);
+        const t0 = Date.now();
+        // @actions/cache hashes the `paths` array into a "version" key — save and
+        // restore MUST pass the same array or the lookup misses even when the
+        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
+        // restore must use the same single-path array. The decompression below
+        // unpacks archivePath → buildCachePath afterwards.
+        const restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
+        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("build_cache_matched_key", restore.matchedKey);
+        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("buildCacheMatchedKey", restore.matchedKey);
+        let buildArchiveBytes = null;
+        let buildInflatedBytes = null;
+        let buildFileCount = null;
+        if (fileExists(archivePath)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+            const haveEncryptKey = (process.env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] ?? "").trim().length > 0;
+            if (magic === "zstd" || magic === "gzip" || haveEncryptKey) {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({
+                        archivePath,
+                        targetDir: buildCachePath,
+                        debug: debugMode,
+                        log: debugLog,
+                        cacheKey: restore.matchedKey || result.buildCache.key,
+                    });
+                    buildArchiveBytes = dr.archiveBytes;
+                    buildInflatedBytes = dr.inflatedBytes;
+                    buildFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
+        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
+        // dir on the cold side; if it's present after decompress, walk it and
+        // set each matching source file's mtime to what cold saw. The replay
+        // is gated by (size, content-hash) match so we never overwrite a
+        // genuinely modified file's mtime — that would underbuild.
+        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
+            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
+            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
+            if (snapshot) {
+                const rt0 = Date.now();
+                try {
+                    // Match the project-root selection that post.ts uses when
+                    // writing the snapshot — the parent of the resolved target-dir,
+                    // not the (outer) GITHUB_WORKSPACE.
+                    const projectRoot = path.dirname(result.targetCache.targetPath);
+                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
+                        workspace: projectRoot,
+                        snapshot,
+                        log: (msg) => logger.log(msg),
+                    });
+                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
+                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
+                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
+                }
+                catch (err) {
+                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+            else {
+                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
+            }
+        }
+        statsCollector.record({
+            label: "build-cache", operation: "restore", hit: restore.hit,
+            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        // Seed an isolated SOLDR_CACHE_DIR from the just-restored build-cache
+        // artifact store (issue #240). Opt-in: only fires when the consumer
+        // declares the isolated root(s) it switches its self-test phase to, so a
+        // daemon-isolated coverage/integration phase starts warm instead of cold.
+        const seedTargets = (0, seed_isolated_cache_js_1.parseIsolatedSeedTargets)(inputs.seedIsolatedBuildCache);
+        if (seedTargets.length > 0) {
+            try {
+                (0, seed_isolated_cache_js_1.seedIsolatedBuildCache)({
+                    sourceZccacheDir: buildCachePath,
+                    targetSoldrRoots: seedTargets,
+                    log: (msg) => logger.log(msg),
+                });
+            }
+            catch (err) {
+                logger.log(`seed-isolated-build-cache: failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    })();
+    // Cargo-registry restore moved here from after-cook. It writes only
+    // $CARGO_HOME/registry/ and has no dependency on soldr being installed;
+    // running it in parallel with target+build trims its ~5s off the critical
+    // path.
+    const cargoRegistryRestorePromise = (async () => {
+        if (!result.cargoRegistryCache.enabled)
+            return;
+        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe([registryArchive], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
+        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
+        let regArchiveBytes = null;
+        let regInflatedBytes = null;
+        let regFileCount = null;
+        if (fileExists(registryArchive)) {
+            // #260: try `soldr load` first for parallel extraction on Windows
+            // (Defender + NTFS bottleneck). Falls through to the legacy
+            // tar+zstd path when the archive isn't soldr-format or the
+            // installed soldr is too old.
+            let soldrLoadUsed = false;
+            try {
+                const sr = await (0, soldr_load_shim_js_1.tryLoadViaSoldr)({
+                    archivePath: registryArchive,
+                    targetDir: result.cargoRegistryCache.path,
+                    soldrPath: result.soldrPath,
+                    soldrVersion: result.soldrVersionResolved,
+                    debug: debugMode,
+                    log: debugLog,
+                    autoDefenderExclude: process.platform === "win32",
+                });
+                soldrLoadUsed = sr.used;
+            }
+            catch (err) {
+                logger.log(`cargo-registry soldr load failed (will fall back to tar+zstd): ${err instanceof Error ? err.message : String(err)}`);
+            }
+            if (soldrLoadUsed) {
+                try {
+                    regArchiveBytes = (await fs.promises.stat(registryArchive)).size;
+                }
+                catch { /* archive may have been removed mid-flight */ }
+            }
+            else {
+                const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
+                const haveEncryptKey = (process.env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] ?? "").trim().length > 0;
+                if (magic === "zstd" || magic === "gzip" || haveEncryptKey) {
+                    try {
+                        const dr = await (0, cache_compress_js_1.decompressCache)({
+                            archivePath: registryArchive,
+                            targetDir: result.cargoRegistryCache.path,
+                            debug: debugMode, log: debugLog,
+                            cacheKey: restore.matchedKey || result.cargoRegistryCache.key,
+                        });
+                        regArchiveBytes = dr.archiveBytes;
+                        regInflatedBytes = dr.inflatedBytes;
+                        regFileCount = dr.fileCount;
+                    }
+                    catch (err) {
+                        logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                    }
+                }
+            }
+        }
+        statsCollector.record({
+            label: "cargo-registry", operation: "restore", hit: restore.hit,
+            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.cargoRegistryCache.restorePrefix],
+            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    })();
+    const dylintRestorePromise = (async () => {
+        if (!result.dylintCache.enabled)
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.dylintCache.paths, result.dylintCache.key, [], logger);
+        core.setOutput("dylint-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("dylint-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("dylint_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("dylint_cache_matched_key", restore.matchedKey);
+        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_HIT", restore.hit ? "true" : "false");
+        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_MATCHED_KEY", restore.matchedKey);
+        core.saveState("dylintCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("dylintCacheMatchedKey", restore.matchedKey);
+        statsCollector.record({
+            label: "dylint-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: result.dylintCache.key,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - t0,
+            timestamp: new Date().toISOString(),
+        });
+        logger.log(`dylint-cache: key=${result.dylintCache.key} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
+    // try/catches, so this should only see rejections for genuine programming
+    // bugs.
+    await Promise.all([
+        setupRestorePromise,
+        targetRestorePromise,
+        buildRestorePromise,
+        cargoRegistryRestorePromise,
+        dylintRestorePromise,
+    ]);
+    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
+    // ---- target-tree-cache (full mode) ----
+    // The bundle path is included in target-cache restore paths above when full
+    // mode is requested, so there's no separate restore here. We keep the phase
+    // marker for parity with the composite step ordering.
+    await (0, phase_timing_js_1.markPhase)("target-tree");
+    await (0, phase_timing_js_1.finishPhase)("target-tree");
+    // Plan soldr-mini-cache restore now, but perform the extract inside the
+    // install phase. Restoring this layer in the background can rewrite the
+    // install dir while later phases spawn PATH tools, which surfaced as Linux
+    // ETXTBSY on the warm demo after soldr-cook started invoking soldr earlier.
+    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
+    const miniInstallDir = path.dirname(result.soldrPath);
+    const miniArchive = `${miniInstallDir}.tar.zst`;
+    let miniHit = false;
+    let miniKey = "";
+    let miniSkipReason = "";
+    let miniRestoreEligible = false;
+    if (miniEnabled) {
+        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
+            hasRef: Boolean(result.soldrRef.trim()),
+            enable: result.enabled,
+            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
+        });
+        if (eligibility.eligible) {
+            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
+            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
+                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+                soldrVersion: version,
+            });
+            miniRestoreEligible = true;
+            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir}`);
+        }
+        else {
+            miniSkipReason = eligibility.reason;
+        }
+    }
+    // Kick off cook restore in the background. It overlaps with the
+    // sequential toolchain + soldr install + shims + verify steps that
+    // follow. By the time the cook phase runs, the restore is done — we
+    // just await the promise. Saves ~5–7 s of warm-build wall clock.
+    //
+    // Why this is safe (vs the disastrous PR #145 which added cook to the
+    // BIG parallel block): cook now races with SMALL ops (rust install
+    // ~1–2 s, soldr install ~2–3 s, shims/verify ~1–2 s). Those don't
+    // contend on disk write bandwidth the way target/build/cargo-registry
+    // restores did. Cook's 2.5 GB tar write becomes the long pole and
+    // hides behind the small ops.
+    //
+    // SAFETY: when target-cache writes to target/ (build-cache-mode: full),
+    // cook restore would race with target-cache restore on the same dir.
+    // The parallel-restore block above already finished target-cache, but
+    // we still want a runtime gate just in case the mode changes.
+    const cookGate = (0, cook_cache_js_1.decideCookGate)({
+        prebuildDeps: inputs.prebuildDeps,
+        cacheUmbrella: cacheEnabled,
+        lockfilePath: result.targetCache.lockfilePath,
+    });
+    const cookActive = cookGate.enabled && result.enabled;
+    let cookFlags = [];
+    let cookKey = "";
+    let cookBaseKey = "";
+    let cookDeltaKey = "";
+    let cookDeltaParentKey = "";
+    let cookDeltaRestoreKeys = [];
+    let cookProjectRoot = "";
+    let cookTargetDir = "";
+    let cookArchive = "";
+    let cookBaseArchive = "";
+    let cookDeltaArchive = "";
+    let cookBaseManifest = "";
+    let cookLayered = false;
+    let cookRestoreT0 = Date.now();
+    let cookRestorePromise = null;
+    let cookLayeredRestorePromise = null;
+    // Skip cook restore when target-cache matched at the lockfile/shape level.
+    // restoreKeyLock = `${prefix}-${targetInputsHash}-${suffix}-` where
+    // targetInputsHash = sha256(toolchain, lockfile, manifest, shape). A
+    // matchedKey starting with restoreKeyLock means the cached entry was built
+    // with the same toolchain + lockfile + shape — its target/deps/ matches
+    // what cook would restore. Covers:
+    //   - exact hit  (matchedKey === current key, also startsWith restoreKeyLock)
+    //   - parent-SHA hit (matchedKey === restoreKeyParent, also startsWith)
+    //   - lock-prefix fallback (any saved entry with same lockfile+shape)
+    // Does NOT cover restoreKeyLockfile fallback (shorter prefix that drops
+    // shape) — different shape may mean different cook output, so cook still
+    // runs there as the safety net.
+    const targetCacheLockMatch = !!targetCacheMatchedKey &&
+        !!result.targetCache.restoreKeyLock &&
+        targetCacheMatchedKey.startsWith(result.targetCache.restoreKeyLock);
+    const cookSkippedDueToTargetHit = cookActive && targetCacheLockMatch;
+    if (cookActive && !cookSkippedDueToTargetHit) {
+        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
+        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
+        const lockHash = result.targetCache.lockfileHash || "no-lock";
+        const cookKeyParts = {
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            flagsHash,
+            lockHash,
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        };
+        cookProjectRoot = path.dirname(result.targetCache.targetPath);
+        cookTargetDir = result.targetCache.targetPath;
+        cookRestoreT0 = Date.now();
+        const deltaInput = inputs.prebuildDepsDeltaCache.trim() || "true";
+        const deltaRequested = !isFalsy(deltaInput);
+        const soldrVersionForCook = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
+        cookLayered = deltaRequested && (0, cook_cache_js_1.supportsLayeredCookCache)(soldrVersionForCook);
+        if (cookLayered) {
+            const shapeHash = (0, cook_cache_js_1.hashCookBuildShape)(result.targetCache.restoreKeyLock || result.targetCache.key);
+            cookBaseKey = (0, cook_cache_js_1.buildCookBaseCacheKey)(cookKeyParts);
+            cookDeltaKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
+                ...cookKeyParts,
+                buildShapeHash: shapeHash,
+                githubSha: ctx.githubSha || "nosha",
+            });
+            if (ctx.parentSha && ctx.parentSha !== ctx.githubSha) {
+                cookDeltaParentKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
+                    ...cookKeyParts,
+                    buildShapeHash: shapeHash,
+                    githubSha: ctx.parentSha,
+                });
+            }
+            cookDeltaRestoreKeys = cookDeltaParentKey ? [cookDeltaParentKey] : [];
+            cookDeltaRestoreKeys.push((0, cook_cache_js_1.buildCookDeltaCacheRestorePrefix)({
+                ...cookKeyParts,
+                buildShapeHash: shapeHash,
+            }));
+            cookBaseArchive = `${cookTargetDir}.soldr-base.tar.zst`;
+            cookDeltaArchive = `${cookTargetDir}.soldr-delta.tar.zst`;
+            cookBaseManifest = `${cookTargetDir}.soldr-base-manifest.pb`;
+            logger.log(`cook: layered keys base=${cookBaseKey} delta=${cookDeltaKey}` +
+                (cookDeltaParentKey ? ` delta-fallback=${cookDeltaParentKey}` : ` (no parent-fallback — parentSha unavailable, #365)`) +
+                ` delta-prefix=${cookDeltaRestoreKeys.at(-1)}` +
+                ` starting archive restore concurrent with install`);
+            cookLayeredRestorePromise = (0, cook_cache_js_1.restoreLayeredCookCacheArchives)({
+                baseKey: cookBaseKey,
+                deltaKey: cookDeltaKey,
+                deltaRestoreKeys: cookDeltaRestoreKeys,
+                baseArchivePath: cookBaseArchive,
+                deltaArchivePath: cookDeltaArchive,
+                log: (msg) => logger.log(msg),
+            });
+        }
+        else {
+            if (deltaRequested) {
+                logger.log(`cook: layered cache requires soldr >=0.7.38; ` +
+                    `version=${soldrVersionForCook || "unknown"} falling back to legacy cook cache`);
+            }
+            else {
+                logger.log("cook: layered cache disabled via prebuild-deps-delta-cache=false");
+            }
+            cookKey = (0, cook_cache_js_1.buildCookCacheKey)(cookKeyParts);
+            cookArchive = `${cookTargetDir}.tar.zst`;
+            logger.log(`cook: key=${cookKey} starting background restore concurrent with install`);
+            cookRestorePromise = (0, cook_cache_js_1.restoreCookCache)({
+                exactKey: cookKey,
+                archivePath: cookArchive,
+                targetDir: cookTargetDir,
+                longWindow: 27,
+                debug: debugMode,
+                log: (msg) => logger.log(msg),
+            });
+        }
+    }
+    // ---- toolchain ----
+    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
+    // toolchain install so we can see which inodes setup-soldr added on
+    // top of the runner image. When solo-toolchain-cache is opted in, a
+    // third snapshot is taken *before* the cache restore so the saved
+    // tarball captures the full above-runner state — not just the
+    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
+    // lifetime axis".
+    await (0, phase_timing_js_1.markPhase)("toolchain");
+    const snapshotRoots = [
+        path.join(result.rustupHome, "toolchains"),
+        path.join(result.cargoHome, "bin"),
+    ];
+    const soloRootMap = {
+        "rustup-toolchains": snapshotRoots[0],
+        "cargo-bin": snapshotRoots[1],
+    };
+    const soloEnabled = isTruthy(inputs.soloToolchainCache);
+    // #310: default-changed from "19" → "9". Measured first-save cost
+    // dropped from ~104s → ~12s on 140 MB toolchain delta; restore stays
+    // bandwidth-bound either way.
+    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "9");
+    let soloKeys = null;
+    let soloMatchedKey = "";
+    let soloExactHit = false;
+    let forceToolchainRepair = false;
+    // Pre-restore snapshot — only needed when solo cache is enabled, so
+    // we can compute the full save-diff (post-install vs runner-image,
+    // not vs post-restore baseline). (#302: timed as sub-phase.)
+    const preRestoreSnapshot = soloEnabled
+        ? await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-pre", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots))
+        : null;
+    if (soloEnabled) {
+        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
+            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        });
+        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
+        const restoreT0 = Date.now();
+        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
+        const restored = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "solo-restore", () => (0, solo_toolchain_cache_js_1.restoreSoloCache)({
+            keys: soloKeys,
+            rootMap: soloRootMap,
+            stagingDir,
+            log: (msg) => logger.log(msg),
+            // #316 follow-up: pass canonical archive path explicitly so
+            // save and restore agree regardless of stagingDir layout.
+            cacheArchivePath: (0, solo_toolchain_cache_js_1.soloCacheArchivePath)(ctx.runnerTemp),
+        }));
+        soloMatchedKey = restored.matchedKey;
+        let verifiedMatch = true;
+        if (restored.verified && restored.matchedKey) {
+            const expected = result.toolchain.cacheChannel.trim();
+            // The rustup home is set up so `rustc` will resolve through the
+            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
+            // the cargo bin one.
+            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
+            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
+                expectedRelease: expected,
+                expectedTargets: result.toolchain.targets,
+                rustcCommand: rustcCmd,
+                log: (msg) => logger.log(msg),
+            });
+            verifiedMatch = verify.match;
+            forceToolchainRepair = restored.verified && !verify.match;
+        }
+        soloExactHit = restored.hit && verifiedMatch;
+        core.saveState("soloToolchainEnabled", "true");
+        core.saveState("soloToolchainExactKey", soloKeys.exact);
+        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
+        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
+        core.saveState("soloToolchainLevel", soloLevel);
+        statsCollector.record({
+            label: "solo-toolchain-cache",
+            operation: "restore",
+            hit: soloExactHit,
+            key: soloKeys.exact,
+            matchedKey: soloMatchedKey,
+            restoreKeys: soloKeys.fallbacks,
+            archiveBytes: restored.restoredBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - restoreT0,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    else {
+        core.saveState("soloToolchainEnabled", "false");
+    }
+    const baselineSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-base", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
+    // #323: when solo-cache exact-hit AND verifyRestoredToolchain
+    // passed, the requested toolchain is already on disk from the
+    // restore. `rustup toolchain install` would be a no-op but still
+    // costs ~8s on hosted runners (self-update check, metadata fetch,
+    // profile diff). Skip the install entirely on the verified
+    // exact-hit path. The snapshot still runs so cache-save logic
+    // downstream sees an unchanged tree (install-delta empty).
+    if (soloExactHit) {
+        logger.log("toolchain: solo-cache exact-hit + verified — skipping rustup install (#323)");
+    }
+    else {
+        await (0, phase_timing_js_1.timeSubPhase)("toolchain", "rustup-install", () => (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({
+            resolveResult: result,
+            setupCacheExactHit,
+            forceRepair: forceToolchainRepair,
+        }));
+    }
+    const postInstallSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-post", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
+    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
+    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
+    // When solo cache is enabled, also compute the save-diff (post-install
+    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
+    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
+        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
+        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
+        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
+        try {
+            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
+            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
+            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
+            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
+                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
+                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
+                `incremental-empty=${toolchainDiff.added.length === 0}`);
+        }
+        catch (err) {
+            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
+        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
+    if (ctx.runnerTemp) {
+        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
+        try {
+            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
+            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
+        }
+        catch (err) {
+            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    await (0, phase_timing_js_1.finishPhase)("toolchain");
+    // ---- install soldr ----
+    // Restore soldr-mini-cache synchronously so the install dir is quiescent
+    // before ensureSoldr's installedVersion() check or any later soldr spawn.
+    await (0, phase_timing_js_1.markPhase)("install");
+    if (miniRestoreEligible) {
+        const miniT0 = Date.now();
+        const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
+            exactKey: miniKey,
+            installDir: miniInstallDir,
+            archivePath: miniArchive,
+            longWindow: 27,
+            debug: debugMode,
+            log: (msg) => logger.log(msg),
+        });
+        miniHit = restore.hit;
+        statsCollector.record({
+            label: "soldr-mini-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: miniKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - miniT0,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    else if (miniSkipReason) {
+        logger.log(`soldr-mini-cache: skipped — ${miniSkipReason}`);
+    }
+    else if (!miniEnabled) {
+        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
+    }
+    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
+    core.saveState("soldrMiniExactKey", miniKey);
+    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
+    core.saveState("soldrMiniInstallDir", miniInstallDir);
+    core.saveState("soldrMiniArchive", miniArchive);
+    if (result.enabled) {
+        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
+        // restored binary at the expected path with the expected version and
+        // short-circuits — no GH fetch.
+        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
+    }
+    else {
+        (0, install_passthrough_js_1.installPassthrough)({
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
+            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
+            "verbatim, and soldr-aware caching/observability is disabled.");
+    }
+    await (0, phase_timing_js_1.finishPhase)("install");
+    // ---- zccache-seed ----
+    // Pin setup-soldr's zccache before user workflow steps. The pinned
+    // install is home-anchored inside soldr, so later self-tests can isolate
+    // SOLDR_CACHE_DIR without repeating release lookup or cargo-install fallback.
+    await (0, phase_timing_js_1.markPhase)("zccache-seed");
+    await (0, zccache_seed_js_1.seedZccache)({
+        soldrPath: result.soldrPath,
+        actionRoot: actionRoot(),
+        enabled: result.enabled,
+        strict: isTruthy(inputs.zccacheSeedStrict),
+        log: (msg) => logger.log(msg),
+        warn: (msg) => logger.warning(msg),
+    });
+    await (0, phase_timing_js_1.finishPhase)("zccache-seed");
+    // Export SOLDR_BINARY so shims can exec it directly
+    core.exportVariable("SOLDR_BINARY", result.soldrPath);
+    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
+    // ---- shims ----
+    if (result.shimsEnabled) {
+        await (0, ensure_shims_js_1.ensureShims)({
+            shimsDir: result.shimsDir,
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+    }
+    // ---- verify ----
+    await (0, phase_timing_js_1.markPhase)("verify");
+    if (result.enabled) {
+        const verify = await (0, verify_soldr_js_1.verifySoldr)({
+            soldrPath: result.soldrPath,
+            buildCacheMode: result.buildCache.mode,
+            requireRustPlan: result.targetCache.enabled,
+        });
+        core.setOutput("soldr-version", verify.soldrVersion);
+        core.setOutput("soldr_version", verify.soldrVersion);
+    }
+    else {
+        core.setOutput("soldr-version", "passthrough");
+        core.setOutput("soldr_version", "passthrough");
+    }
+    await (0, phase_timing_js_1.finishPhase)("verify");
+    // ---- cross-bootstrap (issue #104 MVP) ----
+    // After the Rust toolchain and the soldr binary are both available, but
+    // before the user's own steps run, auto-install cross-compile tooling
+    // for any declared `cross-targets`. Skip entirely if the input is empty
+    // so workflows that don't cross-compile pay zero cost. Failures here are
+    // surfaced as standard exec errors and DO fail the action — the user
+    // explicitly asked for these targets, so a silent skip would be more
+    // surprising than a hard failure.
+    await (0, phase_timing_js_1.markPhase)("cross-bootstrap");
+    const crossTargets = (0, cross_bootstrap_js_1.parseCrossTargets)(inputs.crossTargets);
+    // Track per-lane cache restore outcomes so post.ts knows which lanes to
+    // save (only the ones that missed; saving on an exact hit is wasted I/O).
+    // setup-soldr#106 / Wave 2.1 of zackees/soldr#514.
+    const crossToolCacheRestores = {};
+    if (crossTargets.length > 0) {
+        const tool = (0, cross_bootstrap_js_1.parseCrossTool)(inputs.crossTool);
+        const host = ctx.runnerOs.toLowerCase() || process.platform;
+        logger.log(`cross-bootstrap: host=${host} tool=${tool} targets=${crossTargets.join(",")}`);
+        // Per-(host × target) tool cache restores. One slot per declared lane,
+        // keyed on `tool-<host>-<target>-<toolsHash>-soldr<ver>` (see
+        // crossToolCacheKeyFor in cache-keys.ts). Restore is best-effort: a
+        // miss just means we'll run the normal install path below. Restores
+        // run in parallel — there are no inter-lane dependencies.
+        if (result.crossToolCaches.length > 0) {
+            await Promise.all(result.crossToolCaches.map(async (lane) => {
+                if (lane.paths.length === 0) {
+                    // Unsupported lane (e.g. windows -> apple-darwin): no
+                    // binaries to cache, just record the no-op.
+                    crossToolCacheRestores[lane.target] = { hit: false, matchedKey: "" };
+                    return;
+                }
+                const t0 = Date.now();
+                const restore = await restoreCacheSafe(lane.paths, lane.key, [], logger);
+                crossToolCacheRestores[lane.target] = {
+                    hit: restore.hit,
+                    matchedKey: restore.matchedKey,
+                };
+                statsCollector.record({
+                    label: `cross-tool-cache:${lane.target}`,
+                    operation: "restore",
+                    hit: restore.hit,
+                    key: lane.key,
+                    matchedKey: restore.matchedKey,
+                    restoreKeys: [],
+                    archiveBytes: null,
+                    inflatedBytes: null,
+                    fileCount: null,
+                    durationMs: Date.now() - t0,
+                    timestamp: new Date().toISOString(),
+                });
+                logger.log(`cross-tool-cache: lane=${lane.target} key=${lane.key} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+            }));
+        }
+        const plan = (0, cross_bootstrap_js_1.planCrossBootstrap)({ host, targets: crossTargets, tool });
+        for (const w of plan.warnings)
+            core.warning(w);
+        if (plan.actions.length > 0) {
+            // When every lane hit the per-lane tool cache, the install plan is
+            // already on disk and we can skip the executeCrossBootstrap call
+            // entirely. The cached cargo-zigbuild binary lands at the same path
+            // executeCrossBootstrap would write to ($CARGO_HOME/bin), so the
+            // skipIfPresent guard inside the executor also short-circuits on a
+            // partial hit — we run unconditionally and let the guard sort it.
+            const allLanesHit = result.crossToolCaches.length > 0 &&
+                result.crossToolCaches
+                    .filter((l) => l.paths.length > 0)
+                    .every((l) => crossToolCacheRestores[l.target]?.hit === true);
+            if (allLanesHit) {
+                logger.log("cross-bootstrap: all per-lane tool caches hit — skipping install plan");
+            }
+            else {
+                await (0, cross_bootstrap_js_1.executeCrossBootstrap)(plan, {
+                    log: (msg) => logger.log(msg),
+                    soldrBinary: result.soldrPath,
+                });
+            }
+        }
+        else if (plan.warnings.length === 0) {
+            logger.log("cross-bootstrap: no actions planned (tool=none or empty supported set)");
+        }
+    }
+    // Persist per-lane restore state so post.ts can decide what to save.
+    // Save the lane plans themselves so post.ts doesn't have to recompute
+    // (resolveSetup-level inputs may not be available the same way in post).
+    core.saveState("crossToolCachePlans", JSON.stringify(result.crossToolCaches));
+    core.saveState("crossToolCacheRestores", JSON.stringify(crossToolCacheRestores));
+    await (0, phase_timing_js_1.finishPhase)("cross-bootstrap");
+    // ---- cook (prebuild-deps via soldr-cook) ----
+    // The RESTORE was kicked off as a background promise right after the
+    // parallel-restore block above — we just await its result here. The
+    // RUN (`soldr cook`) still happens in this phase if
+    // the restore missed.
+    // Failures here are logged but never fail the action — the user's
+    // own cargo build will still work without the cooked deps.
+    await (0, phase_timing_js_1.markPhase)("cook");
+    if (cookActive && cookLayeredRestorePromise) {
+        const restore = await cookLayeredRestorePromise;
+        const loaded = await (0, cook_cache_js_1.loadLayeredCookCache)({
+            soldrBinary: result.soldrPath,
+            projectRoot: cookProjectRoot,
+            targetDir: cookTargetDir,
+            baseArchivePath: cookBaseArchive,
+            deltaArchivePath: cookDeltaArchive,
+            baseManifestPath: cookBaseManifest,
+            restore,
+            log: (msg) => logger.log(msg),
+        });
+        const baseReady = (0, cook_cache_js_1.layeredCookBaseReady)(restore, loaded);
+        const deltaReady = (0, cook_cache_js_1.layeredCookDeltaReady)(restore, loaded);
+        statsCollector.record({
+            label: "cook-cache-base",
+            operation: "restore",
+            hit: baseReady,
+            key: cookBaseKey,
+            matchedKey: restore.base.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.base.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: loaded.baseReport?.cacheFilesRestored ?? null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        statsCollector.record({
+            label: "cook-cache-delta",
+            operation: "restore",
+            hit: deltaReady,
+            key: cookDeltaKey,
+            matchedKey: restore.delta.matchedKey,
+            restoreKeys: cookDeltaRestoreKeys,
+            archiveBytes: restore.delta.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: loaded.deltaReport?.cacheFilesRestored ?? null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        let cookRan = false;
+        if (!deltaReady) {
+            const runRes = await (0, cook_cache_js_1.runCook)({
+                soldrBinary: result.soldrPath,
+                projectRoot: cookProjectRoot,
+                flags: cookFlags,
+                log: (msg) => logger.log(msg),
+            });
+            cookRan = runRes.exitCode === 0;
+        }
+        else {
+            logger.log("cook: base+delta cache hit - skipping cook run, target/deps already warm");
+        }
+        const cookSaveLayer = cookRan ? (baseReady ? "delta" : "base") : "none";
+        core.saveState("cookEnabled", "true");
+        core.saveState("cookLayered", "true");
+        core.saveState("cookBaseExactKey", cookBaseKey);
+        core.saveState("cookDeltaExactKey", cookDeltaKey);
+        core.saveState("cookBaseMatchedKey", restore.base.matchedKey);
+        core.saveState("cookDeltaMatchedKey", restore.delta.matchedKey);
+        core.saveState("cookBaseHit", baseReady ? "true" : "false");
+        core.saveState("cookDeltaHit", deltaReady ? "true" : "false");
+        core.saveState("cookHit", deltaReady ? "true" : "false");
+        core.saveState("cookRan", cookRan ? "true" : "false");
+        core.saveState("cookSaveLayer", cookSaveLayer);
+        core.saveState("cookProjectRoot", cookProjectRoot);
+        core.saveState("cookTargetDir", cookTargetDir);
+        core.saveState("cookBaseArchive", cookBaseArchive);
+        core.saveState("cookDeltaArchive", cookDeltaArchive);
+        core.saveState("cookBaseManifest", cookBaseManifest);
+        core.saveState("cookSoldrBinary", result.soldrPath);
+        // #268/#358: cook-cache-base previously used zstd-level 19, but
+        // production observation showed 165s of compress wall-clock per
+        // matrix job for ~224 MB output. In a 5-way matrix where 1 job
+        // wins the cache reservation and 4 lose the race, that's 660s
+        // of post-step CPU wasted per CI cycle. Lowering to -9 cuts the
+        // compress wall-clock ~4× (target ~40s) at the cost of ~25%
+        // larger archive (~280 MB) and ~1s extra upload wall-clock per
+        // save. zstd decompression speed is level-independent, so warm
+        // restores are unaffected. Net: ~125s win per save-attempt, big
+        // multiplier on race-loss scenarios.
+        core.saveState("cookCompressLevel", "9");
+        core.saveState("cookDeltaCompressLevel", "3");
+    }
+    else if (cookActive && cookRestorePromise) {
+        const restore = await cookRestorePromise;
+        statsCollector.record({
+            label: "cook-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: cookKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        let cookRan = false;
+        if (!restore.hit) {
+            const runRes = await (0, cook_cache_js_1.runCook)({
+                soldrBinary: result.soldrPath,
+                projectRoot: cookProjectRoot,
+                flags: cookFlags,
+                log: (msg) => logger.log(msg),
+            });
+            cookRan = runRes.exitCode === 0;
+        }
+        else {
+            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
+        }
+        core.saveState("cookEnabled", "true");
+        core.saveState("cookLayered", "false");
+        core.saveState("cookExactKey", cookKey);
+        core.saveState("cookMatchedKey", restore.matchedKey);
+        core.saveState("cookHit", restore.hit ? "true" : "false");
+        core.saveState("cookRan", cookRan ? "true" : "false");
+        core.saveState("cookTargetDir", cookTargetDir);
+        core.saveState("cookLongWindow", "27");
+        // #268/#358: see saveState("cookCompressLevel", "9") above for
+        // rationale on lowering from -19. Same logic applies to the
+        // non-layered path.
+        core.saveState("cookCompressLevel", "9");
+    }
+    else if (cookSkippedDueToTargetHit) {
+        logger.log(`cook: skipped - target-cache matched at lockfile/shape level (matched=${targetCacheMatchedKey}); cook output would be redundant`);
+        core.saveState("cookEnabled", "false");
+        core.saveState("cookLayered", "false");
+    }
+    else {
+        logger.log(`cook: skipped - ${cookGate.reason}`);
+        core.saveState("cookEnabled", "false");
+        core.saveState("cookLayered", "false");
+    }
+    await (0, phase_timing_js_1.finishPhase)("cook");
+    // ---- shared-target warning ----
+    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
+        buildCacheEnabled,
+        effectiveTargetCacheEnabled: result.targetCache.enabled,
+        buildCacheMode: result.buildCache.mode,
+        targetDir: result.targetCache.targetPath,
+        soldrPath: result.soldrPath,
+    });
+    // ---- shim-bypass diagnostic ----
+    // Issue #160: when shims: true is requested but the effective environment
+    // (PATH ordering, CARGO/RUSTC/RUSTC_WRAPPER overrides) would bypass them,
+    // caching looks configured but compile work runs through plain cargo.
+    // Emit advisory warnings naming each offender. Runs at the very end so it
+    // sees the final state of process.env after every prior phase.
+    if (result.shimsEnabled) {
+        const bypassWarnings = (0, shim_bypass_check_js_1.diagnoseShimBypass)({
+            shimsEnabled: true,
+            shimDir: result.shimsDir,
+            path: process.env["PATH"] ?? "",
+            cargoEnv: process.env["CARGO"],
+            rustcEnv: process.env["RUSTC"],
+            rustcWrapperEnv: process.env["RUSTC_WRAPPER"],
+            soldrBinary: result.soldrPath,
+        });
+        for (const msg of bypassWarnings) {
+            core.warning(msg);
+        }
+        if (bypassWarnings.length === 0) {
+            logger.log(`shim-bypass check clean: shim dir ${result.shimsDir} at PATH front, no competing CARGO/RUSTC/RUSTC_WRAPPER overrides`);
+        }
+    }
+    // ---- stats report ----
+    statsCollector.report(statsMode, (msg) => logger.log(msg));
+    if (statsMode === "detailed") {
+        try {
+            await statsCollector.writeFiles(ctx.runnerTemp);
+            statsCollector.setGithubOutputs();
+        }
+        catch (err) {
+            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    core.saveState("statsCollector", statsCollector.serialize());
+    core.saveState("statsMode", statsMode);
+    core.saveState("compileCacheStats", result.compileCacheStats);
+    core.saveState("runnerTemp", ctx.runnerTemp);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            cacheOutcomes: statsCollector.snapshot(),
+            logger,
+        });
+    }
+    // #269-companion (setup side): one-line aggregate of where each
+    // setup phase's wall-clock went, before we finish the `action`
+    // phase. Mirrors the post-step `cache save totals:` line that
+    // ships from `StatsCollector.saveSummaryOneLine()`. Operators see
+    // the pre-build budget at a glance without scrolling raw
+    // SETUP_SOLDR_PHASE_*_START_MS env vars or hunting through the
+    // timeline. Phases in declared serial order:
+    const setupPhaseSummary = (0, phase_timing_js_1.setupPhaseSummaryOneLine)([
+        "resolve",
+        "parallel-restore",
+        "target-tree",
+        "toolchain",
+        "install",
+        "zccache-seed",
+        "verify",
+        "cross-bootstrap",
+        "cook",
+    ]);
+    if (setupPhaseSummary)
+        core.info(setupPhaseSummary);
+    await (0, phase_timing_js_1.finishPhase)("action");
+    // dirHasContent is exported for tests; suppress unused warning here.
+    void dirHasContent;
+}
+// Auto-invoke only when this module is run as the main entry point. This lets
+// tests import `run` (and helpers) without triggering the side-effectful
+// orchestration. The dist/main.js produced by ncc is invoked directly by the
+// Actions runtime so the check trips and the action executes normally.
+if (typeof process !== "undefined" &&
+    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
+    // import.meta.url is the file URL of this module; argv[1] is the runner
+    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
+    // the dev path — we rely on the env-var opt-out for tests instead.
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    run().catch((err) => {
+        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        core.setFailed(`setup-soldr failed: ${message}`);
+    });
+}
+
+
+/***/ }),
+
+/***/ 86:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18336,7 +19711,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 86:
+/***/ 87:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18349,9 +19724,9 @@ exports.NewRetryPolicyFactory = NewRetryPolicyFactory;
 const abort_controller_1 = __nccwpck_require__(507);
 const RequestPolicy_js_1 = __nccwpck_require__(50);
 const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(486);
+const utils_common_js_1 = __nccwpck_require__(487);
 const log_js_1 = __nccwpck_require__(18);
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(429);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(430);
 /**
  * A factory method used to generated a RetryPolicy factory.
  *
@@ -18567,7 +19942,7 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 
 /***/ }),
 
-/***/ 87:
+/***/ 88:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18576,15 +19951,15 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = exports.useInstrumenter = void 0;
-var instrumenter_js_1 = __nccwpck_require__(419);
+var instrumenter_js_1 = __nccwpck_require__(420);
 Object.defineProperty(exports, "useInstrumenter", ({ enumerable: true, get: function () { return instrumenter_js_1.useInstrumenter; } }));
-var tracingClient_js_1 = __nccwpck_require__(357);
+var tracingClient_js_1 = __nccwpck_require__(358);
 Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: function () { return tracingClient_js_1.createTracingClient; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 88:
+/***/ 89:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -18596,7 +19971,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 89:
+/***/ 90:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18606,7 +19981,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 const { extractBody, mixinBody, cloneBody } = __nccwpck_require__(26)
 const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(527)
-const { FinalizationRegistry } = __nccwpck_require__(426)()
+const { FinalizationRegistry } = __nccwpck_require__(427)()
 const util = __nccwpck_require__(75)
 const {
   isValidHTTPToken,
@@ -18627,12 +20002,12 @@ const {
 } = __nccwpck_require__(33)
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(16)
-const { webidl } = __nccwpck_require__(469)
-const { getGlobalOrigin } = __nccwpck_require__(147)
+const { webidl } = __nccwpck_require__(470)
+const { getGlobalOrigin } = __nccwpck_require__(149)
 const { URLSerializer } = __nccwpck_require__(27)
-const { kHeadersList, kConstruct } = __nccwpck_require__(202)
+const { kHeadersList, kConstruct } = __nccwpck_require__(204)
 const assert = __nccwpck_require__(538)
-const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(482)
+const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(483)
 
 let TransformStream = globalThis.TransformStream
 
@@ -19119,7 +20494,7 @@ class Request {
 
       // 2. Set finalBody to the result of creating a proxy for inputBody.
       if (!TransformStream) {
-        TransformStream = (__nccwpck_require__(264).TransformStream)
+        TransformStream = (__nccwpck_require__(265).TransformStream)
       }
 
       // https://streams.spec.whatwg.org/#readablestream-create-a-proxy
@@ -19550,7 +20925,7 @@ module.exports = { Request, makeRequest }
 
 /***/ }),
 
-/***/ 90:
+/***/ 91:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -19662,7 +21037,7 @@ function normalizeCompileCacheStats(raw) {
 
 /***/ }),
 
-/***/ 91:
+/***/ 92:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -19710,15 +21085,15 @@ exports.shouldRefreshToolchain = shouldRefreshToolchain;
 exports.shouldSkipRefreshForExactHit = shouldSkipRefreshForExactHit;
 exports.tryDelegateToSoldrToolchainEnsure = tryDelegateToSoldrToolchainEnsure;
 exports.ensureRustToolchain = ensureRustToolchain;
-const fs = __importStar(__nccwpck_require__(256));
-const os = __importStar(__nccwpck_require__(391));
+const fs = __importStar(__nccwpck_require__(257));
+const os = __importStar(__nccwpck_require__(392));
 const path = __importStar(__nccwpck_require__(519));
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 const exec = __importStar(__nccwpck_require__(19));
-const io = __importStar(__nccwpck_require__(304));
+const io = __importStar(__nccwpck_require__(305));
 const tc = __importStar(__nccwpck_require__(534));
 const log_utils_js_1 = __nccwpck_require__(52);
-const soldr_toolchain_client_js_1 = __nccwpck_require__(179);
+const soldr_toolchain_client_js_1 = __nccwpck_require__(181);
 function rustupInitTargetTriple() {
     const system = process.platform;
     const arch = process.arch;
@@ -20068,7 +21443,364 @@ async function ensureRustToolchain(opts) {
 
 /***/ }),
 
-/***/ 92:
+/***/ 93:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports._internal = void 0;
+exports.detectHostZccacheTarget = detectHostZccacheTarget;
+exports.hasRequiredZccacheBinaries = hasRequiredZccacheBinaries;
+exports.findVendoredZccacheDir = findVendoredZccacheDir;
+exports.findBundledZccacheDir = findBundledZccacheDir;
+exports.managedReleaseUrl = managedReleaseUrl;
+exports.downloadManagedRelease = downloadManagedRelease;
+exports.seedZccache = seedZccache;
+const fs = __importStar(__nccwpck_require__(257));
+const os = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(519));
+const core = __importStar(__nccwpck_require__(473));
+const exec = __importStar(__nccwpck_require__(19));
+const tc = __importStar(__nccwpck_require__(534));
+const LOCAL_DIR_ENV = "SOLDR_ZCCACHE_LOCAL_DIR";
+const VENDOR_DIR_ENV = "SETUP_SOLDR_ZCCACHE_VENDOR_DIR";
+const SEED_ENV = "SETUP_SOLDR_ZCCACHE_SEEDED";
+const SEED_SOURCE_ENV = "SETUP_SOLDR_ZCCACHE_SEED_SOURCE";
+function normalizeArch(arch) {
+    if (arch === "x64")
+        return "x86_64";
+    if (arch === "arm64")
+        return "aarch64";
+    throw new Error(`unsupported architecture for zccache seed: ${arch}`);
+}
+function detectHostZccacheTarget(platform = process.platform, archValue = process.arch) {
+    const arch = normalizeArch(archValue);
+    if (platform === "win32") {
+        return {
+            target: `${arch}-pc-windows-msvc`,
+            archiveTarget: `${arch}-pc-windows-msvc`,
+            binaryExt: ".exe",
+            archiveExt: "zip",
+        };
+    }
+    if (platform === "darwin") {
+        return {
+            target: `${arch}-apple-darwin`,
+            archiveTarget: `${arch}-apple-darwin`,
+            binaryExt: "",
+            archiveExt: "tar.gz",
+        };
+    }
+    if (platform === "linux") {
+        // zccache publishes musl Linux archives; they are the portable host
+        // binary used by soldr on GNU runners too.
+        return {
+            target: `${arch}-unknown-linux-gnu`,
+            archiveTarget: `${arch}-unknown-linux-musl`,
+            binaryExt: "",
+            archiveExt: "tar.gz",
+        };
+    }
+    throw new Error(`unsupported platform for zccache seed: ${platform}`);
+}
+function requiredBinaryNames(binaryExt) {
+    return ["zccache", "zccache-daemon", "zccache-fp"].map((name) => `${name}${binaryExt}`);
+}
+function hasRequiredZccacheBinaries(dir, binaryExt) {
+    try {
+        const stat = fs.statSync(dir);
+        if (!stat.isDirectory())
+            return false;
+    }
+    catch {
+        return false;
+    }
+    return requiredBinaryNames(binaryExt).every((name) => {
+        try {
+            return fs.statSync(path.join(dir, name)).isFile();
+        }
+        catch {
+            return false;
+        }
+    });
+}
+function uniqueStrings(values) {
+    const seen = new Set();
+    const out = [];
+    for (const value of values) {
+        const normalized = value.trim();
+        if (!normalized || seen.has(normalized))
+            continue;
+        seen.add(normalized);
+        out.push(normalized);
+    }
+    return out;
+}
+function findVendoredZccacheDir(opts) {
+    const env = opts.env ?? process.env;
+    const explicit = (env[VENDOR_DIR_ENV] ?? "").trim();
+    const roots = uniqueStrings([
+        explicit,
+        path.join(opts.actionRoot, "vendor", "zccache", opts.target.target),
+        path.join(opts.actionRoot, "vendor", "zccache", opts.target.archiveTarget),
+        path.join(opts.actionRoot, "zccache", "vendor", opts.target.target),
+        path.join(opts.actionRoot, "zccache", "vendor", opts.target.archiveTarget),
+    ]);
+    for (const root of roots) {
+        for (const candidate of uniqueStrings([root, path.join(root, "bin")])) {
+            if (hasRequiredZccacheBinaries(candidate, opts.target.binaryExt)) {
+                return candidate;
+            }
+        }
+    }
+    return null;
+}
+function findBundledZccacheDir(opts) {
+    const installedDir = path.dirname(opts.soldrPath);
+    if (hasRequiredZccacheBinaries(installedDir, opts.target.binaryExt)) {
+        return installedDir;
+    }
+    return null;
+}
+function managedReleaseUrl(version, target) {
+    const normalized = version.trim().replace(/^v/i, "");
+    const asset = `zccache-v${normalized}-${target.archiveTarget}.${target.archiveExt}`;
+    return `https://github.com/zackees/zccache/releases/download/${normalized}/${asset}`;
+}
+async function downloadManagedRelease(url, target, env = process.env) {
+    const runnerTemp = env["RUNNER_TEMP"]?.trim() || os.tmpdir();
+    const tempDir = fs.mkdtempSync(path.join(runnerTemp, "setup-soldr-zccache-"));
+    const suffix = target.archiveExt === "zip" ? ".zip" : ".tar.gz";
+    const archivePath = path.join(tempDir, `zccache-managed${suffix}`);
+    return await tc.downloadTool(url, archivePath);
+}
+async function runCaptured(execFn, command, args) {
+    let stdout = "";
+    let stderr = "";
+    const code = await execFn(command, args, {
+        silent: true,
+        ignoreReturnCode: true,
+        listeners: {
+            stdout: (data) => {
+                stdout += data.toString("utf8");
+            },
+            stderr: (data) => {
+                stderr += data.toString("utf8");
+            },
+        },
+    });
+    return { code, stdout, stderr };
+}
+function parseInstallStatus(stdout) {
+    let parsed;
+    try {
+        parsed = JSON.parse(stdout);
+    }
+    catch {
+        return null;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+        return null;
+    const payload = parsed;
+    const managedVersion = payload["managed_version"];
+    if (typeof managedVersion !== "string" || !managedVersion.trim())
+        return null;
+    return {
+        managedVersion,
+        pinnedPresent: payload["pinned"] !== null && payload["pinned"] !== undefined,
+        driftFromManaged: payload["drift_from_managed"] === true,
+    };
+}
+async function readInstallStatus(soldrPath, execFn) {
+    const result = await runCaptured(execFn, soldrPath, ["install-zccache", "--status", "--json"]);
+    if (result.code !== 0)
+        return null;
+    return parseInstallStatus(result.stdout);
+}
+function parseRuntimeStatus(stdout) {
+    let parsed;
+    try {
+        parsed = JSON.parse(stdout);
+    }
+    catch {
+        return null;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+        return null;
+    const payload = parsed;
+    const zccache = payload["zccache"];
+    const zccachePayload = zccache && typeof zccache === "object" && !Array.isArray(zccache)
+        ? zccache
+        : {};
+    const source = String(zccachePayload["binary_source"] ?? "").trim();
+    return {
+        managedVersion: String(payload["managed_zccache_version"] ?? "").trim(),
+        zccacheSource: source,
+        // soldr 0.8.7+ reports the compiled-in backend as "in-process";
+        // older releases used "embedded". Both mean setup-soldr must not
+        // attempt the legacy managed-zccache download/seed path.
+        embedded: source === "embedded" || source === "in-process",
+    };
+}
+async function readRuntimeStatus(soldrPath, execFn) {
+    const result = await runCaptured(execFn, soldrPath, ["status", "--json"]);
+    if (result.code !== 0)
+        return null;
+    return parseRuntimeStatus(result.stdout);
+}
+function errorDetail(err) {
+    return err instanceof Error ? (err.message || String(err)) : String(err);
+}
+async function seedZccache(opts) {
+    const warn = opts.warn ?? ((msg) => core.warning(msg));
+    const execFn = opts.execFn ?? exec.exec;
+    const downloadFn = opts.downloadFn ?? downloadManagedRelease;
+    const env = opts.env ?? process.env;
+    const failOrWarn = (message) => {
+        if (opts.strict) {
+            throw new Error(message);
+        }
+        warn(message);
+    };
+    if (!opts.enabled) {
+        opts.log("zccache-seed: skipped - setup-soldr passthrough mode");
+        return;
+    }
+    if ((env[LOCAL_DIR_ENV] ?? "").trim()) {
+        opts.log(`zccache-seed: skipped - ${LOCAL_DIR_ENV} already set`);
+        return;
+    }
+    let target;
+    try {
+        target = detectHostZccacheTarget();
+    }
+    catch (err) {
+        failOrWarn(`setup-soldr: zccache seed skipped: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+    }
+    const runtimeStatus = await readRuntimeStatus(opts.soldrPath, execFn);
+    if (runtimeStatus?.embedded) {
+        opts.log(`zccache-seed: skipped - soldr uses embedded zccache ${runtimeStatus.managedVersion || "(unknown version)"}`);
+        core.exportVariable(SEED_ENV, "true");
+        core.exportVariable(SEED_SOURCE_ENV, "embedded");
+        return;
+    }
+    const status = await readInstallStatus(opts.soldrPath, execFn);
+    if (status?.pinnedPresent && !status.driftFromManaged) {
+        opts.log(`zccache-seed: existing pinned zccache matches managed ${status.managedVersion}`);
+        core.exportVariable(SEED_ENV, "true");
+        core.exportVariable(SEED_SOURCE_ENV, "pinned-existing");
+        return;
+    }
+    const vendored = findVendoredZccacheDir({ actionRoot: opts.actionRoot, target, env });
+    const bundled = vendored ? null : findBundledZccacheDir({ soldrPath: opts.soldrPath, target });
+    const managedUrl = status ? managedReleaseUrl(status.managedVersion, target) : "";
+    if (!vendored && !bundled && !managedUrl) {
+        failOrWarn("setup-soldr: zccache seed failed: could not determine managed zccache version");
+        return;
+    }
+    const sourceKind = vendored ? "vendored" : bundled ? "soldr-release" : "managed-release";
+    let tempRoot = "";
+    let source = vendored ?? bundled ?? "";
+    try {
+        if (!source) {
+            opts.log(`zccache-seed: downloading managed zccache release ${managedUrl}`);
+            try {
+                source = await downloadFn(managedUrl, target, env);
+            }
+            catch (err) {
+                const detail = errorDetail(err);
+                failOrWarn(opts.strict
+                    ? "setup-soldr: zccache seed failed; refusing to continue because the managed " +
+                        "zccache release could not be downloaded and later isolated SOLDR_CACHE_DIR roots " +
+                        "would fall back to cargo-installing zccache" +
+                        (detail ? `: ${detail}` : "")
+                    : "setup-soldr: zccache seed failed; managed zccache release could not be downloaded; " +
+                        "later isolated SOLDR_CACHE_DIR roots may fetch zccache again" +
+                        (detail ? `: ${detail}` : ""));
+                return;
+            }
+            tempRoot = path.dirname(source);
+        }
+        opts.log(`zccache-seed: installing pinned zccache from ${sourceKind} source ${source}`);
+        let install;
+        try {
+            install = await runCaptured(execFn, opts.soldrPath, ["install-zccache", source, "--json"]);
+        }
+        catch (err) {
+            const detail = errorDetail(err);
+            failOrWarn(opts.strict
+                ? "setup-soldr: zccache seed failed; refusing to continue because pinned zccache " +
+                    "installation errored and later isolated SOLDR_CACHE_DIR roots would fall back to " +
+                    "cargo-installing zccache" +
+                    (detail ? `: ${detail}` : "")
+                : "setup-soldr: zccache seed failed; pinned zccache installation errored; later isolated " +
+                    "SOLDR_CACHE_DIR roots may fetch zccache again" +
+                    (detail ? `: ${detail}` : ""));
+            return;
+        }
+        if (install.code !== 0) {
+            const detail = (install.stderr || install.stdout).trim();
+            failOrWarn(opts.strict
+                ? "setup-soldr: zccache seed failed; refusing to continue because later isolated " +
+                    "SOLDR_CACHE_DIR roots would fall back to cargo-installing zccache" +
+                    (detail ? `: ${detail}` : "")
+                : "setup-soldr: zccache seed failed; later isolated SOLDR_CACHE_DIR roots may fetch zccache again" +
+                    (detail ? `: ${detail}` : ""));
+            return;
+        }
+    }
+    finally {
+        if (tempRoot) {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    }
+    core.exportVariable(SEED_ENV, "true");
+    core.exportVariable(SEED_SOURCE_ENV, sourceKind);
+    opts.log(`zccache-seed: pinned zccache installed from ${sourceKind}`);
+}
+exports._internal = {
+    parseRuntimeStatus,
+};
+
+
+/***/ }),
+
+/***/ 94:
 /***/ ((module) => {
 
 "use strict";
@@ -20076,7 +21808,7 @@ module.exports = require("url");
 
 /***/ }),
 
-/***/ 93:
+/***/ 95:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20086,10 +21818,10 @@ module.exports = require("url");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.deserializationPolicyName = void 0;
 exports.deserializationPolicy = deserializationPolicy;
-const interfaces_js_1 = __nccwpck_require__(107);
-const core_rest_pipeline_1 = __nccwpck_require__(109);
-const serializer_js_1 = __nccwpck_require__(492);
-const operationHelpers_js_1 = __nccwpck_require__(444);
+const interfaces_js_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
+const serializer_js_1 = __nccwpck_require__(493);
+const operationHelpers_js_1 = __nccwpck_require__(445);
 const defaultJsonContentTypes = ["application/json", "text/json"];
 const defaultXmlContentTypes = ["application/xml", "application/atom+xml"];
 /**
@@ -20317,7 +22049,7 @@ async function parse(jsonContentTypes, xmlContentTypes, operationResponse, opts,
 
 /***/ }),
 
-/***/ 94:
+/***/ 96:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -20343,7 +22075,7 @@ __export(apiKeyAuthenticationPolicy_exports, {
   apiKeyAuthenticationPolicyName: () => apiKeyAuthenticationPolicyName
 });
 module.exports = __toCommonJS(apiKeyAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(447);
+var import_checkInsecureConnection = __nccwpck_require__(448);
 const apiKeyAuthenticationPolicyName = "apiKeyAuthenticationPolicy";
 function apiKeyAuthenticationPolicy(options) {
   return {
@@ -20369,7 +22101,7 @@ function apiKeyAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 95:
+/***/ 97:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -20423,13 +22155,13 @@ exports.detectCompressMagic = detectCompressMagic;
 exports.planTarPayload = planTarPayload;
 exports.decompressCache = decompressCache;
 exports.compressCache = compressCache;
-const fs = __importStar(__nccwpck_require__(116));
-const os = __importStar(__nccwpck_require__(391));
+const fs = __importStar(__nccwpck_require__(118));
+const os = __importStar(__nccwpck_require__(392));
 const path = __importStar(__nccwpck_require__(519));
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 const exec = __importStar(__nccwpck_require__(19));
-const io = __importStar(__nccwpck_require__(304));
-const cache_encrypt_js_1 = __nccwpck_require__(243);
+const io = __importStar(__nccwpck_require__(305));
+const cache_encrypt_js_1 = __nccwpck_require__(244);
 /**
  * Resolve the encryption config for a cache call. Callers pass `encryption`
  * explicitly for tests; in production they pass `cacheKey` and let the
@@ -21204,7 +22936,7 @@ function parseLevel(value) {
  * Bubbles non-zero exit codes from either side.
  */
 async function runPipe(producer, consumer) {
-    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 205, 23));
+    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 206, 23));
     const [pCmd, pArgs] = producer;
     const [cCmd, cArgs] = consumer;
     await new Promise((resolve, reject) => {
@@ -21244,7 +22976,7 @@ async function runPipe(producer, consumer) {
 
 /***/ }),
 
-/***/ 96:
+/***/ 98:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21256,11 +22988,11 @@ async function runPipe(producer, consumer) {
 
 const assert = __nccwpck_require__(538)
 const net = __nccwpck_require__(520)
-const http = __nccwpck_require__(340)
-const { pipeline } = __nccwpck_require__(138)
+const http = __nccwpck_require__(341)
+const { pipeline } = __nccwpck_require__(140)
 const util = __nccwpck_require__(75)
-const timers = __nccwpck_require__(339)
-const Request = __nccwpck_require__(308)
+const timers = __nccwpck_require__(340)
+const Request = __nccwpck_require__(309)
 const DispatcherBase = __nccwpck_require__(68)
 const {
   RequestContentLengthMismatchError,
@@ -21275,8 +23007,8 @@ const {
   HTTPParserError,
   ResponseExceededMaxSizeError,
   ClientDestroyedError
-} = __nccwpck_require__(500)
-const buildConnector = __nccwpck_require__(273)
+} = __nccwpck_require__(501)
+const buildConnector = __nccwpck_require__(274)
 const {
   kUrl,
   kReset,
@@ -21328,7 +23060,7 @@ const {
   kHTTP2BuildRequest,
   kHTTP2CopyHeaders,
   kHTTP1BuildRequest
-} = __nccwpck_require__(202)
+} = __nccwpck_require__(204)
 
 /** @type {import('http2')} */
 let http2
@@ -21361,7 +23093,7 @@ const kClosedResolve = Symbol('kClosedResolve')
 const channels = {}
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(149)
+  const diagnosticsChannel = __nccwpck_require__(151)
   channels.sendHeaders = diagnosticsChannel.channel('undici:client:sendHeaders')
   channels.beforeConnect = diagnosticsChannel.channel('undici:client:beforeConnect')
   channels.connectError = diagnosticsChannel.channel('undici:client:connectError')
@@ -21734,8 +23466,8 @@ function onHTTP2GoAway (code) {
   resume(client)
 }
 
-const constants = __nccwpck_require__(461)
-const createRedirectInterceptor = __nccwpck_require__(262)
+const constants = __nccwpck_require__(462)
+const createRedirectInterceptor = __nccwpck_require__(263)
 const EMPTY_BUF = Buffer.alloc(0)
 
 async function lazyllhttp () {
@@ -23535,7 +25267,7 @@ module.exports = Client
 
 /***/ }),
 
-/***/ 97:
+/***/ 99:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -23576,16 +25308,16 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 var import_AbortError = __nccwpck_require__(11);
-var import_logger = __nccwpck_require__(253);
-var import_httpHeaders = __nccwpck_require__(497);
-var import_pipelineRequest = __nccwpck_require__(122);
+var import_logger = __nccwpck_require__(254);
+var import_httpHeaders = __nccwpck_require__(498);
+var import_pipelineRequest = __nccwpck_require__(124);
 var import_pipeline = __nccwpck_require__(536);
-var import_restError = __nccwpck_require__(457);
-var import_bytesEncoding = __nccwpck_require__(296);
-var import_defaultHttpClient = __nccwpck_require__(380);
-var import_getClient = __nccwpck_require__(218);
-var import_operationOptionHelpers = __nccwpck_require__(392);
-var import_restError2 = __nccwpck_require__(376);
+var import_restError = __nccwpck_require__(458);
+var import_bytesEncoding = __nccwpck_require__(297);
+var import_defaultHttpClient = __nccwpck_require__(381);
+var import_getClient = __nccwpck_require__(219);
+var import_operationOptionHelpers = __nccwpck_require__(393);
+var import_restError2 = __nccwpck_require__(377);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -23593,17 +25325,17 @@ var import_restError2 = __nccwpck_require__(376);
 
 /***/ }),
 
-/***/ 98:
+/***/ 100:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
-const base64_1 = __nccwpck_require__(313);
-const pb_long_1 = __nccwpck_require__(124);
-const reflection_info_1 = __nccwpck_require__(465);
-const assert_1 = __nccwpck_require__(496);
+const base64_1 = __nccwpck_require__(314);
+const pb_long_1 = __nccwpck_require__(126);
+const reflection_info_1 = __nccwpck_require__(466);
+const assert_1 = __nccwpck_require__(497);
 /**
  * Writes proto3 messages in canonical JSON format using reflection
  * information.
@@ -23831,7 +25563,7 @@ exports.ReflectionJsonWriter = ReflectionJsonWriter;
 
 /***/ }),
 
-/***/ 99:
+/***/ 101:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -23842,7 +25574,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Batch = void 0;
 // In browser, during webpack or browserify bundling, this module will be replaced by 'events'
 // https://github.com/Gozala/events
-const events_1 = __nccwpck_require__(482);
+const events_1 = __nccwpck_require__(483);
 /**
  * States for Batch.
  */
@@ -23972,7 +25704,7 @@ exports.Batch = Batch;
 
 /***/ }),
 
-/***/ 100:
+/***/ 102:
 /***/ ((module) => {
 
 "use strict";
@@ -23980,7 +25712,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 101:
+/***/ 103:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -23989,7 +25721,7 @@ module.exports = require("os");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredentialPolicy = void 0;
-const CredentialPolicy_js_1 = __nccwpck_require__(319);
+const CredentialPolicy_js_1 = __nccwpck_require__(320);
 /**
  * AnonymousCredentialPolicy is used with HTTP(S) requests that read public resources
  * or for use with Shared Access Signatures (SAS).
@@ -24011,7 +25743,7 @@ exports.AnonymousCredentialPolicy = AnonymousCredentialPolicy;
 
 /***/ }),
 
-/***/ 102:
+/***/ 104:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24028,8 +25760,8 @@ const {
   kResult,
   kEvents,
   kAborted
-} = __nccwpck_require__(473)
-const { webidl } = __nccwpck_require__(469)
+} = __nccwpck_require__(474)
+const { webidl } = __nccwpck_require__(470)
 const { kEnumerableProperty } = __nccwpck_require__(75)
 
 class FileReader extends EventTarget {
@@ -24363,7 +26095,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 103:
+/***/ 105:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -24392,7 +26124,7 @@ exports.Credential = Credential;
 
 /***/ }),
 
-/***/ 104:
+/***/ 106:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -24413,7 +26145,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 105:
+/***/ 107:
 /***/ ((module) => {
 
 "use strict";
@@ -24711,7 +26443,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 106:
+/***/ 108:
 /***/ ((module) => {
 
 "use strict";
@@ -24731,7 +26463,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 107:
+/***/ 109:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -24752,7 +26484,7 @@ exports.XML_CHARKEY = "_";
 
 /***/ }),
 
-/***/ 108:
+/***/ 110:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -24782,7 +26514,7 @@ async function cancelablePromiseRace(abortablePromiseBuilders, options) {
 
 /***/ }),
 
-/***/ 109:
+/***/ 111:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -24852,39 +26584,39 @@ __export(src_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(src_exports);
-var import_pipeline = __nccwpck_require__(252);
-var import_createPipelineFromOptions = __nccwpck_require__(289);
-var import_defaultHttpClient = __nccwpck_require__(242);
-var import_httpHeaders = __nccwpck_require__(250);
+var import_pipeline = __nccwpck_require__(253);
+var import_createPipelineFromOptions = __nccwpck_require__(290);
+var import_defaultHttpClient = __nccwpck_require__(243);
+var import_httpHeaders = __nccwpck_require__(251);
 var import_pipelineRequest = __nccwpck_require__(22);
-var import_restError = __nccwpck_require__(364);
-var import_decompressResponsePolicy = __nccwpck_require__(246);
-var import_exponentialRetryPolicy = __nccwpck_require__(403);
-var import_setClientRequestIdPolicy = __nccwpck_require__(158);
+var import_restError = __nccwpck_require__(365);
+var import_decompressResponsePolicy = __nccwpck_require__(247);
+var import_exponentialRetryPolicy = __nccwpck_require__(404);
+var import_setClientRequestIdPolicy = __nccwpck_require__(160);
 var import_logPolicy = __nccwpck_require__(77);
-var import_multipartPolicy = __nccwpck_require__(278);
-var import_proxyPolicy = __nccwpck_require__(485);
-var import_redirectPolicy = __nccwpck_require__(351);
-var import_systemErrorRetryPolicy = __nccwpck_require__(226);
+var import_multipartPolicy = __nccwpck_require__(279);
+var import_proxyPolicy = __nccwpck_require__(486);
+var import_redirectPolicy = __nccwpck_require__(352);
+var import_systemErrorRetryPolicy = __nccwpck_require__(227);
 var import_throttlingRetryPolicy = __nccwpck_require__(25);
-var import_retryPolicy = __nccwpck_require__(220);
-var import_tracingPolicy = __nccwpck_require__(347);
+var import_retryPolicy = __nccwpck_require__(221);
+var import_tracingPolicy = __nccwpck_require__(348);
 var import_defaultRetryPolicy = __nccwpck_require__(61);
-var import_userAgentPolicy = __nccwpck_require__(399);
-var import_tlsPolicy = __nccwpck_require__(386);
-var import_formDataPolicy = __nccwpck_require__(275);
-var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(225);
-var import_ndJsonPolicy = __nccwpck_require__(247);
-var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(200);
-var import_agentPolicy = __nccwpck_require__(238);
-var import_file = __nccwpck_require__(338);
+var import_userAgentPolicy = __nccwpck_require__(400);
+var import_tlsPolicy = __nccwpck_require__(387);
+var import_formDataPolicy = __nccwpck_require__(276);
+var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(226);
+var import_ndJsonPolicy = __nccwpck_require__(248);
+var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(202);
+var import_agentPolicy = __nccwpck_require__(239);
+var import_file = __nccwpck_require__(339);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 
 
 /***/ }),
 
-/***/ 110:
+/***/ 112:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -24910,8 +26642,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(159);
-var import_sanitizer = __nccwpck_require__(129);
+var import_log = __nccwpck_require__(161);
+var import_sanitizer = __nccwpck_require__(131);
 const logPolicyName = "logPolicy";
 function logPolicy(options = {}) {
   const logger = options.logger ?? import_log.logger.info;
@@ -24940,11 +26672,11 @@ function logPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 111:
+/***/ 113:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const { addAbortListener } = __nccwpck_require__(75)
-const { RequestAbortedError } = __nccwpck_require__(500)
+const { RequestAbortedError } = __nccwpck_require__(501)
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')
@@ -25001,7 +26733,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 112:
+/***/ 114:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -25032,7 +26764,7 @@ function rangeToString(iRange) {
 
 /***/ }),
 
-/***/ 113:
+/***/ 115:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25042,15 +26774,15 @@ const {
   Readable,
   Duplex,
   PassThrough
-} = __nccwpck_require__(138)
+} = __nccwpck_require__(140)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(500)
+} = __nccwpck_require__(501)
 const util = __nccwpck_require__(75)
-const { AsyncResource } = __nccwpck_require__(441)
-const { addSignal, removeSignal } = __nccwpck_require__(111)
+const { AsyncResource } = __nccwpck_require__(442)
+const { addSignal, removeSignal } = __nccwpck_require__(113)
 const assert = __nccwpck_require__(538)
 
 const kResume = Symbol('resume')
@@ -25289,7 +27021,7 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 114:
+/***/ 116:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25307,17 +27039,17 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 
 /***/ }),
 
-/***/ 115:
+/***/ 117:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = (__nccwpck_require__(151).EventEmitter)
-const inherits = (__nccwpck_require__(383).inherits)
-const getLimit = __nccwpck_require__(495)
+const EventEmitter = (__nccwpck_require__(153).EventEmitter)
+const inherits = (__nccwpck_require__(384).inherits)
+const getLimit = __nccwpck_require__(496)
 
-const StreamSearch = __nccwpck_require__(121)
+const StreamSearch = __nccwpck_require__(123)
 
 const B_DCRLF = Buffer.from('\r\n\r\n')
 const RE_CRLF = /\r\n/g
@@ -25415,7 +27147,7 @@ module.exports = HeaderParser
 
 /***/ }),
 
-/***/ 116:
+/***/ 118:
 /***/ ((module) => {
 
 "use strict";
@@ -25423,7 +27155,7 @@ module.exports = require("node:fs/promises");
 
 /***/ }),
 
-/***/ 117:
+/***/ 119:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -25451,7 +27183,7 @@ __export(util_exports, {
   toWebResourceLike: () => toWebResourceLike
 });
 module.exports = __toCommonJS(util_exports);
-var import_core_rest_pipeline = __nccwpck_require__(109);
+var import_core_rest_pipeline = __nccwpck_require__(111);
 const originalRequestSymbol = /* @__PURE__ */ Symbol("Original PipelineRequest");
 const originalClientRequestSymbol = /* @__PURE__ */ Symbol.for("@azure/core-client original request");
 function toPipelineRequest(webResource, options = {}) {
@@ -25693,7 +27425,7 @@ class HttpHeaders {
 
 /***/ }),
 
-/***/ 118:
+/***/ 120:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -25739,7 +27471,7 @@ function objectHasProperty(thing, property) {
 
 /***/ }),
 
-/***/ 119:
+/***/ 121:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25749,8 +27481,8 @@ function objectHasProperty(thing, property) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseCAEChallenge = parseCAEChallenge;
 exports.authorizeRequestOnClaimChallenge = authorizeRequestOnClaimChallenge;
-const log_js_1 = __nccwpck_require__(493);
-const base64_js_1 = __nccwpck_require__(450);
+const log_js_1 = __nccwpck_require__(494);
+const base64_js_1 = __nccwpck_require__(451);
 /**
  * Converts: `Bearer a="b", c="d", Bearer d="e", f="g"`.
  * Into: `[ { a: 'b', c: 'd' }, { d: 'e', f: 'g' } ]`.
@@ -25822,7 +27554,7 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 
 /***/ }),
 
-/***/ 120:
+/***/ 122:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25832,8 +27564,8 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.delay = delay;
 exports.calculateRetryDelay = calculateRetryDelay;
-const createAbortablePromise_js_1 = __nccwpck_require__(267);
-const util_1 = __nccwpck_require__(154);
+const createAbortablePromise_js_1 = __nccwpck_require__(268);
+const util_1 = __nccwpck_require__(156);
 const StandardAbortMessage = "The delay was aborted.";
 /**
  * A wrapper for setTimeout that resolves a promise after timeInMs milliseconds.
@@ -25872,7 +27604,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 121:
+/***/ 123:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25904,8 +27636,8 @@ function calculateRetryDelay(retryAttempt, config) {
  * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
-const EventEmitter = (__nccwpck_require__(151).EventEmitter)
-const inherits = (__nccwpck_require__(383).inherits)
+const EventEmitter = (__nccwpck_require__(153).EventEmitter)
+const inherits = (__nccwpck_require__(384).inherits)
 
 function SBMH (needle) {
   if (typeof needle === 'string') {
@@ -26108,7 +27840,7 @@ module.exports = SBMH
 
 /***/ }),
 
-/***/ 122:
+/***/ 124:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26133,8 +27865,8 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_httpHeaders = __nccwpck_require__(497);
-var import_uuidUtils = __nccwpck_require__(404);
+var import_httpHeaders = __nccwpck_require__(498);
+var import_uuidUtils = __nccwpck_require__(405);
 class PipelineRequestImpl {
   url;
   method;
@@ -26187,7 +27919,7 @@ function createPipelineRequest(options) {
 
 /***/ }),
 
-/***/ 123:
+/***/ 125:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -26223,8 +27955,8 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(391));
-var import_node_process = __toESM(__nccwpck_require__(244));
+var import_node_os = __toESM(__nccwpck_require__(392));
+var import_node_process = __toESM(__nccwpck_require__(245));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -26247,14 +27979,14 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 124:
+/***/ 126:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PbLong = exports.PbULong = exports.detectBi = void 0;
-const goog_varint_1 = __nccwpck_require__(211);
+const goog_varint_1 = __nccwpck_require__(212);
 let BI;
 function detectBi() {
     const dv = new DataView(new ArrayBuffer(8));
@@ -26493,7 +28225,7 @@ PbLong.ZERO = new PbLong(0, 0);
 
 /***/ }),
 
-/***/ 125:
+/***/ 127:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -26510,7 +28242,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 126:
+/***/ 128:
 /***/ ((module) => {
 
 "use strict";
@@ -26518,7 +28250,7 @@ module.exports = require("buffer");
 
 /***/ }),
 
-/***/ 127:
+/***/ 129:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -26582,11 +28314,11 @@ exports.buildMiniCacheKey = buildMiniCacheKey;
 exports.restoreMiniCache = restoreMiniCache;
 exports.saveMiniCache = saveMiniCache;
 exports.isEligibleForMiniCache = isEligibleForMiniCache;
-const fs = __importStar(__nccwpck_require__(256));
-const fsp = __importStar(__nccwpck_require__(116));
+const fs = __importStar(__nccwpck_require__(257));
+const fsp = __importStar(__nccwpck_require__(118));
 const path = __importStar(__nccwpck_require__(519));
-const cache = __importStar(__nccwpck_require__(222));
-const cache_compress_js_1 = __nccwpck_require__(95);
+const cache = __importStar(__nccwpck_require__(223));
+const cache_compress_js_1 = __nccwpck_require__(97);
 // Schema segment `v2` (still inside the `soldr-mini-` eviction namespace):
 // v1 entries were archived by setup-soldr <= v0.9.64, whose bundled-payload
 // allowlist dropped `soldr-clang-shim` from the soldr release archive.
@@ -26772,7 +28504,7 @@ function isEligibleForMiniCache(opts) {
 
 /***/ }),
 
-/***/ 128:
+/***/ 130:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -26801,8 +28533,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
-const path = __importStar(__nccwpck_require__(255));
-const pathHelper = __importStar(__nccwpck_require__(229));
+const path = __importStar(__nccwpck_require__(256));
+const pathHelper = __importStar(__nccwpck_require__(230));
 const assert_1 = __importDefault(__nccwpck_require__(538));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -26892,7 +28624,7 @@ exports.Path = Path;
 
 /***/ }),
 
-/***/ 129:
+/***/ 131:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26917,7 +28649,7 @@ __export(sanitizer_exports, {
   Sanitizer: () => Sanitizer
 });
 module.exports = __toCommonJS(sanitizer_exports);
-var import_object = __nccwpck_require__(152);
+var import_object = __nccwpck_require__(154);
 const RedactedString = "REDACTED";
 const defaultAllowedHeaderNames = [
   "x-ms-client-request-id",
@@ -27066,7 +28798,7 @@ class Sanitizer {
 
 /***/ }),
 
-/***/ 130:
+/***/ 132:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -27083,7 +28815,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 131:
+/***/ 133:
 /***/ ((module) => {
 
 "use strict";
@@ -27091,19 +28823,19 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 132:
+/***/ 134:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
-var path = (function () { try { return __nccwpck_require__(255) } catch (e) {}}()) || {
+var path = (function () { try { return __nccwpck_require__(256) } catch (e) {}}()) || {
   sep: '/'
 }
 minimatch.sep = path.sep
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __nccwpck_require__(498)
+var expand = __nccwpck_require__(499)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -28103,7 +29835,7 @@ function regExpEscape (s) {
 
 /***/ }),
 
-/***/ 133:
+/***/ 135:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28138,12 +29870,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
-const os = __importStar(__nccwpck_require__(100));
-const events = __importStar(__nccwpck_require__(482));
-const child = __importStar(__nccwpck_require__(171));
-const path = __importStar(__nccwpck_require__(255));
-const io = __importStar(__nccwpck_require__(304));
-const ioUtil = __importStar(__nccwpck_require__(232));
+const os = __importStar(__nccwpck_require__(102));
+const events = __importStar(__nccwpck_require__(483));
+const child = __importStar(__nccwpck_require__(173));
+const path = __importStar(__nccwpck_require__(256));
+const io = __importStar(__nccwpck_require__(305));
+const ioUtil = __importStar(__nccwpck_require__(233));
 const timers_1 = __nccwpck_require__(521);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
@@ -28728,7 +30460,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 134:
+/***/ 136:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28738,9 +30470,9 @@ class ExecState extends events.EventEmitter {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredentialPolicy = void 0;
 const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(486);
-const CredentialPolicy_js_1 = __nccwpck_require__(319);
-const SharedKeyComparator_js_1 = __nccwpck_require__(183);
+const utils_common_js_1 = __nccwpck_require__(487);
+const CredentialPolicy_js_1 = __nccwpck_require__(320);
+const SharedKeyComparator_js_1 = __nccwpck_require__(185);
 /**
  * StorageSharedKeyCredentialPolicy is a policy used to sign HTTP request with a shared key.
  */
@@ -28884,7 +30616,7 @@ exports.StorageSharedKeyCredentialPolicy = StorageSharedKeyCredentialPolicy;
 
 /***/ }),
 
-/***/ 135:
+/***/ 137:
 /***/ ((module) => {
 
 "use strict";
@@ -28904,7 +30636,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 136:
+/***/ 138:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28913,8 +30645,8 @@ module.exports = {
 
 
 const assert = __nccwpck_require__(538)
-const { Readable } = __nccwpck_require__(138)
-const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(500)
+const { Readable } = __nccwpck_require__(140)
+const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(501)
 const util = __nccwpck_require__(75)
 const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(75)
 
@@ -29196,7 +30928,7 @@ function consumeEnd (consume) {
       resolve(dst.buffer)
     } else if (type === 'blob') {
       if (!Blob) {
-        Blob = (__nccwpck_require__(126).Blob)
+        Blob = (__nccwpck_require__(128).Blob)
       }
       resolve(new Blob(body, { type: stream[kContentType] }))
     }
@@ -29234,7 +30966,7 @@ function consumeFinish (consume, err) {
 
 /***/ }),
 
-/***/ 137:
+/***/ 139:
 /***/ ((module) => {
 
 "use strict";
@@ -29242,7 +30974,7 @@ module.exports = require("querystring");
 
 /***/ }),
 
-/***/ 138:
+/***/ 140:
 /***/ ((module) => {
 
 "use strict";
@@ -29250,7 +30982,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 139:
+/***/ 141:
 /***/ ((module) => {
 
 "use strict";
@@ -29320,7 +31052,7 @@ function range(a, b, str) {
 
 /***/ }),
 
-/***/ 140:
+/***/ 142:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29357,9 +31089,9 @@ const net = __importStar(__nccwpck_require__(520));
 const tls = __importStar(__nccwpck_require__(517));
 const assert_1 = __importDefault(__nccwpck_require__(538));
 const debug_1 = __importDefault(__nccwpck_require__(526));
-const agent_base_1 = __nccwpck_require__(248);
-const url_1 = __nccwpck_require__(92);
-const parse_proxy_response_1 = __nccwpck_require__(431);
+const agent_base_1 = __nccwpck_require__(249);
+const url_1 = __nccwpck_require__(94);
+const parse_proxy_response_1 = __nccwpck_require__(432);
 const debug = (0, debug_1.default)('https-proxy-agent');
 const setServernameFromNonIpHost = (options) => {
     if (options.servername === undefined &&
@@ -29507,7 +31239,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 141:
+/***/ 143:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -29523,9 +31255,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(293);
+const http_client_1 = __nccwpck_require__(294);
 const auth_1 = __nccwpck_require__(29);
-const core_1 = __nccwpck_require__(472);
+const core_1 = __nccwpck_require__(473);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -29591,16 +31323,16 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 142:
+/***/ 144:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
-const binary_format_contract_1 = __nccwpck_require__(344);
-const pb_long_1 = __nccwpck_require__(124);
-const goog_varint_1 = __nccwpck_require__(211);
+const binary_format_contract_1 = __nccwpck_require__(345);
+const pb_long_1 = __nccwpck_require__(126);
+const goog_varint_1 = __nccwpck_require__(212);
 const defaultsRead = {
     readUnknownField: true,
     readerFactory: bytes => new BinaryReader(bytes),
@@ -29782,7 +31514,7 @@ exports.BinaryReader = BinaryReader;
 
 /***/ }),
 
-/***/ 143:
+/***/ 145:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29796,8 +31528,8 @@ const {
   kDefaultTrailers,
   kContentLength,
   kMockDispatch
-} = __nccwpck_require__(483)
-const { InvalidArgumentError } = __nccwpck_require__(500)
+} = __nccwpck_require__(484)
+const { InvalidArgumentError } = __nccwpck_require__(501)
 const { buildURL } = __nccwpck_require__(75)
 
 /**
@@ -29996,7 +31728,7 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 144:
+/***/ 146:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30094,7 +31826,7 @@ exports.reflectionMergePartial = reflectionMergePartial;
 
 /***/ }),
 
-/***/ 145:
+/***/ 147:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30120,7 +31852,7 @@ __export(xml_exports, {
   stringifyXML: () => stringifyXML
 });
 module.exports = __toCommonJS(xml_exports);
-var import_fast_xml_parser = __nccwpck_require__(333);
+var import_fast_xml_parser = __nccwpck_require__(334);
 var import_xml_common = __nccwpck_require__(23);
 function getCommonOptions(options) {
   return {
@@ -30187,22 +31919,22 @@ async function parseXML(str, opts = {}) {
 
 /***/ }),
 
-/***/ 146:
+/***/ 148:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports.request = __nccwpck_require__(522)
-module.exports.stream = __nccwpck_require__(365)
-module.exports.pipeline = __nccwpck_require__(113)
-module.exports.upgrade = __nccwpck_require__(445)
-module.exports.connect = __nccwpck_require__(381)
+module.exports.stream = __nccwpck_require__(366)
+module.exports.pipeline = __nccwpck_require__(115)
+module.exports.upgrade = __nccwpck_require__(446)
+module.exports.connect = __nccwpck_require__(382)
 
 
 /***/ }),
 
-/***/ 147:
+/***/ 149:
 /***/ ((module) => {
 
 "use strict";
@@ -30250,7 +31982,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 148:
+/***/ 150:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30259,7 +31991,7 @@ module.exports = {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollOperation = exports.initOperation = exports.deserializeState = void 0;
-const logger_js_1 = __nccwpck_require__(198);
+const logger_js_1 = __nccwpck_require__(200);
 const constants_js_1 = __nccwpck_require__(66);
 /**
  * Deserializes the state
@@ -30429,7 +32161,7 @@ exports.pollOperation = pollOperation;
 
 /***/ }),
 
-/***/ 149:
+/***/ 151:
 /***/ ((module) => {
 
 "use strict";
@@ -30437,7 +32169,7 @@ module.exports = require("diagnostics_channel");
 
 /***/ }),
 
-/***/ 150:
+/***/ 152:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -30453,7 +32185,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(382);
+	createDebug.humanize = __nccwpck_require__(383);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -30736,7 +32468,7 @@ module.exports = setup;
 
 /***/ }),
 
-/***/ 151:
+/***/ 153:
 /***/ ((module) => {
 
 "use strict";
@@ -30744,7 +32476,7 @@ module.exports = require("node:events");
 
 /***/ }),
 
-/***/ 152:
+/***/ 154:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -30779,7 +32511,7 @@ function isObject(input) {
 
 /***/ }),
 
-/***/ 153:
+/***/ 155:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30847,7 +32579,7 @@ async function resolveSoldrReleaseVersion(repo, version, ref, env, deps) {
 
 /***/ }),
 
-/***/ 154:
+/***/ 156:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30888,15 +32620,15 @@ __export(internal_exports, {
   uint8ArrayToString: () => import_bytesEncoding.uint8ArrayToString
 });
 module.exports = __toCommonJS(internal_exports);
-var import_delay = __nccwpck_require__(487);
+var import_delay = __nccwpck_require__(488);
 var import_random = __nccwpck_require__(518);
-var import_object = __nccwpck_require__(152);
-var import_error = __nccwpck_require__(161);
-var import_sha256 = __nccwpck_require__(208);
-var import_uuidUtils = __nccwpck_require__(404);
-var import_checkEnvironment = __nccwpck_require__(451);
-var import_bytesEncoding = __nccwpck_require__(296);
-var import_sanitizer = __nccwpck_require__(129);
+var import_object = __nccwpck_require__(154);
+var import_error = __nccwpck_require__(163);
+var import_sha256 = __nccwpck_require__(209);
+var import_uuidUtils = __nccwpck_require__(405);
+var import_checkEnvironment = __nccwpck_require__(452);
+var import_bytesEncoding = __nccwpck_require__(297);
+var import_sanitizer = __nccwpck_require__(131);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -30904,7 +32636,7 @@ var import_sanitizer = __nccwpck_require__(129);
 
 /***/ }),
 
-/***/ 155:
+/***/ 157:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30929,7 +32661,7 @@ __export(internal_exports, {
   createLoggerContext: () => import_logger.createLoggerContext
 });
 module.exports = __toCommonJS(internal_exports);
-var import_logger = __nccwpck_require__(253);
+var import_logger = __nccwpck_require__(254);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -30937,7 +32669,7 @@ var import_logger = __nccwpck_require__(253);
 
 /***/ }),
 
-/***/ 156:
+/***/ 158:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -31173,7 +32905,7 @@ exports.PathStylePorts = [
 
 /***/ }),
 
-/***/ 157:
+/***/ 159:
 /***/ ((module) => {
 
 "use strict";
@@ -31181,7 +32913,7 @@ module.exports = require("string_decoder");
 
 /***/ }),
 
-/***/ 158:
+/***/ 160:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -31225,7 +32957,7 @@ function setClientRequestIdPolicy(requestIdHeaderName = "x-ms-client-request-id"
 
 /***/ }),
 
-/***/ 159:
+/***/ 161:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -31250,7 +32982,7 @@ __export(log_exports, {
   logger: () => logger
 });
 module.exports = __toCommonJS(log_exports);
-var import_logger = __nccwpck_require__(253);
+var import_logger = __nccwpck_require__(254);
 const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -31259,7 +32991,7 @@ const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 
 /***/ }),
 
-/***/ 160:
+/***/ 162:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -31285,8 +33017,8 @@ __export(basicAuthenticationPolicy_exports, {
   basicAuthenticationPolicyName: () => basicAuthenticationPolicyName
 });
 module.exports = __toCommonJS(basicAuthenticationPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(296);
-var import_checkInsecureConnection = __nccwpck_require__(447);
+var import_bytesEncoding = __nccwpck_require__(297);
+var import_checkInsecureConnection = __nccwpck_require__(448);
 const basicAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function basicAuthenticationPolicy(options) {
   return {
@@ -31316,7 +33048,7 @@ function basicAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 161:
+/***/ 163:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -31341,7 +33073,7 @@ __export(error_exports, {
   isError: () => isError
 });
 module.exports = __toCommonJS(error_exports);
-var import_object = __nccwpck_require__(152);
+var import_object = __nccwpck_require__(154);
 function isError(e) {
   if ((0, import_object.isObject)(e)) {
     const hasName = typeof e.name === "string";
@@ -31357,7 +33089,7 @@ function isError(e) {
 
 /***/ }),
 
-/***/ 162:
+/***/ 164:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31401,9 +33133,9 @@ exports.ConvertInternalResponseOfListBlobHierarchy = ConvertInternalResponseOfLi
 exports.ExtractPageRangeInfoItems = ExtractPageRangeInfoItems;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_1 = __nccwpck_require__(15);
-const constants_js_1 = __nccwpck_require__(156);
+const constants_js_1 = __nccwpck_require__(158);
 /**
  * Reserved URL characters must be properly escaped for Storage services like Blob or File.
  *
@@ -32171,7 +33903,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 163:
+/***/ 165:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -32201,27 +33933,27 @@ exports.StorageBrowserPolicyFactory = StorageBrowserPolicyFactory;
 
 /***/ }),
 
-/***/ 164:
+/***/ 166:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(202).kConstruct)
+  kConstruct: (__nccwpck_require__(204).kConstruct)
 }
 
 
 /***/ }),
 
-/***/ 165:
+/***/ 167:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionLongConvert = void 0;
-const reflection_info_1 = __nccwpck_require__(465);
+const reflection_info_1 = __nccwpck_require__(466);
 /**
  * Utility method to convert a PbLong or PbUlong to a JavaScript
  * representation during runtime.
@@ -32246,7 +33978,7 @@ exports.reflectionLongConvert = reflectionLongConvert;
 
 /***/ }),
 
-/***/ 166:
+/***/ 168:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -32280,7 +34012,7 @@ const DEFAULT_RETRY_POLICY_COUNT = 3;
 
 /***/ }),
 
-/***/ 167:
+/***/ 169:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -32319,9 +34051,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.uploadCacheArchiveSDK = exports.UploadProgress = void 0;
-const core = __importStar(__nccwpck_require__(472));
-const storage_blob_1 = __nccwpck_require__(460);
-const errors_1 = __nccwpck_require__(315);
+const core = __importStar(__nccwpck_require__(473));
+const storage_blob_1 = __nccwpck_require__(461);
+const errors_1 = __nccwpck_require__(316);
 /**
  * Class for tracking the upload state and displaying stats.
  */
@@ -32454,7 +34186,7 @@ exports.uploadCacheArchiveSDK = uploadCacheArchiveSDK;
 
 /***/ }),
 
-/***/ 168:
+/***/ 170:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -32484,7 +34216,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.req = exports.json = exports.toBuffer = void 0;
-const http = __importStar(__nccwpck_require__(340));
+const http = __importStar(__nccwpck_require__(341));
 const https = __importStar(__nccwpck_require__(76));
 async function toBuffer(stream) {
     let length = 0;
@@ -32527,7 +34259,7 @@ exports.req = req;
 
 /***/ }),
 
-/***/ 169:
+/***/ 171:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -32665,36 +34397,36 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 
 /***/ }),
 
-/***/ 170:
+/***/ 172:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Client = __nccwpck_require__(96)
-const Dispatcher = __nccwpck_require__(490)
-const errors = __nccwpck_require__(500)
-const Pool = __nccwpck_require__(348)
-const BalancedPool = __nccwpck_require__(390)
+const Client = __nccwpck_require__(98)
+const Dispatcher = __nccwpck_require__(491)
+const errors = __nccwpck_require__(501)
+const Pool = __nccwpck_require__(349)
+const BalancedPool = __nccwpck_require__(391)
 const Agent = __nccwpck_require__(6)
 const util = __nccwpck_require__(75)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(146)
-const buildConnector = __nccwpck_require__(273)
-const MockClient = __nccwpck_require__(207)
-const MockAgent = __nccwpck_require__(385)
-const MockPool = __nccwpck_require__(359)
-const mockErrors = __nccwpck_require__(239)
-const ProxyAgent = __nccwpck_require__(352)
-const RetryHandler = __nccwpck_require__(280)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(384)
-const DecoratorHandler = __nccwpck_require__(488)
-const RedirectHandler = __nccwpck_require__(400)
-const createRedirectInterceptor = __nccwpck_require__(262)
+const api = __nccwpck_require__(148)
+const buildConnector = __nccwpck_require__(274)
+const MockClient = __nccwpck_require__(208)
+const MockAgent = __nccwpck_require__(386)
+const MockPool = __nccwpck_require__(360)
+const mockErrors = __nccwpck_require__(240)
+const ProxyAgent = __nccwpck_require__(353)
+const RetryHandler = __nccwpck_require__(281)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(385)
+const DecoratorHandler = __nccwpck_require__(489)
+const RedirectHandler = __nccwpck_require__(401)
+const createRedirectInterceptor = __nccwpck_require__(263)
 
 let hasCrypto
 try {
-  __nccwpck_require__(301)
+  __nccwpck_require__(302)
   hasCrypto = true
 } catch {
   hasCrypto = false
@@ -32773,7 +34505,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   let fetchImpl = null
   module.exports.fetch = async function fetch (resource) {
     if (!fetchImpl) {
-      fetchImpl = (__nccwpck_require__(463).fetch)
+      fetchImpl = (__nccwpck_require__(464).fetch)
     }
 
     try {
@@ -32788,18 +34520,18 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   }
   module.exports.Headers = __nccwpck_require__(527).Headers
   module.exports.Response = __nccwpck_require__(45).Response
-  module.exports.Request = __nccwpck_require__(89).Request
-  module.exports.FormData = __nccwpck_require__(216).FormData
-  module.exports.File = __nccwpck_require__(373).File
-  module.exports.FileReader = __nccwpck_require__(102).FileReader
+  module.exports.Request = __nccwpck_require__(90).Request
+  module.exports.FormData = __nccwpck_require__(217).FormData
+  module.exports.File = __nccwpck_require__(374).File
+  module.exports.FileReader = __nccwpck_require__(104).FileReader
 
-  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(147)
+  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(149)
 
   module.exports.setGlobalOrigin = setGlobalOrigin
   module.exports.getGlobalOrigin = getGlobalOrigin
 
-  const { CacheStorage } = __nccwpck_require__(291)
-  const { kConstruct } = __nccwpck_require__(164)
+  const { CacheStorage } = __nccwpck_require__(292)
+  const { kConstruct } = __nccwpck_require__(166)
 
   // Cache & CacheStorage are tightly coupled with fetch. Even if it may run
   // in an older version of Node, it doesn't have any use without fetch.
@@ -32807,7 +34539,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
 }
 
 if (util.nodeMajor >= 16) {
-  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(396)
+  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(397)
 
   module.exports.deleteCookie = deleteCookie
   module.exports.getCookies = getCookies
@@ -32821,7 +34553,7 @@ if (util.nodeMajor >= 16) {
 }
 
 if (util.nodeMajor >= 18 && hasCrypto) {
-  const { WebSocket } = __nccwpck_require__(310)
+  const { WebSocket } = __nccwpck_require__(311)
 
   module.exports.WebSocket = WebSocket
 }
@@ -32840,7 +34572,7 @@ module.exports.mockErrors = mockErrors
 
 /***/ }),
 
-/***/ 171:
+/***/ 173:
 /***/ ((module) => {
 
 "use strict";
@@ -32848,7 +34580,7 @@ module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 172:
+/***/ 174:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -32861,18 +34593,18 @@ module.exports = require("child_process");
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(224);
-tslib_1.__exportStar(__nccwpck_require__(125), exports);
-tslib_1.__exportStar(__nccwpck_require__(187), exports);
-tslib_1.__exportStar(__nccwpck_require__(130), exports);
-tslib_1.__exportStar(__nccwpck_require__(328), exports);
-tslib_1.__exportStar(__nccwpck_require__(217), exports);
-tslib_1.__exportStar(__nccwpck_require__(277), exports);
+const tslib_1 = __nccwpck_require__(225);
+tslib_1.__exportStar(__nccwpck_require__(127), exports);
+tslib_1.__exportStar(__nccwpck_require__(189), exports);
+tslib_1.__exportStar(__nccwpck_require__(132), exports);
+tslib_1.__exportStar(__nccwpck_require__(329), exports);
+tslib_1.__exportStar(__nccwpck_require__(218), exports);
+tslib_1.__exportStar(__nccwpck_require__(278), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 173:
+/***/ 175:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -32883,11 +34615,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageRetryPolicyName = void 0;
 exports.storageRetryPolicy = storageRetryPolicy;
 const abort_controller_1 = __nccwpck_require__(507);
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_1 = __nccwpck_require__(15);
-const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(337);
+const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(338);
 const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(486);
+const utils_common_js_1 = __nccwpck_require__(487);
 const log_js_1 = __nccwpck_require__(18);
 /**
  * Name of the {@link storageRetryPolicy}
@@ -33047,7 +34779,7 @@ function storageRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 174:
+/***/ 176:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -33063,7 +34795,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.create = void 0;
-const internal_globber_1 = __nccwpck_require__(443);
+const internal_globber_1 = __nccwpck_require__(444);
 /**
  * Constructs a globber
  *
@@ -33080,7 +34812,7 @@ exports.create = create;
 
 /***/ }),
 
-/***/ 175:
+/***/ 177:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -33089,7 +34821,7 @@ exports.create = create;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.UserDelegationKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(281);
+const node_crypto_1 = __nccwpck_require__(282);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -33134,7 +34866,7 @@ exports.UserDelegationKeyCredential = UserDelegationKeyCredential;
 
 /***/ }),
 
-/***/ 176:
+/***/ 178:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -33160,10 +34892,10 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(296);
+var import_bytesEncoding = __nccwpck_require__(297);
 var import_typeGuards = __nccwpck_require__(509);
-var import_uuidUtils = __nccwpck_require__(404);
-var import_concat = __nccwpck_require__(314);
+var import_uuidUtils = __nccwpck_require__(405);
+var import_concat = __nccwpck_require__(315);
 function generateBoundary() {
   return `----AzSDKFormBoundary${(0, import_uuidUtils.randomUUID)()}`;
 }
@@ -33272,12 +35004,12 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 177:
+/***/ 179:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(416)
+const f = __nccwpck_require__(417)
 
 class FloatingDateTime extends Date {
   constructor (value) {
@@ -33304,7 +35036,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 178:
+/***/ 180:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -33431,7 +35163,7 @@ function requestToOptions(request) {
 
 /***/ }),
 
-/***/ 179:
+/***/ 181:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -33490,7 +35222,7 @@ exports.soldrToolchainEnsure = soldrToolchainEnsure;
 exports.soldrToolchainLink = soldrToolchainLink;
 exports.soldrToolchainDoctor = soldrToolchainDoctor;
 const exec = __importStar(__nccwpck_require__(19));
-const verify_soldr_js_1 = __nccwpck_require__(295);
+const verify_soldr_js_1 = __nccwpck_require__(296);
 /**
  * Minimum soldr version that exposes the `toolchain ensure/link/doctor`
  * JSON subcommands. Set by Wave 3.4 of zackees/soldr#514.
@@ -33745,7 +35477,7 @@ async function soldrToolchainDoctor(soldrPath, deps) {
 
 /***/ }),
 
-/***/ 180:
+/***/ 182:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -33757,7 +35489,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 181:
+/***/ 183:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -33766,28 +35498,28 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Note: we do not use `export * from ...` to help tree shakers,
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-var service_type_1 = __nccwpck_require__(491);
+var service_type_1 = __nccwpck_require__(492);
 Object.defineProperty(exports, "ServiceType", ({ enumerable: true, get: function () { return service_type_1.ServiceType; } }));
 var reflection_info_1 = __nccwpck_require__(539);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
 Object.defineProperty(exports, "readMethodOption", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOption; } }));
 Object.defineProperty(exports, "readServiceOption", ({ enumerable: true, get: function () { return reflection_info_1.readServiceOption; } }));
-var rpc_error_1 = __nccwpck_require__(182);
+var rpc_error_1 = __nccwpck_require__(184);
 Object.defineProperty(exports, "RpcError", ({ enumerable: true, get: function () { return rpc_error_1.RpcError; } }));
-var rpc_options_1 = __nccwpck_require__(303);
+var rpc_options_1 = __nccwpck_require__(304);
 Object.defineProperty(exports, "mergeRpcOptions", ({ enumerable: true, get: function () { return rpc_options_1.mergeRpcOptions; } }));
-var rpc_output_stream_1 = __nccwpck_require__(317);
+var rpc_output_stream_1 = __nccwpck_require__(318);
 Object.defineProperty(exports, "RpcOutputStreamController", ({ enumerable: true, get: function () { return rpc_output_stream_1.RpcOutputStreamController; } }));
 var test_transport_1 = __nccwpck_require__(523);
 Object.defineProperty(exports, "TestTransport", ({ enumerable: true, get: function () { return test_transport_1.TestTransport; } }));
 var deferred_1 = __nccwpck_require__(58);
 Object.defineProperty(exports, "Deferred", ({ enumerable: true, get: function () { return deferred_1.Deferred; } }));
 Object.defineProperty(exports, "DeferredState", ({ enumerable: true, get: function () { return deferred_1.DeferredState; } }));
-var duplex_streaming_call_1 = __nccwpck_require__(316);
+var duplex_streaming_call_1 = __nccwpck_require__(317);
 Object.defineProperty(exports, "DuplexStreamingCall", ({ enumerable: true, get: function () { return duplex_streaming_call_1.DuplexStreamingCall; } }));
-var client_streaming_call_1 = __nccwpck_require__(361);
+var client_streaming_call_1 = __nccwpck_require__(362);
 Object.defineProperty(exports, "ClientStreamingCall", ({ enumerable: true, get: function () { return client_streaming_call_1.ClientStreamingCall; } }));
-var server_streaming_call_1 = __nccwpck_require__(464);
+var server_streaming_call_1 = __nccwpck_require__(465);
 Object.defineProperty(exports, "ServerStreamingCall", ({ enumerable: true, get: function () { return server_streaming_call_1.ServerStreamingCall; } }));
 var unary_call_1 = __nccwpck_require__(62);
 Object.defineProperty(exports, "UnaryCall", ({ enumerable: true, get: function () { return unary_call_1.UnaryCall; } }));
@@ -33797,13 +35529,13 @@ Object.defineProperty(exports, "stackDuplexStreamingInterceptors", ({ enumerable
 Object.defineProperty(exports, "stackClientStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackClientStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackServerStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackServerStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackUnaryInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackUnaryInterceptors; } }));
-var server_call_context_1 = __nccwpck_require__(436);
+var server_call_context_1 = __nccwpck_require__(437);
 Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: true, get: function () { return server_call_context_1.ServerCallContextController; } }));
 
 
 /***/ }),
 
-/***/ 182:
+/***/ 184:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -33847,7 +35579,7 @@ exports.RpcError = RpcError;
 
 /***/ }),
 
-/***/ 183:
+/***/ 185:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -33930,7 +35662,7 @@ function isLessThan(lhs, rhs) {
 
 /***/ }),
 
-/***/ 184:
+/***/ 186:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -33939,10 +35671,10 @@ function isLessThan(lhs, rhs) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-const operation_js_1 = __nccwpck_require__(368);
+const operation_js_1 = __nccwpck_require__(369);
 const constants_js_1 = __nccwpck_require__(66);
 const poller_js_1 = __nccwpck_require__(81);
-const operation_js_2 = __nccwpck_require__(148);
+const operation_js_2 = __nccwpck_require__(150);
 /**
  * The LRO Engine, a class that performs polling.
  */
@@ -33970,7 +35702,7 @@ exports.LroEngine = LroEngine;
 
 /***/ }),
 
-/***/ 185:
+/***/ 187:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -35620,7 +37352,7 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 186:
+/***/ 188:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -43963,7 +45695,7 @@ exports.BlockBlobGetBlockListExceptionHeaders = {
 
 /***/ }),
 
-/***/ 187:
+/***/ 189:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -43980,7 +45712,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 188:
+/***/ 190:
 /***/ ((module) => {
 
 "use strict";
@@ -43988,7 +45720,7 @@ module.exports = require("tty");
 
 /***/ }),
 
-/***/ 189:
+/***/ 191:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44002,13 +45734,13 @@ exports.newPipeline = newPipeline;
 exports.getCoreClientOptions = getCoreClientOptions;
 exports.getCredentialFromPipeline = getCredentialFromPipeline;
 const core_http_compat_1 = __nccwpck_require__(79);
-const core_rest_pipeline_1 = __nccwpck_require__(109);
-const core_client_1 = __nccwpck_require__(452);
-const core_xml_1 = __nccwpck_require__(201);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
+const core_client_1 = __nccwpck_require__(453);
+const core_xml_1 = __nccwpck_require__(203);
 const core_auth_1 = __nccwpck_require__(525);
-const log_js_1 = __nccwpck_require__(114);
-const storage_common_1 = __nccwpck_require__(284);
-const constants_js_1 = __nccwpck_require__(156);
+const log_js_1 = __nccwpck_require__(116);
+const storage_common_1 = __nccwpck_require__(285);
+const constants_js_1 = __nccwpck_require__(158);
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return constants_js_1.StorageOAuthScopes; } }));
 /**
  * A helper to decide if a given argument satisfies the Pipeline contract
@@ -44272,7 +46004,7 @@ function isCoreHttpPolicyFactory(factory) {
 
 /***/ }),
 
-/***/ 190:
+/***/ 192:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -44305,7 +46037,7 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 
 /***/ }),
 
-/***/ 191:
+/***/ 193:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -44314,27 +46046,27 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobClient = exports.BlockBlobClient = exports.AppendBlobClient = exports.BlobClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_auth_1 = __nccwpck_require__(525);
 const core_util_1 = __nccwpck_require__(15);
 const core_util_2 = __nccwpck_require__(15);
-const BlobDownloadResponse_js_1 = __nccwpck_require__(438);
-const BlobQueryResponse_js_1 = __nccwpck_require__(209);
-const storage_common_1 = __nccwpck_require__(284);
-const models_js_1 = __nccwpck_require__(427);
+const BlobDownloadResponse_js_1 = __nccwpck_require__(439);
+const BlobQueryResponse_js_1 = __nccwpck_require__(210);
+const storage_common_1 = __nccwpck_require__(285);
+const models_js_1 = __nccwpck_require__(428);
 const PageBlobRangeResponse_js_1 = __nccwpck_require__(32);
-const Pipeline_js_1 = __nccwpck_require__(189);
+const Pipeline_js_1 = __nccwpck_require__(191);
 const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(545);
-const Range_js_1 = __nccwpck_require__(112);
-const StorageClient_js_1 = __nccwpck_require__(467);
-const Batch_js_1 = __nccwpck_require__(99);
-const storage_common_2 = __nccwpck_require__(284);
-const constants_js_1 = __nccwpck_require__(156);
+const Range_js_1 = __nccwpck_require__(114);
+const StorageClient_js_1 = __nccwpck_require__(468);
+const Batch_js_1 = __nccwpck_require__(101);
+const storage_common_2 = __nccwpck_require__(285);
+const constants_js_1 = __nccwpck_require__(158);
 const tracing_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(162);
-const utils_js_1 = __nccwpck_require__(210);
+const utils_common_js_1 = __nccwpck_require__(164);
+const utils_js_1 = __nccwpck_require__(211);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(74);
-const BlobLeaseClient_js_1 = __nccwpck_require__(212);
+const BlobLeaseClient_js_1 = __nccwpck_require__(213);
 /**
  * A BlobClient represents a URL to an Azure Storage blob; the blob may be a block blob,
  * append blob, or page blob.
@@ -47164,17 +48896,17 @@ exports.PageBlobClient = PageBlobClient;
 
 /***/ }),
 
-/***/ 192:
+/***/ 194:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryWriter = void 0;
-const binary_format_contract_1 = __nccwpck_require__(344);
-const reflection_info_1 = __nccwpck_require__(465);
-const assert_1 = __nccwpck_require__(496);
-const pb_long_1 = __nccwpck_require__(124);
+const binary_format_contract_1 = __nccwpck_require__(345);
+const reflection_info_1 = __nccwpck_require__(466);
+const assert_1 = __nccwpck_require__(497);
+const pb_long_1 = __nccwpck_require__(126);
 /**
  * Writes proto3 messages in binary format using reflection information.
  *
@@ -47405,18 +49137,18 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 
 /***/ }),
 
-/***/ 193:
+/***/ 195:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxUnsigned16Bit } = __nccwpck_require__(478)
+const { maxUnsigned16Bit } = __nccwpck_require__(479)
 
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(301)
+  crypto = __nccwpck_require__(302)
 } catch {
 
 }
@@ -47486,7 +49218,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 194:
+/***/ 196:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -47533,13 +49265,13 @@ function isApiKeyCredential(credential) {
 
 /***/ }),
 
-/***/ 195:
+/***/ 197:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(538)
 const {
   ResponseStatusCodeError
-} = __nccwpck_require__(500)
+} = __nccwpck_require__(501)
 const { toUSVString } = __nccwpck_require__(75)
 
 async function getResolveErrorBodyCallback ({ callback, body, contentType, statusCode, statusMessage, headers }) {
@@ -47586,7 +49318,7 @@ module.exports = { getResolveErrorBodyCallback }
 
 /***/ }),
 
-/***/ 196:
+/***/ 198:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -47639,10 +49371,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureShimsLegacy = ensureShimsLegacy;
 exports.tryDelegateToSoldrToolchainLink = tryDelegateToSoldrToolchainLink;
 exports.ensureShims = ensureShims;
-const fs = __importStar(__nccwpck_require__(256));
+const fs = __importStar(__nccwpck_require__(257));
 const path = __importStar(__nccwpck_require__(519));
-const core = __importStar(__nccwpck_require__(472));
-const soldr_toolchain_client_js_1 = __nccwpck_require__(179);
+const core = __importStar(__nccwpck_require__(473));
+const soldr_toolchain_client_js_1 = __nccwpck_require__(181);
 // Tools that route through `soldr <tool>`:
 const ROUTED_TOOLS = ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"];
 // Unix bash shim template (per tool):
@@ -47746,7 +49478,7 @@ async function ensureShims(opts) {
 
 /***/ }),
 
-/***/ 197:
+/***/ 199:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -47868,7 +49600,7 @@ exports.getSelectedOneofValue = getSelectedOneofValue;
 
 /***/ }),
 
-/***/ 198:
+/***/ 200:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47887,14 +49619,14 @@ exports.logger = (0, logger_1.createClientLogger)("core-lro");
 
 /***/ }),
 
-/***/ 199:
+/***/ 201:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 /* eslint-disable object-property-newline */
 
 
-const decodeText = __nccwpck_require__(282)
+const decodeText = __nccwpck_require__(283)
 
 const RE_ENCODED = /%[a-fA-F0-9][a-fA-F0-9]/g
 
@@ -48091,7 +49823,7 @@ module.exports = parseParams
 
 /***/ }),
 
-/***/ 200:
+/***/ 202:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48117,8 +49849,8 @@ __export(auxiliaryAuthenticationHeaderPolicy_exports, {
   auxiliaryAuthenticationHeaderPolicyName: () => auxiliaryAuthenticationHeaderPolicyName
 });
 module.exports = __toCommonJS(auxiliaryAuthenticationHeaderPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(169);
-var import_log = __nccwpck_require__(190);
+var import_tokenCycler = __nccwpck_require__(171);
+var import_log = __nccwpck_require__(192);
 const auxiliaryAuthenticationHeaderPolicyName = "auxiliaryAuthenticationHeaderPolicy";
 const AUTHORIZATION_AUXILIARY_HEADER = "x-ms-authorization-auxiliary";
 async function sendAuthorizeRequest(options) {
@@ -48184,7 +49916,7 @@ function auxiliaryAuthenticationHeaderPolicy(options) {
 
 /***/ }),
 
-/***/ 201:
+/***/ 203:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48212,7 +49944,7 @@ __export(src_exports, {
   stringifyXML: () => import_xml.stringifyXML
 });
 module.exports = __toCommonJS(src_exports);
-var import_xml = __nccwpck_require__(145);
+var import_xml = __nccwpck_require__(147);
 var import_xml_common = __nccwpck_require__(23);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -48221,7 +49953,7 @@ var import_xml_common = __nccwpck_require__(23);
 
 /***/ }),
 
-/***/ 202:
+/***/ 204:
 /***/ ((module) => {
 
 module.exports = {
@@ -48291,7 +50023,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 203:
+/***/ 205:
 /***/ ((module) => {
 
 "use strict";
@@ -48416,1382 +50148,7 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 204:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// setup-soldr entry point. Owned by Agent 2.
-//
-// Replaces the composite action's main-phase steps with a single JS
-// orchestrator. Calls the helpers in src/lib/* in the same order the
-// composite's steps fire.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(256));
-const os = __importStar(__nccwpck_require__(391));
-const path = __importStar(__nccwpck_require__(519));
-const core = __importStar(__nccwpck_require__(472));
-const cache = __importStar(__nccwpck_require__(222));
-const exec = __importStar(__nccwpck_require__(19));
-const log_utils_js_1 = __nccwpck_require__(52);
-const resolve_setup_js_1 = __nccwpck_require__(415);
-const phase_timing_js_1 = __nccwpck_require__(528);
-const ensure_rust_toolchain_js_1 = __nccwpck_require__(91);
-const ensure_soldr_js_1 = __nccwpck_require__(20);
-const verify_soldr_js_1 = __nccwpck_require__(295);
-const install_passthrough_js_1 = __nccwpck_require__(524);
-const normalize_source_mtime_js_1 = __nccwpck_require__(405);
-const detect_shared_target_warning_js_1 = __nccwpck_require__(78);
-const ensure_shims_js_1 = __nccwpck_require__(196);
-const zccache_seed_js_1 = __nccwpck_require__(504);
-const cache_compress_js_1 = __nccwpck_require__(95);
-const soldr_load_shim_js_1 = __nccwpck_require__(34);
-const seed_isolated_cache_js_1 = __nccwpck_require__(322);
-const stats_collector_js_1 = __nccwpck_require__(449);
-const toolchain_snapshot_js_1 = __nccwpck_require__(471);
-const solo_toolchain_cache_js_1 = __nccwpck_require__(31);
-const cook_cache_js_1 = __nccwpck_require__(3);
-const soldr_mini_cache_js_1 = __nccwpck_require__(127);
-const diagnostics_js_1 = __nccwpck_require__(54);
-const shim_bypass_check_js_1 = __nccwpck_require__(323);
-const cross_bootstrap_js_1 = __nccwpck_require__(288);
-const source_mtime_snapshot_js_1 = __nccwpck_require__(395);
-/**
- * Map (hit, matchedKey) → workflow-visible restore-status string.
- * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
- * for the `<layer>-cache-restore-status` outputs declared in action.yml.
- */
-function deriveRestoreStatus(hit, matchedKey) {
-    if (hit)
-        return "exact-hit";
-    if (matchedKey.trim())
-        return "restore-key-hit";
-    return "miss";
-}
-function writeCacheKeysManifest(result, runnerTemp, log) {
-    if (!runnerTemp)
-        return;
-    const keys = [
-        result.setupCache.key,
-        result.buildCache.key,
-        result.targetCache.key,
-        result.cargoRegistryCache.key,
-    ].filter((k) => Boolean(k));
-    if (keys.length === 0)
-        return;
-    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
-    try {
-        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
-        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
-    }
-    catch (err) {
-        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-const TRUTHY = new Set(["1", "true", "yes", "on"]);
-const FALSY = new Set(["0", "false", "no", "off"]);
-function isTruthy(value) {
-    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
-}
-function isFalsy(value) {
-    return FALSY.has(((value ?? "").trim().toLowerCase()));
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
-    }
-}
-function dirHasContent(p) {
-    try {
-        return fs.readdirSync(p).length > 0;
-    }
-    catch {
-        return false;
-    }
-}
-async function runGitCapture(workspace, args) {
-    let stdout = "";
-    let stderr = "";
-    const code = await exec.exec("git", ["-C", workspace, ...args], {
-        silent: true,
-        ignoreReturnCode: true,
-        listeners: {
-            stdout: (data) => { stdout += data.toString("utf8"); },
-            stderr: (data) => { stderr += data.toString("utf8"); },
-        },
-    });
-    return { code, stdout, stderr };
-}
-async function deriveParentSha(workspace, githubSha, logger) {
-    // #365: derive parent SHA so cook-cache-delta + target-cache +
-    // cargo-registry can fall back to the prior commit's saved
-    // entry. Returns "" on any error (no regression from prior
-    // behavior — caller treats "" as "no fallback").
-    //
-    // Strategy: try `git log -1 --format=%P HEAD` first. On a
-    // shallow clone (actions/checkout default fetch-depth=1) this
-    // returns empty for grafted root commits — fall back to
-    // `git cat-file -p HEAD` and parse the `parent` header lines
-    // from the raw commit object, which are preserved even when
-    // the parent commit object isn't present in the local repo.
-    // Pass 1: git log %P (works on full-depth checkouts).
-    try {
-        const { code, stdout, stderr } = await runGitCapture(workspace, [
-            "log", "-1", "--format=%P", "HEAD",
-        ]);
-        if (code === 0) {
-            const first = stdout.trim().split(/\s+/)[0] ?? "";
-            if (/^[0-9a-f]{7,40}$/i.test(first)) {
-                if (first === githubSha)
-                    return "";
-                logger.log(`parent-sha: derived ${first.slice(0, 12)} from git log (#365)`);
-                return first;
-            }
-            // empty / unparseable → fall through to cat-file
-        }
-        else {
-            logger.log(`parent-sha: git log exit=${code} stderr=${stderr.trim().slice(0, 120)}; trying cat-file`);
-        }
-    }
-    catch (err) {
-        logger.log(`parent-sha: git log threw (${err instanceof Error ? err.message : String(err)}); trying cat-file`);
-    }
-    // Pass 2: git cat-file -p HEAD (works on shallow clones — the
-    // commit object's `parent` header is preserved even when the
-    // parent commit isn't fetched).
-    try {
-        const { code, stdout, stderr } = await runGitCapture(workspace, [
-            "cat-file", "-p", "HEAD",
-        ]);
-        if (code !== 0) {
-            logger.log(`parent-sha: cat-file exit=${code} stderr=${stderr.trim().slice(0, 120)}; leaving empty`);
-            return "";
-        }
-        // Raw commit object format:
-        //   tree <sha>
-        //   parent <sha>      ← first parent (mainline)
-        //   parent <sha>      ← second parent (only for merges)
-        //   author ...
-        //   committer ...
-        //
-        //   <message>
-        for (const line of stdout.split("\n")) {
-            if (line.startsWith("parent ")) {
-                const sha = line.slice("parent ".length).trim();
-                if (/^[0-9a-f]{7,40}$/i.test(sha) && sha !== githubSha) {
-                    logger.log(`parent-sha: derived ${sha.slice(0, 12)} from cat-file (#365, shallow-safe)`);
-                    return sha;
-                }
-            }
-            if (line === "")
-                break; // header section ended
-        }
-        logger.log(`parent-sha: cat-file produced no usable parent (root commit?); leaving empty`);
-        return "";
-    }
-    catch (err) {
-        logger.log(`parent-sha: cat-file threw (${err instanceof Error ? err.message : String(err)}); leaving empty`);
-        return "";
-    }
-}
-async function buildActionContext() {
-    const env = process.env;
-    const logger = (0, log_utils_js_1.createLogger)(env);
-    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
-    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
-    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
-    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
-    const githubSha = env["GITHUB_SHA"]?.trim() || "";
-    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
-    // #365: parentSha enables cook-cache-delta + target-cache + cargo-
-    // registry to share entries across consecutive commits. The env
-    // override (ACTION_PARENT_SHA) lets a workflow set it explicitly;
-    // otherwise we derive it from `git log -1 --format=%P HEAD` so the
-    // fallback works out of the box for any repo with non-shallow
-    // checkout. Without this, every push-event run had the delta key
-    // mismatch the prior save (0% hit rate observed on zccache).
-    let parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
-    if (!parentSha && githubSha) {
-        parentSha = await deriveParentSha(workspace, githubSha, logger);
-    }
-    return {
-        env: { ...env },
-        workspace,
-        runnerTemp,
-        runnerOs,
-        runnerArch,
-        githubSha,
-        githubToken,
-        parentSha,
-        logger,
-    };
-}
-function actionRoot() {
-    const explicit = process.env["GITHUB_ACTION_PATH"]?.trim() || process.env["SETUP_SOLDR_ACTION_ROOT"]?.trim();
-    if (explicit)
-        return path.resolve(explicit);
-    const moduleDir = typeof __dirname === "string" ? __dirname : process.cwd();
-    return path.resolve(moduleDir, "..");
-}
-async function restoreCacheSafe(paths, key, restoreKeys, logger) {
-    if (paths.length === 0 || !key) {
-        return { hit: false, matchedKey: "" };
-    }
-    try {
-        const matched = await cache.restoreCache(paths, key, restoreKeys);
-        return { hit: matched === key, matchedKey: matched ?? "" };
-    }
-    catch (err) {
-        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "" };
-    }
-}
-async function run() {
-    const ctx = await buildActionContext();
-    const logger = ctx.logger;
-    await (0, phase_timing_js_1.markPhase)("action");
-    // ---- resolve ----
-    await (0, phase_timing_js_1.markPhase)("resolve");
-    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
-    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
-    await (0, resolve_setup_js_1.applyResolveResult)(result);
-    await (0, phase_timing_js_1.finishPhase)("resolve");
-    // Always emit the cache-keys manifest right after resolve so workflow
-    // steps that run between main and post (e.g. actions/upload-artifact)
-    // can read it. The four keys are fully determined by resolveSetup and
-    // never change later in the run.
-    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
-    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            logger,
-            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
-        });
-    }
-    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
-    if (dryRun) {
-        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
-        await (0, phase_timing_js_1.finishPhase)("action");
-        return;
-    }
-    // Persist resolve state for the post-job step.
-    core.saveState("resolveResult", JSON.stringify(result));
-    core.saveState("buildCacheMode", result.buildCache.mode);
-    core.saveState("logging", logging ? "true" : "false");
-    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
-    const statsMode = result.stats;
-    const debugMode = result.debugMode;
-    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
-    const statsCollector = new stats_collector_js_1.StatsCollector();
-    // ---- source-mtime-normalize ----
-    if (isTruthy(inputs.sourceMtimeNormalize)) {
-        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
-    }
-    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
-    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
-    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
-    core.saveState("setupCacheExactHit", "false");
-    core.saveState("setupCacheMatchedKey", "");
-    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
-    core.saveState("targetCacheExactHit", "false");
-    core.saveState("targetCacheMatchedKey", "");
-    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
-    core.saveState("buildCacheExactHit", "false");
-    core.saveState("buildCacheMatchedKey", "");
-    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
-    core.saveState("cargoRegistryCacheExactHit", "false");
-    core.saveState("cargoRegistryCacheMatchedKey", "");
-    core.saveState("dylintCacheEnabled", result.dylintCache.enabled ? "true" : "false");
-    core.saveState("dylintCacheExactHit", "false");
-    core.saveState("dylintCacheMatchedKey", "");
-    // ---- parallel restores ----
-    // setup-cache, target-cache, build-cache, and cargo-registry write to
-    // disjoint paths and have no inter-dependencies, so they run concurrently.
-    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
-    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
-    //
-    // Layers that must stay sequential (wired below): solo-toolchain (writes
-    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
-    // install dir, must precede ensureSoldr), cook (writes target/ and needs
-    // the soldr binary). Cargo-registry was previously after-cook — it's been
-    // moved into this parallel block because nothing the soldr install path
-    // touches depends on its hydrated cargo registry state.
-    await (0, phase_timing_js_1.markPhase)("parallel-restore");
-    let setupCacheExactHit = false;
-    // Capture target-cache match status so we can skip the redundant cook restore.
-    // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
-    // (~2.5 GB inflated) also contains compiled deps. When target-cache matched
-    // at the lockfile/shape/toolchain level (exact OR parent-SHA OR lock-prefix
-    // fallback), we have target/deps/ already populated with identical content —
-    // cook restore would just overwrite. Skipping saves ~5–10 s per warm run.
-    // A looser restoreKeyLockfile-only match (different shape) is NOT enough to
-    // skip cook, since cook output may differ across shapes.
-    let targetCacheMatchedKey = "";
-    const setupRestorePromise = (async () => {
-        if (!(cacheEnabled && result.setupCache.paths.length > 0))
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
-        setupCacheExactHit = restore.hit;
-        core.setOutput("cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("setup_cache_matched_key", restore.matchedKey);
-        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("setupCacheMatchedKey", restore.matchedKey);
-        // Expose for ensure_rust_toolchain to read via env. Must be visible by
-        // the time toolchain phase runs — guaranteed by the Promise.all below.
-        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
-        statsCollector.record({
-            label: "setup-cache", operation: "restore", hit: restore.hit,
-            key: result.setupCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.setupCache.restorePrefix],
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const targetRestorePromise = (async () => {
-        if (!result.targetCache.enabled)
-            return;
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        if (targetPaths.length === 0)
-            return;
-        const restoreKeys = [];
-        if (result.targetCache.restoreKeyParent)
-            restoreKeys.push(result.targetCache.restoreKeyParent);
-        if (result.targetCache.restoreKeyLock)
-            restoreKeys.push(result.targetCache.restoreKeyLock);
-        if (result.targetCache.restoreKeyLockfile)
-            restoreKeys.push(result.targetCache.restoreKeyLockfile);
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
-        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("target_cache_matched_key", restore.matchedKey);
-        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("targetCacheMatchedKey", restore.matchedKey);
-        targetCacheMatchedKey = restore.matchedKey;
-        statsCollector.record({
-            label: "target-cache", operation: "restore", hit: restore.hit,
-            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const buildRestorePromise = (async () => {
-        if (!buildCacheEnabled)
-            return;
-        const buildCachePath = result.buildCache.path;
-        const archivePath = `${buildCachePath}.tar.zst`;
-        const restoreKeys = [];
-        if (result.buildCache.restoreKeyParent)
-            restoreKeys.push(result.buildCache.restoreKeyParent);
-        if (result.buildCache.restoreKeyToolchain)
-            restoreKeys.push(result.buildCache.restoreKeyToolchain);
-        if (result.buildCache.restoreKeyOsArch)
-            restoreKeys.push(result.buildCache.restoreKeyOsArch);
-        const t0 = Date.now();
-        // @actions/cache hashes the `paths` array into a "version" key — save and
-        // restore MUST pass the same array or the lookup misses even when the
-        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
-        // restore must use the same single-path array. The decompression below
-        // unpacks archivePath → buildCachePath afterwards.
-        const restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
-        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("build_cache_matched_key", restore.matchedKey);
-        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("buildCacheMatchedKey", restore.matchedKey);
-        let buildArchiveBytes = null;
-        let buildInflatedBytes = null;
-        let buildFileCount = null;
-        if (fileExists(archivePath)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-            const haveEncryptKey = (process.env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] ?? "").trim().length > 0;
-            if (magic === "zstd" || magic === "gzip" || haveEncryptKey) {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({
-                        archivePath,
-                        targetDir: buildCachePath,
-                        debug: debugMode,
-                        log: debugLog,
-                        cacheKey: restore.matchedKey || result.buildCache.key,
-                    });
-                    buildArchiveBytes = dr.archiveBytes;
-                    buildInflatedBytes = dr.inflatedBytes;
-                    buildFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
-        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
-        // dir on the cold side; if it's present after decompress, walk it and
-        // set each matching source file's mtime to what cold saw. The replay
-        // is gated by (size, content-hash) match so we never overwrite a
-        // genuinely modified file's mtime — that would underbuild.
-        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
-            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
-            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
-            if (snapshot) {
-                const rt0 = Date.now();
-                try {
-                    // Match the project-root selection that post.ts uses when
-                    // writing the snapshot — the parent of the resolved target-dir,
-                    // not the (outer) GITHUB_WORKSPACE.
-                    const projectRoot = path.dirname(result.targetCache.targetPath);
-                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
-                        workspace: projectRoot,
-                        snapshot,
-                        log: (msg) => logger.log(msg),
-                    });
-                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
-                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
-                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
-                }
-                catch (err) {
-                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-            else {
-                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
-            }
-        }
-        statsCollector.record({
-            label: "build-cache", operation: "restore", hit: restore.hit,
-            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        // Seed an isolated SOLDR_CACHE_DIR from the just-restored build-cache
-        // artifact store (issue #240). Opt-in: only fires when the consumer
-        // declares the isolated root(s) it switches its self-test phase to, so a
-        // daemon-isolated coverage/integration phase starts warm instead of cold.
-        const seedTargets = (0, seed_isolated_cache_js_1.parseIsolatedSeedTargets)(inputs.seedIsolatedBuildCache);
-        if (seedTargets.length > 0) {
-            try {
-                (0, seed_isolated_cache_js_1.seedIsolatedBuildCache)({
-                    sourceZccacheDir: buildCachePath,
-                    targetSoldrRoots: seedTargets,
-                    log: (msg) => logger.log(msg),
-                });
-            }
-            catch (err) {
-                logger.log(`seed-isolated-build-cache: failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    })();
-    // Cargo-registry restore moved here from after-cook. It writes only
-    // $CARGO_HOME/registry/ and has no dependency on soldr being installed;
-    // running it in parallel with target+build trims its ~5s off the critical
-    // path.
-    const cargoRegistryRestorePromise = (async () => {
-        if (!result.cargoRegistryCache.enabled)
-            return;
-        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe([registryArchive], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
-        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
-        let regArchiveBytes = null;
-        let regInflatedBytes = null;
-        let regFileCount = null;
-        if (fileExists(registryArchive)) {
-            // #260: try `soldr load` first for parallel extraction on Windows
-            // (Defender + NTFS bottleneck). Falls through to the legacy
-            // tar+zstd path when the archive isn't soldr-format or the
-            // installed soldr is too old.
-            let soldrLoadUsed = false;
-            try {
-                const sr = await (0, soldr_load_shim_js_1.tryLoadViaSoldr)({
-                    archivePath: registryArchive,
-                    targetDir: result.cargoRegistryCache.path,
-                    soldrPath: result.soldrPath,
-                    soldrVersion: result.soldrVersionResolved,
-                    debug: debugMode,
-                    log: debugLog,
-                    autoDefenderExclude: process.platform === "win32",
-                });
-                soldrLoadUsed = sr.used;
-            }
-            catch (err) {
-                logger.log(`cargo-registry soldr load failed (will fall back to tar+zstd): ${err instanceof Error ? err.message : String(err)}`);
-            }
-            if (soldrLoadUsed) {
-                try {
-                    regArchiveBytes = (await fs.promises.stat(registryArchive)).size;
-                }
-                catch { /* archive may have been removed mid-flight */ }
-            }
-            else {
-                const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
-                const haveEncryptKey = (process.env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] ?? "").trim().length > 0;
-                if (magic === "zstd" || magic === "gzip" || haveEncryptKey) {
-                    try {
-                        const dr = await (0, cache_compress_js_1.decompressCache)({
-                            archivePath: registryArchive,
-                            targetDir: result.cargoRegistryCache.path,
-                            debug: debugMode, log: debugLog,
-                            cacheKey: restore.matchedKey || result.cargoRegistryCache.key,
-                        });
-                        regArchiveBytes = dr.archiveBytes;
-                        regInflatedBytes = dr.inflatedBytes;
-                        regFileCount = dr.fileCount;
-                    }
-                    catch (err) {
-                        logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                    }
-                }
-            }
-        }
-        statsCollector.record({
-            label: "cargo-registry", operation: "restore", hit: restore.hit,
-            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.cargoRegistryCache.restorePrefix],
-            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    })();
-    const dylintRestorePromise = (async () => {
-        if (!result.dylintCache.enabled)
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.dylintCache.paths, result.dylintCache.key, [], logger);
-        core.setOutput("dylint-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("dylint-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("dylint_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("dylint_cache_matched_key", restore.matchedKey);
-        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_HIT", restore.hit ? "true" : "false");
-        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_MATCHED_KEY", restore.matchedKey);
-        core.saveState("dylintCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("dylintCacheMatchedKey", restore.matchedKey);
-        statsCollector.record({
-            label: "dylint-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: result.dylintCache.key,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - t0,
-            timestamp: new Date().toISOString(),
-        });
-        logger.log(`dylint-cache: key=${result.dylintCache.key} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
-    // try/catches, so this should only see rejections for genuine programming
-    // bugs.
-    await Promise.all([
-        setupRestorePromise,
-        targetRestorePromise,
-        buildRestorePromise,
-        cargoRegistryRestorePromise,
-        dylintRestorePromise,
-    ]);
-    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
-    // ---- target-tree-cache (full mode) ----
-    // The bundle path is included in target-cache restore paths above when full
-    // mode is requested, so there's no separate restore here. We keep the phase
-    // marker for parity with the composite step ordering.
-    await (0, phase_timing_js_1.markPhase)("target-tree");
-    await (0, phase_timing_js_1.finishPhase)("target-tree");
-    // Plan soldr-mini-cache restore now, but perform the extract inside the
-    // install phase. Restoring this layer in the background can rewrite the
-    // install dir while later phases spawn PATH tools, which surfaced as Linux
-    // ETXTBSY on the warm demo after soldr-cook started invoking soldr earlier.
-    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
-    const miniInstallDir = path.dirname(result.soldrPath);
-    const miniArchive = `${miniInstallDir}.tar.zst`;
-    let miniHit = false;
-    let miniKey = "";
-    let miniSkipReason = "";
-    let miniRestoreEligible = false;
-    if (miniEnabled) {
-        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
-            hasRef: Boolean(result.soldrRef.trim()),
-            enable: result.enabled,
-            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
-        });
-        if (eligibility.eligible) {
-            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
-            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
-                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-                soldrVersion: version,
-            });
-            miniRestoreEligible = true;
-            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir}`);
-        }
-        else {
-            miniSkipReason = eligibility.reason;
-        }
-    }
-    // Kick off cook restore in the background. It overlaps with the
-    // sequential toolchain + soldr install + shims + verify steps that
-    // follow. By the time the cook phase runs, the restore is done — we
-    // just await the promise. Saves ~5–7 s of warm-build wall clock.
-    //
-    // Why this is safe (vs the disastrous PR #145 which added cook to the
-    // BIG parallel block): cook now races with SMALL ops (rust install
-    // ~1–2 s, soldr install ~2–3 s, shims/verify ~1–2 s). Those don't
-    // contend on disk write bandwidth the way target/build/cargo-registry
-    // restores did. Cook's 2.5 GB tar write becomes the long pole and
-    // hides behind the small ops.
-    //
-    // SAFETY: when target-cache writes to target/ (build-cache-mode: full),
-    // cook restore would race with target-cache restore on the same dir.
-    // The parallel-restore block above already finished target-cache, but
-    // we still want a runtime gate just in case the mode changes.
-    const cookGate = (0, cook_cache_js_1.decideCookGate)({
-        prebuildDeps: inputs.prebuildDeps,
-        cacheUmbrella: cacheEnabled,
-        lockfilePath: result.targetCache.lockfilePath,
-    });
-    const cookActive = cookGate.enabled && result.enabled;
-    let cookFlags = [];
-    let cookKey = "";
-    let cookBaseKey = "";
-    let cookDeltaKey = "";
-    let cookDeltaParentKey = "";
-    let cookDeltaRestoreKeys = [];
-    let cookProjectRoot = "";
-    let cookTargetDir = "";
-    let cookArchive = "";
-    let cookBaseArchive = "";
-    let cookDeltaArchive = "";
-    let cookBaseManifest = "";
-    let cookLayered = false;
-    let cookRestoreT0 = Date.now();
-    let cookRestorePromise = null;
-    let cookLayeredRestorePromise = null;
-    // Skip cook restore when target-cache matched at the lockfile/shape level.
-    // restoreKeyLock = `${prefix}-${targetInputsHash}-${suffix}-` where
-    // targetInputsHash = sha256(toolchain, lockfile, manifest, shape). A
-    // matchedKey starting with restoreKeyLock means the cached entry was built
-    // with the same toolchain + lockfile + shape — its target/deps/ matches
-    // what cook would restore. Covers:
-    //   - exact hit  (matchedKey === current key, also startsWith restoreKeyLock)
-    //   - parent-SHA hit (matchedKey === restoreKeyParent, also startsWith)
-    //   - lock-prefix fallback (any saved entry with same lockfile+shape)
-    // Does NOT cover restoreKeyLockfile fallback (shorter prefix that drops
-    // shape) — different shape may mean different cook output, so cook still
-    // runs there as the safety net.
-    const targetCacheLockMatch = !!targetCacheMatchedKey &&
-        !!result.targetCache.restoreKeyLock &&
-        targetCacheMatchedKey.startsWith(result.targetCache.restoreKeyLock);
-    const cookSkippedDueToTargetHit = cookActive && targetCacheLockMatch;
-    if (cookActive && !cookSkippedDueToTargetHit) {
-        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
-        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
-        const lockHash = result.targetCache.lockfileHash || "no-lock";
-        const cookKeyParts = {
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            flagsHash,
-            lockHash,
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        };
-        cookProjectRoot = path.dirname(result.targetCache.targetPath);
-        cookTargetDir = result.targetCache.targetPath;
-        cookRestoreT0 = Date.now();
-        const deltaInput = inputs.prebuildDepsDeltaCache.trim() || "true";
-        const deltaRequested = !isFalsy(deltaInput);
-        const soldrVersionForCook = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
-        cookLayered = deltaRequested && (0, cook_cache_js_1.supportsLayeredCookCache)(soldrVersionForCook);
-        if (cookLayered) {
-            const shapeHash = (0, cook_cache_js_1.hashCookBuildShape)(result.targetCache.restoreKeyLock || result.targetCache.key);
-            cookBaseKey = (0, cook_cache_js_1.buildCookBaseCacheKey)(cookKeyParts);
-            cookDeltaKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
-                ...cookKeyParts,
-                buildShapeHash: shapeHash,
-                githubSha: ctx.githubSha || "nosha",
-            });
-            if (ctx.parentSha && ctx.parentSha !== ctx.githubSha) {
-                cookDeltaParentKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
-                    ...cookKeyParts,
-                    buildShapeHash: shapeHash,
-                    githubSha: ctx.parentSha,
-                });
-            }
-            cookDeltaRestoreKeys = cookDeltaParentKey ? [cookDeltaParentKey] : [];
-            cookDeltaRestoreKeys.push((0, cook_cache_js_1.buildCookDeltaCacheRestorePrefix)({
-                ...cookKeyParts,
-                buildShapeHash: shapeHash,
-            }));
-            cookBaseArchive = `${cookTargetDir}.soldr-base.tar.zst`;
-            cookDeltaArchive = `${cookTargetDir}.soldr-delta.tar.zst`;
-            cookBaseManifest = `${cookTargetDir}.soldr-base-manifest.pb`;
-            logger.log(`cook: layered keys base=${cookBaseKey} delta=${cookDeltaKey}` +
-                (cookDeltaParentKey ? ` delta-fallback=${cookDeltaParentKey}` : ` (no parent-fallback — parentSha unavailable, #365)`) +
-                ` delta-prefix=${cookDeltaRestoreKeys.at(-1)}` +
-                ` starting archive restore concurrent with install`);
-            cookLayeredRestorePromise = (0, cook_cache_js_1.restoreLayeredCookCacheArchives)({
-                baseKey: cookBaseKey,
-                deltaKey: cookDeltaKey,
-                deltaRestoreKeys: cookDeltaRestoreKeys,
-                baseArchivePath: cookBaseArchive,
-                deltaArchivePath: cookDeltaArchive,
-                log: (msg) => logger.log(msg),
-            });
-        }
-        else {
-            if (deltaRequested) {
-                logger.log(`cook: layered cache requires soldr >=0.7.38; ` +
-                    `version=${soldrVersionForCook || "unknown"} falling back to legacy cook cache`);
-            }
-            else {
-                logger.log("cook: layered cache disabled via prebuild-deps-delta-cache=false");
-            }
-            cookKey = (0, cook_cache_js_1.buildCookCacheKey)(cookKeyParts);
-            cookArchive = `${cookTargetDir}.tar.zst`;
-            logger.log(`cook: key=${cookKey} starting background restore concurrent with install`);
-            cookRestorePromise = (0, cook_cache_js_1.restoreCookCache)({
-                exactKey: cookKey,
-                archivePath: cookArchive,
-                targetDir: cookTargetDir,
-                longWindow: 27,
-                debug: debugMode,
-                log: (msg) => logger.log(msg),
-            });
-        }
-    }
-    // ---- toolchain ----
-    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
-    // toolchain install so we can see which inodes setup-soldr added on
-    // top of the runner image. When solo-toolchain-cache is opted in, a
-    // third snapshot is taken *before* the cache restore so the saved
-    // tarball captures the full above-runner state — not just the
-    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
-    // lifetime axis".
-    await (0, phase_timing_js_1.markPhase)("toolchain");
-    const snapshotRoots = [
-        path.join(result.rustupHome, "toolchains"),
-        path.join(result.cargoHome, "bin"),
-    ];
-    const soloRootMap = {
-        "rustup-toolchains": snapshotRoots[0],
-        "cargo-bin": snapshotRoots[1],
-    };
-    const soloEnabled = isTruthy(inputs.soloToolchainCache);
-    // #310: default-changed from "19" → "9". Measured first-save cost
-    // dropped from ~104s → ~12s on 140 MB toolchain delta; restore stays
-    // bandwidth-bound either way.
-    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "9");
-    let soloKeys = null;
-    let soloMatchedKey = "";
-    let soloExactHit = false;
-    let forceToolchainRepair = false;
-    // Pre-restore snapshot — only needed when solo cache is enabled, so
-    // we can compute the full save-diff (post-install vs runner-image,
-    // not vs post-restore baseline). (#302: timed as sub-phase.)
-    const preRestoreSnapshot = soloEnabled
-        ? await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-pre", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots))
-        : null;
-    if (soloEnabled) {
-        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
-            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        });
-        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
-        const restoreT0 = Date.now();
-        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
-        const restored = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "solo-restore", () => (0, solo_toolchain_cache_js_1.restoreSoloCache)({
-            keys: soloKeys,
-            rootMap: soloRootMap,
-            stagingDir,
-            log: (msg) => logger.log(msg),
-            // #316 follow-up: pass canonical archive path explicitly so
-            // save and restore agree regardless of stagingDir layout.
-            cacheArchivePath: (0, solo_toolchain_cache_js_1.soloCacheArchivePath)(ctx.runnerTemp),
-        }));
-        soloMatchedKey = restored.matchedKey;
-        let verifiedMatch = true;
-        if (restored.verified && restored.matchedKey) {
-            const expected = result.toolchain.cacheChannel.trim();
-            // The rustup home is set up so `rustc` will resolve through the
-            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
-            // the cargo bin one.
-            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
-            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
-                expectedRelease: expected,
-                expectedTargets: result.toolchain.targets,
-                rustcCommand: rustcCmd,
-                log: (msg) => logger.log(msg),
-            });
-            verifiedMatch = verify.match;
-            forceToolchainRepair = restored.verified && !verify.match;
-        }
-        soloExactHit = restored.hit && verifiedMatch;
-        core.saveState("soloToolchainEnabled", "true");
-        core.saveState("soloToolchainExactKey", soloKeys.exact);
-        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
-        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
-        core.saveState("soloToolchainLevel", soloLevel);
-        statsCollector.record({
-            label: "solo-toolchain-cache",
-            operation: "restore",
-            hit: soloExactHit,
-            key: soloKeys.exact,
-            matchedKey: soloMatchedKey,
-            restoreKeys: soloKeys.fallbacks,
-            archiveBytes: restored.restoredBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - restoreT0,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else {
-        core.saveState("soloToolchainEnabled", "false");
-    }
-    const baselineSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-base", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
-    // #323: when solo-cache exact-hit AND verifyRestoredToolchain
-    // passed, the requested toolchain is already on disk from the
-    // restore. `rustup toolchain install` would be a no-op but still
-    // costs ~8s on hosted runners (self-update check, metadata fetch,
-    // profile diff). Skip the install entirely on the verified
-    // exact-hit path. The snapshot still runs so cache-save logic
-    // downstream sees an unchanged tree (install-delta empty).
-    if (soloExactHit) {
-        logger.log("toolchain: solo-cache exact-hit + verified — skipping rustup install (#323)");
-    }
-    else {
-        await (0, phase_timing_js_1.timeSubPhase)("toolchain", "rustup-install", () => (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({
-            resolveResult: result,
-            setupCacheExactHit,
-            forceRepair: forceToolchainRepair,
-        }));
-    }
-    const postInstallSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-post", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
-    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
-    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
-    // When solo cache is enabled, also compute the save-diff (post-install
-    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
-    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
-        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
-        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
-        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
-        try {
-            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
-            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
-            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
-            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
-                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
-                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
-                `incremental-empty=${toolchainDiff.added.length === 0}`);
-        }
-        catch (err) {
-            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
-    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
-        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
-    if (ctx.runnerTemp) {
-        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
-        try {
-            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
-            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
-        }
-        catch (err) {
-            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    await (0, phase_timing_js_1.finishPhase)("toolchain");
-    // ---- install soldr ----
-    // Restore soldr-mini-cache synchronously so the install dir is quiescent
-    // before ensureSoldr's installedVersion() check or any later soldr spawn.
-    await (0, phase_timing_js_1.markPhase)("install");
-    if (miniRestoreEligible) {
-        const miniT0 = Date.now();
-        const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
-            exactKey: miniKey,
-            installDir: miniInstallDir,
-            archivePath: miniArchive,
-            longWindow: 27,
-            debug: debugMode,
-            log: (msg) => logger.log(msg),
-        });
-        miniHit = restore.hit;
-        statsCollector.record({
-            label: "soldr-mini-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: miniKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - miniT0,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else if (miniSkipReason) {
-        logger.log(`soldr-mini-cache: skipped — ${miniSkipReason}`);
-    }
-    else if (!miniEnabled) {
-        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
-    }
-    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
-    core.saveState("soldrMiniExactKey", miniKey);
-    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
-    core.saveState("soldrMiniInstallDir", miniInstallDir);
-    core.saveState("soldrMiniArchive", miniArchive);
-    if (result.enabled) {
-        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
-        // restored binary at the expected path with the expected version and
-        // short-circuits — no GH fetch.
-        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
-    }
-    else {
-        (0, install_passthrough_js_1.installPassthrough)({
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
-            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
-            "verbatim, and soldr-aware caching/observability is disabled.");
-    }
-    await (0, phase_timing_js_1.finishPhase)("install");
-    // ---- zccache-seed ----
-    // Pin setup-soldr's zccache before user workflow steps. The pinned
-    // install is home-anchored inside soldr, so later self-tests can isolate
-    // SOLDR_CACHE_DIR without repeating release lookup or cargo-install fallback.
-    await (0, phase_timing_js_1.markPhase)("zccache-seed");
-    await (0, zccache_seed_js_1.seedZccache)({
-        soldrPath: result.soldrPath,
-        actionRoot: actionRoot(),
-        enabled: result.enabled,
-        strict: isTruthy(inputs.zccacheSeedStrict),
-        log: (msg) => logger.log(msg),
-        warn: (msg) => logger.warning(msg),
-    });
-    await (0, phase_timing_js_1.finishPhase)("zccache-seed");
-    // Export SOLDR_BINARY so shims can exec it directly
-    core.exportVariable("SOLDR_BINARY", result.soldrPath);
-    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
-    // ---- shims ----
-    if (result.shimsEnabled) {
-        await (0, ensure_shims_js_1.ensureShims)({
-            shimsDir: result.shimsDir,
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-    }
-    // ---- verify ----
-    await (0, phase_timing_js_1.markPhase)("verify");
-    if (result.enabled) {
-        const verify = await (0, verify_soldr_js_1.verifySoldr)({
-            soldrPath: result.soldrPath,
-            buildCacheMode: result.buildCache.mode,
-            requireRustPlan: result.targetCache.enabled,
-        });
-        core.setOutput("soldr-version", verify.soldrVersion);
-        core.setOutput("soldr_version", verify.soldrVersion);
-    }
-    else {
-        core.setOutput("soldr-version", "passthrough");
-        core.setOutput("soldr_version", "passthrough");
-    }
-    await (0, phase_timing_js_1.finishPhase)("verify");
-    // ---- cross-bootstrap (issue #104 MVP) ----
-    // After the Rust toolchain and the soldr binary are both available, but
-    // before the user's own steps run, auto-install cross-compile tooling
-    // for any declared `cross-targets`. Skip entirely if the input is empty
-    // so workflows that don't cross-compile pay zero cost. Failures here are
-    // surfaced as standard exec errors and DO fail the action — the user
-    // explicitly asked for these targets, so a silent skip would be more
-    // surprising than a hard failure.
-    await (0, phase_timing_js_1.markPhase)("cross-bootstrap");
-    const crossTargets = (0, cross_bootstrap_js_1.parseCrossTargets)(inputs.crossTargets);
-    // Track per-lane cache restore outcomes so post.ts knows which lanes to
-    // save (only the ones that missed; saving on an exact hit is wasted I/O).
-    // setup-soldr#106 / Wave 2.1 of zackees/soldr#514.
-    const crossToolCacheRestores = {};
-    if (crossTargets.length > 0) {
-        const tool = (0, cross_bootstrap_js_1.parseCrossTool)(inputs.crossTool);
-        const host = ctx.runnerOs.toLowerCase() || process.platform;
-        logger.log(`cross-bootstrap: host=${host} tool=${tool} targets=${crossTargets.join(",")}`);
-        // Per-(host × target) tool cache restores. One slot per declared lane,
-        // keyed on `tool-<host>-<target>-<toolsHash>-soldr<ver>` (see
-        // crossToolCacheKeyFor in cache-keys.ts). Restore is best-effort: a
-        // miss just means we'll run the normal install path below. Restores
-        // run in parallel — there are no inter-lane dependencies.
-        if (result.crossToolCaches.length > 0) {
-            await Promise.all(result.crossToolCaches.map(async (lane) => {
-                if (lane.paths.length === 0) {
-                    // Unsupported lane (e.g. windows -> apple-darwin): no
-                    // binaries to cache, just record the no-op.
-                    crossToolCacheRestores[lane.target] = { hit: false, matchedKey: "" };
-                    return;
-                }
-                const t0 = Date.now();
-                const restore = await restoreCacheSafe(lane.paths, lane.key, [], logger);
-                crossToolCacheRestores[lane.target] = {
-                    hit: restore.hit,
-                    matchedKey: restore.matchedKey,
-                };
-                statsCollector.record({
-                    label: `cross-tool-cache:${lane.target}`,
-                    operation: "restore",
-                    hit: restore.hit,
-                    key: lane.key,
-                    matchedKey: restore.matchedKey,
-                    restoreKeys: [],
-                    archiveBytes: null,
-                    inflatedBytes: null,
-                    fileCount: null,
-                    durationMs: Date.now() - t0,
-                    timestamp: new Date().toISOString(),
-                });
-                logger.log(`cross-tool-cache: lane=${lane.target} key=${lane.key} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-            }));
-        }
-        const plan = (0, cross_bootstrap_js_1.planCrossBootstrap)({ host, targets: crossTargets, tool });
-        for (const w of plan.warnings)
-            core.warning(w);
-        if (plan.actions.length > 0) {
-            // When every lane hit the per-lane tool cache, the install plan is
-            // already on disk and we can skip the executeCrossBootstrap call
-            // entirely. The cached cargo-zigbuild binary lands at the same path
-            // executeCrossBootstrap would write to ($CARGO_HOME/bin), so the
-            // skipIfPresent guard inside the executor also short-circuits on a
-            // partial hit — we run unconditionally and let the guard sort it.
-            const allLanesHit = result.crossToolCaches.length > 0 &&
-                result.crossToolCaches
-                    .filter((l) => l.paths.length > 0)
-                    .every((l) => crossToolCacheRestores[l.target]?.hit === true);
-            if (allLanesHit) {
-                logger.log("cross-bootstrap: all per-lane tool caches hit — skipping install plan");
-            }
-            else {
-                await (0, cross_bootstrap_js_1.executeCrossBootstrap)(plan, {
-                    log: (msg) => logger.log(msg),
-                    soldrBinary: result.soldrPath,
-                });
-            }
-        }
-        else if (plan.warnings.length === 0) {
-            logger.log("cross-bootstrap: no actions planned (tool=none or empty supported set)");
-        }
-    }
-    // Persist per-lane restore state so post.ts can decide what to save.
-    // Save the lane plans themselves so post.ts doesn't have to recompute
-    // (resolveSetup-level inputs may not be available the same way in post).
-    core.saveState("crossToolCachePlans", JSON.stringify(result.crossToolCaches));
-    core.saveState("crossToolCacheRestores", JSON.stringify(crossToolCacheRestores));
-    await (0, phase_timing_js_1.finishPhase)("cross-bootstrap");
-    // ---- cook (prebuild-deps via soldr-cook) ----
-    // The RESTORE was kicked off as a background promise right after the
-    // parallel-restore block above — we just await its result here. The
-    // RUN (`soldr cook`) still happens in this phase if
-    // the restore missed.
-    // Failures here are logged but never fail the action — the user's
-    // own cargo build will still work without the cooked deps.
-    await (0, phase_timing_js_1.markPhase)("cook");
-    if (cookActive && cookLayeredRestorePromise) {
-        const restore = await cookLayeredRestorePromise;
-        const loaded = await (0, cook_cache_js_1.loadLayeredCookCache)({
-            soldrBinary: result.soldrPath,
-            projectRoot: cookProjectRoot,
-            targetDir: cookTargetDir,
-            baseArchivePath: cookBaseArchive,
-            deltaArchivePath: cookDeltaArchive,
-            baseManifestPath: cookBaseManifest,
-            restore,
-            log: (msg) => logger.log(msg),
-        });
-        const baseReady = (0, cook_cache_js_1.layeredCookBaseReady)(restore, loaded);
-        const deltaReady = (0, cook_cache_js_1.layeredCookDeltaReady)(restore, loaded);
-        statsCollector.record({
-            label: "cook-cache-base",
-            operation: "restore",
-            hit: baseReady,
-            key: cookBaseKey,
-            matchedKey: restore.base.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.base.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: loaded.baseReport?.cacheFilesRestored ?? null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        statsCollector.record({
-            label: "cook-cache-delta",
-            operation: "restore",
-            hit: deltaReady,
-            key: cookDeltaKey,
-            matchedKey: restore.delta.matchedKey,
-            restoreKeys: cookDeltaRestoreKeys,
-            archiveBytes: restore.delta.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: loaded.deltaReport?.cacheFilesRestored ?? null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        let cookRan = false;
-        if (!deltaReady) {
-            const runRes = await (0, cook_cache_js_1.runCook)({
-                soldrBinary: result.soldrPath,
-                projectRoot: cookProjectRoot,
-                flags: cookFlags,
-                log: (msg) => logger.log(msg),
-            });
-            cookRan = runRes.exitCode === 0;
-        }
-        else {
-            logger.log("cook: base+delta cache hit - skipping cook run, target/deps already warm");
-        }
-        const cookSaveLayer = cookRan ? (baseReady ? "delta" : "base") : "none";
-        core.saveState("cookEnabled", "true");
-        core.saveState("cookLayered", "true");
-        core.saveState("cookBaseExactKey", cookBaseKey);
-        core.saveState("cookDeltaExactKey", cookDeltaKey);
-        core.saveState("cookBaseMatchedKey", restore.base.matchedKey);
-        core.saveState("cookDeltaMatchedKey", restore.delta.matchedKey);
-        core.saveState("cookBaseHit", baseReady ? "true" : "false");
-        core.saveState("cookDeltaHit", deltaReady ? "true" : "false");
-        core.saveState("cookHit", deltaReady ? "true" : "false");
-        core.saveState("cookRan", cookRan ? "true" : "false");
-        core.saveState("cookSaveLayer", cookSaveLayer);
-        core.saveState("cookProjectRoot", cookProjectRoot);
-        core.saveState("cookTargetDir", cookTargetDir);
-        core.saveState("cookBaseArchive", cookBaseArchive);
-        core.saveState("cookDeltaArchive", cookDeltaArchive);
-        core.saveState("cookBaseManifest", cookBaseManifest);
-        core.saveState("cookSoldrBinary", result.soldrPath);
-        // #268/#358: cook-cache-base previously used zstd-level 19, but
-        // production observation showed 165s of compress wall-clock per
-        // matrix job for ~224 MB output. In a 5-way matrix where 1 job
-        // wins the cache reservation and 4 lose the race, that's 660s
-        // of post-step CPU wasted per CI cycle. Lowering to -9 cuts the
-        // compress wall-clock ~4× (target ~40s) at the cost of ~25%
-        // larger archive (~280 MB) and ~1s extra upload wall-clock per
-        // save. zstd decompression speed is level-independent, so warm
-        // restores are unaffected. Net: ~125s win per save-attempt, big
-        // multiplier on race-loss scenarios.
-        core.saveState("cookCompressLevel", "9");
-        core.saveState("cookDeltaCompressLevel", "3");
-    }
-    else if (cookActive && cookRestorePromise) {
-        const restore = await cookRestorePromise;
-        statsCollector.record({
-            label: "cook-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: cookKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        let cookRan = false;
-        if (!restore.hit) {
-            const runRes = await (0, cook_cache_js_1.runCook)({
-                soldrBinary: result.soldrPath,
-                projectRoot: cookProjectRoot,
-                flags: cookFlags,
-                log: (msg) => logger.log(msg),
-            });
-            cookRan = runRes.exitCode === 0;
-        }
-        else {
-            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
-        }
-        core.saveState("cookEnabled", "true");
-        core.saveState("cookLayered", "false");
-        core.saveState("cookExactKey", cookKey);
-        core.saveState("cookMatchedKey", restore.matchedKey);
-        core.saveState("cookHit", restore.hit ? "true" : "false");
-        core.saveState("cookRan", cookRan ? "true" : "false");
-        core.saveState("cookTargetDir", cookTargetDir);
-        core.saveState("cookLongWindow", "27");
-        // #268/#358: see saveState("cookCompressLevel", "9") above for
-        // rationale on lowering from -19. Same logic applies to the
-        // non-layered path.
-        core.saveState("cookCompressLevel", "9");
-    }
-    else if (cookSkippedDueToTargetHit) {
-        logger.log(`cook: skipped - target-cache matched at lockfile/shape level (matched=${targetCacheMatchedKey}); cook output would be redundant`);
-        core.saveState("cookEnabled", "false");
-        core.saveState("cookLayered", "false");
-    }
-    else {
-        logger.log(`cook: skipped - ${cookGate.reason}`);
-        core.saveState("cookEnabled", "false");
-        core.saveState("cookLayered", "false");
-    }
-    await (0, phase_timing_js_1.finishPhase)("cook");
-    // ---- shared-target warning ----
-    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
-        buildCacheEnabled,
-        effectiveTargetCacheEnabled: result.targetCache.enabled,
-        buildCacheMode: result.buildCache.mode,
-        targetDir: result.targetCache.targetPath,
-        soldrPath: result.soldrPath,
-    });
-    // ---- shim-bypass diagnostic ----
-    // Issue #160: when shims: true is requested but the effective environment
-    // (PATH ordering, CARGO/RUSTC/RUSTC_WRAPPER overrides) would bypass them,
-    // caching looks configured but compile work runs through plain cargo.
-    // Emit advisory warnings naming each offender. Runs at the very end so it
-    // sees the final state of process.env after every prior phase.
-    if (result.shimsEnabled) {
-        const bypassWarnings = (0, shim_bypass_check_js_1.diagnoseShimBypass)({
-            shimsEnabled: true,
-            shimDir: result.shimsDir,
-            path: process.env["PATH"] ?? "",
-            cargoEnv: process.env["CARGO"],
-            rustcEnv: process.env["RUSTC"],
-            rustcWrapperEnv: process.env["RUSTC_WRAPPER"],
-            soldrBinary: result.soldrPath,
-        });
-        for (const msg of bypassWarnings) {
-            core.warning(msg);
-        }
-        if (bypassWarnings.length === 0) {
-            logger.log(`shim-bypass check clean: shim dir ${result.shimsDir} at PATH front, no competing CARGO/RUSTC/RUSTC_WRAPPER overrides`);
-        }
-    }
-    // ---- stats report ----
-    statsCollector.report(statsMode, (msg) => logger.log(msg));
-    if (statsMode === "detailed") {
-        try {
-            await statsCollector.writeFiles(ctx.runnerTemp);
-            statsCollector.setGithubOutputs();
-        }
-        catch (err) {
-            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    core.saveState("statsCollector", statsCollector.serialize());
-    core.saveState("statsMode", statsMode);
-    core.saveState("compileCacheStats", result.compileCacheStats);
-    core.saveState("runnerTemp", ctx.runnerTemp);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            cacheOutcomes: statsCollector.snapshot(),
-            logger,
-        });
-    }
-    // #269-companion (setup side): one-line aggregate of where each
-    // setup phase's wall-clock went, before we finish the `action`
-    // phase. Mirrors the post-step `cache save totals:` line that
-    // ships from `StatsCollector.saveSummaryOneLine()`. Operators see
-    // the pre-build budget at a glance without scrolling raw
-    // SETUP_SOLDR_PHASE_*_START_MS env vars or hunting through the
-    // timeline. Phases in declared serial order:
-    const setupPhaseSummary = (0, phase_timing_js_1.setupPhaseSummaryOneLine)([
-        "resolve",
-        "parallel-restore",
-        "target-tree",
-        "toolchain",
-        "install",
-        "zccache-seed",
-        "verify",
-        "cross-bootstrap",
-        "cook",
-    ]);
-    if (setupPhaseSummary)
-        core.info(setupPhaseSummary);
-    await (0, phase_timing_js_1.finishPhase)("action");
-    // dirHasContent is exported for tests; suppress unused warning here.
-    void dirHasContent;
-}
-// Auto-invoke only when this module is run as the main entry point. This lets
-// tests import `run` (and helpers) without triggering the side-effectful
-// orchestration. The dist/main.js produced by ncc is invoked directly by the
-// Actions runtime so the check trips and the action executes normally.
-if (typeof process !== "undefined" &&
-    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
-    // import.meta.url is the file URL of this module; argv[1] is the runner
-    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
-    // the dev path — we rely on the env-var opt-out for tests instead.
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.setFailed(`setup-soldr failed: ${message}`);
-    });
-}
-
-
-/***/ }),
-
-/***/ 205:
+/***/ 206:
 /***/ ((module) => {
 
 "use strict";
@@ -49799,7 +50156,7 @@ module.exports = require("node:child_process");
 
 /***/ }),
 
-/***/ 206:
+/***/ 207:
 /***/ ((module) => {
 
 "use strict";
@@ -49807,14 +50164,14 @@ module.exports = require("util/types");
 
 /***/ }),
 
-/***/ 207:
+/***/ 208:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(131)
-const Client = __nccwpck_require__(96)
+const { promisify } = __nccwpck_require__(133)
+const Client = __nccwpck_require__(98)
 const { buildMockDispatch } = __nccwpck_require__(8)
 const {
   kDispatches,
@@ -49824,10 +50181,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(483)
-const { MockInterceptor } = __nccwpck_require__(143)
-const Symbols = __nccwpck_require__(202)
-const { InvalidArgumentError } = __nccwpck_require__(500)
+} = __nccwpck_require__(484)
+const { MockInterceptor } = __nccwpck_require__(145)
+const Symbols = __nccwpck_require__(204)
+const { InvalidArgumentError } = __nccwpck_require__(501)
 
 /**
  * MockClient provides an API that extends the Client to influence the mockDispatches.
@@ -49874,7 +50231,7 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 208:
+/***/ 209:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49900,7 +50257,7 @@ __export(sha256_exports, {
   computeSha256Hmac: () => computeSha256Hmac
 });
 module.exports = __toCommonJS(sha256_exports);
-var import_node_crypto = __nccwpck_require__(281);
+var import_node_crypto = __nccwpck_require__(282);
 async function computeSha256Hmac(key, stringToSign, encoding) {
   const decodedKey = Buffer.from(key, "base64");
   return (0, import_node_crypto.createHmac)("sha256", decodedKey).update(stringToSign).digest(encoding);
@@ -49915,7 +50272,7 @@ async function computeSha256Hash(content, encoding) {
 
 /***/ }),
 
-/***/ 209:
+/***/ 210:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50295,7 +50652,7 @@ exports.BlobQueryResponse = BlobQueryResponse;
 
 /***/ }),
 
-/***/ 210:
+/***/ 211:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50308,10 +50665,10 @@ exports.streamToBuffer = streamToBuffer;
 exports.streamToBuffer2 = streamToBuffer2;
 exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
-const tslib_1 = __nccwpck_require__(224);
-const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(256));
-const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(383));
-const constants_js_1 = __nccwpck_require__(156);
+const tslib_1 = __nccwpck_require__(225);
+const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(257));
+const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(384));
+const constants_js_1 = __nccwpck_require__(158);
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
  *
@@ -50442,7 +50799,7 @@ exports.fsCreateReadStream = node_fs_1.default.createReadStream;
 
 /***/ }),
 
-/***/ 211:
+/***/ 212:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -50724,7 +51081,7 @@ exports.varint32read = varint32read;
 
 /***/ }),
 
-/***/ 212:
+/***/ 213:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -50734,9 +51091,9 @@ exports.varint32read = varint32read;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobLeaseClient = void 0;
 const core_util_1 = __nccwpck_require__(15);
-const constants_js_1 = __nccwpck_require__(156);
+const constants_js_1 = __nccwpck_require__(158);
 const tracing_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(162);
+const utils_common_js_1 = __nccwpck_require__(164);
 /**
  * A client that manages leases for a {@link ContainerClient} or a {@link BlobClient}.
  */
@@ -50936,7 +51293,7 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 /***/ }),
 
-/***/ 213:
+/***/ 214:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -51015,8 +51372,8 @@ exports.setupCachePaths = setupCachePaths;
 exports.setupCacheLayout = setupCacheLayout;
 exports.crossToolCacheKeyFor = crossToolCacheKeyFor;
 exports.pathForOutput = pathForOutput;
-const node_crypto_1 = __nccwpck_require__(281);
-const fs = __importStar(__nccwpck_require__(256));
+const node_crypto_1 = __nccwpck_require__(282);
+const fs = __importStar(__nccwpck_require__(257));
 const path = __importStar(__nccwpck_require__(519));
 const TARGET_CACHE_PROFILES = ["thin-v1", "thin-v2"];
 const TARGET_CACHE_BOOL_TRUE = new Set(["true", "1", "yes", "on"]);
@@ -51431,15 +51788,15 @@ function pathForOutput(workspace, p) {
 
 /***/ }),
 
-/***/ 214:
+/***/ 215:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionCreate = void 0;
-const reflection_scalar_default_1 = __nccwpck_require__(475);
-const message_type_contract_1 = __nccwpck_require__(418);
+const reflection_scalar_default_1 = __nccwpck_require__(476);
+const message_type_contract_1 = __nccwpck_require__(419);
 /**
  * Creates an instance of the generic message, using the field
  * information.
@@ -51487,7 +51844,7 @@ exports.reflectionCreate = reflectionCreate;
 
 /***/ }),
 
-/***/ 215:
+/***/ 216:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51499,7 +51856,7 @@ exports.storageBrowserPolicyName = void 0;
 exports.storageBrowserPolicy = storageBrowserPolicy;
 const core_util_1 = __nccwpck_require__(15);
 const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(486);
+const utils_common_js_1 = __nccwpck_require__(487);
 /**
  * The programmatic identifier of the StorageBrowserPolicy.
  */
@@ -51529,7 +51886,7 @@ function storageBrowserPolicy() {
 
 /***/ }),
 
-/***/ 216:
+/***/ 217:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51537,9 +51894,9 @@ function storageBrowserPolicy() {
 
 const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(529)
 const { kState } = __nccwpck_require__(16)
-const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(373)
-const { webidl } = __nccwpck_require__(469)
-const { Blob, File: NativeFile } = __nccwpck_require__(126)
+const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(374)
+const { webidl } = __nccwpck_require__(470)
+const { Blob, File: NativeFile } = __nccwpck_require__(128)
 
 /** @type {globalThis['File']} */
 const File = NativeFile ?? UndiciFile
@@ -51802,7 +52159,7 @@ module.exports = { FormData }
 
 /***/ }),
 
-/***/ 217:
+/***/ 218:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -51819,7 +52176,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 218:
+/***/ 219:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51844,10 +52201,10 @@ __export(getClient_exports, {
   getClient: () => getClient
 });
 module.exports = __toCommonJS(getClient_exports);
-var import_clientHelpers = __nccwpck_require__(503);
-var import_sendRequest = __nccwpck_require__(462);
-var import_urlHelpers = __nccwpck_require__(335);
-var import_checkEnvironment = __nccwpck_require__(451);
+var import_clientHelpers = __nccwpck_require__(504);
+var import_sendRequest = __nccwpck_require__(463);
+var import_urlHelpers = __nccwpck_require__(336);
+var import_checkEnvironment = __nccwpck_require__(452);
 function getClient(endpoint, clientOptions = {}) {
   const pipeline = clientOptions.pipeline ?? (0, import_clientHelpers.createDefaultPipeline)(clientOptions);
   if (clientOptions.additionalPolicies?.length) {
@@ -52002,7 +52359,7 @@ function buildOperation(method, url, pipeline, options, allowInsecureConnection,
 
 /***/ }),
 
-/***/ 219:
+/***/ 220:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52027,8 +52384,8 @@ __export(httpClientAdapter_exports, {
   convertHttpClient: () => convertHttpClient
 });
 module.exports = __toCommonJS(httpClientAdapter_exports);
-var import_response = __nccwpck_require__(424);
-var import_util = __nccwpck_require__(117);
+var import_response = __nccwpck_require__(425);
+var import_util = __nccwpck_require__(119);
 function convertHttpClient(requestPolicyClient) {
   return {
     sendRequest: async (request) => {
@@ -52046,7 +52403,7 @@ function convertHttpClient(requestPolicyClient) {
 
 /***/ }),
 
-/***/ 220:
+/***/ 221:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52072,8 +52429,8 @@ __export(retryPolicy_exports, {
 });
 module.exports = __toCommonJS(retryPolicy_exports);
 var import_logger = __nccwpck_require__(48);
-var import_constants = __nccwpck_require__(166);
-var import_policies = __nccwpck_require__(294);
+var import_constants = __nccwpck_require__(168);
+var import_policies = __nccwpck_require__(295);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("core-rest-pipeline retryPolicy");
 function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAULT_RETRY_POLICY_COUNT }) {
   return (0, import_policies.retryPolicy)(strategies, {
@@ -52087,7 +52444,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 
 /***/ }),
 
-/***/ 221:
+/***/ 222:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52096,7 +52453,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getErrorMessage = getErrorMessage;
-const util_1 = __nccwpck_require__(154);
+const util_1 = __nccwpck_require__(156);
 /**
  * Given what is thought to be an error object, return the message if possible.
  * If the message is missing, returns a stringified version of the input.
@@ -52127,7 +52484,7 @@ function getErrorMessage(e) {
 
 /***/ }),
 
-/***/ 222:
+/***/ 223:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52166,14 +52523,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.restoreCache = exports.isFeatureAvailable = exports.FinalizeCacheError = exports.ReserveCacheError = exports.ValidationError = void 0;
-const core = __importStar(__nccwpck_require__(472));
-const path = __importStar(__nccwpck_require__(255));
+const core = __importStar(__nccwpck_require__(473));
+const path = __importStar(__nccwpck_require__(256));
 const utils = __importStar(__nccwpck_require__(82));
 const cacheHttpClient = __importStar(__nccwpck_require__(38));
 const cacheTwirpClient = __importStar(__nccwpck_require__(67));
 const config_1 = __nccwpck_require__(41);
-const tar_1 = __nccwpck_require__(453);
-const http_client_1 = __nccwpck_require__(293);
+const tar_1 = __nccwpck_require__(454);
+const http_client_1 = __nccwpck_require__(294);
 class ValidationError extends Error {
     constructor(message) {
         super(message);
@@ -52653,7 +53010,7 @@ function saveCacheV2(paths, key, options, enableCrossOsArchive = false) {
 
 /***/ }),
 
-/***/ 223:
+/***/ 224:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -52679,9 +53036,9 @@ __export(extendedClient_exports, {
 });
 module.exports = __toCommonJS(extendedClient_exports);
 var import_disableKeepAlivePolicy = __nccwpck_require__(9);
-var import_core_rest_pipeline = __nccwpck_require__(109);
-var import_core_client = __nccwpck_require__(452);
-var import_response = __nccwpck_require__(424);
+var import_core_rest_pipeline = __nccwpck_require__(111);
+var import_core_client = __nccwpck_require__(453);
+var import_response = __nccwpck_require__(425);
 class ExtendedServiceClient extends import_core_client.ServiceClient {
   constructor(options) {
     super(options);
@@ -52730,7 +53087,7 @@ class ExtendedServiceClient extends import_core_client.ServiceClient {
 
 /***/ }),
 
-/***/ 224:
+/***/ 225:
 /***/ ((module) => {
 
 /******************************************************************************
@@ -53188,7 +53545,7 @@ var __rewriteRelativeImportExtension;
 
 /***/ }),
 
-/***/ 225:
+/***/ 226:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53215,9 +53572,9 @@ __export(bearerTokenAuthenticationPolicy_exports, {
   parseChallenges: () => parseChallenges
 });
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(169);
-var import_log = __nccwpck_require__(190);
-var import_restError = __nccwpck_require__(364);
+var import_tokenCycler = __nccwpck_require__(171);
+var import_log = __nccwpck_require__(192);
+var import_restError = __nccwpck_require__(365);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
   try {
@@ -53407,7 +53764,7 @@ function getCaeChallengeClaims(challenges) {
 
 /***/ }),
 
-/***/ 226:
+/***/ 227:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53433,7 +53790,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(295);
 const systemErrorRetryPolicyName = import_policies.systemErrorRetryPolicyName;
 function systemErrorRetryPolicy(options = {}) {
   return (0, import_policies.systemErrorRetryPolicy)(options);
@@ -53444,7 +53801,7 @@ function systemErrorRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 227:
+/***/ 228:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53458,9 +53815,9 @@ function systemErrorRetryPolicy(options = {}) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
-const tslib_1 = __nccwpck_require__(224);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(186));
+const tslib_1 = __nccwpck_require__(225);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
 /** Class containing Container operations. */
 class ContainerImpl {
@@ -54172,7 +54529,7 @@ const getAccountInfoOperationSpec = {
 
 /***/ }),
 
-/***/ 228:
+/***/ 229:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -54217,7 +54574,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 229:
+/***/ 230:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -54246,7 +54603,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.safeTrimTrailingSeparator = exports.normalizeSeparators = exports.hasRoot = exports.hasAbsoluteRoot = exports.ensureAbsoluteRoot = exports.dirname = void 0;
-const path = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(256));
 const assert_1 = __importDefault(__nccwpck_require__(538));
 const IS_WINDOWS = process.platform === 'win32';
 /**
@@ -54422,20 +54779,20 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 
 /***/ }),
 
-/***/ 230:
+/***/ 231:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-module.exports = __nccwpck_require__(298)
-module.exports.async = __nccwpck_require__(423)
-module.exports.stream = __nccwpck_require__(432)
-module.exports.prettyError = __nccwpck_require__(286)
+module.exports = __nccwpck_require__(299)
+module.exports.async = __nccwpck_require__(424)
+module.exports.stream = __nccwpck_require__(433)
+module.exports.prettyError = __nccwpck_require__(287)
 
 
 /***/ }),
 
-/***/ 231:
+/***/ 232:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -54471,9 +54828,9 @@ exports.HttpProxyAgent = void 0;
 const net = __importStar(__nccwpck_require__(520));
 const tls = __importStar(__nccwpck_require__(517));
 const debug_1 = __importDefault(__nccwpck_require__(526));
-const events_1 = __nccwpck_require__(482);
-const agent_base_1 = __nccwpck_require__(248);
-const url_1 = __nccwpck_require__(92);
+const events_1 = __nccwpck_require__(483);
+const agent_base_1 = __nccwpck_require__(249);
+const url_1 = __nccwpck_require__(94);
 const debug = (0, debug_1.default)('http-proxy-agent');
 /**
  * The `HttpProxyAgent` implements an HTTP Agent subclass that connects
@@ -54590,7 +54947,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 232:
+/***/ 233:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -54627,7 +54984,7 @@ var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
 const fs = __importStar(__nccwpck_require__(542));
-const path = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(256));
 _a = fs.promises
 // export const {open} = 'fs'
 , exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
@@ -54780,7 +55137,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 233:
+/***/ 234:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -54789,8 +55146,8 @@ exports.getCmdPath = getCmdPath;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
-const tslib_1 = __nccwpck_require__(224);
-var poller_js_1 = __nccwpck_require__(331);
+const tslib_1 = __nccwpck_require__(225);
+var poller_js_1 = __nccwpck_require__(332);
 Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: function () { return poller_js_1.createHttpPoller; } }));
 /**
  * This can be uncommented to expose the protocol-agnostic poller
@@ -54804,14 +55161,14 @@ Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: fun
 // } from "./poller/models";
 // export { buildCreatePoller } from "./poller/poller";
 /** legacy */
-tslib_1.__exportStar(__nccwpck_require__(251), exports);
+tslib_1.__exportStar(__nccwpck_require__(252), exports);
 tslib_1.__exportStar(__nccwpck_require__(81), exports);
 tslib_1.__exportStar(__nccwpck_require__(44), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 234:
+/***/ 235:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -54857,7 +55214,7 @@ function apiVersionPolicy(options) {
 
 /***/ }),
 
-/***/ 235:
+/***/ 236:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -55104,7 +55461,7 @@ exports.AbortSignal = AbortSignal;
 
 /***/ }),
 
-/***/ 236:
+/***/ 237:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -55121,7 +55478,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 
 /***/ }),
 
-/***/ 237:
+/***/ 238:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55135,9 +55492,9 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
-const tslib_1 = __nccwpck_require__(224);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(186));
+const tslib_1 = __nccwpck_require__(225);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
 /** Class containing Service operations. */
 class ServiceImpl {
@@ -55457,7 +55814,7 @@ const filterBlobsOperationSpec = {
 
 /***/ }),
 
-/***/ 238:
+/***/ 239:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -55483,7 +55840,7 @@ __export(agentPolicy_exports, {
   agentPolicyName: () => agentPolicyName
 });
 module.exports = __toCommonJS(agentPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(295);
 const agentPolicyName = import_policies.agentPolicyName;
 function agentPolicy(agent) {
   return (0, import_policies.agentPolicy)(agent);
@@ -55494,13 +55851,13 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 239:
+/***/ 240:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { UndiciError } = __nccwpck_require__(500)
+const { UndiciError } = __nccwpck_require__(501)
 
 class MockNotMatchedError extends UndiciError {
   constructor (message) {
@@ -55519,13 +55876,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 240:
+/***/ 241:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Transform } = __nccwpck_require__(138)
+const { Transform } = __nccwpck_require__(140)
 const { Console } = __nccwpck_require__(36)
 
 /**
@@ -55567,7 +55924,7 @@ module.exports = class PendingInterceptorsFormatter {
 
 /***/ }),
 
-/***/ 241:
+/***/ 242:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55579,7 +55936,7 @@ const runtime_2 = __nccwpck_require__(21);
 const runtime_3 = __nccwpck_require__(21);
 const runtime_4 = __nccwpck_require__(21);
 const runtime_5 = __nccwpck_require__(21);
-const cachescope_1 = __nccwpck_require__(408);
+const cachescope_1 = __nccwpck_require__(409);
 // @generated message type with reflection information, may provide speed optimized methods
 class CacheMetadata$Type extends runtime_5.MessageType {
     constructor() {
@@ -55638,7 +55995,7 @@ exports.CacheMetadata = new CacheMetadata$Type();
 
 /***/ }),
 
-/***/ 242:
+/***/ 243:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -55663,8 +56020,8 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_ts_http_runtime = __nccwpck_require__(97);
-var import_wrapAbortSignal = __nccwpck_require__(458);
+var import_ts_http_runtime = __nccwpck_require__(99);
+var import_wrapAbortSignal = __nccwpck_require__(459);
 function createDefaultHttpClient() {
   const client = (0, import_ts_http_runtime.createDefaultHttpClient)();
   return {
@@ -55685,7 +56042,7 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 243:
+/***/ 244:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -55760,12 +56117,12 @@ exports.isEncryptedArchive = isEncryptedArchive;
 exports.getEncryptionConfig = getEncryptionConfig;
 exports.decryptedTempPathFor = decryptedTempPathFor;
 exports._testInMemoryRoundTrip = _testInMemoryRoundTrip;
-const crypto = __importStar(__nccwpck_require__(281));
-const fs = __importStar(__nccwpck_require__(256));
-const fsp = __importStar(__nccwpck_require__(116));
+const crypto = __importStar(__nccwpck_require__(282));
+const fs = __importStar(__nccwpck_require__(257));
+const fsp = __importStar(__nccwpck_require__(118));
 const path = __importStar(__nccwpck_require__(519));
-const os = __importStar(__nccwpck_require__(391));
-const promises_1 = __nccwpck_require__(401);
+const os = __importStar(__nccwpck_require__(392));
+const promises_1 = __nccwpck_require__(402);
 exports.ENCRYPT_MAGIC = Buffer.from("SOLDRENC", "ascii");
 exports.ENCRYPT_VERSION = 0x01;
 exports.IV_BYTES = 12;
@@ -55989,7 +56346,7 @@ exports.tmpdir = os.tmpdir;
 
 /***/ }),
 
-/***/ 244:
+/***/ 245:
 /***/ ((module) => {
 
 "use strict";
@@ -55997,7 +56354,7 @@ module.exports = require("node:process");
 
 /***/ }),
 
-/***/ 245:
+/***/ 246:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56007,8 +56364,8 @@ module.exports = require("node:process");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRequestUrl = getRequestUrl;
 exports.appendQueryParams = appendQueryParams;
-const operationHelpers_js_1 = __nccwpck_require__(444);
-const interfaceHelpers_js_1 = __nccwpck_require__(411);
+const operationHelpers_js_1 = __nccwpck_require__(445);
+const interfaceHelpers_js_1 = __nccwpck_require__(412);
 const CollectionFormatToDelimiterMap = {
     CSV: ",",
     SSV: " ",
@@ -56241,7 +56598,7 @@ function appendQueryParams(url, queryParams, sequenceParams, noOverwrite = false
 
 /***/ }),
 
-/***/ 246:
+/***/ 247:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -56267,7 +56624,7 @@ __export(decompressResponsePolicy_exports, {
   decompressResponsePolicyName: () => decompressResponsePolicyName
 });
 module.exports = __toCommonJS(decompressResponsePolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(295);
 const decompressResponsePolicyName = import_policies.decompressResponsePolicyName;
 function decompressResponsePolicy() {
   return (0, import_policies.decompressResponsePolicy)();
@@ -56278,7 +56635,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 247:
+/***/ 248:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -56325,7 +56682,7 @@ function ndJsonPolicy() {
 
 /***/ }),
 
-/***/ 248:
+/***/ 249:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -56359,9 +56716,9 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Agent = void 0;
 const net = __importStar(__nccwpck_require__(520));
-const http = __importStar(__nccwpck_require__(340));
+const http = __importStar(__nccwpck_require__(341));
 const https_1 = __nccwpck_require__(76);
-__exportStar(__nccwpck_require__(168), exports);
+__exportStar(__nccwpck_require__(170), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
 class Agent extends http.Agent {
     constructor(opts) {
@@ -56510,7 +56867,7 @@ exports.Agent = Agent;
 
 /***/ }),
 
-/***/ 249:
+/***/ 250:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -56553,7 +56910,7 @@ exports.mergeJsonOptions = mergeJsonOptions;
 
 /***/ }),
 
-/***/ 250:
+/***/ 251:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -56578,7 +56935,7 @@ __export(httpHeaders_exports, {
   createHttpHeaders: () => createHttpHeaders
 });
 module.exports = __toCommonJS(httpHeaders_exports);
-var import_ts_http_runtime = __nccwpck_require__(97);
+var import_ts_http_runtime = __nccwpck_require__(99);
 function createHttpHeaders(rawHeaders) {
   return (0, import_ts_http_runtime.createHttpHeaders)(rawHeaders);
 }
@@ -56588,7 +56945,7 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 251:
+/***/ 252:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56597,13 +56954,13 @@ function createHttpHeaders(rawHeaders) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-var lroEngine_js_1 = __nccwpck_require__(184);
+var lroEngine_js_1 = __nccwpck_require__(186);
 Object.defineProperty(exports, "LroEngine", ({ enumerable: true, get: function () { return lroEngine_js_1.LroEngine; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 252:
+/***/ 253:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -56628,7 +56985,7 @@ __export(pipeline_exports, {
   createEmptyPipeline: () => createEmptyPipeline
 });
 module.exports = __toCommonJS(pipeline_exports);
-var import_ts_http_runtime = __nccwpck_require__(97);
+var import_ts_http_runtime = __nccwpck_require__(99);
 function createEmptyPipeline() {
   return (0, import_ts_http_runtime.createEmptyPipeline)();
 }
@@ -56638,7 +56995,7 @@ function createEmptyPipeline() {
 
 /***/ }),
 
-/***/ 253:
+/***/ 254:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -56677,7 +57034,7 @@ __export(logger_exports, {
   setLogLevel: () => setLogLevel
 });
 module.exports = __toCommonJS(logger_exports);
-var import_debug = __toESM(__nccwpck_require__(479));
+var import_debug = __toESM(__nccwpck_require__(480));
 const TYPESPEC_RUNTIME_LOG_LEVELS = ["verbose", "info", "warning", "error"];
 const levelMap = {
   verbose: 400,
@@ -56783,7 +57140,7 @@ function createClientLogger(namespace) {
 
 /***/ }),
 
-/***/ 254:
+/***/ 255:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -56830,7 +57187,7 @@ function isTokenCredential(credential) {
 
 /***/ }),
 
-/***/ 255:
+/***/ 256:
 /***/ ((module) => {
 
 "use strict";
@@ -56838,7 +57195,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 256:
+/***/ 257:
 /***/ ((module) => {
 
 "use strict";
@@ -56846,15 +57203,15 @@ module.exports = require("node:fs");
 
 /***/ }),
 
-/***/ 257:
+/***/ 258:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(469)
+const { webidl } = __nccwpck_require__(470)
 const { kEnumerableProperty } = __nccwpck_require__(75)
-const { MessagePort } = __nccwpck_require__(330)
+const { MessagePort } = __nccwpck_require__(331)
 
 /**
  * @see https://html.spec.whatwg.org/multipage/comms.html#messageevent
@@ -57157,16 +57514,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 258:
+/***/ 259:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryWriter = exports.binaryWriteOptions = void 0;
-const pb_long_1 = __nccwpck_require__(124);
-const goog_varint_1 = __nccwpck_require__(211);
-const assert_1 = __nccwpck_require__(496);
+const pb_long_1 = __nccwpck_require__(126);
+const goog_varint_1 = __nccwpck_require__(212);
+const assert_1 = __nccwpck_require__(497);
 const defaultsWrite = {
     writeUnknownFields: true,
     writerFactory: () => new BinaryWriter(),
@@ -57397,7 +57754,7 @@ exports.BinaryWriter = BinaryWriter;
 
 /***/ }),
 
-/***/ 259:
+/***/ 260:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57406,9 +57763,9 @@ exports.BinaryWriter = BinaryWriter;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
-const AvroReadable_js_1 = __nccwpck_require__(397);
+const AvroReadable_js_1 = __nccwpck_require__(398);
 const abort_controller_1 = __nccwpck_require__(508);
-const buffer_1 = __nccwpck_require__(126);
+const buffer_1 = __nccwpck_require__(128);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
 class AvroReadableFromStream extends AvroReadable_js_1.AvroReadable {
     _position;
@@ -57494,7 +57851,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 
 /***/ }),
 
-/***/ 260:
+/***/ 261:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57503,7 +57860,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 let _defaultHttpClient;
 function getCachedDefaultHttpClient() {
     if (!_defaultHttpClient) {
@@ -57515,7 +57872,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 261:
+/***/ 262:
 /***/ ((module) => {
 
 "use strict";
@@ -57552,13 +57909,13 @@ module.exports = class Pluralizer {
 
 /***/ }),
 
-/***/ 262:
+/***/ 263:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const RedirectHandler = __nccwpck_require__(400)
+const RedirectHandler = __nccwpck_require__(401)
 
 function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections }) {
   return (dispatch) => {
@@ -57581,7 +57938,7 @@ module.exports = createRedirectInterceptor
 
 /***/ }),
 
-/***/ 263:
+/***/ 264:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -57607,7 +57964,7 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(440);
+var import_userAgentPlatform = __nccwpck_require__(441);
 var import_constants = __nccwpck_require__(53);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
@@ -57635,7 +57992,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 264:
+/***/ 265:
 /***/ ((module) => {
 
 "use strict";
@@ -57643,7 +58000,7 @@ module.exports = require("stream/web");
 
 /***/ }),
 
-/***/ 265:
+/***/ 266:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57653,8 +58010,8 @@ module.exports = require("stream/web");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getBodyAsText = getBodyAsText;
 exports.utf8ByteLength = utf8ByteLength;
-const utils_js_1 = __nccwpck_require__(210);
-const constants_js_1 = __nccwpck_require__(156);
+const utils_js_1 = __nccwpck_require__(211);
+const constants_js_1 = __nccwpck_require__(158);
 async function getBodyAsText(batchResponse) {
     let buffer = Buffer.alloc(constants_js_1.BATCH_MAX_PAYLOAD_IN_BYTES);
     const responseLength = await (0, utils_js_1.streamToBuffer2)(batchResponse.readableStreamBody, buffer);
@@ -57669,7 +58026,7 @@ function utf8ByteLength(str) {
 
 /***/ }),
 
-/***/ 266:
+/***/ 267:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -57695,7 +58052,7 @@ __export(wrapAbortSignalLikePolicy_exports, {
   wrapAbortSignalLikePolicyName: () => wrapAbortSignalLikePolicyName
 });
 module.exports = __toCommonJS(wrapAbortSignalLikePolicy_exports);
-var import_wrapAbortSignal = __nccwpck_require__(458);
+var import_wrapAbortSignal = __nccwpck_require__(459);
 const wrapAbortSignalLikePolicyName = "wrapAbortSignalLikePolicy";
 function wrapAbortSignalLikePolicy() {
   return {
@@ -57720,7 +58077,7 @@ function wrapAbortSignalLikePolicy() {
 
 /***/ }),
 
-/***/ 267:
+/***/ 268:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57772,7 +58129,7 @@ function createAbortablePromise(buildPromise, options) {
 
 /***/ }),
 
-/***/ 268:
+/***/ 269:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -57811,8 +58168,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.retryHttpClientResponse = exports.retryTypedResponse = exports.retry = exports.isRetryableStatusCode = exports.isServerErrorStatusCode = exports.isSuccessStatusCode = void 0;
-const core = __importStar(__nccwpck_require__(472));
-const http_client_1 = __nccwpck_require__(293);
+const core = __importStar(__nccwpck_require__(473));
+const http_client_1 = __nccwpck_require__(294);
 const constants_1 = __nccwpck_require__(49);
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
@@ -57916,7 +58273,7 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 
 /***/ }),
 
-/***/ 269:
+/***/ 270:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57925,9 +58282,9 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(281);
-const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(134);
-const Credential_js_1 = __nccwpck_require__(103);
+const node_crypto_1 = __nccwpck_require__(282);
+const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(136);
+const Credential_js_1 = __nccwpck_require__(105);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -57975,7 +58332,7 @@ exports.StorageSharedKeyCredential = StorageSharedKeyCredential;
 
 /***/ }),
 
-/***/ 270:
+/***/ 271:
 /***/ ((module) => {
 
 "use strict";
@@ -57983,7 +58340,7 @@ module.exports = require("node:http");
 
 /***/ }),
 
-/***/ 271:
+/***/ 272:
 /***/ ((module) => {
 
 "use strict";
@@ -57991,7 +58348,7 @@ module.exports = require("node:buffer");
 
 /***/ }),
 
-/***/ 272:
+/***/ 273:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -58021,7 +58378,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDownloadOptions = exports.getUploadOptions = void 0;
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 /**
  * Returns a copy of the upload options with defaults filled in.
  *
@@ -58115,7 +58472,7 @@ exports.getDownloadOptions = getDownloadOptions;
 
 /***/ }),
 
-/***/ 273:
+/***/ 274:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -58124,7 +58481,7 @@ exports.getDownloadOptions = getDownloadOptions;
 const net = __nccwpck_require__(520)
 const assert = __nccwpck_require__(538)
 const util = __nccwpck_require__(75)
-const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(500)
+const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(501)
 
 let tls // include tls conditionally since it is not always available
 
@@ -58312,7 +58669,7 @@ module.exports = buildConnector
 
 /***/ }),
 
-/***/ 274:
+/***/ 275:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -58321,7 +58678,7 @@ module.exports = buildConnector
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageContextClient = void 0;
-const index_js_1 = __nccwpck_require__(306);
+const index_js_1 = __nccwpck_require__(307);
 /**
  * @internal
  */
@@ -58340,7 +58697,7 @@ exports.StorageContextClient = StorageContextClient;
 
 /***/ }),
 
-/***/ 275:
+/***/ 276:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -58366,7 +58723,7 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(295);
 const formDataPolicyName = import_policies.formDataPolicyName;
 function formDataPolicy() {
   return (0, import_policies.formDataPolicy)();
@@ -58377,7 +58734,7 @@ function formDataPolicy() {
 
 /***/ }),
 
-/***/ 276:
+/***/ 277:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -58403,9 +58760,9 @@ __export(multipart_exports, {
   buildMultipartBody: () => buildMultipartBody
 });
 module.exports = __toCommonJS(multipart_exports);
-var import_restError = __nccwpck_require__(457);
-var import_httpHeaders = __nccwpck_require__(497);
-var import_bytesEncoding = __nccwpck_require__(296);
+var import_restError = __nccwpck_require__(458);
+var import_httpHeaders = __nccwpck_require__(498);
+var import_bytesEncoding = __nccwpck_require__(297);
 var import_typeGuards = __nccwpck_require__(509);
 function getHeaderValue(descriptor, headerName) {
   if (descriptor.headers) {
@@ -58515,7 +58872,7 @@ function buildMultipartBody(parts) {
 
 /***/ }),
 
-/***/ 277:
+/***/ 278:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58532,7 +58889,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 278:
+/***/ 279:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -58558,8 +58915,8 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_policies = __nccwpck_require__(294);
-var import_file = __nccwpck_require__(338);
+var import_policies = __nccwpck_require__(295);
+var import_file = __nccwpck_require__(339);
 const multipartPolicyName = import_policies.multipartPolicyName;
 function multipartPolicy() {
   const tspPolicy = (0, import_policies.multipartPolicy)();
@@ -58583,7 +58940,7 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 279:
+/***/ 280:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58678,13 +59035,13 @@ exports.listEnumNumbers = listEnumNumbers;
 
 /***/ }),
 
-/***/ 280:
+/***/ 281:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(538)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(202)
-const { RequestRetryError } = __nccwpck_require__(500)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(204)
+const { RequestRetryError } = __nccwpck_require__(501)
 const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(75)
 
 function calculateRetryAfterHeader (retryAfter) {
@@ -59021,7 +59378,7 @@ module.exports = RetryHandler
 
 /***/ }),
 
-/***/ 281:
+/***/ 282:
 /***/ ((module) => {
 
 "use strict";
@@ -59029,7 +59386,7 @@ module.exports = require("node:crypto");
 
 /***/ }),
 
-/***/ 282:
+/***/ 283:
 /***/ (function(module) {
 
 "use strict";
@@ -59151,7 +59508,7 @@ module.exports = decodeText
 
 /***/ }),
 
-/***/ 283:
+/***/ 284:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -59208,7 +59565,7 @@ exports.readJournal = readJournal;
 exports.summarize = summarize;
 exports.formatJournalSection = formatJournalSection;
 exports.formatRollupsSection = formatRollupsSection;
-const fs = __importStar(__nccwpck_require__(256));
+const fs = __importStar(__nccwpck_require__(257));
 const diagnostics_js_1 = __nccwpck_require__(54);
 const SLOWEST_TOP_N = 20;
 /**
@@ -59502,7 +59859,7 @@ function formatRollupsSection(report) {
 
 /***/ }),
 
-/***/ 284:
+/***/ 285:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59511,32 +59868,32 @@ function formatRollupsSection(report) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
-const tslib_1 = __nccwpck_require__(224);
-tslib_1.__exportStar(__nccwpck_require__(372), exports);
-var cache_js_1 = __nccwpck_require__(260);
+const tslib_1 = __nccwpck_require__(225);
+tslib_1.__exportStar(__nccwpck_require__(373), exports);
+var cache_js_1 = __nccwpck_require__(261);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(88), exports);
-tslib_1.__exportStar(__nccwpck_require__(163), exports);
-tslib_1.__exportStar(__nccwpck_require__(409), exports);
-tslib_1.__exportStar(__nccwpck_require__(103), exports);
-tslib_1.__exportStar(__nccwpck_require__(269), exports);
-tslib_1.__exportStar(__nccwpck_require__(337), exports);
+tslib_1.__exportStar(__nccwpck_require__(89), exports);
+tslib_1.__exportStar(__nccwpck_require__(165), exports);
+tslib_1.__exportStar(__nccwpck_require__(410), exports);
+tslib_1.__exportStar(__nccwpck_require__(105), exports);
+tslib_1.__exportStar(__nccwpck_require__(270), exports);
+tslib_1.__exportStar(__nccwpck_require__(338), exports);
 var RequestPolicy_js_1 = __nccwpck_require__(50);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
-tslib_1.__exportStar(__nccwpck_require__(101), exports);
-tslib_1.__exportStar(__nccwpck_require__(319), exports);
-tslib_1.__exportStar(__nccwpck_require__(215), exports);
-tslib_1.__exportStar(__nccwpck_require__(476), exports);
-tslib_1.__exportStar(__nccwpck_require__(173), exports);
-tslib_1.__exportStar(__nccwpck_require__(134), exports);
-tslib_1.__exportStar(__nccwpck_require__(84), exports);
-tslib_1.__exportStar(__nccwpck_require__(439), exports);
+tslib_1.__exportStar(__nccwpck_require__(103), exports);
+tslib_1.__exportStar(__nccwpck_require__(320), exports);
+tslib_1.__exportStar(__nccwpck_require__(216), exports);
+tslib_1.__exportStar(__nccwpck_require__(477), exports);
 tslib_1.__exportStar(__nccwpck_require__(175), exports);
+tslib_1.__exportStar(__nccwpck_require__(136), exports);
+tslib_1.__exportStar(__nccwpck_require__(84), exports);
+tslib_1.__exportStar(__nccwpck_require__(440), exports);
+tslib_1.__exportStar(__nccwpck_require__(177), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 285:
+/***/ 286:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59549,18 +59906,18 @@ tslib_1.__exportStar(__nccwpck_require__(175), exports);
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(224);
-tslib_1.__exportStar(__nccwpck_require__(237), exports);
-tslib_1.__exportStar(__nccwpck_require__(227), exports);
+const tslib_1 = __nccwpck_require__(225);
+tslib_1.__exportStar(__nccwpck_require__(238), exports);
+tslib_1.__exportStar(__nccwpck_require__(228), exports);
 tslib_1.__exportStar(__nccwpck_require__(51), exports);
-tslib_1.__exportStar(__nccwpck_require__(290), exports);
+tslib_1.__exportStar(__nccwpck_require__(291), exports);
 tslib_1.__exportStar(__nccwpck_require__(28), exports);
-tslib_1.__exportStar(__nccwpck_require__(366), exports);
+tslib_1.__exportStar(__nccwpck_require__(367), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 286:
+/***/ 287:
 /***/ ((module) => {
 
 "use strict";
@@ -59601,7 +59958,7 @@ function prettyError (err, buf) {
 
 /***/ }),
 
-/***/ 287:
+/***/ 288:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59831,7 +60188,7 @@ exports.ContainerSASPermissions = ContainerSASPermissions;
 
 /***/ }),
 
-/***/ 288:
+/***/ 289:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -59901,8 +60258,8 @@ exports.toolVersionsFor = toolVersionsFor;
 exports.crossToolCachePathsFor = crossToolCachePathsFor;
 exports.executeCrossBootstrap = executeCrossBootstrap;
 const path = __importStar(__nccwpck_require__(519));
-const core = __importStar(__nccwpck_require__(472));
-const io = __importStar(__nccwpck_require__(304));
+const core = __importStar(__nccwpck_require__(473));
+const io = __importStar(__nccwpck_require__(305));
 const log_utils_js_1 = __nccwpck_require__(52);
 /** Normalize an os-ish string (RUNNER_OS, process.platform, ...) to one of
  *  `linux` | `darwin` | `windows`.
@@ -60152,7 +60509,7 @@ async function executeCrossBootstrap(plan, opts = {}) {
 
 /***/ }),
 
-/***/ 289:
+/***/ 290:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60178,20 +60535,20 @@ __export(createPipelineFromOptions_exports, {
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(77);
-var import_pipeline = __nccwpck_require__(252);
-var import_redirectPolicy = __nccwpck_require__(351);
-var import_userAgentPolicy = __nccwpck_require__(399);
-var import_multipartPolicy = __nccwpck_require__(278);
-var import_decompressResponsePolicy = __nccwpck_require__(246);
+var import_pipeline = __nccwpck_require__(253);
+var import_redirectPolicy = __nccwpck_require__(352);
+var import_userAgentPolicy = __nccwpck_require__(400);
+var import_multipartPolicy = __nccwpck_require__(279);
+var import_decompressResponsePolicy = __nccwpck_require__(247);
 var import_defaultRetryPolicy = __nccwpck_require__(61);
-var import_formDataPolicy = __nccwpck_require__(275);
+var import_formDataPolicy = __nccwpck_require__(276);
 var import_core_util = __nccwpck_require__(15);
-var import_proxyPolicy = __nccwpck_require__(485);
-var import_setClientRequestIdPolicy = __nccwpck_require__(158);
-var import_agentPolicy = __nccwpck_require__(238);
-var import_tlsPolicy = __nccwpck_require__(386);
-var import_tracingPolicy = __nccwpck_require__(347);
-var import_wrapAbortSignalLikePolicy = __nccwpck_require__(266);
+var import_proxyPolicy = __nccwpck_require__(486);
+var import_setClientRequestIdPolicy = __nccwpck_require__(160);
+var import_agentPolicy = __nccwpck_require__(239);
+var import_tlsPolicy = __nccwpck_require__(387);
+var import_tracingPolicy = __nccwpck_require__(348);
+var import_wrapAbortSignalLikePolicy = __nccwpck_require__(267);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_core_util.isNodeLike) {
@@ -60225,7 +60582,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 290:
+/***/ 291:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60239,9 +60596,9 @@ function createPipelineFromOptions(options) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(224);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(186));
+const tslib_1 = __nccwpck_require__(225);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
 /** Class containing PageBlob operations. */
 class PageBlobImpl {
@@ -60695,15 +61052,15 @@ const copyIncrementalOperationSpec = {
 
 /***/ }),
 
-/***/ 291:
+/***/ 292:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(164)
+const { kConstruct } = __nccwpck_require__(166)
 const { Cache } = __nccwpck_require__(13)
-const { webidl } = __nccwpck_require__(469)
+const { webidl } = __nccwpck_require__(470)
 const { kEnumerableProperty } = __nccwpck_require__(75)
 
 class CacheStorage {
@@ -60847,7 +61204,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 292:
+/***/ 293:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60856,9 +61213,9 @@ module.exports = {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createClientPipeline = createClientPipeline;
-const deserializationPolicy_js_1 = __nccwpck_require__(93);
-const core_rest_pipeline_1 = __nccwpck_require__(109);
-const serializationPolicy_js_1 = __nccwpck_require__(501);
+const deserializationPolicy_js_1 = __nccwpck_require__(95);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
+const serializationPolicy_js_1 = __nccwpck_require__(502);
 /**
  * Creates a new Pipeline for use with a Service Client.
  * Adds in deserializationPolicy by default.
@@ -60883,7 +61240,7 @@ function createClientPipeline(options = {}) {
 
 /***/ }),
 
-/***/ 293:
+/***/ 294:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -60923,11 +61280,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
-const http = __importStar(__nccwpck_require__(340));
+const http = __importStar(__nccwpck_require__(341));
 const https = __importStar(__nccwpck_require__(76));
-const pm = __importStar(__nccwpck_require__(321));
+const pm = __importStar(__nccwpck_require__(322));
 const tunnel = __importStar(__nccwpck_require__(532));
-const undici_1 = __nccwpck_require__(170);
+const undici_1 = __nccwpck_require__(172);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -61542,7 +61899,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 294:
+/***/ 295:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -61594,20 +61951,20 @@ __export(internal_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(internal_exports);
-var import_agentPolicy = __nccwpck_require__(477);
-var import_decompressResponsePolicy = __nccwpck_require__(367);
-var import_defaultRetryPolicy = __nccwpck_require__(336);
+var import_agentPolicy = __nccwpck_require__(478);
+var import_decompressResponsePolicy = __nccwpck_require__(368);
+var import_defaultRetryPolicy = __nccwpck_require__(337);
 var import_exponentialRetryPolicy = __nccwpck_require__(535);
 var import_retryPolicy = __nccwpck_require__(17);
 var import_systemErrorRetryPolicy = __nccwpck_require__(30);
 var import_throttlingRetryPolicy = __nccwpck_require__(533);
-var import_formDataPolicy = __nccwpck_require__(350);
-var import_logPolicy = __nccwpck_require__(110);
-var import_multipartPolicy = __nccwpck_require__(176);
+var import_formDataPolicy = __nccwpck_require__(351);
+var import_logPolicy = __nccwpck_require__(112);
+var import_multipartPolicy = __nccwpck_require__(178);
 var import_proxyPolicy = __nccwpck_require__(43);
-var import_redirectPolicy = __nccwpck_require__(329);
-var import_tlsPolicy = __nccwpck_require__(228);
-var import_userAgentPolicy = __nccwpck_require__(370);
+var import_redirectPolicy = __nccwpck_require__(330);
+var import_tlsPolicy = __nccwpck_require__(229);
+var import_userAgentPolicy = __nccwpck_require__(371);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -61615,7 +61972,7 @@ var import_userAgentPolicy = __nccwpck_require__(370);
 
 /***/ }),
 
-/***/ 295:
+/***/ 296:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61806,7 +62163,7 @@ async function verifySoldr(opts) {
 
 /***/ }),
 
-/***/ 296:
+/***/ 297:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -61845,7 +62202,7 @@ function stringToUint8Array(value, format) {
 
 /***/ }),
 
-/***/ 297:
+/***/ 298:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -61969,15 +62326,15 @@ function buildOutputs(result) {
 
 /***/ }),
 
-/***/ 298:
+/***/ 299:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseString
 
-const TOMLParser = __nccwpck_require__(356)
-const prettyError = __nccwpck_require__(286)
+const TOMLParser = __nccwpck_require__(357)
+const prettyError = __nccwpck_require__(287)
 
 function parseString (str) {
   if (global.Buffer && global.Buffer.isBuffer(str)) {
@@ -61995,7 +62352,7 @@ function parseString (str) {
 
 /***/ }),
 
-/***/ 299:
+/***/ 300:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62007,11 +62364,11 @@ exports.generateAccountSASQueryParameters = generateAccountSASQueryParameters;
 exports.generateAccountSASQueryParametersInternal = generateAccountSASQueryParametersInternal;
 const AccountSASPermissions_js_1 = __nccwpck_require__(64);
 const AccountSASResourceTypes_js_1 = __nccwpck_require__(2);
-const AccountSASServices_js_1 = __nccwpck_require__(388);
-const SasIPRange_js_1 = __nccwpck_require__(369);
+const AccountSASServices_js_1 = __nccwpck_require__(389);
+const SasIPRange_js_1 = __nccwpck_require__(370);
 const SASQueryParameters_js_1 = __nccwpck_require__(537);
-const constants_js_1 = __nccwpck_require__(156);
-const utils_common_js_1 = __nccwpck_require__(162);
+const constants_js_1 = __nccwpck_require__(158);
+const utils_common_js_1 = __nccwpck_require__(164);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -62106,15 +62463,15 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 
 /***/ }),
 
-/***/ 300:
+/***/ 301:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
-const reflection_info_1 = __nccwpck_require__(465);
-const oneof_1 = __nccwpck_require__(197);
+const reflection_info_1 = __nccwpck_require__(466);
+const oneof_1 = __nccwpck_require__(199);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
     constructor(info) {
@@ -62344,7 +62701,7 @@ exports.ReflectionTypeCheck = ReflectionTypeCheck;
 
 /***/ }),
 
-/***/ 301:
+/***/ 302:
 /***/ ((module) => {
 
 "use strict";
@@ -62352,7 +62709,7 @@ module.exports = require("crypto");
 
 /***/ }),
 
-/***/ 302:
+/***/ 303:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62378,8 +62735,8 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(123);
-var import_constants = __nccwpck_require__(166);
+var import_userAgentPlatform = __nccwpck_require__(125);
+var import_constants = __nccwpck_require__(168);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
   for (const [key, value] of telemetryInfo) {
@@ -62405,7 +62762,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 303:
+/***/ 304:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62479,7 +62836,7 @@ function copy(a, into) {
 
 /***/ }),
 
-/***/ 304:
+/***/ 305:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -62515,8 +62872,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
 const assert_1 = __nccwpck_require__(538);
-const path = __importStar(__nccwpck_require__(255));
-const ioUtil = __importStar(__nccwpck_require__(232));
+const path = __importStar(__nccwpck_require__(256));
+const ioUtil = __importStar(__nccwpck_require__(233));
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -62785,14 +63142,14 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 305:
+/***/ 306:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.maskSecretUrls = exports.maskSigUrl = void 0;
-const core_1 = __nccwpck_require__(472);
+const core_1 = __nccwpck_require__(473);
 /**
  * Masks the `sig` parameter in a URL and sets it as a secret.
  *
@@ -62866,7 +63223,7 @@ exports.maskSecretUrls = maskSecretUrls;
 
 /***/ }),
 
-/***/ 306:
+/***/ 307:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62880,16 +63237,16 @@ exports.maskSecretUrls = maskSecretUrls;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(224);
-tslib_1.__exportStar(__nccwpck_require__(484), exports);
-var storageClient_js_1 = __nccwpck_require__(459);
+const tslib_1 = __nccwpck_require__(225);
+tslib_1.__exportStar(__nccwpck_require__(485), exports);
+var storageClient_js_1 = __nccwpck_require__(460);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(172), exports);
+tslib_1.__exportStar(__nccwpck_require__(174), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 307:
+/***/ 308:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -62939,7 +63296,7 @@ exports.AzureKeyCredential = AzureKeyCredential;
 
 /***/ }),
 
-/***/ 308:
+/***/ 309:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62948,9 +63305,9 @@ exports.AzureKeyCredential = AzureKeyCredential;
 const {
   InvalidArgumentError,
   NotSupportedError
-} = __nccwpck_require__(500)
+} = __nccwpck_require__(501)
 const assert = __nccwpck_require__(538)
-const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(202)
+const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(204)
 const util = __nccwpck_require__(75)
 
 // tokenRegExp and headerCharRegex have been lifted from
@@ -62981,7 +63338,7 @@ const channels = {}
 let extractBody
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(149)
+  const diagnosticsChannel = __nccwpck_require__(151)
   channels.create = diagnosticsChannel.channel('undici:request:create')
   channels.bodySent = diagnosticsChannel.channel('undici:request:bodySent')
   channels.headers = diagnosticsChannel.channel('undici:request:headers')
@@ -63446,7 +63803,7 @@ module.exports = Request
 
 /***/ }),
 
-/***/ 309:
+/***/ 310:
 /***/ ((module) => {
 
 "use strict";
@@ -63750,17 +64107,17 @@ function stringifyComplexTable (prefix, indent, key, value) {
 
 /***/ }),
 
-/***/ 310:
+/***/ 311:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(469)
+const { webidl } = __nccwpck_require__(470)
 const { DOMException } = __nccwpck_require__(33)
 const { URLSerializer } = __nccwpck_require__(27)
-const { getGlobalOrigin } = __nccwpck_require__(147)
-const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(478)
+const { getGlobalOrigin } = __nccwpck_require__(149)
+const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(479)
 const {
   kWebSocketURL,
   kReadyState,
@@ -63769,14 +64126,14 @@ const {
   kResponse,
   kSentClose,
   kByteParser
-} = __nccwpck_require__(106)
+} = __nccwpck_require__(108)
 const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(63)
-const { establishWebSocketConnection } = __nccwpck_require__(374)
-const { WebsocketFrameSend } = __nccwpck_require__(193)
-const { ByteParser } = __nccwpck_require__(494)
+const { establishWebSocketConnection } = __nccwpck_require__(375)
+const { WebsocketFrameSend } = __nccwpck_require__(195)
+const { ByteParser } = __nccwpck_require__(495)
 const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(75)
-const { getGlobalDispatcher } = __nccwpck_require__(384)
-const { types } = __nccwpck_require__(131)
+const { getGlobalDispatcher } = __nccwpck_require__(385)
+const { types } = __nccwpck_require__(133)
 
 let experimentalWarned = false
 
@@ -64399,7 +64756,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 311:
+/***/ 312:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -64451,11 +64808,11 @@ exports.rustChannelManifestRelease = rustChannelManifestRelease;
 exports.resolveToolchainCacheChannel = resolveToolchainCacheChannel;
 exports.loadToolchainSpec = loadToolchainSpec;
 exports.systemRustupSatisfiesRequest = systemRustupSatisfiesRequest;
-const node_crypto_1 = __nccwpck_require__(281);
-const fs = __importStar(__nccwpck_require__(256));
+const node_crypto_1 = __nccwpck_require__(282);
+const fs = __importStar(__nccwpck_require__(257));
 const path = __importStar(__nccwpck_require__(519));
-const toml = __importStar(__nccwpck_require__(412));
-const io = __importStar(__nccwpck_require__(304));
+const toml = __importStar(__nccwpck_require__(413));
+const io = __importStar(__nccwpck_require__(305));
 const exec = __importStar(__nccwpck_require__(19));
 const ROLLING_TOOLCHAIN_ALIASES = ["stable", "beta", "nightly"];
 /**
@@ -64787,7 +65144,7 @@ async function defaultWhich(cmd) {
 
 /***/ }),
 
-/***/ 312:
+/***/ 313:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65122,7 +65479,7 @@ class AvroRecordType extends AvroType {
 
 /***/ }),
 
-/***/ 313:
+/***/ 314:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65248,7 +65605,7 @@ exports.base64encode = base64encode;
 
 /***/ }),
 
-/***/ 314:
+/***/ 315:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65273,7 +65630,7 @@ __export(concat_exports, {
   concat: () => concat
 });
 module.exports = __toCommonJS(concat_exports);
-var import_stream = __nccwpck_require__(138);
+var import_stream = __nccwpck_require__(140);
 var import_typeGuards = __nccwpck_require__(509);
 async function* streamAsyncIterator() {
   const reader = this.getReader();
@@ -65335,7 +65692,7 @@ async function concat(sources) {
 
 /***/ }),
 
-/***/ 315:
+/***/ 316:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65412,7 +65769,7 @@ UsageError.isUsageErrorMessage = (msg) => {
 
 /***/ }),
 
-/***/ 316:
+/***/ 317:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -65469,7 +65826,7 @@ exports.DuplexStreamingCall = DuplexStreamingCall;
 
 /***/ }),
 
-/***/ 317:
+/***/ 318:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65647,7 +66004,7 @@ exports.RpcOutputStreamController = RpcOutputStreamController;
 
 /***/ }),
 
-/***/ 318:
+/***/ 319:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65669,7 +66026,7 @@ exports.enumToMap = enumToMap;
 
 /***/ }),
 
-/***/ 319:
+/***/ 320:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65709,7 +66066,7 @@ exports.CredentialPolicy = CredentialPolicy;
 
 /***/ }),
 
-/***/ 320:
+/***/ 321:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65718,11 +66075,11 @@ exports.CredentialPolicy = CredentialPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BatchResponseParser = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_http_compat_1 = __nccwpck_require__(79);
-const constants_js_1 = __nccwpck_require__(156);
-const BatchUtils_js_1 = __nccwpck_require__(265);
-const log_js_1 = __nccwpck_require__(114);
+const constants_js_1 = __nccwpck_require__(158);
+const BatchUtils_js_1 = __nccwpck_require__(266);
+const log_js_1 = __nccwpck_require__(116);
 const HTTP_HEADER_DELIMITER = ": ";
 const SPACE_DELIMITER = " ";
 const NOT_FOUND = -1;
@@ -65862,7 +66219,7 @@ exports.BatchResponseParser = BatchResponseParser;
 
 /***/ }),
 
-/***/ 321:
+/***/ 322:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65964,7 +66321,7 @@ class DecodedURL extends URL {
 
 /***/ }),
 
-/***/ 322:
+/***/ 323:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -66020,9 +66377,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseIsolatedSeedTargets = parseIsolatedSeedTargets;
 exports.shouldSeedBuildCacheEntry = shouldSeedBuildCacheEntry;
 exports.seedIsolatedBuildCache = seedIsolatedBuildCache;
-const fs = __importStar(__nccwpck_require__(256));
+const fs = __importStar(__nccwpck_require__(257));
 const path = __importStar(__nccwpck_require__(519));
-const cache_compress_js_1 = __nccwpck_require__(95);
+const cache_compress_js_1 = __nccwpck_require__(97);
 const TRANSIENT_SEED_SUFFIXES = [".lock", ".lck", ".sock", ".pid", ".tmp", ".temp", ".part", ".partial"];
 /** Parse the `seed-isolated-build-cache` input into isolated SOLDR_CACHE_DIR roots. */
 function parseIsolatedSeedTargets(value) {
@@ -66169,7 +66526,7 @@ function seedIsolatedBuildCache(opts) {
 
 /***/ }),
 
-/***/ 323:
+/***/ 324:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -66395,7 +66752,7 @@ function diagnoseShimBypass(input) {
 
 /***/ }),
 
-/***/ 324:
+/***/ 325:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -66536,7 +66893,7 @@ function flattenResponse(fullResponse, responseSpec) {
 
 /***/ }),
 
-/***/ 325:
+/***/ 326:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66545,7 +66902,7 @@ function flattenResponse(fullResponse, responseSpec) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.buildCreatePoller = void 0;
-const operation_js_1 = __nccwpck_require__(148);
+const operation_js_1 = __nccwpck_require__(150);
 const constants_js_1 = __nccwpck_require__(66);
 const core_util_1 = __nccwpck_require__(15);
 const createStateProxy = () => ({
@@ -66717,7 +67074,7 @@ exports.buildCreatePoller = buildCreatePoller;
 
 /***/ }),
 
-/***/ 326:
+/***/ 327:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66726,14 +67083,14 @@ exports.buildCreatePoller = buildCreatePoller;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(109);
-const pipeline_js_1 = __nccwpck_require__(292);
-const utils_js_1 = __nccwpck_require__(324);
-const httpClientCache_js_1 = __nccwpck_require__(410);
-const operationHelpers_js_1 = __nccwpck_require__(444);
-const urlHelpers_js_1 = __nccwpck_require__(245);
-const interfaceHelpers_js_1 = __nccwpck_require__(411);
-const log_js_1 = __nccwpck_require__(493);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
+const pipeline_js_1 = __nccwpck_require__(293);
+const utils_js_1 = __nccwpck_require__(325);
+const httpClientCache_js_1 = __nccwpck_require__(411);
+const operationHelpers_js_1 = __nccwpck_require__(445);
+const urlHelpers_js_1 = __nccwpck_require__(246);
+const interfaceHelpers_js_1 = __nccwpck_require__(412);
+const log_js_1 = __nccwpck_require__(494);
 /**
  * Initializes a new instance of the ServiceClient.
  */
@@ -66900,7 +67257,7 @@ function getCredentialScopes(options) {
 
 /***/ }),
 
-/***/ 327:
+/***/ 328:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -66925,18 +67282,18 @@ __export(createPipelineFromOptions_exports, {
   createPipelineFromOptions: () => createPipelineFromOptions
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
-var import_logPolicy = __nccwpck_require__(110);
+var import_logPolicy = __nccwpck_require__(112);
 var import_pipeline = __nccwpck_require__(536);
-var import_redirectPolicy = __nccwpck_require__(329);
-var import_userAgentPolicy = __nccwpck_require__(370);
-var import_decompressResponsePolicy = __nccwpck_require__(367);
-var import_defaultRetryPolicy = __nccwpck_require__(336);
-var import_formDataPolicy = __nccwpck_require__(350);
-var import_checkEnvironment = __nccwpck_require__(451);
+var import_redirectPolicy = __nccwpck_require__(330);
+var import_userAgentPolicy = __nccwpck_require__(371);
+var import_decompressResponsePolicy = __nccwpck_require__(368);
+var import_defaultRetryPolicy = __nccwpck_require__(337);
+var import_formDataPolicy = __nccwpck_require__(351);
+var import_checkEnvironment = __nccwpck_require__(452);
 var import_proxyPolicy = __nccwpck_require__(43);
-var import_agentPolicy = __nccwpck_require__(477);
-var import_tlsPolicy = __nccwpck_require__(228);
-var import_multipartPolicy = __nccwpck_require__(176);
+var import_agentPolicy = __nccwpck_require__(478);
+var import_tlsPolicy = __nccwpck_require__(229);
+var import_multipartPolicy = __nccwpck_require__(178);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_checkEnvironment.isNodeLike) {
@@ -66966,7 +67323,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 328:
+/***/ 329:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -66983,7 +67340,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 329:
+/***/ 330:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67009,7 +67366,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_log = __nccwpck_require__(159);
+var import_log = __nccwpck_require__(161);
 const redirectPolicyName = "redirectPolicy";
 const allowedRedirect = ["GET", "HEAD"];
 function redirectPolicy(options = {}) {
@@ -67055,7 +67412,7 @@ async function handleRedirect(next, response, maxRetries, allowCrossOriginRedire
 
 /***/ }),
 
-/***/ 330:
+/***/ 331:
 /***/ ((module) => {
 
 "use strict";
@@ -67063,7 +67420,7 @@ module.exports = require("worker_threads");
 
 /***/ }),
 
-/***/ 331:
+/***/ 332:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67073,7 +67430,7 @@ module.exports = require("worker_threads");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
 const operation_js_1 = __nccwpck_require__(57);
-const poller_js_1 = __nccwpck_require__(325);
+const poller_js_1 = __nccwpck_require__(326);
 /**
  * Creates a poller that can be used to poll a long-running operation.
  * @param lro - Description of the long-running operation
@@ -67118,7 +67475,7 @@ exports.createHttpPoller = createHttpPoller;
 
 /***/ }),
 
-/***/ 332:
+/***/ 333:
 /***/ ((module) => {
 
 "use strict";
@@ -67126,14 +67483,14 @@ module.exports = require("perf_hooks");
 
 /***/ }),
 
-/***/ 333:
+/***/ 334:
 /***/ ((module) => {
 
 (()=>{"use strict";var t={d:(e,n)=>{for(var i in n)t.o(n,i)&&!t.o(e,i)&&Object.defineProperty(e,i,{enumerable:!0,get:n[i]})},o:(t,e)=>Object.prototype.hasOwnProperty.call(t,e),r:t=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(t,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(t,"__esModule",{value:!0})}},e={};t.r(e),t.d(e,{XMLBuilder:()=>ie,XMLParser:()=>Lt,XMLValidator:()=>se});const n=":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD",i=new RegExp("^["+n+"]["+n+"\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$");function s(t,e){const n=[];let i=e.exec(t);for(;i;){const s=[];s.startIndex=e.lastIndex-i[0].length;const r=i.length;for(let t=0;t<r;t++)s.push(i[t]);n.push(s),i=e.exec(t)}return n}const r=function(t){return!(null==i.exec(t))},o=["hasOwnProperty","toString","valueOf","__defineGetter__","__defineSetter__","__lookupGetter__","__lookupSetter__"],a=["__proto__","constructor","prototype"],h={allowBooleanAttributes:!1,unpairedTags:[]};function l(t,e){e=Object.assign({},h,e);const n=[];let i=!1,s=!1;"\ufeff"===t[0]&&(t=t.substr(1));for(let r=0;r<t.length;r++)if("<"===t[r]&&"?"===t[r+1]){if(r+=2,r=p(t,r),r.err)return r}else{if("<"!==t[r]){if(u(t[r]))continue;return b("InvalidChar","char '"+t[r]+"' is not expected.",w(t,r))}{let o=r;if(r++,"!"===t[r]){r=c(t,r);continue}{let a=!1;"/"===t[r]&&(a=!0,r++);let h="";for(;r<t.length&&">"!==t[r]&&" "!==t[r]&&"\t"!==t[r]&&"\n"!==t[r]&&"\r"!==t[r];r++)h+=t[r];if(h=h.trim(),"/"===h[h.length-1]&&(h=h.substring(0,h.length-1),r--),!E(h)){let e;return e=0===h.trim().length?"Invalid space after '<'.":"Tag '"+h+"' is an invalid name.",b("InvalidTag",e,w(t,r))}const l=g(t,r);if(!1===l)return b("InvalidAttr","Attributes for '"+h+"' have open quote.",w(t,r));let d=l.value;if(r=l.index,"/"===d[d.length-1]){const n=r-d.length;d=d.substring(0,d.length-1);const s=x(d,e);if(!0!==s)return b(s.err.code,s.err.msg,w(t,n+s.err.line));i=!0}else if(a){if(!l.tagClosed)return b("InvalidTag","Closing tag '"+h+"' doesn't have proper closing.",w(t,r));if(d.trim().length>0)return b("InvalidTag","Closing tag '"+h+"' can't have attributes or invalid starting.",w(t,o));if(0===n.length)return b("InvalidTag","Closing tag '"+h+"' has not been opened.",w(t,o));{const e=n.pop();if(h!==e.tagName){let n=w(t,e.tagStartPos);return b("InvalidTag","Expected closing tag '"+e.tagName+"' (opened in line "+n.line+", col "+n.col+") instead of closing tag '"+h+"'.",w(t,o))}0==n.length&&(s=!0)}}else{const a=x(d,e);if(!0!==a)return b(a.err.code,a.err.msg,w(t,r-d.length+a.err.line));if(!0===s)return b("InvalidXml","Multiple possible root nodes found.",w(t,r));-1!==e.unpairedTags.indexOf(h)||n.push({tagName:h,tagStartPos:o}),i=!0}for(r++;r<t.length;r++)if("<"===t[r]){if("!"===t[r+1]){r++,r=c(t,r);continue}if("?"!==t[r+1])break;if(r=p(t,++r),r.err)return r}else if("&"===t[r]){const e=N(t,r);if(-1==e)return b("InvalidChar","char '&' is not expected.",w(t,r));r=e}else if(!0===s&&!u(t[r]))return b("InvalidXml","Extra text at the end",w(t,r));"<"===t[r]&&r--}}}return i?1==n.length?b("InvalidTag","Unclosed tag '"+n[0].tagName+"'.",w(t,n[0].tagStartPos)):!(n.length>0)||b("InvalidXml","Invalid '"+JSON.stringify(n.map(t=>t.tagName),null,4).replace(/\r?\n/g,"")+"' found.",{line:1,col:1}):b("InvalidXml","Start tag expected.",1)}function u(t){return" "===t||"\t"===t||"\n"===t||"\r"===t}function p(t,e){const n=e;for(;e<t.length;e++)if("?"==t[e]||" "==t[e]){const i=t.substr(n,e-n);if(e>5&&"xml"===i)return b("InvalidXml","XML declaration allowed only at the start of the document.",w(t,e));if("?"==t[e]&&">"==t[e+1]){e++;break}continue}return e}function c(t,e){if(t.length>e+5&&"-"===t[e+1]&&"-"===t[e+2]){for(e+=3;e<t.length;e++)if("-"===t[e]&&"-"===t[e+1]&&">"===t[e+2]){e+=2;break}}else if(t.length>e+8&&"D"===t[e+1]&&"O"===t[e+2]&&"C"===t[e+3]&&"T"===t[e+4]&&"Y"===t[e+5]&&"P"===t[e+6]&&"E"===t[e+7]){let n=1;for(e+=8;e<t.length;e++)if("<"===t[e])n++;else if(">"===t[e]&&(n--,0===n))break}else if(t.length>e+9&&"["===t[e+1]&&"C"===t[e+2]&&"D"===t[e+3]&&"A"===t[e+4]&&"T"===t[e+5]&&"A"===t[e+6]&&"["===t[e+7])for(e+=8;e<t.length;e++)if("]"===t[e]&&"]"===t[e+1]&&">"===t[e+2]){e+=2;break}return e}const d='"',f="'";function g(t,e){let n="",i="",s=!1;for(;e<t.length;e++){if(t[e]===d||t[e]===f)""===i?i=t[e]:i!==t[e]||(i="");else if(">"===t[e]&&""===i){s=!0;break}n+=t[e]}return""===i&&{value:n,index:e,tagClosed:s}}const m=new RegExp("(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['\"])(([\\s\\S])*?)\\5)?","g");function x(t,e){const n=s(t,m),i={};for(let t=0;t<n.length;t++){if(0===n[t][1].length)return b("InvalidAttr","Attribute '"+n[t][2]+"' has no space in starting.",v(n[t]));if(void 0!==n[t][3]&&void 0===n[t][4])return b("InvalidAttr","Attribute '"+n[t][2]+"' is without value.",v(n[t]));if(void 0===n[t][3]&&!e.allowBooleanAttributes)return b("InvalidAttr","boolean attribute '"+n[t][2]+"' is not allowed.",v(n[t]));const s=n[t][2];if(!y(s))return b("InvalidAttr","Attribute '"+s+"' is an invalid name.",v(n[t]));if(Object.prototype.hasOwnProperty.call(i,s))return b("InvalidAttr","Attribute '"+s+"' is repeated.",v(n[t]));i[s]=1}return!0}function N(t,e){if(";"===t[++e])return-1;if("#"===t[e])return function(t,e){let n=/\d/;for("x"===t[e]&&(e++,n=/[\da-fA-F]/);e<t.length;e++){if(";"===t[e])return e;if(!t[e].match(n))break}return-1}(t,++e);let n=0;for(;e<t.length;e++,n++)if(!(t[e].match(/\w/)&&n<20)){if(";"===t[e])break;return-1}return e}function b(t,e,n){return{err:{code:t,msg:e,line:n.line||n,col:n.col}}}function y(t){return r(t)}function E(t){return r(t)}function w(t,e){const n=t.substring(0,e).split(/\r?\n/);return{line:n.length,col:n[n.length-1].length+1}}function v(t){return t.startIndex+t[1].length}const S=t=>o.includes(t)?"__"+t:t,_={preserveOrder:!1,attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,removeNSPrefix:!1,allowBooleanAttributes:!1,parseTagValue:!0,parseAttributeValue:!1,trimValues:!0,cdataPropName:!1,numberParseOptions:{hex:!0,leadingZeros:!0,eNotation:!0},tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},stopNodes:[],alwaysCreateTextNode:!1,isArray:()=>!1,commentPropName:!1,unpairedTags:[],processEntities:!0,htmlEntities:!1,entityDecoder:null,ignoreDeclaration:!1,ignorePiTags:!1,transformTagName:!1,transformAttributeName:!1,updateTag:function(t,e,n){return t},captureMetaData:!1,maxNestedTags:100,strictReservedNames:!0,jPath:!0,onDangerousProperty:S};function A(t,e){if("string"!=typeof t)return;const n=t.toLowerCase();if(o.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);if(a.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`)}function T(t,e){return"boolean"==typeof t?{enabled:t,maxEntitySize:1e4,maxExpansionDepth:1e4,maxTotalExpansions:1/0,maxExpandedLength:1e5,maxEntityCount:1e3,allowedTags:null,tagFilter:null,appliesTo:"all"}:"object"==typeof t&&null!==t?{enabled:!1!==t.enabled,maxEntitySize:Math.max(1,t.maxEntitySize??1e4),maxExpansionDepth:Math.max(1,t.maxExpansionDepth??1e4),maxTotalExpansions:Math.max(1,t.maxTotalExpansions??1/0),maxExpandedLength:Math.max(1,t.maxExpandedLength??1e5),maxEntityCount:Math.max(1,t.maxEntityCount??1e3),allowedTags:t.allowedTags??null,tagFilter:t.tagFilter??null,appliesTo:t.appliesTo??"all"}:T(!0)}const C=function(t){const e=Object.assign({},_,t),n=[{value:e.attributeNamePrefix,name:"attributeNamePrefix"},{value:e.attributesGroupName,name:"attributesGroupName"},{value:e.textNodeName,name:"textNodeName"},{value:e.cdataPropName,name:"cdataPropName"},{value:e.commentPropName,name:"commentPropName"}];for(const{value:t,name:e}of n)t&&A(t,e);return null===e.onDangerousProperty&&(e.onDangerousProperty=S),e.processEntities=T(e.processEntities,e.htmlEntities),e.unpairedTagsSet=new Set(e.unpairedTags),e.stopNodes&&Array.isArray(e.stopNodes)&&(e.stopNodes=e.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),e};let P;P="function"!=typeof Symbol?"@@xmlMetadata":Symbol("XML Node Metadata");class ${constructor(t){this.tagname=t,this.child=[],this[":@"]=Object.create(null)}add(t,e){"__proto__"===t&&(t="#__proto__"),this.child.push({[t]:e})}addChild(t,e){"__proto__"===t.tagname&&(t.tagname="#__proto__"),t[":@"]&&Object.keys(t[":@"]).length>0?this.child.push({[t.tagname]:t.child,":@":t[":@"]}):this.child.push({[t.tagname]:t.child}),void 0!==e&&(this.child[this.child.length-1][P]={startIndex:e})}static getMetaDataSymbol(){return P}}const O=":A-Za-z_À-ÖØ-öø-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�",I=":A-Za-z_À-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�𐀀-󯿿",V=I+"\\-\\.\\d·̀-ͯ҇‿-⁀",D=(t,e,n="")=>{const i=`[${t.replace(":","")}][${e.replace(":","")}]*`;return{name:new RegExp(`^[${t}][${e}]*$`,n),ncName:new RegExp(`^${i}$`,n),qName:new RegExp(`^${i}(?::${i})?$`,n),nmToken:new RegExp(`^[${e}]+$`,n),nmTokens:new RegExp(`^[${e}]+(?:\\s+[${e}]+)*$`,n)}},M=D(O,O+"\\-\\.\\d·̀-ͯ‿-⁀"),j=D(I,V,"u"),L=(t,{xmlVersion:e="1.0"}={})=>((t="1.0")=>"1.1"===t?j:M)(e).qName.test(t);class k{constructor(t,e){this.suppressValidationErr=!t,this.options=t,this.xmlVersion=e||1}setXmlVersion(t=1){this.xmlVersion=t}readDocType(t,e){const n=Object.create(null);let i=0;if("O"!==t[e+3]||"C"!==t[e+4]||"T"!==t[e+5]||"Y"!==t[e+6]||"P"!==t[e+7]||"E"!==t[e+8])throw new Error("Invalid Tag instead of DOCTYPE");{e+=9;let s=1,r=!1,o=!1,a="";for(;e<t.length;e++)if("<"!==t[e]||o)if(">"===t[e]){if(o?"-"===t[e-1]&&"-"===t[e-2]&&(o=!1,s--):s--,0===s)break}else"["===t[e]?r=!0:a+=t[e];else{if(r&&F(t,"!ENTITY",e)){let s,r;if(e+=7,[s,r,e]=this.readEntityExp(t,e+1,this.suppressValidationErr),-1===r.indexOf("&")){if(!1!==this.options.enabled&&null!=this.options.maxEntityCount&&i>=this.options.maxEntityCount)throw new Error(`Entity count (${i+1}) exceeds maximum allowed (${this.options.maxEntityCount})`);n[s]=r,i++}}else if(r&&F(t,"!ELEMENT",e)){e+=8;const{index:n}=this.readElementExp(t,e+1);e=n}else if(r&&F(t,"!ATTLIST",e))e+=8;else if(r&&F(t,"!NOTATION",e)){e+=9;const{index:n}=this.readNotationExp(t,e+1,this.suppressValidationErr);e=n}else{if(!F(t,"!--",e))throw new Error("Invalid DOCTYPE");o=!0}s++,a=""}if(0!==s)throw new Error("Unclosed DOCTYPE")}return{entities:n,i:e}}readEntityExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e])&&'"'!==t[e]&&"'"!==t[e];)e++;let i=t.substring(n,e);if(G(i,{xmlVersion:this.xmlVersion}),e=R(t,e),!this.suppressValidationErr){if("SYSTEM"===t.substring(e,e+6).toUpperCase())throw new Error("External entities are not supported");if("%"===t[e])throw new Error("Parameter entities are not supported")}let s="";if([e,s]=this.readIdentifierVal(t,e,"entity"),!1!==this.options.enabled&&null!=this.options.maxEntitySize&&s.length>this.options.maxEntitySize)throw new Error(`Entity "${i}" size (${s.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`);return[i,s,--e]}readNotationExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);!this.suppressValidationErr&&G(i,{xmlVersion:this.xmlVersion}),e=R(t,e);const s=t.substring(e,e+6).toUpperCase();if(!this.suppressValidationErr&&"SYSTEM"!==s&&"PUBLIC"!==s)throw new Error(`Expected SYSTEM or PUBLIC, found "${s}"`);e+=s.length,e=R(t,e);let r=null,o=null;if("PUBLIC"===s)[e,r]=this.readIdentifierVal(t,e,"publicIdentifier"),'"'!==t[e=R(t,e)]&&"'"!==t[e]||([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"));else if("SYSTEM"===s&&([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"),!this.suppressValidationErr&&!o))throw new Error("Missing mandatory system identifier for SYSTEM notation");return{notationName:i,publicIdentifier:r,systemIdentifier:o,index:--e}}readIdentifierVal(t,e,n){let i="";const s=t[e];if('"'!==s&&"'"!==s)throw new Error(`Expected quoted string, found "${s}"`);const r=++e;for(;e<t.length&&t[e]!==s;)e++;if(i=t.substring(r,e),t[e]!==s)throw new Error(`Unterminated ${n} value`);return[++e,i]}readElementExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);if(!this.suppressValidationErr&&!L(i,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid element name: "${i}"`);let s="";if("E"===t[e=R(t,e)]&&F(t,"MPTY",e))e+=4;else if("A"===t[e]&&F(t,"NY",e))e+=2;else if("("===t[e]){const n=++e;for(;e<t.length&&")"!==t[e];)e++;if(s=t.substring(n,e),")"!==t[e])throw new Error("Unterminated content model")}else if(!this.suppressValidationErr)throw new Error(`Invalid Element Expression, found "${t[e]}"`);return{elementName:i,contentModel:s.trim(),index:e}}readAttlistExp(t,e){let n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);for(G(i,{xmlVersion:this.xmlVersion}),n=e=R(t,e);e<t.length&&!/\s/.test(t[e]);)e++;let s=t.substring(n,e);if(!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid attribute name: "${s}"`);e=R(t,e);let r="";if("NOTATION"===t.substring(e,e+8).toUpperCase()){if(r="NOTATION","("!==t[e=R(t,e+=8)])throw new Error(`Expected '(', found "${t[e]}"`);e++;let n=[];for(;e<t.length&&")"!==t[e];){const i=e;for(;e<t.length&&"|"!==t[e]&&")"!==t[e];)e++;let s=t.substring(i,e);if(s=s.trim(),!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid notation name: "${s}"`);n.push(s),"|"===t[e]&&(e++,e=R(t,e))}if(")"!==t[e])throw new Error("Unterminated list of notations");e++,r+=" ("+n.join("|")+")"}else{const n=e;for(;e<t.length&&!/\s/.test(t[e]);)e++;r+=t.substring(n,e);const i=["CDATA","ID","IDREF","IDREFS","ENTITY","ENTITIES","NMTOKEN","NMTOKENS"];if(!this.suppressValidationErr&&!i.includes(r.toUpperCase()))throw new Error(`Invalid attribute type: "${r}"`)}e=R(t,e);let o="";return"#REQUIRED"===t.substring(e,e+8).toUpperCase()?(o="#REQUIRED",e+=8):"#IMPLIED"===t.substring(e,e+7).toUpperCase()?(o="#IMPLIED",e+=7):[e,o]=this.readIdentifierVal(t,e,"ATTLIST"),{elementName:i,attributeName:s,attributeType:r,defaultValue:o,index:e}}}const R=(t,e)=>{for(;e<t.length&&/\s/.test(t[e]);)e++;return e};function F(t,e,n){for(let i=0;i<e.length;i++)if(e[i]!==t[n+i+1])return!1;return!0}function G(t,e){if(L(t,{xmlVersion:e}))return t;throw new Error(`Invalid entity name ${t}`)}const U=/^[-+]?0x[a-fA-F0-9]+$/,B=/^0b[01]+$/,W=/^0o[0-7]+$/,z=/^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/,X={hex:!0,binary:!1,octal:!1,leadingZeros:!0,decimalPoint:".",eNotation:!0,infinity:"original"};const Y=/^([-+])?(0*)(\d*(\.\d*)?[eE][-\+]?\d+)$/;function q(t,e){const n=t.trim();if(2!==e&&8!==e||(t=n.substring(2)),parseInt)return parseInt(t,e);if(Number.parseInt)return Number.parseInt(t,e);if(window&&window.parseInt)return window.parseInt(t,e);throw new Error("parseInt, Number.parseInt, window.parseInt are not supported")}class Z{constructor(t){this._matcher=t}get separator(){return this._matcher.separator}getCurrentTag(){const t=this._matcher.path;return t.length>0?t[t.length-1].tag:void 0}getCurrentNamespace(){const t=this._matcher.path;return t.length>0?t[t.length-1].namespace:void 0}getAttrValue(t){const e=this._matcher.path;if(0!==e.length)return e[e.length-1].values?.[t]}hasAttr(t){const e=this._matcher.path;if(0===e.length)return!1;const n=e[e.length-1];return void 0!==n.values&&t in n.values}getPosition(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].position??0}getCounter(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this._matcher.path.length}toString(t,e=!0){return this._matcher.toString(t,e)}toArray(){return this._matcher.path.map(t=>t.tag)}matches(t){return this._matcher.matches(t)}matchesAny(t){return t.matchesAny(this._matcher)}}class J{constructor(t={}){this.separator=t.separator||".",this.path=[],this.siblingStacks=[],this._pathStringCache=null,this._view=new Z(this)}push(t,e=null,n=null){this._pathStringCache=null,this.path.length>0&&(this.path[this.path.length-1].values=void 0);const i=this.path.length;this.siblingStacks[i]||(this.siblingStacks[i]=new Map);const s=this.siblingStacks[i],r=n?`${n}:${t}`:t,o=s.get(r)||0;let a=0;for(const t of s.values())a+=t;s.set(r,o+1);const h={tag:t,position:a,counter:o};null!=n&&(h.namespace=n),null!=e&&(h.values=e),this.path.push(h)}pop(){if(0===this.path.length)return;this._pathStringCache=null;const t=this.path.pop();return this.siblingStacks.length>this.path.length+1&&(this.siblingStacks.length=this.path.length+1),t}updateCurrent(t){if(this.path.length>0){const e=this.path[this.path.length-1];null!=t&&(e.values=t)}}getCurrentTag(){return this.path.length>0?this.path[this.path.length-1].tag:void 0}getCurrentNamespace(){return this.path.length>0?this.path[this.path.length-1].namespace:void 0}getAttrValue(t){if(0!==this.path.length)return this.path[this.path.length-1].values?.[t]}hasAttr(t){if(0===this.path.length)return!1;const e=this.path[this.path.length-1];return void 0!==e.values&&t in e.values}getPosition(){return 0===this.path.length?-1:this.path[this.path.length-1].position??0}getCounter(){return 0===this.path.length?-1:this.path[this.path.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this.path.length}toString(t,e=!0){const n=t||this.separator;if(n===this.separator&&!0===e){if(null!==this._pathStringCache)return this._pathStringCache;const t=this.path.map(t=>t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n);return this._pathStringCache=t,t}return this.path.map(t=>e&&t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n)}toArray(){return this.path.map(t=>t.tag)}reset(){this._pathStringCache=null,this.path=[],this.siblingStacks=[]}matches(t){const e=t.segments;return 0!==e.length&&(t.hasDeepWildcard()?this._matchWithDeepWildcard(e):this._matchSimple(e))}_matchSimple(t){if(this.path.length!==t.length)return!1;for(let e=0;e<t.length;e++)if(!this._matchSegment(t[e],this.path[e],e===this.path.length-1))return!1;return!0}_matchWithDeepWildcard(t){let e=this.path.length-1,n=t.length-1;for(;n>=0&&e>=0;){const i=t[n];if("deep-wildcard"===i.type){if(n--,n<0)return!0;const i=t[n];let s=!1;for(let t=e;t>=0;t--)if(this._matchSegment(i,this.path[t],t===this.path.length-1)){e=t-1,n--,s=!0;break}if(!s)return!1}else{if(!this._matchSegment(i,this.path[e],e===this.path.length-1))return!1;e--,n--}}return n<0}_matchSegment(t,e,n){if("*"!==t.tag&&t.tag!==e.tag)return!1;if(void 0!==t.namespace&&"*"!==t.namespace&&t.namespace!==e.namespace)return!1;if(void 0!==t.attrName){if(!n)return!1;if(!e.values||!(t.attrName in e.values))return!1;if(void 0!==t.attrValue&&String(e.values[t.attrName])!==String(t.attrValue))return!1}if(void 0!==t.position){if(!n)return!1;const i=e.counter??0;if("first"===t.position&&0!==i)return!1;if("odd"===t.position&&i%2!=1)return!1;if("even"===t.position&&i%2!=0)return!1;if("nth"===t.position&&i!==t.positionValue)return!1}return!0}matchesAny(t){return t.matchesAny(this)}snapshot(){return{path:this.path.map(t=>({...t})),siblingStacks:this.siblingStacks.map(t=>new Map(t))}}restore(t){this._pathStringCache=null,this.path=t.path.map(t=>({...t})),this.siblingStacks=t.siblingStacks.map(t=>new Map(t))}readOnly(){return this._view}}class K{constructor(t,e={},n){this.pattern=t,this.separator=e.separator||".",this.segments=this._parse(t),this.data=n,this._hasDeepWildcard=this.segments.some(t=>"deep-wildcard"===t.type),this._hasAttributeCondition=this.segments.some(t=>void 0!==t.attrName),this._hasPositionSelector=this.segments.some(t=>void 0!==t.position)}_parse(t){const e=[];let n=0,i="";for(;n<t.length;)t[n]===this.separator?n+1<t.length&&t[n+1]===this.separator?(i.trim()&&(e.push(this._parseSegment(i.trim())),i=""),e.push({type:"deep-wildcard"}),n+=2):(i.trim()&&e.push(this._parseSegment(i.trim())),i="",n++):(i+=t[n],n++);return i.trim()&&e.push(this._parseSegment(i.trim())),e}_parseSegment(t){const e={type:"tag"};let n=null,i=t;const s=t.match(/^([^\[]+)(\[[^\]]*\])(.*)$/);if(s&&(i=s[1]+s[3],s[2])){const t=s[2].slice(1,-1);t&&(n=t)}let r,o,a=i;if(i.includes("::")){const e=i.indexOf("::");if(r=i.substring(0,e).trim(),a=i.substring(e+2).trim(),!r)throw new Error(`Invalid namespace in pattern: ${t}`)}let h=null;if(a.includes(":")){const t=a.lastIndexOf(":"),e=a.substring(0,t).trim(),n=a.substring(t+1).trim();["first","last","odd","even"].includes(n)||/^nth\(\d+\)$/.test(n)?(o=e,h=n):o=a}else o=a;if(!o)throw new Error(`Invalid segment pattern: ${t}`);if(e.tag=o,r&&(e.namespace=r),n)if(n.includes("=")){const t=n.indexOf("=");e.attrName=n.substring(0,t).trim(),e.attrValue=n.substring(t+1).trim()}else e.attrName=n.trim();if(h){const t=h.match(/^nth\((\d+)\)$/);t?(e.position="nth",e.positionValue=parseInt(t[1],10)):e.position=h}return e}get length(){return this.segments.length}hasDeepWildcard(){return this._hasDeepWildcard}hasAttributeCondition(){return this._hasAttributeCondition}hasPositionSelector(){return this._hasPositionSelector}toString(){return this.pattern}}class Q{constructor(){this._byDepthAndTag=new Map,this._wildcardByDepth=new Map,this._deepWildcards=[],this._patterns=new Set,this._sealed=!1}add(t){if(this._sealed)throw new TypeError("ExpressionSet is sealed. Create a new ExpressionSet to add more expressions.");if(this._patterns.has(t.pattern))return this;if(this._patterns.add(t.pattern),t.hasDeepWildcard())return this._deepWildcards.push(t),this;const e=t.length,n=t.segments[t.segments.length-1],i=n?.tag;if(i&&"*"!==i){const n=`${e}:${i}`;this._byDepthAndTag.has(n)||this._byDepthAndTag.set(n,[]),this._byDepthAndTag.get(n).push(t)}else this._wildcardByDepth.has(e)||this._wildcardByDepth.set(e,[]),this._wildcardByDepth.get(e).push(t);return this}addAll(t){for(const e of t)this.add(e);return this}has(t){return this._patterns.has(t.pattern)}get size(){return this._patterns.size}seal(){return this._sealed=!0,this}get isSealed(){return this._sealed}matchesAny(t){return null!==this.findMatch(t)}findMatch(t){const e=t.getDepth(),n=`${e}:${t.getCurrentTag()}`,i=this._byDepthAndTag.get(n);if(i)for(let e=0;e<i.length;e++)if(t.matches(i[e]))return i[e];const s=this._wildcardByDepth.get(e);if(s)for(let e=0;e<s.length;e++)if(t.matches(s[e]))return s[e];for(let e=0;e<this._deepWildcards.length;e++)if(t.matches(this._deepWildcards[e]))return this._deepWildcards[e];return null}}const H={cent:"¢",pound:"£",curren:"¤",yen:"¥",euro:"€",dollar:"$",euro:"€",fnof:"ƒ",inr:"₹",af:"؋",birr:"ብር",peso:"₱",rub:"₽",won:"₩",yuan:"¥",cedil:"¸"},tt={amp:"&",apos:"'",gt:">",lt:"<",quot:'"'},et={nbsp:" ",copy:"©",reg:"®",trade:"™",mdash:"—",ndash:"–",hellip:"…",laquo:"«",raquo:"»",lsquo:"‘",rsquo:"’",ldquo:"“",rdquo:"”",bull:"•",para:"¶",sect:"§",deg:"°",frac12:"½",frac14:"¼",frac34:"¾"},nt=new Set("!?\\\\/[]$%{}^&*()<>|+");function it(t){if("#"===t[0])throw new Error(`[EntityReplacer] Invalid character '#' in entity name: "${t}"`);for(const e of t)if(nt.has(e))throw new Error(`[EntityReplacer] Invalid character '${e}' in entity name: "${t}"`);return t}function st(...t){const e=Object.create(null);for(const n of t)if(n)for(const t of Object.keys(n)){const i=n[t];if("string"==typeof i)e[t]=i;else if(i&&"object"==typeof i&&void 0!==i.val){const n=i.val;"string"==typeof n&&(e[t]=n)}}return e}const rt="external",ot="base",at="all",ht=Object.freeze({allow:0,leave:1,remove:2,throw:3}),lt=new Set([9,10,13]);class ut{constructor(t={}){var e;this._limit=t.limit||{},this._maxTotalExpansions=this._limit.maxTotalExpansions||0,this._maxExpandedLength=this._limit.maxExpandedLength||0,this._postCheck="function"==typeof t.postCheck?t.postCheck:t=>t,this._limitTiers=(e=this._limit.applyLimitsTo??rt)&&e!==rt?e===at?new Set([at]):e===ot?new Set([ot]):Array.isArray(e)?new Set(e):new Set([rt]):new Set([rt]),this._numericAllowed=t.numericAllowed??!0,this._baseMap=st(tt,t.namedEntities||null),this._externalMap=Object.create(null),this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this._removeSet=new Set(t.remove&&Array.isArray(t.remove)?t.remove:[]),this._leaveSet=new Set(t.leave&&Array.isArray(t.leave)?t.leave:[]);const n=function(t){if(!t)return{xmlVersion:1,onLevel:ht.allow,nullLevel:ht.remove};const e=1.1===t.xmlVersion?1.1:1,n=ht[t.onNCR]??ht.allow,i=ht[t.nullNCR]??ht.remove;return{xmlVersion:e,onLevel:n,nullLevel:Math.max(i,ht.remove)}}(t.ncr);this._ncrXmlVersion=n.xmlVersion,this._ncrOnLevel=n.onLevel,this._ncrNullLevel=n.nullLevel}setExternalEntities(t){if(t)for(const e of Object.keys(t))it(e);this._externalMap=st(t)}addExternalEntity(t,e){it(t),"string"==typeof e&&-1===e.indexOf("&")&&(this._externalMap[t]=e)}addInputEntities(t){this._totalExpansions=0,this._expandedLength=0,this._inputMap=st(t)}reset(){return this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this}setXmlVersion(t){this._ncrXmlVersion=1.1===t?1.1:1}decode(t){if("string"!=typeof t||0===t.length)return t;const e=t,n=[],i=t.length;let s=0,r=0;const o=this._maxTotalExpansions>0,a=this._maxExpandedLength>0,h=o||a;for(;r<i;){if(38!==t.charCodeAt(r)){r++;continue}let e=r+1;for(;e<i&&59!==t.charCodeAt(e)&&e-r<=32;)e++;if(e>=i||59!==t.charCodeAt(e)){r++;continue}const l=t.slice(r+1,e);if(0===l.length){r++;continue}let u,p;if(this._removeSet.has(l))u="",void 0===p&&(p=rt);else{if(this._leaveSet.has(l)){r++;continue}if(35===l.charCodeAt(0)){const t=this._resolveNCR(l);if(void 0===t){r++;continue}u=t,p=ot}else{const t=this._resolveName(l);u=t?.value,p=t?.tier}}if(void 0!==u){if(r>s&&n.push(t.slice(s,r)),n.push(u),s=e+1,r=s,h&&this._tierCounts(p)){if(o&&(this._totalExpansions++,this._totalExpansions>this._maxTotalExpansions))throw new Error(`[EntityReplacer] Entity expansion count limit exceeded: ${this._totalExpansions} > ${this._maxTotalExpansions}`);if(a){const t=u.length-(l.length+2);if(t>0&&(this._expandedLength+=t,this._expandedLength>this._maxExpandedLength))throw new Error(`[EntityReplacer] Expanded content length limit exceeded: ${this._expandedLength} > ${this._maxExpandedLength}`)}}}else r++}s<i&&n.push(t.slice(s));const l=0===n.length?t:n.join("");return this._postCheck(l,e)}_tierCounts(t){return!!this._limitTiers.has(at)||this._limitTiers.has(t)}_resolveName(t){return t in this._inputMap?{value:this._inputMap[t],tier:rt}:t in this._externalMap?{value:this._externalMap[t],tier:rt}:t in this._baseMap?{value:this._baseMap[t],tier:ot}:void 0}_classifyNCR(t){return 0===t?this._ncrNullLevel:t>=55296&&t<=57343||1===this._ncrXmlVersion&&t>=1&&t<=31&&!lt.has(t)?ht.remove:-1}_applyNCRAction(t,e,n){switch(t){case ht.allow:return String.fromCodePoint(n);case ht.remove:return"";case ht.leave:return;case ht.throw:throw new Error(`[EntityDecoder] Prohibited numeric character reference &${e}; (U+${n.toString(16).toUpperCase().padStart(4,"0")})`);default:return String.fromCodePoint(n)}}_resolveNCR(t){const e=t.charCodeAt(1);let n;if(n=120===e||88===e?parseInt(t.slice(2),16):parseInt(t.slice(1),10),Number.isNaN(n)||n<0||n>1114111)return;const i=this._classifyNCR(n);if(!this._numericAllowed&&i<ht.remove)return;const s=-1===i?this._ncrOnLevel:Math.max(this._ncrOnLevel,i);return this._applyNCRAction(s,t,n)}}function pt(t,e){if(!t)return{};const n=e.attributesGroupName?t[e.attributesGroupName]:t;if(!n)return{};const i={};for(const t in n)t.startsWith(e.attributeNamePrefix)?i[t.substring(e.attributeNamePrefix.length)]=n[t]:i[t]=n[t];return i}function ct(t){if(!t||"string"!=typeof t)return;const e=t.indexOf(":");if(-1!==e&&e>0){const n=t.substring(0,e);if("xmlns"!==n)return n}}class dt{constructor(t,e){var n;this.options=t,this.currentNode=null,this.tagsNodeStack=[],this.parseXml=Nt,this.parseTextData=ft,this.resolveNameSpace=gt,this.buildAttributesMap=xt,this.isItStopNode=wt,this.replaceEntitiesValue=yt,this.readStopNodeData=At,this.saveTextToParentTag=Et,this.addChild=bt,this.ignoreAttributesFn="function"==typeof(n=this.options.ignoreAttributes)?n:Array.isArray(n)?t=>{for(const e of n){if("string"==typeof e&&t===e)return!0;if(e instanceof RegExp&&e.test(t))return!0}}:()=>!1,this.entityExpansionCount=0,this.currentExpandedLength=0;let i={...tt};this.options.entityDecoder?this.entityDecoder=this.options.entityDecoder:("object"==typeof this.options.htmlEntities?i=this.options.htmlEntities:!0===this.options.htmlEntities&&(i={...et,...H}),this.entityDecoder=new ut({namedEntities:{...i,...e},numericAllowed:this.options.htmlEntities,limit:{maxTotalExpansions:this.options.processEntities.maxTotalExpansions,maxExpandedLength:this.options.processEntities.maxExpandedLength,applyLimitsTo:this.options.processEntities.appliesTo}})),this.matcher=new J,this.readonlyMatcher=this.matcher.readOnly(),this.isCurrentNodeStopNode=!1,this.stopNodeExpressionsSet=new Q;const s=this.options.stopNodes;if(s&&s.length>0){for(let t=0;t<s.length;t++){const e=s[t];"string"==typeof e?this.stopNodeExpressionsSet.add(new K(e)):e instanceof K&&this.stopNodeExpressionsSet.add(e)}this.stopNodeExpressionsSet.seal()}}}function ft(t,e,n,i,s,r,o){const a=this.options;if(void 0!==t&&(a.trimValues&&!i&&(t=t.trim()),t.length>0)){o||(t=this.replaceEntitiesValue(t,e,n));const i=a.jPath?n.toString():n,h=a.tagValueProcessor(e,t,i,s,r);return null==h?t:typeof h!=typeof t||h!==t?h:a.trimValues||t.trim()===t?Tt(t,a.parseTagValue,a.numberParseOptions):t}}function gt(t){if(this.options.removeNSPrefix){const e=t.split(":"),n="/"===t.charAt(0)?"/":"";if("xmlns"===e[0])return"";2===e.length&&(t=n+e[1])}return t}const mt=new RegExp("([^\\s=]+)\\s*(=\\s*(['\"])([\\s\\S]*?)\\3)?","gm");function xt(t,e,n,i=!1){const r=this.options;if(!0===i||!0!==r.ignoreAttributes&&"string"==typeof t){const i=s(t,mt),o=i.length,a={},h=new Array(o);let l=!1;const u={};for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]),s=i[t][4];if(e.length&&void 0!==s){let i=s;r.trimValues&&(i=i.trim()),i=this.replaceEntitiesValue(i,n,this.readonlyMatcher),h[t]=i,u[e]=i,l=!0}}l&&"object"==typeof e&&e.updateCurrent&&e.updateCurrent(u);const p=r.jPath?e.toString():this.readonlyMatcher;let c=!1;for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]);if(this.ignoreAttributesFn(e,p))continue;let n=r.attributeNamePrefix+e;if(e.length)if(r.transformAttributeName&&(n=r.transformAttributeName(n)),n=Pt(n,r),void 0!==i[t][4]){const i=h[t],s=r.attributeValueProcessor(e,i,p);a[n]=null==s?i:typeof s!=typeof i||s!==i?s:Tt(i,r.parseAttributeValue,r.numberParseOptions),c=!0}else r.allowBooleanAttributes&&(a[n]=!0,c=!0)}if(!c)return;if(r.attributesGroupName&&!r.preserveOrder){const t={};return t[r.attributesGroupName]=a,t}return a}}const Nt=function(t){t=t.replace(/\r\n?/g,"\n");const e=new $("!xml");let n=e,i="";this.matcher.reset(),this.entityDecoder.reset(),this.entityExpansionCount=0,this.currentExpandedLength=0;const s=this.options,r=new k(s.processEntities),o=t.length;for(let a=0;a<o;a++)if("<"===t[a]){const h=t.charCodeAt(a+1);if(47===h){const e=vt(t,">",a,"Closing Tag is not closed.");let r=t.substring(a+2,e).trim();if(s.removeNSPrefix){const t=r.indexOf(":");-1!==t&&(r=r.substr(t+1))}r=Ct(s.transformTagName,r,"",s).tagName,n&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher));const o=this.matcher.getCurrentTag();if(r&&s.unpairedTagsSet.has(r))throw new Error(`Unpaired tag can not be used as closing tag: </${r}>`);o&&s.unpairedTagsSet.has(o)&&(this.matcher.pop(),this.tagsNodeStack.pop()),this.matcher.pop(),this.isCurrentNodeStopNode=!1,n=this.tagsNodeStack.pop(),i="",a=e}else if(63===h){let e=_t(t,a,!1,"?>");if(!e)throw new Error("Pi Tag is not closed.");i=this.saveTextToParentTag(i,n,this.readonlyMatcher);const o=this.buildAttributesMap(e.tagExp,this.matcher,e.tagName,!0);if(o){const t=o[this.options.attributeNamePrefix+"version"];this.entityDecoder.setXmlVersion(Number(t)||1),r.setXmlVersion(Number(t)||1)}if(s.ignoreDeclaration&&"?xml"===e.tagName||s.ignorePiTags);else{const t=new $(e.tagName);t.add(s.textNodeName,""),e.tagName!==e.tagExp&&e.attrExpPresent&&!0!==s.ignoreAttributes&&(t[":@"]=o),this.addChild(n,t,this.readonlyMatcher,a)}a=e.closeIndex+1}else if(33===h&&45===t.charCodeAt(a+2)&&45===t.charCodeAt(a+3)){const e=vt(t,"--\x3e",a+4,"Comment is not closed.");if(s.commentPropName){const r=t.substring(a+4,e-2);i=this.saveTextToParentTag(i,n,this.readonlyMatcher),n.add(s.commentPropName,[{[s.textNodeName]:r}])}a=e}else if(33===h&&68===t.charCodeAt(a+2)){const e=r.readDocType(t,a);this.entityDecoder.addInputEntities(e.entities),a=e.i}else if(33===h&&91===t.charCodeAt(a+2)){const e=vt(t,"]]>",a,"CDATA is not closed.")-2,r=t.substring(a+9,e);i=this.saveTextToParentTag(i,n,this.readonlyMatcher);let o=this.parseTextData(r,n.tagname,this.readonlyMatcher,!0,!1,!0,!0);null==o&&(o=""),s.cdataPropName?n.add(s.cdataPropName,[{[s.textNodeName]:r}]):n.add(s.textNodeName,o),a=e+2}else{let r=_t(t,a,s.removeNSPrefix);if(!r){const e=t.substring(Math.max(0,a-50),Math.min(o,a+50));throw new Error(`readTagExp returned undefined at position ${a}. Context: "${e}"`)}let h=r.tagName;const l=r.rawTagName;let u=r.tagExp,p=r.attrExpPresent,c=r.closeIndex;if(({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s)),s.strictReservedNames&&(h===s.commentPropName||h===s.cdataPropName||h===s.textNodeName||h===s.attributesGroupName))throw new Error(`Invalid tag name: ${h}`);n&&i&&"!xml"!==n.tagname&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher,!1));const d=n;d&&s.unpairedTagsSet.has(d.tagname)&&(n=this.tagsNodeStack.pop(),this.matcher.pop());let f=!1;u.length>0&&u.lastIndexOf("/")===u.length-1&&(f=!0,"/"===h[h.length-1]?(h=h.substr(0,h.length-1),u=h):u=u.substr(0,u.length-1),p=h!==u);let g,m=null,x={};g=ct(l),h!==e.tagname&&this.matcher.push(h,{},g),h!==u&&p&&(m=this.buildAttributesMap(u,this.matcher,h),m&&(x=pt(m,s))),h!==e.tagname&&(this.isCurrentNodeStopNode=this.isItStopNode());const N=a;if(this.isCurrentNodeStopNode){let e="";if(f)a=r.closeIndex;else if(s.unpairedTagsSet.has(h))a=r.closeIndex;else{const n=this.readStopNodeData(t,l,c+1);if(!n)throw new Error(`Unexpected end of ${l}`);a=n.i,e=n.tagContent}const i=new $(h);m&&(i[":@"]=m),i.add(s.textNodeName,e),this.matcher.pop(),this.isCurrentNodeStopNode=!1,this.addChild(n,i,this.readonlyMatcher,N)}else{if(f){({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s));const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1}else{if(s.unpairedTagsSet.has(h)){const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1,a=r.closeIndex;continue}{const t=new $(h);if(this.tagsNodeStack.length>s.maxNestedTags)throw new Error("Maximum nested tags exceeded");this.tagsNodeStack.push(n),m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),n=t}}i="",a=c}}}else i+=t[a];return e.child};function bt(t,e,n,i){this.options.captureMetaData||(i=void 0);const s=this.options.jPath?n.toString():n,r=this.options.updateTag(e.tagname,s,e[":@"]);!1===r||("string"==typeof r?(e.tagname=r,t.addChild(e,i)):t.addChild(e,i))}function yt(t,e,n){const i=this.options.processEntities;if(!i||!i.enabled)return t;if(i.allowedTags){const s=this.options.jPath?n.toString():n;if(!(Array.isArray(i.allowedTags)?i.allowedTags.includes(e):i.allowedTags(e,s)))return t}if(i.tagFilter){const s=this.options.jPath?n.toString():n;if(!i.tagFilter(e,s))return t}return this.entityDecoder.decode(t)}function Et(t,e,n,i){return t&&(void 0===i&&(i=0===e.child.length),void 0!==(t=this.parseTextData(t,e.tagname,n,!1,!!e[":@"]&&0!==Object.keys(e[":@"]).length,i))&&""!==t&&e.add(this.options.textNodeName,t),t=""),t}function wt(){return 0!==this.stopNodeExpressionsSet.size&&this.matcher.matchesAny(this.stopNodeExpressionsSet)}function vt(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s+e.length-1}function St(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s}function _t(t,e,n,i=">"){const s=function(t,e,n=">"){let i=0;const s=t.length,r=n.charCodeAt(0),o=n.length>1?n.charCodeAt(1):-1;let a="",h=e;for(let n=e;n<s;n++){const e=t.charCodeAt(n);if(i)e===i&&(i=0);else if(34===e||39===e)i=e;else if(e===r){if(-1===o)return a+=t.substring(h,n),{data:a,index:n};if(t.charCodeAt(n+1)===o)return a+=t.substring(h,n),{data:a,index:n}}else 9!==e||i||(a+=t.substring(h,n)+" ",h=n+1)}}(t,e+1,i);if(!s)return;let r=s.data;const o=s.index,a=r.search(/\s/);let h=r,l=!0;-1!==a&&(h=r.substring(0,a),r=r.substring(a+1).trimStart());const u=h;if(n){const t=h.indexOf(":");-1!==t&&(h=h.substr(t+1),l=h!==s.data.substr(t+1))}return{tagName:h,tagExp:r,closeIndex:o,attrExpPresent:l,rawTagName:u}}function At(t,e,n){const i=n;let s=1;const r=t.length;for(;n<r;n++)if("<"===t[n]){const r=t.charCodeAt(n+1);if(47===r){const r=St(t,">",n,`${e} is not closed`);if(t.substring(n+2,r).trim()===e&&(s--,0===s))return{tagContent:t.substring(i,n),i:r};n=r}else if(63===r)n=vt(t,"?>",n+1,"StopNode is not closed.");else if(33===r&&45===t.charCodeAt(n+2)&&45===t.charCodeAt(n+3))n=vt(t,"--\x3e",n+3,"StopNode is not closed.");else if(33===r&&91===t.charCodeAt(n+2))n=vt(t,"]]>",n,"StopNode is not closed.")-2;else{const i=_t(t,n,!1);i&&((i&&i.tagName)===e&&"/"!==i.tagExp[i.tagExp.length-1]&&s++,n=i.closeIndex)}}}function Tt(t,e,n){if(e&&"string"==typeof t){const e=t.trim();return"true"===e||"false"!==e&&function(t,e={}){if(e=Object.assign({},X,e),!t||"string"!=typeof t)return t;let n=t.trim();if(0===n.length)return t;if(void 0!==e.skipLike&&e.skipLike.test(n))return t;if("0"===n)return 0;if(e.hex&&U.test(n))return q(n,16);if(e.binary&&B.test(n))return q(n,2);if(e.octal&&W.test(n))return q(n,8);if(isFinite(n)){if(n.includes("e")||n.includes("E"))return function(t,e,n){if(!n.eNotation)return t;const i=e.match(Y);if(i){let s=i[1]||"";const r=-1===i[3].indexOf("e")?"E":"e",o=i[2],a=s?t[o.length+1]===r:t[o.length]===r;return o.length>1&&a?t:(1!==o.length||!i[3].startsWith(`.${r}`)&&i[3][0]!==r)&&o.length>0?n.leadingZeros&&!a?(e=(i[1]||"")+i[3],Number(e)):t:Number(e)}return t}(t,n,e);{const s=z.exec(n);if(s){const r=s[1]||"",o=s[2];let a=(i=s[3])&&-1!==i.indexOf(".")?("."===(i=i.replace(/0+$/,""))?i="0":"."===i[0]?i="0"+i:"."===i[i.length-1]&&(i=i.substring(0,i.length-1)),i):i;const h=r?"."===t[o.length+1]:"."===t[o.length];if(!e.leadingZeros&&(o.length>1||1===o.length&&!h))return t;{const i=Number(n),s=String(i);if(0===i)return i;if(-1!==s.search(/[eE]/))return e.eNotation?i:t;if(-1!==n.indexOf("."))return"0"===s||s===a||s===`${r}${a}`?i:t;let h=o?a:n;return o?h===s||r+h===s?i:t:h===s||h===r+s?i:t}}return t}}var i;return function(t,e,n){const i=e===1/0;switch(n.infinity.toLowerCase()){case"null":return null;case"infinity":return e;case"string":return i?"Infinity":"-Infinity";default:return t}}(t,Number(n),e)}(t,n)}return void 0!==t?t:""}function Ct(t,e,n,i){if(t){const i=t(e);n===e&&(n=i),e=i}return{tagName:e=Pt(e,i),tagExp:n}}function Pt(t,e){if(a.includes(t))throw new Error(`[SECURITY] Invalid name: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);return o.includes(t)?e.onDangerousProperty(t):t}const $t=$.getMetaDataSymbol();function Ot(t,e){if(!t||"object"!=typeof t)return{};if(!e)return t;const n={};for(const i in t)i.startsWith(e)?n[i.substring(e.length)]=t[i]:n[i]=t[i];return n}function It(t,e,n,i){return Vt(t,e,n,i)}function Vt(t,e,n,i){let s;const r={};for(let o=0;o<t.length;o++){const a=t[o],h=Dt(a);if(void 0!==h&&h!==e.textNodeName){const t=Ot(a[":@"]||{},e.attributeNamePrefix);n.push(h,t)}if(h===e.textNodeName)void 0===s?s=a[h]:s+=""+a[h];else{if(void 0===h)continue;if(a[h]){let t=Vt(a[h],e,n,i);const s=jt(t,e);if(0===Object.keys(t).length&&e.alwaysCreateTextNode&&(t[e.textNodeName]=""),a[":@"]?Mt(t,a[":@"],i,e):1!==Object.keys(t).length||void 0===t[e.textNodeName]||e.alwaysCreateTextNode?0===Object.keys(t).length&&(e.alwaysCreateTextNode?t[e.textNodeName]="":t=""):t=t[e.textNodeName],void 0!==a[$t]&&"object"==typeof t&&null!==t&&(t[$t]=a[$t]),void 0!==r[h]&&Object.prototype.hasOwnProperty.call(r,h))Array.isArray(r[h])||(r[h]=[r[h]]),r[h].push(t);else{const n=e.jPath?i.toString():i;e.isArray(h,n,s)?r[h]=[t]:r[h]=t}void 0!==h&&h!==e.textNodeName&&n.pop()}}}return"string"==typeof s?s.length>0&&(r[e.textNodeName]=s):void 0!==s&&(r[e.textNodeName]=s),r}function Dt(t){const e=Object.keys(t);for(let t=0;t<e.length;t++){const n=e[t];if(":@"!==n)return n}}function Mt(t,e,n,i){if(e){const s=Object.keys(e),r=s.length;for(let o=0;o<r;o++){const r=s[o],a=r.startsWith(i.attributeNamePrefix)?r.substring(i.attributeNamePrefix.length):r,h=i.jPath?n.toString()+"."+a:n;i.isArray(r,h,!0,!0)?t[r]=[e[r]]:t[r]=e[r]}}}function jt(t,e){const{textNodeName:n}=e,i=Object.keys(t).length;return 0===i||!(1!==i||!t[n]&&"boolean"!=typeof t[n]&&0!==t[n])}class Lt{constructor(t){this.externalEntities={},this.options=C(t)}parse(t,e){if("string"!=typeof t&&t.toString)t=t.toString();else if("string"!=typeof t)throw new Error("XML data is accepted in String or Bytes[] form.");if(e){!0===e&&(e={});const n=l(t,e);if(!0!==n)throw Error(`${n.err.msg}:${n.err.line}:${n.err.col}`)}const n=new dt(this.options,this.externalEntities),i=n.parseXml(t);return this.options.preserveOrder||void 0===i?i:It(i,this.options,n.matcher,n.readonlyMatcher)}addEntity(t,e){if(-1!==e.indexOf("&"))throw new Error("Entity value can't have '&'");if(-1!==t.indexOf("&")||-1!==t.indexOf(";"))throw new Error("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");if("&"===e)throw new Error("An entity with value '&' is not permitted");this.externalEntities[t]=e}static getMetaDataSymbol(){return $.getMetaDataSymbol()}}function kt(t){return String(t).replace(/--/g,"- -").replace(/--/g,"- -").replace(/-$/,"- ")}function Rt(t){return String(t).replace(/\]\]>/g,"]]]]><![CDATA[>")}function Ft(t){return String(t).replace(/"/g,"&quot;").replace(/'/g,"&apos;")}function Gt(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function Ut(t,e){let n="";e.format&&(n="\n");const i=[];if(e.stopNodes&&Array.isArray(e.stopNodes))for(let t=0;t<e.stopNodes.length;t++){const n=e.stopNodes[t];"string"==typeof n?i.push(new K(n)):n instanceof K&&i.push(n)}const s=function(t,e){if(!Array.isArray(t)||0===t.length)return"1.0";const n=t[0];if("?xml"===Yt(n)){const t=n[":@"];if(t){const n=e.attributeNamePrefix+"version";if(t[n])return t[n]}}return"1.0"}(t,e);return Bt(t,e,n,new J,i,s)}function Bt(t,e,n,i,s,r){let o="",a=!1;if(e.maxNestedTags&&i.getDepth()>e.maxNestedTags)throw new Error("Maximum nested tags exceeded");if(!Array.isArray(t)){if(null!=t){let n=t.toString();return n=Jt(n,e),n}return""}for(let h=0;h<t.length;h++){const l=t[h],u=Yt(l);if(void 0===u)continue;const p=u===e.textNodeName||u===e.cdataPropName||u===e.commentPropName||"?"===u[0]?u:Gt(u,!1,e,i,r),c=Wt(l[":@"],e);i.push(p,c);const d=Zt(i,s);if(p===e.textNodeName){let t=l[u];d||(t=e.tagValueProcessor(p,t),t=Jt(t,e)),a&&(o+=n),o+=t,a=!1,i.pop();continue}if(p===e.cdataPropName){a&&(o+=n),o+=`<![CDATA[${Rt(l[u][0][e.textNodeName])}]]>`,a=!1,i.pop();continue}if(p===e.commentPropName){o+=n+`\x3c!--${kt(l[u][0][e.textNodeName])}--\x3e`,a=!0,i.pop();continue}if("?"===p[0]){o+=("?xml"===p?"":n)+`<${p}${qt(l[":@"],e,d,i,r)}?>`,a=!0,i.pop();continue}let f=n;""!==f&&(f+=e.indentBy);const g=n+`<${p}${qt(l[":@"],e,d,i,r)}`;let m;m=d?zt(l[u],e):Bt(l[u],e,f,i,s,r),-1!==e.unpairedTags.indexOf(p)?e.suppressUnpairedNode?o+=g+">":o+=g+"/>":m&&0!==m.length||!e.suppressEmptyNode?m&&m.endsWith(">")?o+=g+`>${m}${n}</${p}>`:(o+=g+">",m&&""!==n&&(m.includes("/>")||m.includes("</"))?o+=n+e.indentBy+m+n:o+=m,o+=`</${p}>`):o+=g+"/>",a=!0,i.pop()}return o}function Wt(t,e){if(!t||e.ignoreAttributes)return null;const n={};let i=!1;for(let s in t)Object.prototype.hasOwnProperty.call(t,s)&&(n[s.startsWith(e.attributeNamePrefix)?s.substr(e.attributeNamePrefix.length):s]=Ft(t[s]),i=!0);return i?n:null}function zt(t,e){if(!Array.isArray(t))return null!=t?t.toString():"";let n="";for(let i=0;i<t.length;i++){const s=t[i],r=Yt(s);if(r===e.textNodeName)n+=s[r];else if(r===e.cdataPropName)n+=s[r][0][e.textNodeName];else if(r===e.commentPropName)n+=s[r][0][e.textNodeName];else{if(r&&"?"===r[0])continue;if(r){const t=Xt(s[":@"],e),i=zt(s[r],e);i&&0!==i.length?n+=`<${r}${t}>${i}</${r}>`:n+=`<${r}${t}/>`}}}return n}function Xt(t,e){let n="";if(t&&!e.ignoreAttributes)for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;let s=t[i];!0===s&&e.suppressBooleanAttributes?n+=` ${i.substr(e.attributeNamePrefix.length)}`:n+=` ${i.substr(e.attributeNamePrefix.length)}="${Ft(s)}"`}return n}function Yt(t){const e=Object.keys(t);for(let n=0;n<e.length;n++){const i=e[n];if(Object.prototype.hasOwnProperty.call(t,i)&&":@"!==i)return i}}function qt(t,e,n,i,s){let r="";if(t&&!e.ignoreAttributes)for(let o in t){if(!Object.prototype.hasOwnProperty.call(t,o))continue;const a=o.substr(e.attributeNamePrefix.length),h=n?a:Gt(a,!0,e,i,s);let l;n?l=t[o]:(l=e.attributeValueProcessor(o,t[o]),l=Jt(l,e)),!0===l&&e.suppressBooleanAttributes?r+=` ${h}`:r+=` ${h}="${Ft(l)}"`}return r}function Zt(t,e){if(!e||0===e.length)return!1;for(let n=0;n<e.length;n++)if(t.matches(e[n]))return!0;return!1}function Jt(t,e){if(t&&t.length>0&&e.processEntities)for(let n=0;n<e.entities.length;n++){const i=e.entities[n];t=t.replace(i.regex,i.val)}return t}const Kt={attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,cdataPropName:!1,format:!1,indentBy:"  ",suppressEmptyNode:!1,suppressUnpairedNode:!0,suppressBooleanAttributes:!0,tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},preserveOrder:!1,commentPropName:!1,unpairedTags:[],entities:[{regex:new RegExp("&","g"),val:"&amp;"},{regex:new RegExp(">","g"),val:"&gt;"},{regex:new RegExp("<","g"),val:"&lt;"},{regex:new RegExp("'","g"),val:"&apos;"},{regex:new RegExp('"',"g"),val:"&quot;"}],processEntities:!0,stopNodes:[],oneListGroup:!1,maxNestedTags:100,jPath:!0,sanitizeName:!1};function Qt(t){if(this.options=Object.assign({},Kt,t),this.options.stopNodes&&Array.isArray(this.options.stopNodes)&&(this.options.stopNodes=this.options.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),this.stopNodeExpressions=[],this.options.stopNodes&&Array.isArray(this.options.stopNodes))for(let t=0;t<this.options.stopNodes.length;t++){const e=this.options.stopNodes[t];"string"==typeof e?this.stopNodeExpressions.push(new K(e)):e instanceof K&&this.stopNodeExpressions.push(e)}var e;!0===this.options.ignoreAttributes||this.options.attributesGroupName?this.isAttribute=function(){return!1}:(this.ignoreAttributesFn="function"==typeof(e=this.options.ignoreAttributes)?e:Array.isArray(e)?t=>{for(const n of e){if("string"==typeof n&&t===n)return!0;if(n instanceof RegExp&&n.test(t))return!0}}:()=>!1,this.attrPrefixLen=this.options.attributeNamePrefix.length,this.isAttribute=ne),this.processTextOrObjNode=te,this.options.format?(this.indentate=ee,this.tagEndChar=">\n",this.newLine="\n"):(this.indentate=function(){return""},this.tagEndChar=">",this.newLine="")}function Ht(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function te(t,e,n,i,s){const r=this.extractAttributes(t);if(i.push(e,r),this.checkStopNode(i)){const s=this.buildRawContent(t),r=this.buildAttributesForStopNode(t);return i.pop(),this.buildObjectNode(s,e,r,n)}const o=this.j2x(t,n+1,i,s);return i.pop(),"?"===e[0]?this.buildTextValNode("",e,o.attrStr,n,i):void 0!==t[this.options.textNodeName]&&1===Object.keys(t).length?this.buildTextValNode(t[this.options.textNodeName],e,o.attrStr,n,i):this.buildObjectNode(o.val,e,o.attrStr,n)}function ee(t){return this.options.indentBy.repeat(t)}function ne(t){return!(!t.startsWith(this.options.attributeNamePrefix)||t===this.options.textNodeName)&&t.substr(this.attrPrefixLen)}Qt.prototype.build=function(t){if(this.options.preserveOrder)return Ut(t,this.options);{Array.isArray(t)&&this.options.arrayNodeName&&this.options.arrayNodeName.length>1&&(t={[this.options.arrayNodeName]:t});const e=new J,n=function(t,e){const n=t["?xml"];if(n&&"object"==typeof n){if(e.attributesGroupName&&n[e.attributesGroupName]){const t=n[e.attributesGroupName][e.attributeNamePrefix+"version"];if(t)return t}const t=n[e.attributeNamePrefix+"version"];if(t)return t}return"1.0"}(t,this.options);return this.j2x(t,0,e,n).val}},Qt.prototype.j2x=function(t,e,n,i){let s="",r="";if(this.options.maxNestedTags&&n.getDepth()>=this.options.maxNestedTags)throw new Error("Maximum nested tags exceeded");const o=this.options.jPath?n.toString():n,a=this.checkStopNode(n);for(let h in t){if(!Object.prototype.hasOwnProperty.call(t,h))continue;const l=h===this.options.textNodeName||h===this.options.cdataPropName||h===this.options.commentPropName||this.options.attributesGroupName&&h===this.options.attributesGroupName||this.isAttribute(h)||"?"===h[0]?h:Ht(h,!1,this.options,n,i);if(void 0===t[h])this.isAttribute(h)&&(r+="");else if(null===t[h])this.isAttribute(h)||l===this.options.cdataPropName||l===this.options.commentPropName?r+="":"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if(t[h]instanceof Date)r+=this.buildTextValNode(t[h],l,"",e,n);else if("object"!=typeof t[h]){const u=this.isAttribute(h);if(u&&!this.ignoreAttributesFn(u,o)){const e=Ht(u,!0,this.options,n,i);s+=this.buildAttrPairStr(e,""+t[h],a)}else if(!u)if(h===this.options.textNodeName){let e=this.options.tagValueProcessor(h,""+t[h]);r+=this.replaceEntitiesValue(e)}else{n.push(l);const i=this.checkStopNode(n);if(n.pop(),i){const n=""+t[h];r+=""===n?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+n+"</"+l+this.tagEndChar}else r+=this.buildTextValNode(t[h],l,"",e,n)}}else if(Array.isArray(t[h])){const s=t[h].length;let o="",a="";for(let u=0;u<s;u++){const s=t[h][u];if(void 0===s);else if(null===s)"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if("object"==typeof s)if(this.options.oneListGroup){n.push(l);const t=this.j2x(s,e+1,n,i);n.pop(),o+=t.val,this.options.attributesGroupName&&s.hasOwnProperty(this.options.attributesGroupName)&&(a+=t.attrStr)}else o+=this.processTextOrObjNode(s,l,e,n,i);else if(this.options.oneListGroup){let t=this.options.tagValueProcessor(l,s);t=this.replaceEntitiesValue(t),o+=t}else{n.push(l);const t=this.checkStopNode(n);if(n.pop(),t){const t=""+s;o+=""===t?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+t+"</"+l+this.tagEndChar}else o+=this.buildTextValNode(s,l,"",e,n)}}this.options.oneListGroup&&(o=this.buildObjectNode(o,l,a,e)),r+=o}else if(this.options.attributesGroupName&&h===this.options.attributesGroupName){const e=Object.keys(t[h]),r=e.length;for(let o=0;o<r;o++){const r=Ht(e[o],!0,this.options,n,i);s+=this.buildAttrPairStr(r,""+t[h][e[o]],a)}}else r+=this.processTextOrObjNode(t[h],l,e,n,i)}return{attrStr:s,val:r}},Qt.prototype.buildAttrPairStr=function(t,e,n){return n||(e=this.options.attributeValueProcessor(t,""+e),e=this.replaceEntitiesValue(e)),this.options.suppressBooleanAttributes&&"true"===e?" "+t:" "+t+'="'+Ft(e)+'"'},Qt.prototype.extractAttributes=function(t){if(!t||"object"!=typeof t)return null;const e={};let n=!1;if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const i=t[this.options.attributesGroupName];for(let t in i)Object.prototype.hasOwnProperty.call(i,t)&&(e[t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t]=Ft(i[t]),n=!0)}else for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;const s=this.isAttribute(i);s&&(e[s]=Ft(t[i]),n=!0)}return n?e:null},Qt.prototype.buildRawContent=function(t){if("string"==typeof t)return t;if("object"!=typeof t||null===t)return String(t);if(void 0!==t[this.options.textNodeName])return t[this.options.textNodeName];let e="";for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;if(this.isAttribute(n))continue;if(this.options.attributesGroupName&&n===this.options.attributesGroupName)continue;const i=t[n];if(n===this.options.textNodeName)e+=i;else if(Array.isArray(i)){for(let t of i)if("string"==typeof t||"number"==typeof t)e+=`<${n}>${t}</${n}>`;else if("object"==typeof t&&null!==t){const i=this.buildRawContent(t),s=this.buildAttributesForStopNode(t);e+=""===i?`<${n}${s}/>`:`<${n}${s}>${i}</${n}>`}}else if("object"==typeof i&&null!==i){const t=this.buildRawContent(i),s=this.buildAttributesForStopNode(i);e+=""===t?`<${n}${s}/>`:`<${n}${s}>${t}</${n}>`}else e+=`<${n}>${i}</${n}>`}return e},Qt.prototype.buildAttributesForStopNode=function(t){if(!t||"object"!=typeof t)return"";let e="";if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const n=t[this.options.attributesGroupName];for(let t in n){if(!Object.prototype.hasOwnProperty.call(n,t))continue;const i=t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t,s=n[t];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}else for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;const i=this.isAttribute(n);if(i){const s=t[n];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}return e},Qt.prototype.buildObjectNode=function(t,e,n,i){if(""===t)return"?"===e[0]?this.indentate(i)+"<"+e+n+"?"+this.tagEndChar:this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar;if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s="</"+e+this.tagEndChar,r="";return"?"===e[0]&&(r="?",s=""),!n&&""!==n||-1!==t.indexOf("<")?!1!==this.options.commentPropName&&e===this.options.commentPropName&&0===r.length?this.indentate(i)+`\x3c!--${t}--\x3e`+this.newLine:this.indentate(i)+"<"+e+n+r+this.tagEndChar+t+this.indentate(i)+s:this.indentate(i)+"<"+e+n+r+">"+t+s}},Qt.prototype.closeTag=function(t){let e="";return-1!==this.options.unpairedTags.indexOf(t)?this.options.suppressUnpairedNode||(e="/"):e=this.options.suppressEmptyNode?"/":`></${t}`,e},Qt.prototype.checkStopNode=function(t){if(!this.stopNodeExpressions||0===this.stopNodeExpressions.length)return!1;for(let e=0;e<this.stopNodeExpressions.length;e++)if(t.matches(this.stopNodeExpressions[e]))return!0;return!1},Qt.prototype.buildTextValNode=function(t,e,n,i,s){if(!1!==this.options.cdataPropName&&e===this.options.cdataPropName){const e=Rt(t);return this.indentate(i)+`<![CDATA[${e}]]>`+this.newLine}if(!1!==this.options.commentPropName&&e===this.options.commentPropName){const e=kt(t);return this.indentate(i)+`\x3c!--${e}--\x3e`+this.newLine}if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s=this.options.tagValueProcessor(e,t);return s=this.replaceEntitiesValue(s),""===s?this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar:this.indentate(i)+"<"+e+n+">"+s+"</"+e+this.tagEndChar}},Qt.prototype.replaceEntitiesValue=function(t){if(t&&t.length>0&&this.options.processEntities)for(let e=0;e<this.options.entities.length;e++){const n=this.options.entities[e];t=t.replace(n.regex,n.val)}return t};const ie=Qt,se={validate:l};module.exports=e})();
 
 /***/ }),
 
-/***/ 334:
+/***/ 335:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67151,7 +67508,7 @@ var KnownEncryptionAlgorithmType;
 
 /***/ }),
 
-/***/ 335:
+/***/ 336:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -67380,7 +67737,7 @@ function replaceAll(value, searchValue, replaceValue) {
 
 /***/ }),
 
-/***/ 336:
+/***/ 337:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67406,7 +67763,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(407);
+var import_exponentialRetryStrategy = __nccwpck_require__(408);
 var import_throttlingRetryStrategy = __nccwpck_require__(39);
 var import_retryPolicy = __nccwpck_require__(17);
 var import_constants = __nccwpck_require__(53);
@@ -67426,7 +67783,7 @@ function defaultRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 337:
+/***/ 338:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67435,10 +67792,10 @@ function defaultRetryPolicy(options = {}) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageRetryPolicyFactory = exports.NewRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = void 0;
-const StorageRetryPolicy_js_1 = __nccwpck_require__(86);
+const StorageRetryPolicy_js_1 = __nccwpck_require__(87);
 Object.defineProperty(exports, "StorageRetryPolicy", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.StorageRetryPolicy; } }));
 Object.defineProperty(exports, "NewRetryPolicyFactory", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.NewRetryPolicyFactory; } }));
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(429);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(430);
 Object.defineProperty(exports, "StorageRetryPolicyType", ({ enumerable: true, get: function () { return StorageRetryPolicyType_js_1.StorageRetryPolicyType; } }));
 /**
  * StorageRetryPolicyFactory is a factory class helping generating {@link StorageRetryPolicy} objects.
@@ -67467,7 +67824,7 @@ exports.StorageRetryPolicyFactory = StorageRetryPolicyFactory;
 
 /***/ }),
 
-/***/ 338:
+/***/ 339:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67573,7 +67930,7 @@ function toArrayBuffer(source) {
 
 /***/ }),
 
-/***/ 339:
+/***/ 340:
 /***/ ((module) => {
 
 "use strict";
@@ -67678,7 +68035,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 340:
+/***/ 341:
 /***/ ((module) => {
 
 "use strict";
@@ -67686,7 +68043,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 341:
+/***/ 342:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67705,7 +68062,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 342:
+/***/ 343:
 /***/ (function(module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -67744,12 +68101,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._readLinuxVersionFile = exports._getOsVersion = exports._findMatch = void 0;
-const semver = __importStar(__nccwpck_require__(185));
-const core_1 = __nccwpck_require__(472);
+const semver = __importStar(__nccwpck_require__(187));
+const core_1 = __nccwpck_require__(473);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
-const os = __nccwpck_require__(100);
-const cp = __nccwpck_require__(171);
+const os = __nccwpck_require__(102);
+const cp = __nccwpck_require__(173);
 const fs = __nccwpck_require__(542);
 function _findMatch(versionSpec, stable, candidates, archFilter) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -67841,7 +68198,7 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
-/***/ 343:
+/***/ 344:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -67871,7 +68228,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-const path = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(256));
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
  * replaced with /.
@@ -67910,7 +68267,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 344:
+/***/ 345:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -68018,7 +68375,7 @@ var WireType;
 
 /***/ }),
 
-/***/ 345:
+/***/ 346:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68029,17 +68386,17 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatch = void 0;
 const core_util_1 = __nccwpck_require__(15);
 const core_auth_1 = __nccwpck_require__(525);
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_2 = __nccwpck_require__(15);
-const storage_common_1 = __nccwpck_require__(284);
-const Clients_js_1 = __nccwpck_require__(191);
+const storage_common_1 = __nccwpck_require__(285);
+const Clients_js_1 = __nccwpck_require__(193);
 const Mutex_js_1 = __nccwpck_require__(530);
-const Pipeline_js_1 = __nccwpck_require__(189);
-const utils_common_js_1 = __nccwpck_require__(162);
-const core_xml_1 = __nccwpck_require__(201);
-const constants_js_1 = __nccwpck_require__(156);
+const Pipeline_js_1 = __nccwpck_require__(191);
+const utils_common_js_1 = __nccwpck_require__(164);
+const core_xml_1 = __nccwpck_require__(203);
+const constants_js_1 = __nccwpck_require__(158);
 const tracing_js_1 = __nccwpck_require__(35);
-const core_client_1 = __nccwpck_require__(452);
+const core_client_1 = __nccwpck_require__(453);
 /**
  * A BlobBatch represents an aggregated set of operations on blobs.
  * Currently, only `delete` and `setAccessTier` are supported.
@@ -68303,7 +68660,7 @@ function batchHeaderFilterPolicy() {
 
 /***/ }),
 
-/***/ 346:
+/***/ 347:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68312,17 +68669,17 @@ function batchHeaderFilterPolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = exports.AvroReadable = exports.AvroReader = void 0;
-var AvroReader_js_1 = __nccwpck_require__(433);
+var AvroReader_js_1 = __nccwpck_require__(434);
 Object.defineProperty(exports, "AvroReader", ({ enumerable: true, get: function () { return AvroReader_js_1.AvroReader; } }));
-var AvroReadable_js_1 = __nccwpck_require__(397);
+var AvroReadable_js_1 = __nccwpck_require__(398);
 Object.defineProperty(exports, "AvroReadable", ({ enumerable: true, get: function () { return AvroReadable_js_1.AvroReadable; } }));
-var AvroReadableFromStream_js_1 = __nccwpck_require__(259);
+var AvroReadableFromStream_js_1 = __nccwpck_require__(260);
 Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, get: function () { return AvroReadableFromStream_js_1.AvroReadableFromStream; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 347:
+/***/ 348:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68348,13 +68705,13 @@ __export(tracingPolicy_exports, {
   tracingPolicyName: () => tracingPolicyName
 });
 module.exports = __toCommonJS(tracingPolicy_exports);
-var import_core_tracing = __nccwpck_require__(87);
-var import_constants = __nccwpck_require__(166);
-var import_userAgent = __nccwpck_require__(302);
-var import_log = __nccwpck_require__(190);
+var import_core_tracing = __nccwpck_require__(88);
+var import_constants = __nccwpck_require__(168);
+var import_userAgent = __nccwpck_require__(303);
+var import_log = __nccwpck_require__(192);
 var import_core_util = __nccwpck_require__(15);
-var import_restError = __nccwpck_require__(364);
-var import_util = __nccwpck_require__(154);
+var import_restError = __nccwpck_require__(365);
+var import_util = __nccwpck_require__(156);
 const tracingPolicyName = "tracingPolicy";
 function tracingPolicy(options = {}) {
   const userAgentPromise = (0, import_userAgent.getUserAgentValue)(options.userAgentPrefix);
@@ -68468,7 +68825,7 @@ function tryProcessResponse(span, response) {
 
 /***/ }),
 
-/***/ 348:
+/***/ 349:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68480,14 +68837,14 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher
-} = __nccwpck_require__(377)
-const Client = __nccwpck_require__(96)
+} = __nccwpck_require__(378)
+const Client = __nccwpck_require__(98)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(500)
+} = __nccwpck_require__(501)
 const util = __nccwpck_require__(75)
-const { kUrl, kInterceptors } = __nccwpck_require__(202)
-const buildConnector = __nccwpck_require__(273)
+const { kUrl, kInterceptors } = __nccwpck_require__(204)
+const buildConnector = __nccwpck_require__(274)
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -68584,7 +68941,7 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 349:
+/***/ 350:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68610,7 +68967,7 @@ __export(oauth2AuthenticationPolicy_exports, {
   oauth2AuthenticationPolicyName: () => oauth2AuthenticationPolicyName
 });
 module.exports = __toCommonJS(oauth2AuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(447);
+var import_checkInsecureConnection = __nccwpck_require__(448);
 const oauth2AuthenticationPolicyName = "oauth2AuthenticationPolicy";
 function oauth2AuthenticationPolicy(options) {
   return {
@@ -68636,7 +68993,7 @@ function oauth2AuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 350:
+/***/ 351:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68662,9 +69019,9 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(296);
-var import_checkEnvironment = __nccwpck_require__(451);
-var import_httpHeaders = __nccwpck_require__(497);
+var import_bytesEncoding = __nccwpck_require__(297);
+var import_checkEnvironment = __nccwpck_require__(452);
+var import_httpHeaders = __nccwpck_require__(498);
 const formDataPolicyName = "formDataPolicy";
 function formDataToFormDataMap(formData) {
   const formDataMap = {};
@@ -68752,7 +69109,7 @@ async function prepareFormData(formData, request) {
 
 /***/ }),
 
-/***/ 351:
+/***/ 352:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68778,7 +69135,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(295);
 const redirectPolicyName = import_policies.redirectPolicyName;
 function redirectPolicy(options = {}) {
   return (0, import_policies.redirectPolicy)(options);
@@ -68789,19 +69146,19 @@ function redirectPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 352:
+/***/ 353:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(202)
-const { URL } = __nccwpck_require__(92)
+const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(204)
+const { URL } = __nccwpck_require__(94)
 const Agent = __nccwpck_require__(6)
-const Pool = __nccwpck_require__(348)
+const Pool = __nccwpck_require__(349)
 const DispatcherBase = __nccwpck_require__(68)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(500)
-const buildConnector = __nccwpck_require__(273)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(501)
+const buildConnector = __nccwpck_require__(274)
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -68986,19 +69343,19 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 353:
+/***/ 354:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonReader = void 0;
-const json_typings_1 = __nccwpck_require__(406);
-const base64_1 = __nccwpck_require__(313);
-const reflection_info_1 = __nccwpck_require__(465);
-const pb_long_1 = __nccwpck_require__(124);
-const assert_1 = __nccwpck_require__(496);
-const reflection_long_convert_1 = __nccwpck_require__(165);
+const json_typings_1 = __nccwpck_require__(407);
+const base64_1 = __nccwpck_require__(314);
+const reflection_info_1 = __nccwpck_require__(466);
+const pb_long_1 = __nccwpck_require__(126);
+const assert_1 = __nccwpck_require__(497);
+const reflection_long_convert_1 = __nccwpck_require__(167);
 /**
  * Reads proto3 messages in canonical JSON format using reflection information.
  *
@@ -69311,7 +69668,7 @@ exports.ReflectionJsonReader = ReflectionJsonReader;
 
 /***/ }),
 
-/***/ 354:
+/***/ 355:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -69327,7 +69684,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
-const os_1 = __nccwpck_require__(100);
+const os_1 = __nccwpck_require__(102);
 const fs_1 = __nccwpck_require__(542);
 const { access, appendFile, writeFile } = fs_1.promises;
 exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
@@ -69601,7 +69958,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 355:
+/***/ 356:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -69684,13 +70041,13 @@ exports.utf8read = utf8read;
 
 /***/ }),
 
-/***/ 356:
+/***/ 357:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 /* eslint-disable no-new-wrappers, no-eval, camelcase, operator-linebreak */
-module.exports = makeParserClass(__nccwpck_require__(437))
+module.exports = makeParserClass(__nccwpck_require__(438))
 module.exports.makeParserClass = makeParserClass
 
 class TomlError extends Error {
@@ -69711,10 +70068,10 @@ TomlError.wrap = err => {
 }
 module.exports.TomlError = TomlError
 
-const createDateTime = __nccwpck_require__(393)
-const createDateTimeFloat = __nccwpck_require__(177)
+const createDateTime = __nccwpck_require__(394)
+const createDateTimeFloat = __nccwpck_require__(179)
 const createDate = __nccwpck_require__(60)
-const createTime = __nccwpck_require__(358)
+const createTime = __nccwpck_require__(359)
 
 const CTRL_I = 0x09
 const CTRL_J = 0x0A
@@ -71071,7 +71428,7 @@ function makeParserClass (Parser) {
 
 /***/ }),
 
-/***/ 357:
+/***/ 358:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71080,8 +71437,8 @@ function makeParserClass (Parser) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = createTracingClient;
-const instrumenter_js_1 = __nccwpck_require__(419);
-const tracingContext_js_1 = __nccwpck_require__(378);
+const instrumenter_js_1 = __nccwpck_require__(420);
+const tracingContext_js_1 = __nccwpck_require__(379);
 /**
  * Creates a new tracing client.
  *
@@ -71159,12 +71516,12 @@ function createTracingClient(options) {
 
 /***/ }),
 
-/***/ 358:
+/***/ 359:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(416)
+const f = __nccwpck_require__(417)
 
 class Time extends Date {
   constructor (value) {
@@ -71189,14 +71546,14 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 359:
+/***/ 360:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(131)
-const Pool = __nccwpck_require__(348)
+const { promisify } = __nccwpck_require__(133)
+const Pool = __nccwpck_require__(349)
 const { buildMockDispatch } = __nccwpck_require__(8)
 const {
   kDispatches,
@@ -71206,10 +71563,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(483)
-const { MockInterceptor } = __nccwpck_require__(143)
-const Symbols = __nccwpck_require__(202)
-const { InvalidArgumentError } = __nccwpck_require__(500)
+} = __nccwpck_require__(484)
+const { MockInterceptor } = __nccwpck_require__(145)
+const Symbols = __nccwpck_require__(204)
+const { InvalidArgumentError } = __nccwpck_require__(501)
 
 /**
  * MockPool provides an API that extends the Pool to influence the mockDispatches.
@@ -71256,7 +71613,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 360:
+/***/ 361:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -71310,9 +71667,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tripleToCcRsSuffix = tripleToCcRsSuffix;
 exports.detectMuslCcEnv = detectMuslCcEnv;
 exports.tryDelegateToSoldrDoctorMuslCc = tryDelegateToSoldrDoctorMuslCc;
-const fs = __importStar(__nccwpck_require__(256));
+const fs = __importStar(__nccwpck_require__(257));
 const path = __importStar(__nccwpck_require__(519));
-const soldr_toolchain_client_js_1 = __nccwpck_require__(179);
+const soldr_toolchain_client_js_1 = __nccwpck_require__(181);
 const MUSL_TRIPLE_RE = /^[a-z0-9_]+-unknown-linux-musl$/;
 function tripleToCcRsSuffix(triple) {
     return triple.replace(/-/g, "_");
@@ -71490,7 +71847,7 @@ async function tryDelegateToSoldrDoctorMuslCc(opts) {
 
 /***/ }),
 
-/***/ 361:
+/***/ 362:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -71548,7 +71905,7 @@ exports.ClientStreamingCall = ClientStreamingCall;
 
 /***/ }),
 
-/***/ 362:
+/***/ 363:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -72311,7 +72668,7 @@ exports.Decompress = Decompress;
 
 /***/ }),
 
-/***/ 363:
+/***/ 364:
 /***/ ((module) => {
 
 module.exports = function (xs, fn) {
@@ -72331,7 +72688,7 @@ var isArray = Array.isArray || function (xs) {
 
 /***/ }),
 
-/***/ 364:
+/***/ 365:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -72357,7 +72714,7 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_ts_http_runtime = __nccwpck_require__(97);
+var import_ts_http_runtime = __nccwpck_require__(99);
 const RestError = import_ts_http_runtime.RestError;
 function isRestError(e) {
   return (0, import_ts_http_runtime.isRestError)(e);
@@ -72368,22 +72725,22 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 365:
+/***/ 366:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { finished, PassThrough } = __nccwpck_require__(138)
+const { finished, PassThrough } = __nccwpck_require__(140)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(500)
+} = __nccwpck_require__(501)
 const util = __nccwpck_require__(75)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(195)
-const { AsyncResource } = __nccwpck_require__(441)
-const { addSignal, removeSignal } = __nccwpck_require__(111)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(197)
+const { AsyncResource } = __nccwpck_require__(442)
+const { addSignal, removeSignal } = __nccwpck_require__(113)
 
 class StreamHandler extends AsyncResource {
   constructor (opts, factory, callback) {
@@ -72596,7 +72953,7 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 366:
+/***/ 367:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72610,9 +72967,9 @@ module.exports = stream
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(224);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(186));
+const tslib_1 = __nccwpck_require__(225);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
 /** Class containing BlockBlob operations. */
 class BlockBlobImpl {
@@ -72976,7 +73333,7 @@ const getBlockListOperationSpec = {
 
 /***/ }),
 
-/***/ 367:
+/***/ 368:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -73021,7 +73378,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 368:
+/***/ 369:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73031,7 +73388,7 @@ function decompressResponsePolicy() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GenericPollOperation = void 0;
 const operation_js_1 = __nccwpck_require__(57);
-const logger_js_1 = __nccwpck_require__(198);
+const logger_js_1 = __nccwpck_require__(200);
 const createStateProxy = () => ({
     initState: (config) => ({ config, isStarted: true }),
     setCanceled: (state) => (state.isCancelled = true),
@@ -73116,7 +73473,7 @@ exports.GenericPollOperation = GenericPollOperation;
 
 /***/ }),
 
-/***/ 369:
+/***/ 370:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -73139,7 +73496,7 @@ function ipRangeToString(ipRange) {
 
 /***/ }),
 
-/***/ 370:
+/***/ 371:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -73165,7 +73522,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(263);
+var import_userAgent = __nccwpck_require__(264);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -73187,7 +73544,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 371:
+/***/ 372:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73195,7 +73552,7 @@ function userAgentPolicy(options = {}) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getUserAgentString = void 0;
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const packageJson = __nccwpck_require__(481);
+const packageJson = __nccwpck_require__(482);
 /**
  * Ensure that this User Agent String is used in all HTTP calls so that we can monitor telemetry between different versions of this package
  */
@@ -73207,7 +73564,7 @@ exports.getUserAgentString = getUserAgentString;
 
 /***/ }),
 
-/***/ 372:
+/***/ 373:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73216,8 +73573,8 @@ exports.getUserAgentString = getUserAgentString;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BufferScheduler = void 0;
-const events_1 = __nccwpck_require__(482);
-const PooledBuffer_js_1 = __nccwpck_require__(379);
+const events_1 = __nccwpck_require__(483);
+const PooledBuffer_js_1 = __nccwpck_require__(380);
 /**
  * This class accepts a Node.js Readable stream as input, and keeps reading data
  * from the stream into the internal buffer structure, until it reaches maxBuffers.
@@ -73496,17 +73853,17 @@ exports.BufferScheduler = BufferScheduler;
 
 /***/ }),
 
-/***/ 373:
+/***/ 374:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Blob, File: NativeFile } = __nccwpck_require__(126)
-const { types } = __nccwpck_require__(131)
+const { Blob, File: NativeFile } = __nccwpck_require__(128)
+const { types } = __nccwpck_require__(133)
 const { kState } = __nccwpck_require__(16)
 const { isBlobLike } = __nccwpck_require__(529)
-const { webidl } = __nccwpck_require__(469)
+const { webidl } = __nccwpck_require__(470)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(27)
 const { kEnumerableProperty } = __nccwpck_require__(75)
 const encoder = new TextEncoder()
@@ -73848,27 +74205,27 @@ module.exports = { File, FileLike, isFileLike }
 
 /***/ }),
 
-/***/ 374:
+/***/ 375:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const diagnosticsChannel = __nccwpck_require__(149)
-const { uid, states } = __nccwpck_require__(478)
+const diagnosticsChannel = __nccwpck_require__(151)
+const { uid, states } = __nccwpck_require__(479)
 const {
   kReadyState,
   kSentClose,
   kByteParser,
   kReceivedClose
-} = __nccwpck_require__(106)
+} = __nccwpck_require__(108)
 const { fireEvent, failWebsocketConnection } = __nccwpck_require__(63)
-const { CloseEvent } = __nccwpck_require__(257)
-const { makeRequest } = __nccwpck_require__(89)
-const { fetching } = __nccwpck_require__(463)
+const { CloseEvent } = __nccwpck_require__(258)
+const { makeRequest } = __nccwpck_require__(90)
+const { fetching } = __nccwpck_require__(464)
 const { Headers } = __nccwpck_require__(527)
-const { getGlobalDispatcher } = __nccwpck_require__(384)
-const { kHeadersList } = __nccwpck_require__(202)
+const { getGlobalDispatcher } = __nccwpck_require__(385)
+const { kHeadersList } = __nccwpck_require__(204)
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -73878,7 +74235,7 @@ channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(301)
+  crypto = __nccwpck_require__(302)
 } catch {
 
 }
@@ -74147,7 +74504,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 375:
+/***/ 376:
 /***/ ((module) => {
 
 "use strict";
@@ -74163,7 +74520,7 @@ module.exports = (flag, argv = process.argv) => {
 
 /***/ }),
 
-/***/ 376:
+/***/ 377:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -74188,8 +74545,8 @@ __export(restError_exports, {
   createRestError: () => createRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_restError = __nccwpck_require__(457);
-var import_httpHeaders = __nccwpck_require__(497);
+var import_restError = __nccwpck_require__(458);
+var import_httpHeaders = __nccwpck_require__(498);
 function createRestError(messageOrResponse, response) {
   const resp = typeof messageOrResponse === "string" ? response : messageOrResponse;
   const internalError = resp.body?.error ?? resp.body;
@@ -74219,15 +74576,15 @@ function statusCodeToNumber(statusCode) {
 
 /***/ }),
 
-/***/ 377:
+/***/ 378:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const DispatcherBase = __nccwpck_require__(68)
-const FixedQueue = __nccwpck_require__(203)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(202)
+const FixedQueue = __nccwpck_require__(205)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(204)
 const PoolStats = __nccwpck_require__(24)
 
 const kClients = Symbol('clients')
@@ -74421,7 +74778,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 378:
+/***/ 379:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -74481,7 +74838,7 @@ exports.TracingContextImpl = TracingContextImpl;
 
 /***/ }),
 
-/***/ 379:
+/***/ 380:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74490,9 +74847,9 @@ exports.TracingContextImpl = TracingContextImpl;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
-const tslib_1 = __nccwpck_require__(224);
-const BuffersStream_js_1 = __nccwpck_require__(394);
-const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(271));
+const tslib_1 = __nccwpck_require__(225);
+const BuffersStream_js_1 = __nccwpck_require__(395);
+const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(272));
 /**
  * maxBufferLength is max size of each buffer in the pooled buffers.
  */
@@ -74588,7 +74945,7 @@ exports.PooledBuffer = PooledBuffer;
 
 /***/ }),
 
-/***/ 380:
+/***/ 381:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -74613,7 +74970,7 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_nodeHttpClient = __nccwpck_require__(454);
+var import_nodeHttpClient = __nccwpck_require__(455);
 function createDefaultHttpClient() {
   return (0, import_nodeHttpClient.createNodeHttpClient)();
 }
@@ -74624,16 +74981,16 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 381:
+/***/ 382:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { AsyncResource } = __nccwpck_require__(441)
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(500)
+const { AsyncResource } = __nccwpck_require__(442)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(501)
 const util = __nccwpck_require__(75)
-const { addSignal, removeSignal } = __nccwpck_require__(111)
+const { addSignal, removeSignal } = __nccwpck_require__(113)
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -74736,7 +75093,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 382:
+/***/ 383:
 /***/ ((module) => {
 
 /**
@@ -74905,7 +75262,7 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 383:
+/***/ 384:
 /***/ ((module) => {
 
 "use strict";
@@ -74913,7 +75270,7 @@ module.exports = require("node:util");
 
 /***/ }),
 
-/***/ 384:
+/***/ 385:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74922,7 +75279,7 @@ module.exports = require("node:util");
 // We include a version number for the Dispatcher API. In case of breaking changes,
 // this version number must be increased to avoid conflicts.
 const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
-const { InvalidArgumentError } = __nccwpck_require__(500)
+const { InvalidArgumentError } = __nccwpck_require__(501)
 const Agent = __nccwpck_require__(6)
 
 if (getGlobalDispatcher() === undefined) {
@@ -74953,13 +75310,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 385:
+/***/ 386:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(202)
+const { kClients } = __nccwpck_require__(204)
 const Agent = __nccwpck_require__(6)
 const {
   kAgent,
@@ -74971,14 +75328,14 @@ const {
   kGetNetConnect,
   kOptions,
   kFactory
-} = __nccwpck_require__(483)
-const MockClient = __nccwpck_require__(207)
-const MockPool = __nccwpck_require__(359)
+} = __nccwpck_require__(484)
+const MockClient = __nccwpck_require__(208)
+const MockPool = __nccwpck_require__(360)
 const { matchValue, buildMockOptions } = __nccwpck_require__(8)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(500)
-const Dispatcher = __nccwpck_require__(490)
-const Pluralizer = __nccwpck_require__(261)
-const PendingInterceptorsFormatter = __nccwpck_require__(240)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(501)
+const Dispatcher = __nccwpck_require__(491)
+const Pluralizer = __nccwpck_require__(262)
+const PendingInterceptorsFormatter = __nccwpck_require__(241)
 
 class FakeWeakRef {
   constructor (value) {
@@ -75132,7 +75489,7 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 386:
+/***/ 387:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -75158,7 +75515,7 @@ __export(tlsPolicy_exports, {
   tlsPolicyName: () => tlsPolicyName
 });
 module.exports = __toCommonJS(tlsPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(295);
 const tlsPolicyName = import_policies.tlsPolicyName;
 function tlsPolicy(tlsSettings) {
   return (0, import_policies.tlsPolicy)(tlsSettings);
@@ -75169,7 +75526,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 387:
+/***/ 388:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -75262,7 +75619,7 @@ function readRawInputs(env) {
 
 /***/ }),
 
-/***/ 388:
+/***/ 389:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -75351,7 +75708,7 @@ exports.AccountSASServices = AccountSASServices;
 
 /***/ }),
 
-/***/ 389:
+/***/ 390:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -75377,7 +75734,7 @@ __export(bearerAuthenticationPolicy_exports, {
   bearerAuthenticationPolicyName: () => bearerAuthenticationPolicyName
 });
 module.exports = __toCommonJS(bearerAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(447);
+var import_checkInsecureConnection = __nccwpck_require__(448);
 const bearerAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function bearerAuthenticationPolicy(options) {
   return {
@@ -75405,7 +75762,7 @@ function bearerAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 390:
+/***/ 391:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75414,7 +75771,7 @@ function bearerAuthenticationPolicy(options) {
 const {
   BalancedPoolMissingUpstreamError,
   InvalidArgumentError
-} = __nccwpck_require__(500)
+} = __nccwpck_require__(501)
 const {
   PoolBase,
   kClients,
@@ -75422,9 +75779,9 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(377)
-const Pool = __nccwpck_require__(348)
-const { kUrl, kInterceptors } = __nccwpck_require__(202)
+} = __nccwpck_require__(378)
+const Pool = __nccwpck_require__(349)
+const { kUrl, kInterceptors } = __nccwpck_require__(204)
 const { parseOrigin } = __nccwpck_require__(75)
 const kFactory = Symbol('factory')
 
@@ -75603,7 +75960,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 391:
+/***/ 392:
 /***/ ((module) => {
 
 "use strict";
@@ -75611,7 +75968,7 @@ module.exports = require("node:os");
 
 /***/ }),
 
-/***/ 392:
+/***/ 393:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -75655,7 +76012,7 @@ function operationOptionsToRequestParameters(options) {
 
 /***/ }),
 
-/***/ 393:
+/***/ 394:
 /***/ ((module) => {
 
 "use strict";
@@ -75673,7 +76030,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 394:
+/***/ 395:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75682,7 +76039,7 @@ module.exports = value => {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BuffersStream = void 0;
-const node_stream_1 = __nccwpck_require__(442);
+const node_stream_1 = __nccwpck_require__(443);
 /**
  * This class generates a readable stream from the data in an array of buffers.
  */
@@ -75781,7 +76138,7 @@ exports.BuffersStream = BuffersStream;
 
 /***/ }),
 
-/***/ 395:
+/***/ 396:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -75846,10 +76203,10 @@ exports.snapshotSourceMtimes = snapshotSourceMtimes;
 exports.replaySourceMtimes = replaySourceMtimes;
 exports.writeSnapshotFile = writeSnapshotFile;
 exports.readSnapshotFile = readSnapshotFile;
-const fs = __importStar(__nccwpck_require__(256));
+const fs = __importStar(__nccwpck_require__(257));
 const path = __importStar(__nccwpck_require__(519));
-const node_crypto_1 = __nccwpck_require__(281);
-const normalize_source_mtime_js_1 = __nccwpck_require__(405);
+const node_crypto_1 = __nccwpck_require__(282);
+const normalize_source_mtime_js_1 = __nccwpck_require__(406);
 exports.SNAPSHOT_FILENAME = "setup-soldr-source-mtimes.json";
 async function hashFile(absolute) {
     // sha256 prefix (first 32 hex = 128 bits). Streaming so we don't load
@@ -76018,15 +76375,15 @@ function readSnapshotFile(filePath) {
 
 /***/ }),
 
-/***/ 396:
+/***/ 397:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { parseSetCookie } = __nccwpck_require__(435)
-const { stringify } = __nccwpck_require__(421)
-const { webidl } = __nccwpck_require__(469)
+const { parseSetCookie } = __nccwpck_require__(436)
+const { stringify } = __nccwpck_require__(422)
+const { webidl } = __nccwpck_require__(470)
 const { Headers } = __nccwpck_require__(527)
 
 /**
@@ -76209,7 +76566,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 397:
+/***/ 398:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -76225,7 +76582,7 @@ exports.AvroReadable = AvroReadable;
 
 /***/ }),
 
-/***/ 398:
+/***/ 399:
 /***/ ((module) => {
 
 "use strict";
@@ -76233,7 +76590,7 @@ module.exports = require("node:https");
 
 /***/ }),
 
-/***/ 399:
+/***/ 400:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76259,7 +76616,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(302);
+var import_userAgent = __nccwpck_require__(303);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -76280,17 +76637,17 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 400:
+/***/ 401:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const util = __nccwpck_require__(75)
-const { kBodyUsed } = __nccwpck_require__(202)
+const { kBodyUsed } = __nccwpck_require__(204)
 const assert = __nccwpck_require__(538)
-const { InvalidArgumentError } = __nccwpck_require__(500)
-const EE = __nccwpck_require__(482)
+const { InvalidArgumentError } = __nccwpck_require__(501)
+const EE = __nccwpck_require__(483)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
 
@@ -76509,7 +76866,7 @@ module.exports = RedirectHandler
 
 /***/ }),
 
-/***/ 401:
+/***/ 402:
 /***/ ((module) => {
 
 "use strict";
@@ -76517,7 +76874,7 @@ module.exports = require("node:stream/promises");
 
 /***/ }),
 
-/***/ 402:
+/***/ 403:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -76543,7 +76900,7 @@ function arraysEqual(a, b) {
 
 /***/ }),
 
-/***/ 403:
+/***/ 404:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76569,7 +76926,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(295);
 const exponentialRetryPolicyName = import_policies.exponentialRetryPolicyName;
 function exponentialRetryPolicy(options = {}) {
   return (0, import_policies.exponentialRetryPolicy)(options);
@@ -76580,7 +76937,7 @@ function exponentialRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 404:
+/***/ 405:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -76615,7 +76972,7 @@ function randomUUID() {
 
 /***/ }),
 
-/***/ 405:
+/***/ 406:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -76666,7 +77023,7 @@ exports.isGitRepo = isGitRepo;
 exports.listTrackedFiles = listTrackedFiles;
 exports.normalizeWorkspace = normalizeWorkspace;
 exports.normalizeSourceMtime = normalizeSourceMtime;
-const fs = __importStar(__nccwpck_require__(256));
+const fs = __importStar(__nccwpck_require__(257));
 const path = __importStar(__nccwpck_require__(519));
 const exec = __importStar(__nccwpck_require__(19));
 const log_utils_js_1 = __nccwpck_require__(52);
@@ -76901,7 +77258,7 @@ exports._internal = {
 
 /***/ }),
 
-/***/ 406:
+/***/ 407:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -76934,7 +77291,7 @@ exports.isJsonObject = isJsonObject;
 
 /***/ }),
 
-/***/ 407:
+/***/ 408:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76961,7 +77318,7 @@ __export(exponentialRetryStrategy_exports, {
   isSystemError: () => isSystemError
 });
 module.exports = __toCommonJS(exponentialRetryStrategy_exports);
-var import_delay = __nccwpck_require__(487);
+var import_delay = __nccwpck_require__(488);
 var import_throttlingRetryStrategy = __nccwpck_require__(39);
 const DEFAULT_CLIENT_RETRY_INTERVAL = 1e3;
 const DEFAULT_CLIENT_MAX_RETRY_INTERVAL = 1e3 * 64;
@@ -77007,7 +77364,7 @@ function isSystemError(err) {
 
 /***/ }),
 
-/***/ 408:
+/***/ 409:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77077,7 +77434,7 @@ exports.CacheScope = new CacheScope$Type();
 
 /***/ }),
 
-/***/ 409:
+/***/ 410:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77086,8 +77443,8 @@ exports.CacheScope = new CacheScope$Type();
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredential = void 0;
-const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(101);
-const Credential_js_1 = __nccwpck_require__(103);
+const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(103);
+const Credential_js_1 = __nccwpck_require__(105);
 /**
  * AnonymousCredential provides a credentialPolicyCreator member used to create
  * AnonymousCredentialPolicy objects. AnonymousCredentialPolicy is used with
@@ -77110,7 +77467,7 @@ exports.AnonymousCredential = AnonymousCredential;
 
 /***/ }),
 
-/***/ 410:
+/***/ 411:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77119,7 +77476,7 @@ exports.AnonymousCredential = AnonymousCredential;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 let cachedHttpClient;
 function getCachedDefaultHttpClient() {
     if (!cachedHttpClient) {
@@ -77131,7 +77488,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 411:
+/***/ 412:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77141,7 +77498,7 @@ function getCachedDefaultHttpClient() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getStreamingResponseStatusCodes = getStreamingResponseStatusCodes;
 exports.getPathStringFromParameter = getPathStringFromParameter;
-const serializer_js_1 = __nccwpck_require__(492);
+const serializer_js_1 = __nccwpck_require__(493);
 /**
  * Gets the list of status codes for streaming responses.
  * @internal
@@ -77181,18 +77538,18 @@ function getPathStringFromParameter(parameter) {
 
 /***/ }),
 
-/***/ 412:
+/***/ 413:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-exports.parse = __nccwpck_require__(230)
-exports.stringify = __nccwpck_require__(309)
+exports.parse = __nccwpck_require__(231)
+exports.stringify = __nccwpck_require__(310)
 
 
 /***/ }),
 
-/***/ 413:
+/***/ 414:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77200,19 +77557,19 @@ exports.stringify = __nccwpck_require__(309)
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobServiceClient = void 0;
 const core_auth_1 = __nccwpck_require__(525);
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_1 = __nccwpck_require__(15);
-const Pipeline_js_1 = __nccwpck_require__(189);
+const Pipeline_js_1 = __nccwpck_require__(191);
 const ContainerClient_js_1 = __nccwpck_require__(70);
-const utils_common_js_1 = __nccwpck_require__(162);
-const storage_common_1 = __nccwpck_require__(284);
-const utils_common_js_2 = __nccwpck_require__(162);
+const utils_common_js_1 = __nccwpck_require__(164);
+const storage_common_1 = __nccwpck_require__(285);
+const utils_common_js_2 = __nccwpck_require__(164);
 const tracing_js_1 = __nccwpck_require__(35);
-const BlobBatchClient_js_1 = __nccwpck_require__(414);
-const StorageClient_js_1 = __nccwpck_require__(467);
+const BlobBatchClient_js_1 = __nccwpck_require__(415);
+const StorageClient_js_1 = __nccwpck_require__(468);
 const AccountSASPermissions_js_1 = __nccwpck_require__(64);
-const AccountSASSignatureValues_js_1 = __nccwpck_require__(299);
-const AccountSASServices_js_1 = __nccwpck_require__(388);
+const AccountSASSignatureValues_js_1 = __nccwpck_require__(300);
+const AccountSASServices_js_1 = __nccwpck_require__(389);
 /**
  * A BlobServiceClient represents a Client to the Azure Storage Blob service allowing you
  * to manipulate blob containers.
@@ -77905,7 +78262,7 @@ exports.BlobServiceClient = BlobServiceClient;
 
 /***/ }),
 
-/***/ 414:
+/***/ 415:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77914,14 +78271,14 @@ exports.BlobServiceClient = BlobServiceClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatchClient = void 0;
-const BatchResponseParser_js_1 = __nccwpck_require__(320);
-const BatchUtils_js_1 = __nccwpck_require__(265);
-const BlobBatch_js_1 = __nccwpck_require__(345);
+const BatchResponseParser_js_1 = __nccwpck_require__(321);
+const BatchUtils_js_1 = __nccwpck_require__(266);
+const BlobBatch_js_1 = __nccwpck_require__(346);
 const tracing_js_1 = __nccwpck_require__(35);
-const storage_common_1 = __nccwpck_require__(284);
-const StorageContextClient_js_1 = __nccwpck_require__(274);
-const Pipeline_js_1 = __nccwpck_require__(189);
-const utils_common_js_1 = __nccwpck_require__(162);
+const storage_common_1 = __nccwpck_require__(285);
+const StorageContextClient_js_1 = __nccwpck_require__(275);
+const Pipeline_js_1 = __nccwpck_require__(191);
+const utils_common_js_1 = __nccwpck_require__(164);
 /**
  * A BlobBatchClient allows you to make batched requests to the Azure Storage Blob service.
  *
@@ -78088,7 +78445,7 @@ exports.BlobBatchClient = BlobBatchClient;
 
 /***/ }),
 
-/***/ 415:
+/***/ 416:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -78137,29 +78494,29 @@ exports.resolveRustupStrategy = resolveRustupStrategy;
 exports.detectZccachePrivateOverlap = detectZccachePrivateOverlap;
 exports.resolveSetup = resolveSetup;
 exports.applyResolveResult = applyResolveResult;
-const os = __importStar(__nccwpck_require__(391));
+const os = __importStar(__nccwpck_require__(392));
 const path = __importStar(__nccwpck_require__(519));
-const fs = __importStar(__nccwpck_require__(256));
-const core = __importStar(__nccwpck_require__(472));
-const cache_keys_js_1 = __nccwpck_require__(213);
-const cross_bootstrap_js_1 = __nccwpck_require__(288);
+const fs = __importStar(__nccwpck_require__(257));
+const core = __importStar(__nccwpck_require__(473));
+const cache_keys_js_1 = __nccwpck_require__(214);
+const cross_bootstrap_js_1 = __nccwpck_require__(289);
 const log_utils_js_1 = __nccwpck_require__(52);
-const cache_encrypt_js_1 = __nccwpck_require__(243);
-const detect_musl_cc_js_1 = __nccwpck_require__(360);
+const cache_encrypt_js_1 = __nccwpck_require__(244);
+const detect_musl_cc_js_1 = __nccwpck_require__(361);
 Object.defineProperty(exports, "detectMuslCcEnv", ({ enumerable: true, get: function () { return detect_musl_cc_js_1.detectMuslCcEnv; } }));
-const build_outputs_js_1 = __nccwpck_require__(297);
+const build_outputs_js_1 = __nccwpck_require__(298);
 Object.defineProperty(exports, "buildOutputs", ({ enumerable: true, get: function () { return build_outputs_js_1.buildOutputs; } }));
-const raw_inputs_js_1 = __nccwpck_require__(387);
+const raw_inputs_js_1 = __nccwpck_require__(388);
 Object.defineProperty(exports, "readRawInputs", ({ enumerable: true, get: function () { return raw_inputs_js_1.readRawInputs; } }));
 const phase_timing_js_1 = __nccwpck_require__(528);
-const input_parsers_js_1 = __nccwpck_require__(90);
+const input_parsers_js_1 = __nccwpck_require__(91);
 Object.defineProperty(exports, "detectUserLinkerEnv", ({ enumerable: true, get: function () { return input_parsers_js_1.detectUserLinkerEnv; } }));
 Object.defineProperty(exports, "parseCacheShutdownOnIdleSeconds", ({ enumerable: true, get: function () { return input_parsers_js_1.parseCacheShutdownOnIdleSeconds; } }));
 Object.defineProperty(exports, "parseRustBacktrace", ({ enumerable: true, get: function () { return input_parsers_js_1.parseRustBacktrace; } }));
-const fetch_release_js_1 = __nccwpck_require__(153);
+const fetch_release_js_1 = __nccwpck_require__(155);
 const python_json_js_1 = __nccwpck_require__(12);
 Object.defineProperty(exports, "pythonDefaultJson", ({ enumerable: true, get: function () { return python_json_js_1.pythonDefaultJson; } }));
-const toolchain_js_1 = __nccwpck_require__(311);
+const toolchain_js_1 = __nccwpck_require__(312);
 const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
 const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
 const ALLOWED_LINKER_VALUES = [
@@ -78557,7 +78914,7 @@ async function resolveSetup(ctx, inputs, deps) {
     // so canonical_json_stringify is wrong; mirror Python's default separators
     // (", " and ": ") to match byte-for-byte.
     const signatureString = (0, python_json_js_1.pythonDefaultJson)(toolchainSignature);
-    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 281, 23));
+    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 282, 23));
     const digest = createHash("sha256").update(signatureString, "utf8").digest("hex").slice(0, 16);
     const runnerOs = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_OS"] ?? process.platform).toLowerCase());
     const runnerArch = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_ARCH"] ?? "unknown").toLowerCase());
@@ -79130,7 +79487,7 @@ async function applyResolveResult(result) {
 
 /***/ }),
 
-/***/ 416:
+/***/ 417:
 /***/ ((module) => {
 
 "use strict";
@@ -79144,15 +79501,15 @@ module.exports = (d, num) => {
 
 /***/ }),
 
-/***/ 417:
+/***/ 418:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const Decoder = __nccwpck_require__(46)
-const decodeText = __nccwpck_require__(282)
-const getLimit = __nccwpck_require__(495)
+const decodeText = __nccwpck_require__(283)
+const getLimit = __nccwpck_require__(496)
 
 const RE_CHARSET = /^charset$/i
 
@@ -79342,7 +79699,7 @@ module.exports = UrlEncoded
 
 /***/ }),
 
-/***/ 418:
+/***/ 419:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -79360,7 +79717,7 @@ exports.MESSAGE_TYPE = Symbol.for("protobuf-ts/message-type");
 
 /***/ }),
 
-/***/ 419:
+/***/ 420:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -79372,8 +79729,8 @@ exports.createDefaultTracingSpan = createDefaultTracingSpan;
 exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
-const tracingContext_js_1 = __nccwpck_require__(378);
-const state_js_1 = __nccwpck_require__(104);
+const tracingContext_js_1 = __nccwpck_require__(379);
+const state_js_1 = __nccwpck_require__(106);
 function createDefaultTracingSpan() {
     return {
         end: () => {
@@ -79436,17 +79793,17 @@ function getInstrumenter() {
 
 /***/ }),
 
-/***/ 420:
+/***/ 421:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
-const binary_format_contract_1 = __nccwpck_require__(344);
-const reflection_info_1 = __nccwpck_require__(465);
-const reflection_long_convert_1 = __nccwpck_require__(165);
-const reflection_scalar_default_1 = __nccwpck_require__(475);
+const binary_format_contract_1 = __nccwpck_require__(345);
+const reflection_info_1 = __nccwpck_require__(466);
+const reflection_long_convert_1 = __nccwpck_require__(167);
+const reflection_scalar_default_1 = __nccwpck_require__(476);
 /**
  * Reads proto3 messages in binary format using reflection information.
  *
@@ -79627,7 +79984,7 @@ exports.ReflectionBinaryReader = ReflectionBinaryReader;
 
 /***/ }),
 
-/***/ 421:
+/***/ 422:
 /***/ ((module) => {
 
 "use strict";
@@ -79909,7 +80266,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 422:
+/***/ 423:
 /***/ ((module) => {
 
 "use strict";
@@ -79917,15 +80274,15 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 423:
+/***/ 424:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseAsync
 
-const TOMLParser = __nccwpck_require__(356)
-const prettyError = __nccwpck_require__(286)
+const TOMLParser = __nccwpck_require__(357)
+const prettyError = __nccwpck_require__(287)
 
 function parseAsync (str, opts) {
   if (!opts) opts = {}
@@ -79955,7 +80312,7 @@ function parseAsync (str, opts) {
 
 /***/ }),
 
-/***/ 424:
+/***/ 425:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -79981,8 +80338,8 @@ __export(response_exports, {
   toPipelineResponse: () => toPipelineResponse
 });
 module.exports = __toCommonJS(response_exports);
-var import_core_rest_pipeline = __nccwpck_require__(109);
-var import_util = __nccwpck_require__(117);
+var import_core_rest_pipeline = __nccwpck_require__(111);
+var import_util = __nccwpck_require__(119);
 const originalResponse = /* @__PURE__ */ Symbol("Original FullOperationResponse");
 function toCompatResponse(response, options) {
   let request = (0, import_util.toWebResourceLike)(response.request);
@@ -80038,7 +80395,7 @@ function toPipelineResponse(compatResponse) {
 
 /***/ }),
 
-/***/ 425:
+/***/ 426:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -80064,7 +80421,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOptions = void 0;
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 /**
  * Returns a copy with defaults filled in.
  */
@@ -80095,7 +80452,7 @@ exports.getOptions = getOptions;
 
 /***/ }),
 
-/***/ 426:
+/***/ 427:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80103,7 +80460,7 @@ exports.getOptions = getOptions;
 
 /* istanbul ignore file: only for Node 12 */
 
-const { kConnected, kSize } = __nccwpck_require__(202)
+const { kConnected, kSize } = __nccwpck_require__(204)
 
 class CompatWeakRef {
   constructor (value) {
@@ -80151,7 +80508,7 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 427:
+/***/ 428:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80163,7 +80520,7 @@ exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTie
 exports.toAccessTier = toAccessTier;
 exports.ensureCpkIfSpecified = ensureCpkIfSpecified;
 exports.getBlobServiceAccountAudience = getBlobServiceAccountAudience;
-const constants_js_1 = __nccwpck_require__(156);
+const constants_js_1 = __nccwpck_require__(158);
 /**
  * Represents the access tier on a blob.
  * For detailed information about block blob level tiering see {@link https://learn.microsoft.com/azure/storage/blobs/storage-blob-storage-tiers|Hot, cool and archive storage tiers.}
@@ -80279,19 +80636,19 @@ function getBlobServiceAccountAudience(storageAccountName) {
 
 /***/ }),
 
-/***/ 428:
+/***/ 429:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(442).Writable)
-const { inherits } = __nccwpck_require__(383)
+const WritableStream = (__nccwpck_require__(443).Writable)
+const { inherits } = __nccwpck_require__(384)
 const Dicer = __nccwpck_require__(14)
 
 const MultipartParser = __nccwpck_require__(0)
-const UrlencodedParser = __nccwpck_require__(417)
-const parseParams = __nccwpck_require__(199)
+const UrlencodedParser = __nccwpck_require__(418)
+const parseParams = __nccwpck_require__(201)
 
 function Busboy (opts) {
   if (!(this instanceof Busboy)) { return new Busboy(opts) }
@@ -80372,7 +80729,7 @@ module.exports.Dicer = Dicer
 
 /***/ }),
 
-/***/ 429:
+/***/ 430:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -80399,7 +80756,7 @@ var StorageRetryPolicyType;
 
 /***/ }),
 
-/***/ 430:
+/***/ 431:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -80441,7 +80798,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDetails = exports.isLinux = exports.isMacOS = exports.isWindows = exports.arch = exports.platform = void 0;
-const os_1 = __importDefault(__nccwpck_require__(100));
+const os_1 = __importDefault(__nccwpck_require__(102));
 const exec = __importStar(__nccwpck_require__(19));
 const getWindowsInfo = () => __awaiter(void 0, void 0, void 0, function* () {
     const { stdout: version } = yield exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Version"', undefined, {
@@ -80500,7 +80857,7 @@ exports.getDetails = getDetails;
 
 /***/ }),
 
-/***/ 431:
+/***/ 432:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -80608,15 +80965,15 @@ exports.parseProxyResponse = parseProxyResponse;
 
 /***/ }),
 
-/***/ 432:
+/***/ 433:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseStream
 
-const stream = __nccwpck_require__(138)
-const TOMLParser = __nccwpck_require__(356)
+const stream = __nccwpck_require__(140)
+const TOMLParser = __nccwpck_require__(357)
 
 function parseStream (stm) {
   if (stm) {
@@ -80696,7 +81053,7 @@ function parseTransform () {
 
 /***/ }),
 
-/***/ 433:
+/***/ 434:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80707,9 +81064,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReader = void 0;
 // TODO: Do a review of non-interfaces
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
-const AvroConstants_js_1 = __nccwpck_require__(236);
-const AvroParser_js_1 = __nccwpck_require__(312);
-const utils_common_js_1 = __nccwpck_require__(402);
+const AvroConstants_js_1 = __nccwpck_require__(237);
+const AvroParser_js_1 = __nccwpck_require__(313);
+const utils_common_js_1 = __nccwpck_require__(403);
 class AvroReader {
     _dataStream;
     _headerStream;
@@ -80823,7 +81180,7 @@ exports.AvroReader = AvroReader;
 
 /***/ }),
 
-/***/ 434:
+/***/ 435:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80833,13 +81190,13 @@ exports.CacheService = exports.GetCacheEntryDownloadURLResponse = exports.GetCac
 // @generated by protobuf-ts 2.9.1 with parameter long_type_string,client_none,generate_dependencies
 // @generated from protobuf file "results/api/v1/cache.proto" (package "github.actions.results.api.v1", syntax proto3)
 // tslint:disable
-const runtime_rpc_1 = __nccwpck_require__(181);
+const runtime_rpc_1 = __nccwpck_require__(183);
 const runtime_1 = __nccwpck_require__(21);
 const runtime_2 = __nccwpck_require__(21);
 const runtime_3 = __nccwpck_require__(21);
 const runtime_4 = __nccwpck_require__(21);
 const runtime_5 = __nccwpck_require__(21);
-const cachemetadata_1 = __nccwpck_require__(241);
+const cachemetadata_1 = __nccwpck_require__(242);
 // @generated message type with reflection information, may provide speed optimized methods
 class CreateCacheEntryRequest$Type extends runtime_5.MessageType {
     constructor() {
@@ -81232,14 +81589,14 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 
 /***/ }),
 
-/***/ 435:
+/***/ 436:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(135)
-const { isCTLExcludingHtab } = __nccwpck_require__(421)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(137)
+const { isCTLExcludingHtab } = __nccwpck_require__(422)
 const { collectASequenceOfCodePointsFast } = __nccwpck_require__(27)
 const assert = __nccwpck_require__(538)
 
@@ -81557,7 +81914,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 436:
+/***/ 437:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -81625,7 +81982,7 @@ exports.ServerCallContextController = ServerCallContextController;
 
 /***/ }),
 
-/***/ 437:
+/***/ 438:
 /***/ ((module) => {
 
 "use strict";
@@ -81760,7 +82117,7 @@ module.exports = Parser
 
 /***/ }),
 
-/***/ 438:
+/***/ 439:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82236,7 +82593,7 @@ exports.BlobDownloadResponse = BlobDownloadResponse;
 
 /***/ }),
 
-/***/ 439:
+/***/ 440:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -82281,7 +82638,7 @@ function storageRequestFailureDetailsParserPolicy() {
 
 /***/ }),
 
-/***/ 440:
+/***/ 441:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -82317,8 +82674,8 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(391));
-var import_node_process = __toESM(__nccwpck_require__(244));
+var import_node_os = __toESM(__nccwpck_require__(392));
+var import_node_process = __toESM(__nccwpck_require__(245));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -82341,7 +82698,7 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 441:
+/***/ 442:
 /***/ ((module) => {
 
 "use strict";
@@ -82349,7 +82706,7 @@ module.exports = require("async_hooks");
 
 /***/ }),
 
-/***/ 442:
+/***/ 443:
 /***/ ((module) => {
 
 "use strict";
@@ -82357,7 +82714,7 @@ module.exports = require("node:stream");
 
 /***/ }),
 
-/***/ 443:
+/***/ 444:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -82411,10 +82768,10 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DefaultGlobber = void 0;
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 const fs = __importStar(__nccwpck_require__(542));
-const globOptionsHelper = __importStar(__nccwpck_require__(425));
-const path = __importStar(__nccwpck_require__(255));
+const globOptionsHelper = __importStar(__nccwpck_require__(426));
+const path = __importStar(__nccwpck_require__(256));
 const patternHelper = __importStar(__nccwpck_require__(47));
 const internal_match_kind_1 = __nccwpck_require__(540);
 const internal_pattern_1 = __nccwpck_require__(514);
@@ -82599,7 +82956,7 @@ exports.DefaultGlobber = DefaultGlobber;
 
 /***/ }),
 
-/***/ 444:
+/***/ 445:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82609,7 +82966,7 @@ exports.DefaultGlobber = DefaultGlobber;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOperationArgumentValueFromParameter = getOperationArgumentValueFromParameter;
 exports.getOperationRequestInfo = getOperationRequestInfo;
-const state_js_1 = __nccwpck_require__(341);
+const state_js_1 = __nccwpck_require__(342);
 /**
  * @internal
  * Retrieves the value to use for a given operation argument
@@ -82704,16 +83061,16 @@ function getOperationRequestInfo(request) {
 
 /***/ }),
 
-/***/ 445:
+/***/ 446:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(500)
-const { AsyncResource } = __nccwpck_require__(441)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(501)
+const { AsyncResource } = __nccwpck_require__(442)
 const util = __nccwpck_require__(75)
-const { addSignal, removeSignal } = __nccwpck_require__(111)
+const { addSignal, removeSignal } = __nccwpck_require__(113)
 const assert = __nccwpck_require__(538)
 
 class UpgradeHandler extends AsyncResource {
@@ -82817,14 +83174,14 @@ module.exports = upgrade
 
 /***/ }),
 
-/***/ 446:
+/***/ 447:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const os = __nccwpck_require__(100);
-const tty = __nccwpck_require__(188);
-const hasFlag = __nccwpck_require__(375);
+const os = __nccwpck_require__(102);
+const tty = __nccwpck_require__(190);
+const hasFlag = __nccwpck_require__(376);
 
 const {env} = process;
 
@@ -82960,7 +83317,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 447:
+/***/ 448:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -82985,7 +83342,7 @@ __export(checkInsecureConnection_exports, {
   ensureSecureConnection: () => ensureSecureConnection
 });
 module.exports = __toCommonJS(checkInsecureConnection_exports);
-var import_log = __nccwpck_require__(159);
+var import_log = __nccwpck_require__(161);
 let insecureConnectionWarningEmmitted = false;
 function allowInsecureConnection(request, options) {
   if (options.allowInsecureConnection && request.allowInsecureConnection) {
@@ -83022,14 +83379,14 @@ function ensureSecureConnection(request, options) {
 
 /***/ }),
 
-/***/ 448:
+/***/ 449:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CacheServiceClientProtobuf = exports.CacheServiceClientJSON = void 0;
-const cache_1 = __nccwpck_require__(434);
+const cache_1 = __nccwpck_require__(435);
 class CacheServiceClientJSON {
     constructor(rpc) {
         this.rpc = rpc;
@@ -83097,7 +83454,7 @@ exports.CacheServiceClientProtobuf = CacheServiceClientProtobuf;
 
 /***/ }),
 
-/***/ 449:
+/***/ 450:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -83137,9 +83494,9 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StatsCollector = void 0;
-const fs = __importStar(__nccwpck_require__(116));
+const fs = __importStar(__nccwpck_require__(118));
 const path = __importStar(__nccwpck_require__(519));
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 function fmtBytes(n) {
     if (n === null)
         return "-";
@@ -83405,7 +83762,7 @@ exports.StatsCollector = StatsCollector;
 
 /***/ }),
 
-/***/ 450:
+/***/ 451:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -83454,7 +83811,7 @@ function decodeStringToString(value) {
 
 /***/ }),
 
-/***/ 451:
+/***/ 452:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -83499,7 +83856,7 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 
 /***/ }),
 
-/***/ 452:
+/***/ 453:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -83508,31 +83865,31 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.authorizeRequestOnTenantChallenge = exports.authorizeRequestOnClaimChallenge = exports.serializationPolicyName = exports.serializationPolicy = exports.deserializationPolicyName = exports.deserializationPolicy = exports.XML_CHARKEY = exports.XML_ATTRKEY = exports.createClientPipeline = exports.ServiceClient = exports.MapperTypeNames = exports.createSerializer = void 0;
-var serializer_js_1 = __nccwpck_require__(492);
+var serializer_js_1 = __nccwpck_require__(493);
 Object.defineProperty(exports, "createSerializer", ({ enumerable: true, get: function () { return serializer_js_1.createSerializer; } }));
 Object.defineProperty(exports, "MapperTypeNames", ({ enumerable: true, get: function () { return serializer_js_1.MapperTypeNames; } }));
-var serviceClient_js_1 = __nccwpck_require__(326);
+var serviceClient_js_1 = __nccwpck_require__(327);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
-var pipeline_js_1 = __nccwpck_require__(292);
+var pipeline_js_1 = __nccwpck_require__(293);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
-var interfaces_js_1 = __nccwpck_require__(107);
+var interfaces_js_1 = __nccwpck_require__(109);
 Object.defineProperty(exports, "XML_ATTRKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_ATTRKEY; } }));
 Object.defineProperty(exports, "XML_CHARKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_CHARKEY; } }));
-var deserializationPolicy_js_1 = __nccwpck_require__(93);
+var deserializationPolicy_js_1 = __nccwpck_require__(95);
 Object.defineProperty(exports, "deserializationPolicy", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicy; } }));
 Object.defineProperty(exports, "deserializationPolicyName", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicyName; } }));
-var serializationPolicy_js_1 = __nccwpck_require__(501);
+var serializationPolicy_js_1 = __nccwpck_require__(502);
 Object.defineProperty(exports, "serializationPolicy", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicy; } }));
 Object.defineProperty(exports, "serializationPolicyName", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicyName; } }));
-var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(119);
+var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(121);
 Object.defineProperty(exports, "authorizeRequestOnClaimChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnClaimChallenge_js_1.authorizeRequestOnClaimChallenge; } }));
-var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(178);
+var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(180);
 Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnTenantChallenge_js_1.authorizeRequestOnTenantChallenge; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 453:
+/***/ 454:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -83572,9 +83929,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTar = exports.extractTar = exports.listTar = void 0;
 const exec_1 = __nccwpck_require__(19);
-const io = __importStar(__nccwpck_require__(304));
+const io = __importStar(__nccwpck_require__(305));
 const fs_1 = __nccwpck_require__(542);
-const path = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(256));
 const utils = __importStar(__nccwpck_require__(82));
 const constants_1 = __nccwpck_require__(49);
 const IS_WINDOWS = process.platform === 'win32';
@@ -83811,7 +84168,7 @@ exports.createTar = createTar;
 
 /***/ }),
 
-/***/ 454:
+/***/ 455:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -83847,15 +84204,15 @@ __export(nodeHttpClient_exports, {
   getBodyLength: () => getBodyLength
 });
 module.exports = __toCommonJS(nodeHttpClient_exports);
-var import_node_http = __toESM(__nccwpck_require__(270));
-var import_node_https = __toESM(__nccwpck_require__(398));
+var import_node_http = __toESM(__nccwpck_require__(271));
+var import_node_https = __toESM(__nccwpck_require__(399));
 var import_node_zlib = __toESM(__nccwpck_require__(531));
-var import_node_stream = __nccwpck_require__(442);
+var import_node_stream = __nccwpck_require__(443);
 var import_AbortError = __nccwpck_require__(11);
-var import_httpHeaders = __nccwpck_require__(497);
-var import_restError = __nccwpck_require__(457);
-var import_log = __nccwpck_require__(159);
-var import_sanitizer = __nccwpck_require__(129);
+var import_httpHeaders = __nccwpck_require__(498);
+var import_restError = __nccwpck_require__(458);
+var import_log = __nccwpck_require__(161);
+var import_sanitizer = __nccwpck_require__(131);
 const DEFAULT_TLS_SETTINGS = {};
 function isReadableStream(body) {
   return body && typeof body.pipe === "function";
@@ -84160,13 +84517,13 @@ function createNodeHttpClient() {
 
 /***/ }),
 
-/***/ 455:
+/***/ 456:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(469)
+const { webidl } = __nccwpck_require__(470)
 
 const kState = Symbol('ProgressEvent state')
 
@@ -84246,7 +84603,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 456:
+/***/ 457:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -84279,9 +84636,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const crypto = __importStar(__nccwpck_require__(301));
+const crypto = __importStar(__nccwpck_require__(302));
 const fs = __importStar(__nccwpck_require__(542));
-const os = __importStar(__nccwpck_require__(100));
+const os = __importStar(__nccwpck_require__(102));
 const utils_1 = __nccwpck_require__(516);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -84315,7 +84672,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 457:
+/***/ 458:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -84341,9 +84698,9 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_error = __nccwpck_require__(161);
+var import_error = __nccwpck_require__(163);
 var import_inspect = __nccwpck_require__(1);
-var import_sanitizer = __nccwpck_require__(129);
+var import_sanitizer = __nccwpck_require__(131);
 const errorSanitizer = new import_sanitizer.Sanitizer();
 class RestError extends Error {
   /**
@@ -84417,7 +84774,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 458:
+/***/ 459:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -84470,7 +84827,7 @@ function wrapAbortSignalLike(abortSignalLike) {
 
 /***/ }),
 
-/***/ 459:
+/***/ 460:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84484,9 +84841,9 @@ function wrapAbortSignalLike(abortSignalLike) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(224);
+const tslib_1 = __nccwpck_require__(225);
 const coreHttpCompat = tslib_1.__importStar(__nccwpck_require__(79));
-const index_js_1 = __nccwpck_require__(285);
+const index_js_1 = __nccwpck_require__(286);
 class StorageClient extends coreHttpCompat.ExtendedServiceClient {
     url;
     version;
@@ -84543,7 +84900,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 460:
+/***/ 461:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84552,36 +84909,36 @@ exports.StorageClient = StorageClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = exports.StorageSharedKeyCredentialPolicy = exports.StorageSharedKeyCredential = exports.StorageRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = exports.Credential = exports.CredentialPolicy = exports.BaseRequestPolicy = exports.AnonymousCredentialPolicy = exports.AnonymousCredential = exports.StorageOAuthScopes = exports.newPipeline = exports.isPipelineLike = exports.Pipeline = exports.getBlobServiceAccountAudience = exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTier = exports.generateBlobSASQueryParameters = exports.generateAccountSASQueryParameters = void 0;
-const tslib_1 = __nccwpck_require__(224);
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const tslib_1 = __nccwpck_require__(225);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
-tslib_1.__exportStar(__nccwpck_require__(413), exports);
-tslib_1.__exportStar(__nccwpck_require__(191), exports);
+tslib_1.__exportStar(__nccwpck_require__(414), exports);
+tslib_1.__exportStar(__nccwpck_require__(193), exports);
 tslib_1.__exportStar(__nccwpck_require__(70), exports);
-tslib_1.__exportStar(__nccwpck_require__(212), exports);
+tslib_1.__exportStar(__nccwpck_require__(213), exports);
 tslib_1.__exportStar(__nccwpck_require__(64), exports);
 tslib_1.__exportStar(__nccwpck_require__(2), exports);
-tslib_1.__exportStar(__nccwpck_require__(388), exports);
-var AccountSASSignatureValues_js_1 = __nccwpck_require__(299);
+tslib_1.__exportStar(__nccwpck_require__(389), exports);
+var AccountSASSignatureValues_js_1 = __nccwpck_require__(300);
 Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(345), exports);
-tslib_1.__exportStar(__nccwpck_require__(414), exports);
-tslib_1.__exportStar(__nccwpck_require__(180), exports);
+tslib_1.__exportStar(__nccwpck_require__(346), exports);
+tslib_1.__exportStar(__nccwpck_require__(415), exports);
+tslib_1.__exportStar(__nccwpck_require__(182), exports);
 tslib_1.__exportStar(__nccwpck_require__(515), exports);
 var BlobSASSignatureValues_js_1 = __nccwpck_require__(74);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(287), exports);
-var models_js_1 = __nccwpck_require__(427);
+tslib_1.__exportStar(__nccwpck_require__(288), exports);
+var models_js_1 = __nccwpck_require__(428);
 Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: function () { return models_js_1.BlockBlobTier; } }));
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
 Object.defineProperty(exports, "getBlobServiceAccountAudience", ({ enumerable: true, get: function () { return models_js_1.getBlobServiceAccountAudience; } }));
-var Pipeline_js_1 = __nccwpck_require__(189);
+var Pipeline_js_1 = __nccwpck_require__(191);
 Object.defineProperty(exports, "Pipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.Pipeline; } }));
 Object.defineProperty(exports, "isPipelineLike", ({ enumerable: true, get: function () { return Pipeline_js_1.isPipelineLike; } }));
 Object.defineProperty(exports, "newPipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.newPipeline; } }));
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return Pipeline_js_1.StorageOAuthScopes; } }));
-var storage_common_1 = __nccwpck_require__(284);
+var storage_common_1 = __nccwpck_require__(285);
 Object.defineProperty(exports, "AnonymousCredential", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredential; } }));
 Object.defineProperty(exports, "AnonymousCredentialPolicy", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredentialPolicy; } }));
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return storage_common_1.BaseRequestPolicy; } }));
@@ -84595,21 +84952,21 @@ Object.defineProperty(exports, "StorageSharedKeyCredentialPolicy", ({ enumerable
 Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
 tslib_1.__exportStar(__nccwpck_require__(537), exports);
-tslib_1.__exportStar(__nccwpck_require__(334), exports);
-var log_js_1 = __nccwpck_require__(114);
+tslib_1.__exportStar(__nccwpck_require__(335), exports);
+var log_js_1 = __nccwpck_require__(116);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 461:
+/***/ 462:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SPECIAL_HEADERS = exports.HEADER_STATE = exports.MINOR = exports.MAJOR = exports.CONNECTION_TOKEN_CHARS = exports.HEADER_CHARS = exports.TOKEN = exports.STRICT_TOKEN = exports.HEX = exports.URL_CHAR = exports.STRICT_URL_CHAR = exports.USERINFO_CHARS = exports.MARK = exports.ALPHANUM = exports.NUM = exports.HEX_MAP = exports.NUM_MAP = exports.ALPHA = exports.FINISH = exports.H_METHOD_MAP = exports.METHOD_MAP = exports.METHODS_RTSP = exports.METHODS_ICE = exports.METHODS_HTTP = exports.METHODS = exports.LENIENT_FLAGS = exports.FLAGS = exports.TYPE = exports.ERROR = void 0;
-const utils_1 = __nccwpck_require__(318);
+const utils_1 = __nccwpck_require__(319);
 // C headers
 var ERROR;
 (function (ERROR) {
@@ -84887,7 +85244,7 @@ exports.SPECIAL_HEADERS = {
 
 /***/ }),
 
-/***/ 462:
+/***/ 463:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -84913,12 +85270,12 @@ __export(sendRequest_exports, {
   sendRequest: () => sendRequest
 });
 module.exports = __toCommonJS(sendRequest_exports);
-var import_restError = __nccwpck_require__(457);
-var import_httpHeaders = __nccwpck_require__(497);
-var import_pipelineRequest = __nccwpck_require__(122);
-var import_clientHelpers = __nccwpck_require__(503);
+var import_restError = __nccwpck_require__(458);
+var import_httpHeaders = __nccwpck_require__(498);
+var import_pipelineRequest = __nccwpck_require__(124);
+var import_clientHelpers = __nccwpck_require__(504);
 var import_typeGuards = __nccwpck_require__(509);
-var import_multipart = __nccwpck_require__(276);
+var import_multipart = __nccwpck_require__(277);
 async function sendRequest(method, url, pipeline, options = {}, customHttpClient) {
   const httpClient = customHttpClient ?? (0, import_clientHelpers.getCachedDefaultHttpsClient)();
   const request = buildPipelineRequest(method, url, options);
@@ -85071,7 +85428,7 @@ function createParseError(response, err) {
 
 /***/ }),
 
-/***/ 463:
+/***/ 464:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -85087,8 +85444,8 @@ const {
   makeResponse
 } = __nccwpck_require__(45)
 const { Headers } = __nccwpck_require__(527)
-const { Request, makeRequest } = __nccwpck_require__(89)
-const zlib = __nccwpck_require__(422)
+const { Request, makeRequest } = __nccwpck_require__(90)
+const zlib = __nccwpck_require__(423)
 const {
   bytesMatch,
   makePolicyContainer,
@@ -85130,15 +85487,15 @@ const {
   subresourceSet,
   DOMException
 } = __nccwpck_require__(33)
-const { kHeadersList } = __nccwpck_require__(202)
-const EE = __nccwpck_require__(482)
-const { Readable, pipeline } = __nccwpck_require__(138)
+const { kHeadersList } = __nccwpck_require__(204)
+const EE = __nccwpck_require__(483)
+const { Readable, pipeline } = __nccwpck_require__(140)
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(75)
 const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(27)
-const { TransformStream } = __nccwpck_require__(264)
-const { getGlobalDispatcher } = __nccwpck_require__(384)
-const { webidl } = __nccwpck_require__(469)
-const { STATUS_CODES } = __nccwpck_require__(340)
+const { TransformStream } = __nccwpck_require__(265)
+const { getGlobalDispatcher } = __nccwpck_require__(385)
+const { webidl } = __nccwpck_require__(470)
+const { STATUS_CODES } = __nccwpck_require__(341)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
 /** @type {import('buffer').resolveObjectURL} */
@@ -85880,7 +86237,7 @@ function schemeFetch (fetchParams) {
     }
     case 'blob:': {
       if (!resolveObjectURL) {
-        resolveObjectURL = (__nccwpck_require__(126).resolveObjectURL)
+        resolveObjectURL = (__nccwpck_require__(128).resolveObjectURL)
       }
 
       // 1. Let blobURLEntry be request’s current URL’s blob URL entry.
@@ -86879,7 +87236,7 @@ async function httpNetworkFetch (
   // cancelAlgorithm set to cancelAlgorithm, highWaterMark set to
   // highWaterMark, and sizeAlgorithm set to sizeAlgorithm.
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(264).ReadableStream)
+    ReadableStream = (__nccwpck_require__(265).ReadableStream)
   }
 
   const stream = new ReadableStream(
@@ -87227,7 +87584,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 464:
+/***/ 465:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -87285,14 +87642,14 @@ exports.ServerStreamingCall = ServerStreamingCall;
 
 /***/ }),
 
-/***/ 465:
+/***/ 466:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.readMessageOption = exports.readFieldOption = exports.readFieldOptions = exports.normalizeFieldInfo = exports.RepeatType = exports.LongType = exports.ScalarType = void 0;
-const lower_camel_case_1 = __nccwpck_require__(466);
+const lower_camel_case_1 = __nccwpck_require__(467);
 /**
  * Scalar value types. This is a subset of field types declared by protobuf
  * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
@@ -87451,7 +87808,7 @@ exports.readMessageOption = readMessageOption;
 
 /***/ }),
 
-/***/ 466:
+/***/ 467:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -87494,7 +87851,7 @@ exports.lowerCamelCase = lowerCamelCase;
 
 /***/ }),
 
-/***/ 467:
+/***/ 468:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -87503,9 +87860,9 @@ exports.lowerCamelCase = lowerCamelCase;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const StorageContextClient_js_1 = __nccwpck_require__(274);
-const Pipeline_js_1 = __nccwpck_require__(189);
-const utils_common_js_1 = __nccwpck_require__(162);
+const StorageContextClient_js_1 = __nccwpck_require__(275);
+const Pipeline_js_1 = __nccwpck_require__(191);
+const utils_common_js_1 = __nccwpck_require__(164);
 /**
  * A StorageClient represents a based URL class for {@link BlobServiceClient}, {@link ContainerClient}
  * and etc.
@@ -87557,7 +87914,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 468:
+/***/ 469:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -87632,13 +87989,13 @@ function parseHeaderValueAsNumber(response, headerName) {
 
 /***/ }),
 
-/***/ 469:
+/***/ 470:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { types } = __nccwpck_require__(131)
+const { types } = __nccwpck_require__(133)
 const { hasOwn, toUSVString } = __nccwpck_require__(529)
 
 /** @type {import('../../types/webidl').Webidl} */
@@ -88286,15 +88643,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 470:
+/***/ 471:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /**
  * Module dependencies.
  */
 
-const tty = __nccwpck_require__(188);
-const util = __nccwpck_require__(131);
+const tty = __nccwpck_require__(190);
+const util = __nccwpck_require__(133);
 
 /**
  * This is the Node.js implementation of `debug()`.
@@ -88320,7 +88677,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = __nccwpck_require__(446);
+	const supportsColor = __nccwpck_require__(447);
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [
@@ -88528,7 +88885,7 @@ function init(debug) {
 	}
 }
 
-module.exports = __nccwpck_require__(150)(exports);
+module.exports = __nccwpck_require__(152)(exports);
 
 const {formatters} = module.exports;
 
@@ -88556,7 +88913,7 @@ formatters.O = function (v) {
 
 /***/ }),
 
-/***/ 471:
+/***/ 472:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -88610,7 +88967,7 @@ exports.walkSnapshot = walkSnapshot;
 exports.diffSnapshots = diffSnapshots;
 exports.diffStats = diffStats;
 exports.serializeManifest = serializeManifest;
-const fs = __importStar(__nccwpck_require__(116));
+const fs = __importStar(__nccwpck_require__(118));
 const path = __importStar(__nccwpck_require__(519));
 function entryKey(root, relpath) {
     return `${root}#${relpath}`;
@@ -88722,7 +89079,7 @@ function serializeManifest(diff, stats) {
 
 /***/ }),
 
-/***/ 472:
+/***/ 473:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -88762,11 +89119,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.platform = exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = exports.markdownSummary = exports.summary = exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(544);
-const file_command_1 = __nccwpck_require__(456);
+const file_command_1 = __nccwpck_require__(457);
 const utils_1 = __nccwpck_require__(516);
-const os = __importStar(__nccwpck_require__(100));
-const path = __importStar(__nccwpck_require__(255));
-const oidc_utils_1 = __nccwpck_require__(141);
+const os = __importStar(__nccwpck_require__(102));
+const path = __importStar(__nccwpck_require__(256));
+const oidc_utils_1 = __nccwpck_require__(143);
 /**
  * The code to exit an action
  */
@@ -89051,29 +89408,29 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(354);
+var summary_1 = __nccwpck_require__(355);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(354);
+var summary_2 = __nccwpck_require__(355);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(343);
+var path_utils_1 = __nccwpck_require__(344);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
 /**
  * Platform utilities exports
  */
-exports.platform = __importStar(__nccwpck_require__(430));
+exports.platform = __importStar(__nccwpck_require__(431));
 //# sourceMappingURL=core.js.map
 
 /***/ }),
 
-/***/ 473:
+/***/ 474:
 /***/ ((module) => {
 
 "use strict";
@@ -89091,14 +89448,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 474:
+/***/ 475:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionEquals = void 0;
-const reflection_info_1 = __nccwpck_require__(465);
+const reflection_info_1 = __nccwpck_require__(466);
 /**
  * Determines whether two message of the same type have the same field values.
  * Checks for deep equality, traversing repeated fields, oneof groups, maps
@@ -89176,16 +89533,16 @@ function repeatedMsgEq(type, a, b) {
 
 /***/ }),
 
-/***/ 475:
+/***/ 476:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
-const reflection_info_1 = __nccwpck_require__(465);
-const reflection_long_convert_1 = __nccwpck_require__(165);
-const pb_long_1 = __nccwpck_require__(124);
+const reflection_info_1 = __nccwpck_require__(466);
+const reflection_long_convert_1 = __nccwpck_require__(167);
+const pb_long_1 = __nccwpck_require__(126);
 /**
  * Creates the default value for a scalar type.
  */
@@ -89221,7 +89578,7 @@ exports.reflectionScalarDefault = reflectionScalarDefault;
 
 /***/ }),
 
-/***/ 476:
+/***/ 477:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -89259,7 +89616,7 @@ function storageCorrectContentLengthPolicy() {
 
 /***/ }),
 
-/***/ 477:
+/***/ 478:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -89304,7 +89661,7 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 478:
+/***/ 479:
 /***/ ((module) => {
 
 "use strict";
@@ -89363,7 +89720,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 479:
+/***/ 480:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -89388,7 +89745,7 @@ __export(debug_exports, {
   default: () => debug_default
 });
 module.exports = __toCommonJS(debug_exports);
-var import_log = __nccwpck_require__(499);
+var import_log = __nccwpck_require__(500);
 const debugEnvVariable = typeof process !== "undefined" && process.env && process.env.DEBUG || void 0;
 let enabledString;
 let enabledNamespaces = [];
@@ -89553,7 +89910,7 @@ var debug_default = debugObj;
 
 /***/ }),
 
-/***/ 480:
+/***/ 481:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* eslint-env browser */
@@ -89813,7 +90170,7 @@ function localstorage() {
 	}
 }
 
-module.exports = __nccwpck_require__(150)(exports);
+module.exports = __nccwpck_require__(152)(exports);
 
 const {formatters} = module.exports;
 
@@ -89832,7 +90189,7 @@ formatters.j = function (v) {
 
 /***/ }),
 
-/***/ 481:
+/***/ 482:
 /***/ ((module) => {
 
 "use strict";
@@ -89840,7 +90197,7 @@ module.exports = /*#__PURE__*/JSON.parse('{"name":"@actions/cache","version":"4.
 
 /***/ }),
 
-/***/ 482:
+/***/ 483:
 /***/ ((module) => {
 
 "use strict";
@@ -89848,7 +90205,7 @@ module.exports = require("events");
 
 /***/ }),
 
-/***/ 483:
+/***/ 484:
 /***/ ((module) => {
 
 "use strict";
@@ -89879,7 +90236,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 484:
+/***/ 485:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -90153,7 +90510,7 @@ var KnownStorageErrorCode;
 
 /***/ }),
 
-/***/ 485:
+/***/ 486:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -90180,7 +90537,7 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(295);
 const proxyPolicyName = import_policies.proxyPolicyName;
 function getDefaultProxySettings(proxyUrl) {
   return (0, import_policies.getDefaultProxySettings)(proxyUrl);
@@ -90194,7 +90551,7 @@ function proxyPolicy(proxySettings, options) {
 
 /***/ }),
 
-/***/ 486:
+/***/ 487:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -90229,7 +90586,7 @@ exports.attachCredential = attachCredential;
 exports.httpAuthorizationToString = httpAuthorizationToString;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(109);
+const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_1 = __nccwpck_require__(15);
 const constants_js_1 = __nccwpck_require__(40);
 /**
@@ -90774,7 +91131,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 487:
+/***/ 488:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -90813,7 +91170,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 488:
+/***/ 489:
 /***/ ((module) => {
 
 "use strict";
@@ -90856,7 +91213,7 @@ module.exports = class DecoratorHandler {
 
 /***/ }),
 
-/***/ 489:
+/***/ 490:
 /***/ ((module) => {
 
 "use strict";
@@ -90878,13 +91235,13 @@ module.exports = function basename (path) {
 
 /***/ }),
 
-/***/ 490:
+/***/ 491:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = __nccwpck_require__(482)
+const EventEmitter = __nccwpck_require__(483)
 
 class Dispatcher extends EventEmitter {
   dispatch () {
@@ -90905,7 +91262,7 @@ module.exports = Dispatcher
 
 /***/ }),
 
-/***/ 491:
+/***/ 492:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -90925,7 +91282,7 @@ exports.ServiceType = ServiceType;
 
 /***/ }),
 
-/***/ 492:
+/***/ 493:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -90935,10 +91292,10 @@ exports.ServiceType = ServiceType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
-const tslib_1 = __nccwpck_require__(224);
-const base64 = tslib_1.__importStar(__nccwpck_require__(450));
-const interfaces_js_1 = __nccwpck_require__(107);
-const utils_js_1 = __nccwpck_require__(324);
+const tslib_1 = __nccwpck_require__(225);
+const base64 = tslib_1.__importStar(__nccwpck_require__(451));
+const interfaces_js_1 = __nccwpck_require__(109);
+const utils_js_1 = __nccwpck_require__(325);
 class SerializerImpl {
     modelMappers;
     isXML;
@@ -91858,7 +92215,7 @@ exports.MapperTypeNames = {
 
 /***/ }),
 
-/***/ 493:
+/***/ 494:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -91873,18 +92230,18 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 
 /***/ }),
 
-/***/ 494:
+/***/ 495:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Writable } = __nccwpck_require__(138)
-const diagnosticsChannel = __nccwpck_require__(149)
-const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(478)
-const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(106)
+const { Writable } = __nccwpck_require__(140)
+const diagnosticsChannel = __nccwpck_require__(151)
+const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(479)
+const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(108)
 const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(63)
-const { WebsocketFrameSend } = __nccwpck_require__(193)
+const { WebsocketFrameSend } = __nccwpck_require__(195)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -92225,7 +92582,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 495:
+/***/ 496:
 /***/ ((module) => {
 
 "use strict";
@@ -92249,7 +92606,7 @@ module.exports = function getLimit (limits, name, defaultLimit) {
 
 /***/ }),
 
-/***/ 496:
+/***/ 497:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -92300,7 +92657,7 @@ exports.assertFloat32 = assertFloat32;
 
 /***/ }),
 
-/***/ 497:
+/***/ 498:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -92413,11 +92770,11 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 498:
+/***/ 499:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __nccwpck_require__(363);
-var balanced = __nccwpck_require__(139);
+var concatMap = __nccwpck_require__(364);
+var balanced = __nccwpck_require__(141);
 
 module.exports = expandTop;
 
@@ -92623,7 +92980,7 @@ function expand(str, max, isTop) {
 
 /***/ }),
 
-/***/ 499:
+/***/ 500:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -92658,9 +93015,9 @@ __export(log_exports, {
   log: () => log
 });
 module.exports = __toCommonJS(log_exports);
-var import_node_os = __nccwpck_require__(391);
-var import_node_util = __toESM(__nccwpck_require__(383));
-var import_node_process = __toESM(__nccwpck_require__(244));
+var import_node_os = __nccwpck_require__(392);
+var import_node_util = __toESM(__nccwpck_require__(384));
+var import_node_process = __toESM(__nccwpck_require__(245));
 function log(message, ...args) {
   import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
 }
@@ -92671,7 +93028,7 @@ function log(message, ...args) {
 
 /***/ }),
 
-/***/ 500:
+/***/ 501:
 /***/ ((module) => {
 
 "use strict";
@@ -92909,7 +93266,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 501:
+/***/ 502:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -92921,10 +93278,10 @@ exports.serializationPolicyName = void 0;
 exports.serializationPolicy = serializationPolicy;
 exports.serializeHeaders = serializeHeaders;
 exports.serializeRequestBody = serializeRequestBody;
-const interfaces_js_1 = __nccwpck_require__(107);
-const operationHelpers_js_1 = __nccwpck_require__(444);
-const serializer_js_1 = __nccwpck_require__(492);
-const interfaceHelpers_js_1 = __nccwpck_require__(411);
+const interfaces_js_1 = __nccwpck_require__(109);
+const operationHelpers_js_1 = __nccwpck_require__(445);
+const serializer_js_1 = __nccwpck_require__(493);
+const interfaceHelpers_js_1 = __nccwpck_require__(412);
 /**
  * The programmatic identifier of the serializationPolicy.
  */
@@ -93073,7 +93430,7 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 /***/ }),
 
-/***/ 502:
+/***/ 503:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -93081,11 +93438,11 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 var net = __nccwpck_require__(520);
 var tls = __nccwpck_require__(517);
-var http = __nccwpck_require__(340);
+var http = __nccwpck_require__(341);
 var https = __nccwpck_require__(76);
-var events = __nccwpck_require__(482);
+var events = __nccwpck_require__(483);
 var assert = __nccwpck_require__(538);
-var util = __nccwpck_require__(131);
+var util = __nccwpck_require__(133);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -93345,7 +93702,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 503:
+/***/ 504:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -93371,14 +93728,14 @@ __export(clientHelpers_exports, {
   getCachedDefaultHttpsClient: () => getCachedDefaultHttpsClient
 });
 module.exports = __toCommonJS(clientHelpers_exports);
-var import_defaultHttpClient = __nccwpck_require__(380);
-var import_createPipelineFromOptions = __nccwpck_require__(327);
-var import_apiVersionPolicy = __nccwpck_require__(234);
-var import_credentials = __nccwpck_require__(194);
-var import_apiKeyAuthenticationPolicy = __nccwpck_require__(94);
-var import_basicAuthenticationPolicy = __nccwpck_require__(160);
-var import_bearerAuthenticationPolicy = __nccwpck_require__(389);
-var import_oauth2AuthenticationPolicy = __nccwpck_require__(349);
+var import_defaultHttpClient = __nccwpck_require__(381);
+var import_createPipelineFromOptions = __nccwpck_require__(328);
+var import_apiVersionPolicy = __nccwpck_require__(235);
+var import_credentials = __nccwpck_require__(196);
+var import_apiKeyAuthenticationPolicy = __nccwpck_require__(96);
+var import_basicAuthenticationPolicy = __nccwpck_require__(162);
+var import_bearerAuthenticationPolicy = __nccwpck_require__(390);
+var import_oauth2AuthenticationPolicy = __nccwpck_require__(350);
 let cachedHttpClient;
 function createDefaultPipeline(options = {}) {
   const pipeline = (0, import_createPipelineFromOptions.createPipelineFromOptions)(options);
@@ -93418,360 +93775,6 @@ function getCachedDefaultHttpsClient() {
 
 /***/ }),
 
-/***/ 504:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports._internal = void 0;
-exports.detectHostZccacheTarget = detectHostZccacheTarget;
-exports.hasRequiredZccacheBinaries = hasRequiredZccacheBinaries;
-exports.findVendoredZccacheDir = findVendoredZccacheDir;
-exports.findBundledZccacheDir = findBundledZccacheDir;
-exports.managedReleaseUrl = managedReleaseUrl;
-exports.downloadManagedRelease = downloadManagedRelease;
-exports.seedZccache = seedZccache;
-const fs = __importStar(__nccwpck_require__(256));
-const os = __importStar(__nccwpck_require__(391));
-const path = __importStar(__nccwpck_require__(519));
-const core = __importStar(__nccwpck_require__(472));
-const exec = __importStar(__nccwpck_require__(19));
-const tc = __importStar(__nccwpck_require__(534));
-const LOCAL_DIR_ENV = "SOLDR_ZCCACHE_LOCAL_DIR";
-const VENDOR_DIR_ENV = "SETUP_SOLDR_ZCCACHE_VENDOR_DIR";
-const SEED_ENV = "SETUP_SOLDR_ZCCACHE_SEEDED";
-const SEED_SOURCE_ENV = "SETUP_SOLDR_ZCCACHE_SEED_SOURCE";
-function normalizeArch(arch) {
-    if (arch === "x64")
-        return "x86_64";
-    if (arch === "arm64")
-        return "aarch64";
-    throw new Error(`unsupported architecture for zccache seed: ${arch}`);
-}
-function detectHostZccacheTarget(platform = process.platform, archValue = process.arch) {
-    const arch = normalizeArch(archValue);
-    if (platform === "win32") {
-        return {
-            target: `${arch}-pc-windows-msvc`,
-            archiveTarget: `${arch}-pc-windows-msvc`,
-            binaryExt: ".exe",
-            archiveExt: "zip",
-        };
-    }
-    if (platform === "darwin") {
-        return {
-            target: `${arch}-apple-darwin`,
-            archiveTarget: `${arch}-apple-darwin`,
-            binaryExt: "",
-            archiveExt: "tar.gz",
-        };
-    }
-    if (platform === "linux") {
-        // zccache publishes musl Linux archives; they are the portable host
-        // binary used by soldr on GNU runners too.
-        return {
-            target: `${arch}-unknown-linux-gnu`,
-            archiveTarget: `${arch}-unknown-linux-musl`,
-            binaryExt: "",
-            archiveExt: "tar.gz",
-        };
-    }
-    throw new Error(`unsupported platform for zccache seed: ${platform}`);
-}
-function requiredBinaryNames(binaryExt) {
-    return ["zccache", "zccache-daemon", "zccache-fp"].map((name) => `${name}${binaryExt}`);
-}
-function hasRequiredZccacheBinaries(dir, binaryExt) {
-    try {
-        const stat = fs.statSync(dir);
-        if (!stat.isDirectory())
-            return false;
-    }
-    catch {
-        return false;
-    }
-    return requiredBinaryNames(binaryExt).every((name) => {
-        try {
-            return fs.statSync(path.join(dir, name)).isFile();
-        }
-        catch {
-            return false;
-        }
-    });
-}
-function uniqueStrings(values) {
-    const seen = new Set();
-    const out = [];
-    for (const value of values) {
-        const normalized = value.trim();
-        if (!normalized || seen.has(normalized))
-            continue;
-        seen.add(normalized);
-        out.push(normalized);
-    }
-    return out;
-}
-function findVendoredZccacheDir(opts) {
-    const env = opts.env ?? process.env;
-    const explicit = (env[VENDOR_DIR_ENV] ?? "").trim();
-    const roots = uniqueStrings([
-        explicit,
-        path.join(opts.actionRoot, "vendor", "zccache", opts.target.target),
-        path.join(opts.actionRoot, "vendor", "zccache", opts.target.archiveTarget),
-        path.join(opts.actionRoot, "zccache", "vendor", opts.target.target),
-        path.join(opts.actionRoot, "zccache", "vendor", opts.target.archiveTarget),
-    ]);
-    for (const root of roots) {
-        for (const candidate of uniqueStrings([root, path.join(root, "bin")])) {
-            if (hasRequiredZccacheBinaries(candidate, opts.target.binaryExt)) {
-                return candidate;
-            }
-        }
-    }
-    return null;
-}
-function findBundledZccacheDir(opts) {
-    const installedDir = path.dirname(opts.soldrPath);
-    if (hasRequiredZccacheBinaries(installedDir, opts.target.binaryExt)) {
-        return installedDir;
-    }
-    return null;
-}
-function managedReleaseUrl(version, target) {
-    const normalized = version.trim().replace(/^v/i, "");
-    const asset = `zccache-v${normalized}-${target.archiveTarget}.${target.archiveExt}`;
-    return `https://github.com/zackees/zccache/releases/download/${normalized}/${asset}`;
-}
-async function downloadManagedRelease(url, target, env = process.env) {
-    const runnerTemp = env["RUNNER_TEMP"]?.trim() || os.tmpdir();
-    const tempDir = fs.mkdtempSync(path.join(runnerTemp, "setup-soldr-zccache-"));
-    const suffix = target.archiveExt === "zip" ? ".zip" : ".tar.gz";
-    const archivePath = path.join(tempDir, `zccache-managed${suffix}`);
-    return await tc.downloadTool(url, archivePath);
-}
-async function runCaptured(execFn, command, args) {
-    let stdout = "";
-    let stderr = "";
-    const code = await execFn(command, args, {
-        silent: true,
-        ignoreReturnCode: true,
-        listeners: {
-            stdout: (data) => {
-                stdout += data.toString("utf8");
-            },
-            stderr: (data) => {
-                stderr += data.toString("utf8");
-            },
-        },
-    });
-    return { code, stdout, stderr };
-}
-function parseInstallStatus(stdout) {
-    let parsed;
-    try {
-        parsed = JSON.parse(stdout);
-    }
-    catch {
-        return null;
-    }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
-        return null;
-    const payload = parsed;
-    const managedVersion = payload["managed_version"];
-    if (typeof managedVersion !== "string" || !managedVersion.trim())
-        return null;
-    return {
-        managedVersion,
-        pinnedPresent: payload["pinned"] !== null && payload["pinned"] !== undefined,
-        driftFromManaged: payload["drift_from_managed"] === true,
-    };
-}
-async function readInstallStatus(soldrPath, execFn) {
-    const result = await runCaptured(execFn, soldrPath, ["install-zccache", "--status", "--json"]);
-    if (result.code !== 0)
-        return null;
-    return parseInstallStatus(result.stdout);
-}
-function parseRuntimeStatus(stdout) {
-    let parsed;
-    try {
-        parsed = JSON.parse(stdout);
-    }
-    catch {
-        return null;
-    }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
-        return null;
-    const payload = parsed;
-    const zccache = payload["zccache"];
-    const zccachePayload = zccache && typeof zccache === "object" && !Array.isArray(zccache)
-        ? zccache
-        : {};
-    const source = String(zccachePayload["binary_source"] ?? "").trim();
-    return {
-        managedVersion: String(payload["managed_zccache_version"] ?? "").trim(),
-        zccacheSource: source,
-        embedded: source === "embedded",
-    };
-}
-async function readRuntimeStatus(soldrPath, execFn) {
-    const result = await runCaptured(execFn, soldrPath, ["status", "--json"]);
-    if (result.code !== 0)
-        return null;
-    return parseRuntimeStatus(result.stdout);
-}
-function errorDetail(err) {
-    return err instanceof Error ? (err.message || String(err)) : String(err);
-}
-async function seedZccache(opts) {
-    const warn = opts.warn ?? ((msg) => core.warning(msg));
-    const execFn = opts.execFn ?? exec.exec;
-    const downloadFn = opts.downloadFn ?? downloadManagedRelease;
-    const env = opts.env ?? process.env;
-    const failOrWarn = (message) => {
-        if (opts.strict) {
-            throw new Error(message);
-        }
-        warn(message);
-    };
-    if (!opts.enabled) {
-        opts.log("zccache-seed: skipped - setup-soldr passthrough mode");
-        return;
-    }
-    if ((env[LOCAL_DIR_ENV] ?? "").trim()) {
-        opts.log(`zccache-seed: skipped - ${LOCAL_DIR_ENV} already set`);
-        return;
-    }
-    let target;
-    try {
-        target = detectHostZccacheTarget();
-    }
-    catch (err) {
-        failOrWarn(`setup-soldr: zccache seed skipped: ${err instanceof Error ? err.message : String(err)}`);
-        return;
-    }
-    const runtimeStatus = await readRuntimeStatus(opts.soldrPath, execFn);
-    if (runtimeStatus?.embedded) {
-        opts.log(`zccache-seed: skipped - soldr uses embedded zccache ${runtimeStatus.managedVersion || "(unknown version)"}`);
-        core.exportVariable(SEED_ENV, "true");
-        core.exportVariable(SEED_SOURCE_ENV, "embedded");
-        return;
-    }
-    const status = await readInstallStatus(opts.soldrPath, execFn);
-    if (status?.pinnedPresent && !status.driftFromManaged) {
-        opts.log(`zccache-seed: existing pinned zccache matches managed ${status.managedVersion}`);
-        core.exportVariable(SEED_ENV, "true");
-        core.exportVariable(SEED_SOURCE_ENV, "pinned-existing");
-        return;
-    }
-    const vendored = findVendoredZccacheDir({ actionRoot: opts.actionRoot, target, env });
-    const bundled = vendored ? null : findBundledZccacheDir({ soldrPath: opts.soldrPath, target });
-    const managedUrl = status ? managedReleaseUrl(status.managedVersion, target) : "";
-    if (!vendored && !bundled && !managedUrl) {
-        failOrWarn("setup-soldr: zccache seed failed: could not determine managed zccache version");
-        return;
-    }
-    const sourceKind = vendored ? "vendored" : bundled ? "soldr-release" : "managed-release";
-    let tempRoot = "";
-    let source = vendored ?? bundled ?? "";
-    try {
-        if (!source) {
-            opts.log(`zccache-seed: downloading managed zccache release ${managedUrl}`);
-            try {
-                source = await downloadFn(managedUrl, target, env);
-            }
-            catch (err) {
-                const detail = errorDetail(err);
-                failOrWarn(opts.strict
-                    ? "setup-soldr: zccache seed failed; refusing to continue because the managed " +
-                        "zccache release could not be downloaded and later isolated SOLDR_CACHE_DIR roots " +
-                        "would fall back to cargo-installing zccache" +
-                        (detail ? `: ${detail}` : "")
-                    : "setup-soldr: zccache seed failed; managed zccache release could not be downloaded; " +
-                        "later isolated SOLDR_CACHE_DIR roots may fetch zccache again" +
-                        (detail ? `: ${detail}` : ""));
-                return;
-            }
-            tempRoot = path.dirname(source);
-        }
-        opts.log(`zccache-seed: installing pinned zccache from ${sourceKind} source ${source}`);
-        let install;
-        try {
-            install = await runCaptured(execFn, opts.soldrPath, ["install-zccache", source, "--json"]);
-        }
-        catch (err) {
-            const detail = errorDetail(err);
-            failOrWarn(opts.strict
-                ? "setup-soldr: zccache seed failed; refusing to continue because pinned zccache " +
-                    "installation errored and later isolated SOLDR_CACHE_DIR roots would fall back to " +
-                    "cargo-installing zccache" +
-                    (detail ? `: ${detail}` : "")
-                : "setup-soldr: zccache seed failed; pinned zccache installation errored; later isolated " +
-                    "SOLDR_CACHE_DIR roots may fetch zccache again" +
-                    (detail ? `: ${detail}` : ""));
-            return;
-        }
-        if (install.code !== 0) {
-            const detail = (install.stderr || install.stdout).trim();
-            failOrWarn(opts.strict
-                ? "setup-soldr: zccache seed failed; refusing to continue because later isolated " +
-                    "SOLDR_CACHE_DIR roots would fall back to cargo-installing zccache" +
-                    (detail ? `: ${detail}` : "")
-                : "setup-soldr: zccache seed failed; later isolated SOLDR_CACHE_DIR roots may fetch zccache again" +
-                    (detail ? `: ${detail}` : ""));
-            return;
-        }
-    }
-    finally {
-        if (tempRoot) {
-            fs.rmSync(tempRoot, { recursive: true, force: true });
-        }
-    }
-    core.exportVariable(SEED_ENV, "true");
-    core.exportVariable(SEED_SOURCE_ENV, sourceKind);
-    opts.log(`zccache-seed: pinned zccache installed from ${sourceKind}`);
-}
-exports._internal = {
-    parseRuntimeStatus,
-};
-
-
-/***/ }),
-
 /***/ 505:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -93782,7 +93785,7 @@ exports._internal = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetriableReadableStream = void 0;
 const abort_controller_1 = __nccwpck_require__(508);
-const node_stream_1 = __nccwpck_require__(442);
+const node_stream_1 = __nccwpck_require__(443);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -94131,8 +94134,8 @@ exports.AbortError = AbortError;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQuickQueryStream = void 0;
-const node_stream_1 = __nccwpck_require__(442);
-const index_js_1 = __nccwpck_require__(346);
+const node_stream_1 = __nccwpck_require__(443);
+const index_js_1 = __nccwpck_require__(347);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -94278,13 +94281,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
-const os = __importStar(__nccwpck_require__(100));
-const path = __importStar(__nccwpck_require__(255));
-const pathHelper = __importStar(__nccwpck_require__(229));
+const os = __importStar(__nccwpck_require__(102));
+const path = __importStar(__nccwpck_require__(256));
+const pathHelper = __importStar(__nccwpck_require__(230));
 const assert_1 = __importDefault(__nccwpck_require__(538));
-const minimatch_1 = __nccwpck_require__(132);
+const minimatch_1 = __nccwpck_require__(134);
 const internal_match_kind_1 = __nccwpck_require__(540);
-const internal_path_1 = __nccwpck_require__(128);
+const internal_path_1 = __nccwpck_require__(130);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, isImplicitPattern = false, segments, homedir) {
@@ -94838,15 +94841,15 @@ module.exports = require("timers");
 "use strict";
 
 
-const Readable = __nccwpck_require__(136)
+const Readable = __nccwpck_require__(138)
 const {
   InvalidArgumentError,
   RequestAbortedError
-} = __nccwpck_require__(500)
+} = __nccwpck_require__(501)
 const util = __nccwpck_require__(75)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(195)
-const { AsyncResource } = __nccwpck_require__(441)
-const { addSignal, removeSignal } = __nccwpck_require__(111)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(197)
+const { AsyncResource } = __nccwpck_require__(442)
+const { addSignal, removeSignal } = __nccwpck_require__(113)
 
 class RequestHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -95036,14 +95039,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TestTransport = void 0;
-const rpc_error_1 = __nccwpck_require__(182);
+const rpc_error_1 = __nccwpck_require__(184);
 const runtime_1 = __nccwpck_require__(21);
-const rpc_output_stream_1 = __nccwpck_require__(317);
-const rpc_options_1 = __nccwpck_require__(303);
+const rpc_output_stream_1 = __nccwpck_require__(318);
+const rpc_options_1 = __nccwpck_require__(304);
 const unary_call_1 = __nccwpck_require__(62);
-const server_streaming_call_1 = __nccwpck_require__(464);
-const client_streaming_call_1 = __nccwpck_require__(361);
-const duplex_streaming_call_1 = __nccwpck_require__(316);
+const server_streaming_call_1 = __nccwpck_require__(465);
+const client_streaming_call_1 = __nccwpck_require__(362);
+const duplex_streaming_call_1 = __nccwpck_require__(317);
 /**
  * Transport for testing.
  */
@@ -95397,7 +95400,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._internal = void 0;
 exports.installPassthrough = installPassthrough;
-const fs = __importStar(__nccwpck_require__(256));
+const fs = __importStar(__nccwpck_require__(257));
 const path = __importStar(__nccwpck_require__(519));
 const STUB_VERSION = "passthrough";
 function bashStub() {
@@ -95514,7 +95517,7 @@ exports._internal = { bashStub, cmdStub, STUB_VERSION };
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isTokenCredential = exports.isSASCredential = exports.AzureSASCredential = exports.isNamedKeyCredential = exports.AzureNamedKeyCredential = exports.isKeyCredential = exports.AzureKeyCredential = void 0;
-var azureKeyCredential_js_1 = __nccwpck_require__(307);
+var azureKeyCredential_js_1 = __nccwpck_require__(308);
 Object.defineProperty(exports, "AzureKeyCredential", ({ enumerable: true, get: function () { return azureKeyCredential_js_1.AzureKeyCredential; } }));
 var keyCredential_js_1 = __nccwpck_require__(42);
 Object.defineProperty(exports, "isKeyCredential", ({ enumerable: true, get: function () { return keyCredential_js_1.isKeyCredential; } }));
@@ -95524,7 +95527,7 @@ Object.defineProperty(exports, "isNamedKeyCredential", ({ enumerable: true, get:
 var azureSASCredential_js_1 = __nccwpck_require__(37);
 Object.defineProperty(exports, "AzureSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.AzureSASCredential; } }));
 Object.defineProperty(exports, "isSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.isSASCredential; } }));
-var tokenCredential_js_1 = __nccwpck_require__(254);
+var tokenCredential_js_1 = __nccwpck_require__(255);
 Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: function () { return tokenCredential_js_1.isTokenCredential; } }));
 //# sourceMappingURL=index.js.map
 
@@ -95539,9 +95542,9 @@ Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: fu
  */
 
 if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
-	module.exports = __nccwpck_require__(480);
+	module.exports = __nccwpck_require__(481);
 } else {
-	module.exports = __nccwpck_require__(470);
+	module.exports = __nccwpck_require__(471);
 }
 
 
@@ -95555,7 +95558,7 @@ if (typeof process === 'undefined' || process.type === 'renderer' || process.bro
 
 
 
-const { kHeadersList, kConstruct } = __nccwpck_require__(202)
+const { kHeadersList, kConstruct } = __nccwpck_require__(204)
 const { kGuard } = __nccwpck_require__(16)
 const { kEnumerableProperty } = __nccwpck_require__(75)
 const {
@@ -95563,8 +95566,8 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(529)
-const util = __nccwpck_require__(131)
-const { webidl } = __nccwpck_require__(469)
+const util = __nccwpck_require__(133)
+const { webidl } = __nccwpck_require__(470)
 const assert = __nccwpck_require__(538)
 
 const kHeadersMap = Symbol('headers map')
@@ -96196,7 +96199,7 @@ exports.markPhase = markPhase;
 exports.finishPhase = finishPhase;
 exports.setupPhaseSummaryOneLine = setupPhaseSummaryOneLine;
 exports.timeSubPhase = timeSubPhase;
-const core = __importStar(__nccwpck_require__(472));
+const core = __importStar(__nccwpck_require__(473));
 function phaseEnvName(name) {
     const cleaned = name.replace(/[^A-Za-z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase() || "PHASE";
     return `SETUP_SOLDR_PHASE_${cleaned}_START_MS`;
@@ -96341,11 +96344,11 @@ function readSubPhaseDurations(parent) {
 
 
 const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(33)
-const { getGlobalOrigin } = __nccwpck_require__(147)
-const { performance } = __nccwpck_require__(332)
+const { getGlobalOrigin } = __nccwpck_require__(149)
+const { performance } = __nccwpck_require__(333)
 const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(75)
 const assert = __nccwpck_require__(538)
-const { isUint8Array } = __nccwpck_require__(206)
+const { isUint8Array } = __nccwpck_require__(207)
 
 let supportedHashes = []
 
@@ -96354,7 +96357,7 @@ let supportedHashes = []
 let crypto
 
 try {
-  crypto = __nccwpck_require__(301)
+  crypto = __nccwpck_require__(302)
   const possibleRelevantHashes = ['sha256', 'sha384', 'sha512']
   supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
 /* c8 ignore next 3 */
@@ -97307,7 +97310,7 @@ let ReadableStream = globalThis.ReadableStream
 
 function isReadableStreamLike (stream) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(264).ReadableStream)
+    ReadableStream = (__nccwpck_require__(265).ReadableStream)
   }
 
   return stream instanceof ReadableStream || (
@@ -97573,7 +97576,7 @@ module.exports = require("node:zlib");
 /***/ 532:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(502);
+module.exports = __nccwpck_require__(503);
 
 
 /***/ }),
@@ -97662,17 +97665,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.evaluateVersions = exports.isExplicitVersion = exports.findFromManifest = exports.getManifestFromRepo = exports.findAllVersions = exports.find = exports.cacheFile = exports.cacheDir = exports.extractZip = exports.extractXar = exports.extractTar = exports.extract7z = exports.downloadTool = exports.HTTPError = void 0;
-const core = __importStar(__nccwpck_require__(472));
-const io = __importStar(__nccwpck_require__(304));
-const crypto = __importStar(__nccwpck_require__(301));
+const core = __importStar(__nccwpck_require__(473));
+const io = __importStar(__nccwpck_require__(305));
+const crypto = __importStar(__nccwpck_require__(302));
 const fs = __importStar(__nccwpck_require__(542));
-const mm = __importStar(__nccwpck_require__(342));
-const os = __importStar(__nccwpck_require__(100));
-const path = __importStar(__nccwpck_require__(255));
-const httpm = __importStar(__nccwpck_require__(293));
-const semver = __importStar(__nccwpck_require__(185));
-const stream = __importStar(__nccwpck_require__(138));
-const util = __importStar(__nccwpck_require__(131));
+const mm = __importStar(__nccwpck_require__(343));
+const os = __importStar(__nccwpck_require__(102));
+const path = __importStar(__nccwpck_require__(256));
+const httpm = __importStar(__nccwpck_require__(294));
+const semver = __importStar(__nccwpck_require__(187));
+const stream = __importStar(__nccwpck_require__(140));
+const util = __importStar(__nccwpck_require__(133));
 const assert_1 = __nccwpck_require__(538);
 const exec_1 = __nccwpck_require__(19);
 const retry_helper_1 = __nccwpck_require__(10);
@@ -98322,7 +98325,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(407);
+var import_exponentialRetryStrategy = __nccwpck_require__(408);
 var import_retryPolicy = __nccwpck_require__(17);
 var import_constants = __nccwpck_require__(53);
 const exponentialRetryPolicyName = "exponentialRetryPolicy";
@@ -98569,8 +98572,8 @@ function createEmptyPipeline() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SASQueryParameters = exports.SASProtocol = void 0;
-const SasIPRange_js_1 = __nccwpck_require__(369);
-const utils_common_js_1 = __nccwpck_require__(162);
+const SasIPRange_js_1 = __nccwpck_require__(370);
+const utils_common_js_1 = __nccwpck_require__(164);
 /**
  * Protocols for generated SAS.
  */
@@ -99039,20 +99042,20 @@ var MatchKind;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(418);
-const reflection_info_1 = __nccwpck_require__(465);
-const reflection_type_check_1 = __nccwpck_require__(300);
-const reflection_json_reader_1 = __nccwpck_require__(353);
-const reflection_json_writer_1 = __nccwpck_require__(98);
-const reflection_binary_reader_1 = __nccwpck_require__(420);
-const reflection_binary_writer_1 = __nccwpck_require__(192);
-const reflection_create_1 = __nccwpck_require__(214);
-const reflection_merge_partial_1 = __nccwpck_require__(144);
-const json_typings_1 = __nccwpck_require__(406);
-const json_format_contract_1 = __nccwpck_require__(249);
-const reflection_equals_1 = __nccwpck_require__(474);
-const binary_writer_1 = __nccwpck_require__(258);
-const binary_reader_1 = __nccwpck_require__(142);
+const message_type_contract_1 = __nccwpck_require__(419);
+const reflection_info_1 = __nccwpck_require__(466);
+const reflection_type_check_1 = __nccwpck_require__(301);
+const reflection_json_reader_1 = __nccwpck_require__(354);
+const reflection_json_writer_1 = __nccwpck_require__(100);
+const reflection_binary_reader_1 = __nccwpck_require__(421);
+const reflection_binary_writer_1 = __nccwpck_require__(194);
+const reflection_create_1 = __nccwpck_require__(215);
+const reflection_merge_partial_1 = __nccwpck_require__(146);
+const json_typings_1 = __nccwpck_require__(407);
+const json_format_contract_1 = __nccwpck_require__(250);
+const reflection_equals_1 = __nccwpck_require__(475);
+const binary_writer_1 = __nccwpck_require__(259);
+const binary_reader_1 = __nccwpck_require__(144);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
 const messageTypeDescriptor = baseDescriptors[message_type_contract_1.MESSAGE_TYPE] = {};
 /**
@@ -99337,7 +99340,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(100));
+const os = __importStar(__nccwpck_require__(102));
 const utils_1 = __nccwpck_require__(516);
 /**
  * Commands
@@ -99420,7 +99423,7 @@ function escapeProperty(s) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBeginCopyFromUrlPoller = void 0;
 const core_util_1 = __nccwpck_require__(15);
-const core_lro_1 = __nccwpck_require__(233);
+const core_lro_1 = __nccwpck_require__(234);
 /**
  * This is the poller returned by {@link BlobClient.beginCopyFromURL}.
  * This can not be instantiated directly outside of this package.
@@ -99655,7 +99658,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(204);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(85);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/src/lib/zccache-seed.ts
+++ b/src/lib/zccache-seed.ts
@@ -240,7 +240,10 @@ function parseRuntimeStatus(stdout: string): RuntimeStatus | null {
   return {
     managedVersion: String(payload["managed_zccache_version"] ?? "").trim(),
     zccacheSource: source,
-    embedded: source === "embedded",
+    // soldr 0.8.7+ reports the compiled-in backend as "in-process";
+    // older releases used "embedded". Both mean setup-soldr must not
+    // attempt the legacy managed-zccache download/seed path.
+    embedded: source === "embedded" || source === "in-process",
   };
 }
 


### PR DESCRIPTION
Fixes #415\n\nSoldr 0.8.7 reports its compiled-in zccache backend as inary_source: in-process, while setup-soldr only recognized the older embedded spelling. Treat both as the embedded backend so strict zccache seeding skips the obsolete managed-download path. Includes regression coverage and rebuilt Linux action bundles.