### PR TITLE
test(dylint): neutralize historical fixture pins

### DIFF
--- a/__tests__/raw-inputs.test.ts
+++ b/__tests__/raw-inputs.test.ts
@@ -93,19 +93,21 @@ test("zccache seed strict input round-trips through readRawInputs", () => {
 });
 
 test("dylint cache inputs round-trip through readRawInputs", () => {
+  // Deliberately synthetic values: this test verifies opaque input round-tripping,
+  // not supported Dylint versions or a real dylint-driver revision.
   const r = readRawInputs({
     "INPUT_DYLINT-CACHE": "true",
     "INPUT_DYLINT-TOOLCHAIN": "nightly-2026-03-26",
-    "INPUT_DYLINT-DRIVER-REV": "4bd91ce",
-    "INPUT_CARGO-DYLINT-VERSION": "5.0.0",
-    "INPUT_DYLINT-LINK-VERSION": "5.0.0",
+    "INPUT_DYLINT-DRIVER-REV": "fixture-revision",
+    "INPUT_CARGO-DYLINT-VERSION": "99.98.97",
+    "INPUT_DYLINT-LINK-VERSION": "97.98.99",
     "INPUT_DYLINT-CACHE-PATHS": "cache/dylint",
   });
   assert.equal(r.dylintCache, "true");
   assert.equal(r.dylintToolchain, "nightly-2026-03-26");
-  assert.equal(r.dylintDriverRev, "4bd91ce");
-  assert.equal(r.cargoDylintVersion, "5.0.0");
-  assert.equal(r.dylintLinkVersion, "5.0.0");
+  assert.equal(r.dylintDriverRev, "fixture-revision");
+  assert.equal(r.cargoDylintVersion, "99.98.97");
+  assert.equal(r.dylintLinkVersion, "97.98.99");
   assert.equal(r.dylintCachePaths, "cache/dylint");
 });
 

--- a/__tests__/resolve-setup.test.ts
+++ b/__tests__/resolve-setup.test.ts
@@ -181,18 +181,21 @@ test("invalid compress level rejected", async () => {
 });
 
 test("dylint cache is opt-in and exports driver path plus exact-key material", async () => {
+  // Deliberately synthetic overrides: this covers cache-key compatibility,
+  // not active Dylint pins or a real dylint-driver revision.
+  const fixtureDriverRev = "0123456789abcdef0123456789abcdef01234567";
   const { result, outputs } = await run({}, {
     "INPUT_DYLINT-CACHE": "true",
     "INPUT_DYLINT-TOOLCHAIN": "nightly-2026-03-26",
-    "INPUT_DYLINT-DRIVER-REV": "4bd91ce7729b74c7ee5664bbb588f7baf30b4a09",
-    "INPUT_CARGO-DYLINT-VERSION": "5.0.0",
-    "INPUT_DYLINT-LINK-VERSION": "5.0.0",
+    "INPUT_DYLINT-DRIVER-REV": fixtureDriverRev,
+    "INPUT_CARGO-DYLINT-VERSION": "99.98.97",
+    "INPUT_DYLINT-LINK-VERSION": "97.98.99",
   });
 
   assert.equal(result.dylintCache.enabled, true);
   assert.equal(result.dylintCache.hostTriple, "x86_64-unknown-linux-gnu");
   assert.equal(result.dylintCache.toolchain, "nightly-2026-03-26");
-  assert.equal(result.dylintCache.driverRev, "4bd91ce7729b74c7ee5664bbb588f7baf30b4a09");
+  assert.equal(result.dylintCache.driverRev, fixtureDriverRev);
   assert.match(result.dylintCache.key, /^setup-soldr-dylint-v1-linux-x64-x86_64-unknown-linux-gnu-/);
   assert.ok(result.dylintCache.paths.some((p) => p.includes("cargo-dylint*")));
   assert.ok(result.dylintCache.paths.some((p) => p.includes("dylint-drivers")));


### PR DESCRIPTION
## Summary
- replace historical Dylint 5.0.0 fixture values with clearly synthetic versions
- replace the historical dylint-driver revision fixture with synthetic opaque values
- document that these tests cover override round-tripping and cache-key compatibility, not active tool pins

No production behavior changes.

Related: https://github.com/zackees/soldr/issues/1784

## Validation
- `npm run typecheck`
- `npm run lint:vendor-prose`
- `node --test --test-timeout=120000 --experimental-strip-types --import ./__tests__/register-loader.mjs __tests__/raw-inputs.test.ts __tests__/resolve-setup.test.ts` (134 passed)