### PR TITLE
chore(release): consume soldr 0.8.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.8.9`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.8.13`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -622,7 +622,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.9`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.13`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.8.9.
+    description: Soldr version or tag to install. Defaults to 0.8.13.
     required: false
-    default: "0.8.9"
+    default: "0.8.13"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -146,7 +146,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.9"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.13"
 
 
 def _load_action() -> dict:


### PR DESCRIPTION
## What changed

- default setup-soldr from soldr 0.8.9 to 0.8.13
- update the public input documentation and manifest contract test

## Why

zccache's sanctioned perf matrix was still installing soldr 0.8.8. That release could abort long builds and, on populated Windows caches, miss compile dispatch while daemon startup recursively re-applied ACLs. soldr 0.8.13 includes the no-global-deadline fix and the running-process 4.5.12 Windows startup fix.

## Validation

- action manifest contract: 4 passed
- full Node unit suite: passed
- soldr 0.8.13 release assets and PyPI/npm publication: verified by the autonomous release workflow