### PR TITLE
chore: default to soldr 0.8.8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.8.7.
+    description: Soldr version or tag to install. Defaults to 0.8.8.
     required: false
-    default: "0.8.7"
+    default: "0.8.8"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -146,7 +146,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.7"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.8"
 
 
 def _load_action() -> dict:


### PR DESCRIPTION
Consume the newly published soldr 0.8.8 release, which carries the PyO3 metadata toolchain fix from soldr#1628. Updates action.yml's default and its contract test. Follow-up to setup-soldr#420.