### PR TITLE
chore(release): consume soldr 0.8.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.18`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.20`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -524,7 +524,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.8.18`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.8.20`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -622,7 +622,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.18`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.20`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.8.18.
+    description: Soldr version or tag to install. Defaults to 0.8.20.
     required: false
-    default: "0.8.18"
+    default: "0.8.20"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/dist/main.js
+++ b/dist/main.js
@@ -18227,7 +18227,7 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageRetryPolicy = void 0;
 exports.NewRetryPolicyFactory = NewRetryPolicyFactory;
-const abort_controller_1 = __nccwpck_require__(509);
+const abort_controller_1 = __nccwpck_require__(508);
 const RequestPolicy_js_1 = __nccwpck_require__(50);
 const constants_js_1 = __nccwpck_require__(40);
 const utils_common_js_1 = __nccwpck_require__(487);
@@ -33120,7 +33120,7 @@ tslib_1.__exportStar(__nccwpck_require__(276), exports);
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageRetryPolicyName = void 0;
 exports.storageRetryPolicy = storageRetryPolicy;
-const abort_controller_1 = __nccwpck_require__(509);
+const abort_controller_1 = __nccwpck_require__(508);
 const core_rest_pipeline_1 = __nccwpck_require__(110);
 const core_util_1 = __nccwpck_require__(15);
 const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(337);
@@ -55775,7 +55775,7 @@ exports.BinaryWriter = BinaryWriter;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
 const AvroReadable_js_1 = __nccwpck_require__(399);
-const abort_controller_1 = __nccwpck_require__(507);
+const abort_controller_1 = __nccwpck_require__(509);
 const buffer_1 = __nccwpck_require__(127);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
 class AvroReadableFromStream extends AvroReadable_js_1.AvroReadable {
@@ -56097,7 +56097,7 @@ function wrapAbortSignalLikePolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createAbortablePromise = createAbortablePromise;
-const abort_controller_1 = __nccwpck_require__(508);
+const abort_controller_1 = __nccwpck_require__(507);
 /**
  * Creates an abortable promise.
  * @param buildPromise - A function that takes the resolve and reject functions as parameters.
@@ -93269,7 +93269,7 @@ function getCachedDefaultHttpsClient() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetriableReadableStream = void 0;
-const abort_controller_1 = __nccwpck_require__(507);
+const abort_controller_1 = __nccwpck_require__(509);
 const node_stream_1 = __nccwpck_require__(443);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -94047,7 +94047,7 @@ exports._internal = {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(512);
+var AbortError_js_1 = __nccwpck_require__(513);
 Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
 //# sourceMappingURL=index.js.map
 
@@ -94062,7 +94062,7 @@ Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function 
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(513);
+var AbortError_js_1 = __nccwpck_require__(511);
 Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
 //# sourceMappingURL=index.js.map
 
@@ -94077,7 +94077,7 @@ Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function 
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(511);
+var AbortError_js_1 = __nccwpck_require__(512);
 Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
 //# sourceMappingURL=index.js.map
 

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -146,7 +146,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.18"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.20"
 
 
 def _load_action() -> dict:


### PR DESCRIPTION
## Summary
- make 0.8.20 the default Soldr release for setup-soldr
- refresh documentation, contract test, and generated action bundle

## Dependency
Merge after https://github.com/zackees/soldr/pull/1759 publishes Soldr 0.8.20; the action default must always resolve to a published GitHub Release asset.

## Validation
- npm run build:main
- npm run typecheck
- uv run --no-project --with pyyaml --with pytest pytest -q tests/test_action_target_cache_wiring.py
- full npm test exceeded the local one-minute runner limit (the harness terminated with EPIPE, without an assertion failure).