### PR TITLE
chore(release): consume soldr 0.8.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.23`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.30`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -526,7 +526,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.8.23`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.8.30`. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
 | `cache-dir` | Override the runner-local cache/state root used for the installed `soldr` binary and any managed rustup state this action rehydrates. |
@@ -627,7 +627,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.23`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.30`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.8.23.
+    description: Soldr version or tag to install. Defaults to 0.8.30.
     required: false
-    default: "0.8.23"
+    default: "0.8.30"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -157,7 +157,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.23"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.30"
 
 
 def _load_action() -> dict:


### PR DESCRIPTION
Bumps the default soldr version from `0.8.23` to `0.8.30`, picking up seven releases of fixes.

## Why now

Notable changes for setup-soldr consumers, from the `v0.8.23...v0.8.30` range:

| Area | Change | Upstream |
|---|---|---|
| **glibc/musl axis** | Stop installing a gnu binary the host's glibc cannot load; take the runs-anywhere build when libc detection fails | soldr#2079, soldr#2081 |
| **Portability floors** | Ratchet the glibc floor of `-gnu` artifacts; verify musl binaries are statically linked; ratchet the macOS minimum version and the Windows DLL imports | soldr#2080, soldr#2064, soldr#2084, soldr#2085, soldr#2086 |
| **Install reliability** | Retry transient network errors in the catalogue and syslib fetch paths | soldr#2135 |
| **Windows** | Stop the managed daemon popping a console on the via-self path | soldr#2043 |
| **Perf** | Publish `BuildSessionStart` concurrently with cargo; attribute the warm cost to that IPC | soldr#2052, soldr#2053 |
| **macOS install** | The installer could not run on a stock Mac (bash 3.2) | soldr#2130 |

The glibc/musl and portability-floor work is the most relevant to this action, since the cache key space explicitly carries a `libc` axis and the action installs a per-runner-target released binary.

## Verification

Run locally against this branch:

- `node scripts/check-default-release-readiness.mjs` → **Release readiness passed for v0.8.30 (5 supported targets)** — confirms the `action.yml` default resolves to a published release with an asset for every supported runner target.
- `npm test` → **687 tests, 0 fail** (675 pass, 12 skipped).
- `python -m pytest tests/` → **20 passed**.
- `npm run typecheck` → clean.

No `dist/` rebuild is needed: the default version lives in `action.yml`, not in compiled TypeScript (a full-repo grep for the old version string hits only `action.yml`, `README.md`, and `tests/test_action_target_cache_wiring.py`).

The `Setup Soldr Contract` check on this PR re-verifies the default against the published release and every supported runner asset, and the action workflow exercises the real install path.

## v0 rollout

Per `CLAUDE.md`, `v0` moves only via `update-v0-tag.yml` after the exact `main` SHA passes `Setup Soldr Contract` — that follows this merge, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)