### PR TITLE
chore: default to soldr 0.8.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.18`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.21`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -524,7 +524,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.8.18`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.8.21`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -625,7 +625,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.18`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.21`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.8.18.
+    description: Soldr version or tag to install. Defaults to 0.8.21.
     required: false
-    default: "0.8.18"
+    default: "0.8.21"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -157,7 +157,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.18"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.21"
 
 
 def _load_action() -> dict:


### PR DESCRIPTION
Bumps the default soldr pin from 0.8.18 to 0.8.21 in action.yml, README, and the strict contract test.

0.8.21 is now published on PyPI, npm, and GitHub Releases with tag v0.8.21 (release run 30016700826 succeeded). 0.8.21 carries the Dylint transparent-nightly scoping (zackees/soldr#1786) that the dylint caching inputs added in #437 depend on.

Part of zackees/soldr#1788 Phase 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)