### PR TITLE
chore(release): consume soldr 0.8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.8.6`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.8.9`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -622,7 +622,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.6`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.9`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.8.8.
+    description: Soldr version or tag to install. Defaults to 0.8.9.
     required: false
-    default: "0.8.8"
+    default: "0.8.9"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -146,7 +146,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.8"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.9"
 
 
 def _load_action() -> dict:


### PR DESCRIPTION
Updates setup-soldr's action default and contract expectation to the released soldr v0.8.9, which contains the private broker/zccache state isolation fix from soldr#1635 and zccache#1085. Validation: npm test, npm run typecheck, and npm run build passed.