### PR TITLE
perf(cargo-registry): add split Soldr archive path

### DIFF
--- a/.github/workflows/cargo-registry-soldr-benchmark.yml
+++ b/.github/workflows/cargo-registry-soldr-benchmark.yml
@@ -1,0 +1,109 @@
+name: Cargo registry Soldr benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      reps:
+        description: "Restore repetitions per codec (minimum 3)"
+        required: true
+        default: "3"
+        type: string
+      runner:
+        description: "Windows runner label"
+        required: true
+        default: "windows-2025"
+        type: string
+      file-count:
+        description: "Deterministic registry fixture file count"
+        required: true
+        default: "50000"
+        type: string
+      assert-thresholds:
+        description: "Fail unless Soldr is under 25 s and at least 3x faster"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Windows cargo-registry restore benchmark
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 45
+    steps:
+      - name: Check out benchmark revision
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install Soldr without reusable caches
+        id: setup
+        uses: ./
+        with:
+          cache: false
+          build-cache: false
+          target-cache: false
+          cargo-registry-cache: false
+          solo-toolchain-cache: false
+          soldr-mini-cache: false
+          prebuild-deps: none
+
+      - name: Ensure the legacy zstd codec is available
+        shell: pwsh
+        run: |
+          if (-not (Get-Command zstd -ErrorAction SilentlyContinue)) {
+            $toolRoot = Join-Path $env:RUNNER_TEMP "cargo-registry-zstd-1.5.7"
+            $zipPath = Join-Path $toolRoot "zstd.zip"
+            New-Item -ItemType Directory -Path $toolRoot -Force | Out-Null
+            Invoke-WebRequest `
+              -Uri "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-v1.5.7-win64.zip" `
+              -OutFile $zipPath
+            $digest = (Get-FileHash -Algorithm SHA256 -LiteralPath $zipPath).Hash.ToLowerInvariant()
+            if ($digest -ne "acb4e8111511749dc7a3ebedca9b04190e37a17afeb73f55d4425dbf0b90fad9") {
+              throw "zstd archive SHA-256 mismatch: $digest"
+            }
+            Expand-Archive -LiteralPath $zipPath -DestinationPath $toolRoot -Force
+            $zstd = Get-ChildItem -Path $toolRoot -Recurse -Filter zstd.exe | Select-Object -First 1
+            if (-not $zstd) { throw "downloaded zstd archive did not contain zstd.exe" }
+            $zstd.DirectoryName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          }
+
+      - name: Verify benchmark codec
+        shell: pwsh
+        run: zstd --version
+
+      - name: Validate benchmark inputs
+        shell: pwsh
+        run: |
+          $reps = [int]"${{ inputs.reps }}"
+          $files = [int]"${{ inputs.file-count }}"
+          if ($reps -lt 3) { throw "reps must be at least 3" }
+          if ($files -lt 1) { throw "file-count must be positive" }
+
+      - name: Benchmark legacy and Soldr restores
+        shell: pwsh
+        env:
+          SOLDR_BIN: ${{ steps.setup.outputs.soldr-path }}
+          BENCH_RUNNER: ${{ inputs.runner }}
+          BENCH_ASSERT_THRESHOLDS: ${{ inputs.assert-thresholds }}
+        run: >-
+          node scripts/bench-cargo-registry-archives.mjs
+          --reps "${{ inputs.reps }}"
+          --file-count "${{ inputs.file-count }}"
+          --output-dir benchmark-output
+
+      - name: Upload raw benchmark evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-registry-soldr-benchmark-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            benchmark-output/cargo-registry-archive-benchmark.csv
+            benchmark-output/cargo-registry-archive-benchmark.md
+          if-no-files-found: error
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Make the cargo-registry Soldr path reachable behind
+  `SOLDR_CARGO_REGISTRY_VIA_SOLDR=1` (#266). The v2 cache owns a Soldr archive
+  for `registry/` plus a separate tar+zstd archive containing only
+  `.global-cache` and `git/`; credentials, binaries, and unrelated Cargo home
+  state remain excluded. Cache download still overlaps the other layers, while
+  extraction now waits for the installed Soldr runtime to be verified. Add a
+  Windows 2025 benchmark workflow with alternating legacy/Soldr restores, raw
+  CSV, content validation, and fixed 25-second/3x decision gates. Legacy-v1
+  remains the default until that evidence passes; encrypted entries and Soldr
+  versions older than 0.7.47 also remain on v1. Windows v2 restores bootstrap
+  pinned, SHA-256-verified zstd 1.5.7 when no zstd executable is on PATH.
+
 - Default to soldr `0.8.6` (was `0.8.5`). This release restores the managed
   Windows MSVC cross-build lanes, including ARM64 target provisioning and
   clang-cl argument-mode handling (soldr#1559), and carries the multicall

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ preferred for new workflows.
 | `cache-encrypt-key` | Optional 256-bit AES key (64-char hex, 44-char base64, or 43-char base64url). When set, every managed cache layer's `.tar.zst` archive is wrapped with AES-256-GCM before upload and verified+decrypted on restore. Pass via a GitHub Actions secret. See "Release-grade usage: encrypted cache" below. (#387) |
 | `cache-encrypt-on-failure` | Behavior when an encrypted entry fails GCM authentication (wrong key, tampered ciphertext, or AAD mismatch). Default `error` stops the run; `skip` logs the failure and treats the entry as a cold miss. Has no effect when `cache-encrypt-key` is empty. (#387) |
 | `source-mtime-normalize` | Opt-in. When `true`, rewrite the mtime of tracked Rust build-input files under `${{ github.workspace }}` to each file's last-commit timestamp before the target-cache restore. Default `false`. See "Source mtime normalization" below. |
-| `cargo-registry-cache` | When `true`, setup-soldr caches `~/.cargo/registry` directly as a fast-zstd `.tar.zst` and exports `SOLDR_SKIP_CARGO_REGISTRY_SAVE=1` so zccache CLI's built-in registry save no-ops. Requires zccache `>=1.4.4` (skip-flag support). Default `false` keeps the default cache footprint small; opt in when registry restore timing beats upload/retention cost. |
+| `cargo-registry-cache` | When `true`, setup-soldr caches `~/.cargo/registry`, `.global-cache`, and `git/` and exports `SOLDR_SKIP_CARGO_REGISTRY_SAVE=1` so zccache CLI's built-in registry save no-ops. The codec defaults to legacy tar+zstd while the Soldr-v2 Windows benchmark is collected; `SOLDR_CARGO_REGISTRY_VIA_SOLDR=1` opts into the split parallel-extract format. Requires zccache `>=1.4.4` (skip-flag support). Default `false` keeps the layer itself off. |
 | `dylint` | Enable Dylint mode. Default `false`, so normal jobs do not fetch the nightly map, restore or install a nightly, substitute toolchains, or prepare Dylint caches. When `true`, setup-soldr maps the configured exact Rust release to the newest compatible dated nightly and scopes that identity to Soldr's Dylint subprocesses. |
 | `dylint-foundation-cache` | Cache the exact Dylint nightly/components plus cargo-dylint, dylint-link, and compatible driver. Default `true` in Dylint mode and inert otherwise. The key includes the dated nightly, compiler release, and full compiler commit. |
 | `dylint-output-cache` | Restore and save the isolated custom-library and workspace-check trees separately from the long-lived foundation. Default `true` in Dylint mode and inert otherwise; a save requires a successful Dylint run. |
@@ -686,15 +686,25 @@ larger-cache behavior re-enables it explicitly:
 - `target-cache: true` (or `build-cache-mode: full`) restores the full `target/`
   artifact tree across runs again, rather than the default `once` rust-plan
   bundle.
-- `cargo-registry-cache: true` caches `~/.cargo/registry` directly as a
-  fast-zstd archive again.
+- `cargo-registry-cache: true` caches `~/.cargo/registry` plus Cargo's
+  `.global-cache` and `git/` companion state. The legacy-v1 codec is the
+  default until the checked-in Windows 2025 benchmark passes both fixed gates.
+  Set `SOLDR_CARGO_REGISTRY_VIA_SOLDR=1` to opt into the v2 split layout now;
+  set it to `0`, `false`, `no`, or `off` for an explicit legacy rollback.
+  Encrypted entries and Soldr versions older than `0.7.47` always use v1.
+  On Windows, v2 bootstraps a pinned, SHA-256-verified zstd 1.5.7 executable
+  under `RUNNER_TEMP` when the runner does not already provide one.
 
 These are opt-in because they pay a real save/restore cost that only some
 workloads earn back. The `cargo-registry-cache` restore is especially expensive
 on Windows: the registry is tens of thousands of small files, and restore has
 been observed at roughly 47–50 s — a key reason it is default-off and should be
 opted into only where the workload measures a net win over upload/retention
-cost.
+cost. Run the manual `cargo-registry-soldr-benchmark.yml` workflow to compare
+three or more alternating restores from one deterministic fixture. It emits raw
+CSV and a Markdown median summary; the default-on gate is Soldr under 25 seconds,
+at least 3x faster than legacy, with every file-count and SHA-256 validation
+passing.
 
 ### Cache policy presets
 

--- a/__tests__/cargo-registry-archive.test.ts
+++ b/__tests__/cargo-registry-archive.test.ts
@@ -1,0 +1,213 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  cargoRegistryArchiveFormat,
+  cargoRegistryZstdAsset,
+  cargoRegistryPayloadCensus,
+  cargoRegistryPayloadPaths,
+  extractCargoRegistryExtrasArchive,
+  planCargoRegistryArchive,
+  restoreCargoRegistryArchive,
+  saveCargoRegistryArchive,
+  writeCargoRegistryExtrasArchive,
+  type CargoRegistryArchiveOperations,
+} from "../src/lib/cargo-registry-archive.js";
+
+test("cargo-registry v2 plans two deterministic runner-temp archives", () => {
+  const cargoHome = path.join("runner", "cargo-home");
+  const plan = planCargoRegistryArchive({
+    format: "soldr-v2",
+    cargoHome,
+    runnerTemp: path.join("runner", "temp"),
+  });
+  assert.equal(
+    plan.registryArchivePath,
+    path.join(
+      "runner",
+      "temp",
+      "setup-soldr-cargo-registry",
+      "v2",
+      "registry.soldr.tar.zst",
+    ),
+  );
+  assert.equal(
+    plan.extrasArchivePath,
+    path.join("runner", "temp", "setup-soldr-cargo-registry", "v2", "extras.tar.zst"),
+  );
+  assert.deepEqual(plan.restorePaths, [plan.registryArchivePath, plan.extrasArchivePath]);
+  assert.ok(!plan.restorePaths.some((entry) => entry === cargoHome));
+});
+
+test("format selection preserves encryption, rollback, source-ref, and old-runtime fallbacks", () => {
+  assert.equal(
+    cargoRegistryArchiveFormat({ encrypted: false, viaSoldr: true, sourceRef: false }),
+    "soldr-v2",
+  );
+  assert.equal(
+    cargoRegistryArchiveFormat({ encrypted: true, viaSoldr: true, sourceRef: false }),
+    "legacy-v1",
+  );
+  assert.equal(
+    cargoRegistryArchiveFormat({ encrypted: false, viaSoldr: false, sourceRef: false }),
+    "legacy-v1",
+  );
+  assert.equal(
+    cargoRegistryArchiveFormat({ encrypted: false, viaSoldr: true, sourceRef: true }),
+    "legacy-v1",
+  );
+  assert.equal(
+    cargoRegistryArchiveFormat({
+      encrypted: false,
+      viaSoldr: true,
+      sourceRef: false,
+      runtimeCompatible: false,
+    }),
+    "legacy-v1",
+  );
+});
+
+test("Windows zstd bootstrap is pinned to the verified upstream win64 release", () => {
+  assert.equal(
+    cargoRegistryZstdAsset("x64"),
+    "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-v1.5.7-win64.zip",
+  );
+  assert.throws(() => cargoRegistryZstdAsset("ia32"), /does not support 32-bit/);
+});
+
+test("companion archive round trips without requiring a standalone zstd executable", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "cargo-registry-extras-"));
+  const cargoHome = path.join(root, "cargo-home");
+  const archive = path.join(root, "extras.tar.zst");
+  try {
+    await fs.mkdir(path.join(cargoHome, "git", "db"), { recursive: true });
+    await fs.writeFile(path.join(cargoHome, ".global-cache"), "gc state");
+    await fs.writeFile(path.join(cargoHome, "git", "db", "HEAD"), "git state");
+    const extras = [path.join(cargoHome, ".global-cache"), path.join(cargoHome, "git")];
+    await writeCargoRegistryExtrasArchive(cargoHome, extras, archive);
+    await fs.rm(path.join(cargoHome, ".global-cache"), { force: true });
+    await fs.rm(path.join(cargoHome, "git"), { recursive: true, force: true });
+    await extractCargoRegistryExtrasArchive(cargoHome, archive);
+    assert.equal(await fs.readFile(path.join(cargoHome, ".global-cache"), "utf8"), "gc state");
+    assert.equal(await fs.readFile(path.join(cargoHome, "git", "db", "HEAD"), "utf8"), "git state");
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("v2 round trip owns registry and Cargo extras but never unrelated CARGO_HOME files", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "cargo-registry-archive-"));
+  const cargoHome = path.join(root, "cargo-home");
+  const snapshot = path.join(root, "snapshot");
+  const runnerTemp = path.join(root, "runner-temp");
+  const plan = planCargoRegistryArchive({ format: "soldr-v2", cargoHome, runnerTemp });
+  const copiedExtras: string[] = [];
+  const operations: CargoRegistryArchiveOperations = {
+    async saveRegistry(cacheDir, archivePath) {
+      await fs.cp(cacheDir, path.join(snapshot, "registry"), { recursive: true });
+      await fs.writeFile(archivePath, "registry archive marker");
+      return true;
+    },
+    async restoreRegistry(_archivePath, targetDir) {
+      await fs.cp(path.join(snapshot, "registry"), targetDir, { recursive: true });
+      return true;
+    },
+    async saveExtras(_cargoHome, extras, archivePath) {
+      for (const extra of extras) {
+        const basename = path.basename(extra);
+        copiedExtras.push(basename);
+        await fs.cp(extra, path.join(snapshot, basename), { recursive: true });
+      }
+      await fs.writeFile(archivePath, "extras archive marker");
+    },
+    async restoreExtras(targetCargoHome) {
+      for (const basename of copiedExtras) {
+        await fs.cp(path.join(snapshot, basename), path.join(targetCargoHome, basename), {
+          recursive: true,
+        });
+      }
+    },
+  };
+
+  try {
+    await fs.mkdir(path.join(cargoHome, "registry"), { recursive: true });
+    await fs.mkdir(path.join(cargoHome, "git", "db"), { recursive: true });
+    await fs.writeFile(path.join(cargoHome, "registry", "crate.cache"), "registry payload");
+    await fs.writeFile(path.join(cargoHome, ".global-cache"), "cargo gc state");
+    await fs.writeFile(path.join(cargoHome, "git", "db", "HEAD"), "git payload");
+    await fs.writeFile(path.join(cargoHome, "credentials.toml"), "secret must stay local");
+    await fs.mkdir(path.dirname(plan.registryArchivePath), { recursive: true });
+
+    const payload = await cargoRegistryPayloadPaths(cargoHome);
+    assert.deepEqual(payload.extras.map((entry) => path.basename(entry)), [".global-cache", "git"]);
+    const census = await cargoRegistryPayloadCensus(cargoHome, 10);
+    assert.ok(census.inputs.includes("registry"));
+    assert.ok(census.inputs.includes(".global-cache"));
+    assert.ok(census.inputs.includes("git"));
+    assert.ok(!JSON.stringify(census).includes("credentials.toml"));
+    await saveCargoRegistryArchive({
+      plan,
+      cargoHome,
+      soldrPath: "fake-soldr",
+      soldrVersion: "0.7.47",
+      operations,
+    });
+    assert.deepEqual(copiedExtras, [".global-cache", "git"]);
+    assert.equal(await fs.readFile(path.join(cargoHome, "credentials.toml"), "utf8"), "secret must stay local");
+
+    await fs.rm(path.join(cargoHome, "registry"), { recursive: true, force: true });
+    await fs.rm(path.join(cargoHome, ".global-cache"), { force: true });
+    await fs.rm(path.join(cargoHome, "git"), { recursive: true, force: true });
+    await restoreCargoRegistryArchive({
+      plan,
+      cargoHome,
+      soldrPath: "fake-soldr",
+      soldrVersion: "0.7.47",
+      cacheKey: "v2-test-key",
+      operations,
+    });
+
+    assert.equal(await fs.readFile(path.join(cargoHome, "registry", "crate.cache"), "utf8"), "registry payload");
+    assert.equal(await fs.readFile(path.join(cargoHome, ".global-cache"), "utf8"), "cargo gc state");
+    assert.equal(await fs.readFile(path.join(cargoHome, "git", "db", "HEAD"), "utf8"), "git payload");
+    assert.equal(await fs.readFile(path.join(cargoHome, "credentials.toml"), "utf8"), "secret must stay local");
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("missing optional extras are valid and corrupt v2 registry restores fail visibly", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "cargo-registry-archive-"));
+  const cargoHome = path.join(root, "cargo-home");
+  const plan = planCargoRegistryArchive({
+    format: "soldr-v2",
+    cargoHome,
+    runnerTemp: path.join(root, "runner-temp"),
+  });
+  try {
+    await fs.mkdir(path.join(cargoHome, "registry"), { recursive: true });
+    await fs.mkdir(path.dirname(plan.registryArchivePath), { recursive: true });
+    await fs.writeFile(plan.registryArchivePath, "corrupt registry archive");
+    await fs.writeFile(plan.extrasArchivePath, "empty extras archive");
+    await assert.rejects(
+      () =>
+        restoreCargoRegistryArchive({
+          plan,
+          cargoHome,
+          soldrPath: "fake-soldr",
+          soldrVersion: "0.7.47",
+          cacheKey: "exact-hit-key",
+          operations: {
+            restoreRegistry: async () => false,
+            restoreExtras: async () => undefined,
+          },
+        }),
+      /corrupt or incompatible/,
+    );
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -25,3 +25,27 @@ test("main.run is callable and returns a Promise", async () => {
   // Detach so unhandled rejection doesn't taint the test process.
   p.catch(() => undefined);
 });
+
+test("cargo-registry encryption failures honor skip only for legacy-v1", async () => {
+  const mod = (await import("../src/main.js")) as {
+    shouldSkipCargoRegistryExtractionError: (
+      err: unknown,
+      format: "legacy-v1" | "soldr-v2",
+      onFailure: string,
+    ) => boolean;
+  };
+  for (const code of ["EAUTHFAIL", "EENCNOKEY"]) {
+    const err = Object.assign(new Error(code), { code });
+    assert.equal(mod.shouldSkipCargoRegistryExtractionError(err, "legacy-v1", "skip"), true);
+    assert.equal(mod.shouldSkipCargoRegistryExtractionError(err, "legacy-v1", "error"), false);
+    assert.equal(mod.shouldSkipCargoRegistryExtractionError(err, "soldr-v2", "skip"), false);
+  }
+  assert.equal(
+    mod.shouldSkipCargoRegistryExtractionError(
+      Object.assign(new Error("corrupt"), { code: "EBADARCHIVE" }),
+      "legacy-v1",
+      "skip",
+    ),
+    false,
+  );
+});

--- a/__tests__/post.test.ts
+++ b/__tests__/post.test.ts
@@ -6,6 +6,41 @@ import * as path from "node:path";
 
 process.env["SETUP_SOLDR_TEST_IMPORT"] = "1";
 
+test("post payload fail policy marks failure and cache reservation races require proof", async () => {
+  const mod = (await import("../src/post.js")) as {
+    applyCachePayloadOversizeAction: (
+      action: "skip" | "fail",
+      message: string,
+      setFailed: (message: string) => void,
+    ) => "oversize-skip" | "failed";
+    classifyCacheSaveReservation: (
+      id: number,
+      key: string,
+      probe: () => Promise<string | undefined>,
+    ) => Promise<"saved" | "race-skip" | "failed">;
+  };
+  const failures: string[] = [];
+  assert.equal(
+    mod.applyCachePayloadOversizeAction("fail", "payload too large", (message) => failures.push(message)),
+    "failed",
+  );
+  assert.deepEqual(failures, ["payload too large"]);
+  assert.equal(
+    mod.applyCachePayloadOversizeAction("skip", "payload too large", (message) => failures.push(message)),
+    "oversize-skip",
+  );
+  assert.deepEqual(failures, ["payload too large"]);
+  assert.equal(await mod.classifyCacheSaveReservation(42, "key", async () => undefined), "saved");
+  assert.equal(await mod.classifyCacheSaveReservation(-1, "key", async () => "key"), "race-skip");
+  assert.equal(await mod.classifyCacheSaveReservation(-1, "key", async () => undefined), "failed");
+  assert.equal(
+    await mod.classifyCacheSaveReservation(-1, "key", async () => {
+      throw new Error("probe failed");
+    }),
+    "failed",
+  );
+});
+
 function mkTmp(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }

--- a/__tests__/resolve-setup.test.ts
+++ b/__tests__/resolve-setup.test.ts
@@ -1141,6 +1141,42 @@ test("cache=true (default) leaves per-layer flags in charge", async () => {
   assert.notEqual(result.envExports["SOLDR_BUILD_CACHE_MODE"], "off");
 });
 
+test("cargo-registry explicit Soldr opt-in selects v2 only for a compatible unencrypted release", async () => {
+  const original = process.env["SOLDR_CARGO_REGISTRY_VIA_SOLDR"];
+  process.env["SOLDR_CARGO_REGISTRY_VIA_SOLDR"] = "1";
+  try {
+    const { result } = await run({}, {
+      INPUT_VERSION: "0.8.39",
+      INPUT_CARGO_REGISTRY_CACHE: "true",
+    });
+    assert.equal(result.cargoRegistryCache.archive.format, "soldr-v2");
+    assert.match(result.cargoRegistryCache.key, /^setup-soldr-cargoregistry-v2-/);
+    assert.equal(result.cargoRegistryCache.archive.restorePaths.length, 2);
+    assert.ok(
+      result.cargoRegistryCache.archive.restorePaths.every((entry) =>
+        entry.includes(`${path.sep}setup-soldr-cargo-registry${path.sep}v2${path.sep}`),
+      ),
+    );
+
+    const encrypted = await run({}, {
+      INPUT_VERSION: "0.8.39",
+      INPUT_CARGO_REGISTRY_CACHE: "true",
+      INPUT_CACHE_ENCRYPT_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    });
+    assert.equal(encrypted.result.cargoRegistryCache.archive.format, "legacy-v1");
+    assert.match(encrypted.result.cargoRegistryCache.key, /^setup-soldr-cargoregistry-v1-/);
+
+    const old = await run({}, {
+      INPUT_VERSION: "0.7.11",
+      INPUT_CARGO_REGISTRY_CACHE: "true",
+    });
+    assert.equal(old.result.cargoRegistryCache.archive.format, "legacy-v1");
+  } finally {
+    if (original === undefined) delete process.env["SOLDR_CARGO_REGISTRY_VIA_SOLDR"];
+    else process.env["SOLDR_CARGO_REGISTRY_VIA_SOLDR"] = original;
+  }
+});
+
 test("cache-shutdown-on-idle rejects malformed values", async () => {
   await assert.rejects(
     () => run({}, { INPUT_CACHE_SHUTDOWN_ON_IDLE: "thirty" }),

--- a/__tests__/soldr-load-shim.test.ts
+++ b/__tests__/soldr-load-shim.test.ts
@@ -5,6 +5,8 @@ import * as os from "node:os";
 import * as fs from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 
+import "./cargo-registry-archive.test.ts";
+
 import {
   detectSoldrManifest,
   semverGte,
@@ -15,6 +17,78 @@ import {
   MIN_SOLDR_VERSION_FOR_LOAD,
   MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP,
 } from "../src/lib/soldr-load-shim.js";
+import {
+  cargoRegistryArchiveFormat,
+  planCargoRegistryArchive,
+  cargoRegistryPayloadPaths,
+} from "../src/lib/cargo-registry-archive.js";
+
+test("v2 cargo-registry plan owns registry and optional extras without CARGO_HOME", () => {
+  const cargoHome = path.join("runner", "cargo-home");
+  const plan = planCargoRegistryArchive({
+    format: "soldr-v2",
+    cargoHome,
+    runnerTemp: path.join("runner", "temp"),
+  });
+  assert.equal(plan.format, "soldr-v2");
+  assert.equal(plan.registryArchivePath, path.join("runner", "temp", "setup-soldr-cargo-registry", "v2", "registry.soldr.tar.zst"));
+  assert.equal(plan.extrasArchivePath, path.join("runner", "temp", "setup-soldr-cargo-registry", "v2", "extras.tar.zst"));
+  assert.deepEqual(plan.restorePaths, [plan.registryArchivePath, plan.extrasArchivePath]);
+  assert.ok(!plan.restorePaths.includes(cargoHome));
+});
+
+test("legacy cargo-registry plan preserves the v1 combined archive", () => {
+  const cargoHome = path.join("runner", "cargo-home");
+  const plan = planCargoRegistryArchive({
+    format: "legacy-v1",
+    cargoHome,
+    runnerTemp: path.join("runner", "temp"),
+  });
+  assert.equal(plan.format, "legacy-v1");
+  assert.equal(plan.registryArchivePath, `${path.join(cargoHome, "registry")}.tar.zst`);
+  assert.equal(plan.extrasArchivePath, "");
+  assert.deepEqual(plan.restorePaths, [plan.registryArchivePath]);
+});
+
+test("cargo-registry format keeps encryption and explicit rollback on legacy v1", () => {
+  assert.equal(cargoRegistryArchiveFormat({ encrypted: true, viaSoldr: true, sourceRef: false }), "legacy-v1");
+  assert.equal(cargoRegistryArchiveFormat({ encrypted: false, viaSoldr: false, sourceRef: false }), "legacy-v1");
+  assert.equal(cargoRegistryArchiveFormat({ encrypted: false, viaSoldr: true, sourceRef: false }), "soldr-v2");
+  assert.equal(cargoRegistryArchiveFormat({ encrypted: false, viaSoldr: true, sourceRef: true }), "legacy-v1");
+});
+
+test("cargo-registry payload allowlist excludes credentials, bin, and unrelated state", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "cargo-registry-plan-"));
+  try {
+    await fs.mkdir(path.join(tmp, "registry"));
+    await fs.mkdir(path.join(tmp, "git"));
+    await fs.mkdir(path.join(tmp, "bin"));
+    await fs.writeFile(path.join(tmp, ".global-cache"), "gc");
+    await fs.writeFile(path.join(tmp, "credentials.toml"), "secret");
+    const payload = await cargoRegistryPayloadPaths(tmp);
+    assert.deepEqual(payload, {
+      registry: path.join(tmp, "registry"),
+      extras: [path.join(tmp, ".global-cache"), path.join(tmp, "git")],
+    });
+    assert.ok(!JSON.stringify(payload).includes("credentials.toml"));
+    assert.ok(!JSON.stringify(payload).includes(`${path.sep}bin`));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("missing optional cargo-registry extras are valid", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "cargo-registry-plan-"));
+  try {
+    await fs.mkdir(path.join(tmp, "registry"));
+    assert.deepEqual(await cargoRegistryPayloadPaths(tmp), {
+      registry: path.join(tmp, "registry"),
+      extras: [],
+    });
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
 
 test("semverGte: handles MAJOR.MINOR.PATCH ordering", () => {
   assert.equal(semverGte("0.7.46", MIN_SOLDR_VERSION_FOR_LOAD), true);
@@ -189,30 +263,6 @@ test("trySaveViaSoldr: gated off when soldr version is too old (even with env on
         archivePath: path.join(tmp, "out.tar.zst"),
         soldrPath: "/fake/path/soldr",
         soldrVersion: "0.7.46", // one below the 0.7.47 minimum
-      });
-      assert.equal(r.used, false);
-    } finally {
-      await fs.rm(tmp, { recursive: true, force: true });
-    }
-  } finally {
-    if (orig === undefined) delete process.env[CARGO_REGISTRY_VIA_SOLDR_ENV];
-    else process.env[CARGO_REGISTRY_VIA_SOLDR_ENV] = orig;
-  }
-});
-
-test("trySaveViaSoldr: gated off when extraBasenames is non-empty (#263 limitation)", async () => {
-  const orig = process.env[CARGO_REGISTRY_VIA_SOLDR_ENV];
-  process.env[CARGO_REGISTRY_VIA_SOLDR_ENV] = "1";
-  try {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "soldr-save-shim-"));
-    try {
-      await fs.mkdir(path.join(tmp, "cache"));
-      const r = await trySaveViaSoldr({
-        cacheDir: path.join(tmp, "cache"),
-        archivePath: path.join(tmp, "out.tar.zst"),
-        soldrPath: "/fake/path/soldr",
-        soldrVersion: MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP,
-        extraBasenames: [".global-cache", "git"],
       });
       assert.equal(r.used, false);
     } finally {

--- a/action.yml
+++ b/action.yml
@@ -378,13 +378,20 @@ inputs:
   cargo-registry-cache:
     description: >
       When "true", setup-soldr manages a separate actions/cache step
-      for ~/.cargo/registry that pre-compresses the directory into a single
-      .tar.zst via the embedded setup-soldr-cache-compress sub-action. The
-      same archive also bundles ~/.cargo/.global-cache (cargo's RFC-3413 GC
-      database — without it every job's cargo-gc sees fresh access times and
-      conservatively keeps everything) and ~/.cargo/git/ (bare mirrors and
-      checkouts for git-source crate deps; missing on cold checkouts and
-      silently skipped in that case). See setup-soldr#102. Also exports
+      for ~/.cargo/registry. The legacy-v1 codec stores registry plus the
+      companion ~/.cargo/.global-cache and ~/.cargo/git payloads in one
+      tar+zstd archive. The opt-in Soldr-v2 codec stores registry in a Soldr
+      archive for parallel extraction and keeps only those two companions in
+      a second tar+zstd archive; set SOLDR_CARGO_REGISTRY_VIA_SOLDR=1 to use
+      it while Windows benchmark evidence is collected. Encryption, an
+      explicit false-like env value, a source-ref build, or Soldr older than
+      0.7.47 retains legacy-v1. When zstd is absent on Windows, v2 fetches the
+      pinned, SHA-256-verified upstream zstd 1.5.7 executable into RUNNER_TEMP.
+      The Cargo GC database prevents each job from
+      seeing fresh access times and conservatively retaining everything;
+      ~/.cargo/git contains bare mirrors and checkouts for git-source crate
+      dependencies. Missing companions are silently skipped. See
+      setup-soldr#102. Also exports
       SOLDR_SKIP_CARGO_REGISTRY_SAVE=1 so the zccache CLI's built-in
       cargo-registry save (honored in zccache >=1.4.4) no-ops and the
       payload is not double-saved. Default "false" keeps setup-soldr's

--- a/dist/main.js
+++ b/dist/main.js
@@ -14,15 +14,15 @@
 //  * support limits.fieldNameSize
 //     -- this will require modifications to utils.parseParams
 
-const { Readable } = __nccwpck_require__(442)
-const { inherits } = __nccwpck_require__(385)
+const { Readable } = __nccwpck_require__(443)
+const { inherits } = __nccwpck_require__(384)
 
-const Dicer = __nccwpck_require__(15)
+const Dicer = __nccwpck_require__(14)
 
-const parseParams = __nccwpck_require__(197)
-const decodeText = __nccwpck_require__(283)
-const basename = __nccwpck_require__(493)
-const getLimit = __nccwpck_require__(499)
+const parseParams = __nccwpck_require__(194)
+const decodeText = __nccwpck_require__(282)
+const basename = __nccwpck_require__(494)
+const getLimit = __nccwpck_require__(500)
 
 const RE_BOUNDARY = /^boundary$/i
 const RE_FIELD = /^form-data$/i
@@ -340,7 +340,7 @@ __export(inspect_exports, {
   custom: () => custom
 });
 module.exports = __toCommonJS(inspect_exports);
-var import_node_util = __nccwpck_require__(385);
+var import_node_util = __nccwpck_require__(384);
 const custom = import_node_util.inspect.custom;
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -469,17 +469,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = exports.downloadCacheHttpClient = exports.DownloadProgress = void 0;
-const core = __importStar(__nccwpck_require__(474));
-const http_client_1 = __nccwpck_require__(293);
-const storage_blob_1 = __nccwpck_require__(460);
-const buffer = __importStar(__nccwpck_require__(124));
-const fs = __importStar(__nccwpck_require__(546));
-const stream = __importStar(__nccwpck_require__(135));
-const util = __importStar(__nccwpck_require__(128));
-const utils = __importStar(__nccwpck_require__(81));
-const constants_1 = __nccwpck_require__(49);
-const requestUtils_1 = __nccwpck_require__(269);
-const abort_controller_1 = __nccwpck_require__(233);
+const core = __importStar(__nccwpck_require__(475));
+const http_client_1 = __nccwpck_require__(291);
+const storage_blob_1 = __nccwpck_require__(461);
+const buffer = __importStar(__nccwpck_require__(121));
+const fs = __importStar(__nccwpck_require__(547));
+const stream = __importStar(__nccwpck_require__(132));
+const util = __importStar(__nccwpck_require__(125));
+const utils = __importStar(__nccwpck_require__(78));
+const constants_1 = __nccwpck_require__(47);
+const requestUtils_1 = __nccwpck_require__(267);
+const abort_controller_1 = __nccwpck_require__(231);
 /**
  * Pipes the body of a HTTP response to a stream
  *
@@ -839,14 +839,14 @@ exports.SearchState = SearchState;
 "use strict";
 
 
-const { InvalidArgumentError } = __nccwpck_require__(504)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(200)
-const DispatcherBase = __nccwpck_require__(68)
-const Pool = __nccwpck_require__(346)
-const Client = __nccwpck_require__(94)
-const util = __nccwpck_require__(75)
-const createRedirectInterceptor = __nccwpck_require__(263)
-const { WeakRef, FinalizationRegistry } = __nccwpck_require__(425)()
+const { InvalidArgumentError } = __nccwpck_require__(505)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(197)
+const DispatcherBase = __nccwpck_require__(65)
+const Pool = __nccwpck_require__(344)
+const Client = __nccwpck_require__(91)
+const util = __nccwpck_require__(72)
+const createRedirectInterceptor = __nccwpck_require__(261)
+const { WeakRef, FinalizationRegistry } = __nccwpck_require__(426)()
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -1053,11 +1053,11 @@ exports.buildMiniCacheKey = buildMiniCacheKey;
 exports.restoreMiniCache = restoreMiniCache;
 exports.saveMiniCache = saveMiniCache;
 exports.isEligibleForMiniCache = isEligibleForMiniCache;
-const fs = __importStar(__nccwpck_require__(257));
-const fsp = __importStar(__nccwpck_require__(114));
-const path = __importStar(__nccwpck_require__(522));
-const cache = __importStar(__nccwpck_require__(218));
-const cache_compress_js_1 = __nccwpck_require__(480);
+const fs = __importStar(__nccwpck_require__(255));
+const fsp = __importStar(__nccwpck_require__(111));
+const path = __importStar(__nccwpck_require__(523));
+const cache = __importStar(__nccwpck_require__(217));
+const cache_compress_js_1 = __nccwpck_require__(481);
 // Schema segment `v2` (still inside the `soldr-mini-` eviction namespace):
 // v1 entries were archived by setup-soldr <= v0.9.64, whose bundled-payload
 // allowlist dropped `soldr-clang-shim` from the soldr release archive.
@@ -1253,7 +1253,7 @@ function isEligibleForMiniCache(opts) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AzureNamedKeyCredential = void 0;
 exports.isNamedKeyCredential = isNamedKeyCredential;
-const core_util_1 = __nccwpck_require__(16);
+const core_util_1 = __nccwpck_require__(15);
 /**
  * A static name/key-based credential that supports updating
  * the underlying name and key values.
@@ -1325,21 +1325,21 @@ function isNamedKeyCredential(credential) {
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(237)
+const { MockNotMatchedError } = __nccwpck_require__(235)
 const {
   kDispatches,
   kMockAgent,
   kOriginalDispatch,
   kOrigin,
   kGetNetConnect
-} = __nccwpck_require__(487)
-const { buildURL, nop } = __nccwpck_require__(75)
-const { STATUS_CODES } = __nccwpck_require__(338)
+} = __nccwpck_require__(488)
+const { buildURL, nop } = __nccwpck_require__(72)
+const { STATUS_CODES } = __nccwpck_require__(336)
 const {
   types: {
     isPromise
   }
-} = __nccwpck_require__(128)
+} = __nccwpck_require__(125)
 
 function matchValue (match, value) {
   if (typeof match === 'string') {
@@ -1764,7 +1764,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetryHelper = void 0;
-const core = __importStar(__nccwpck_require__(474));
+const core = __importStar(__nccwpck_require__(475));
 /**
  * Internal class for retries
  */
@@ -1904,1157 +1904,23 @@ function formatDefaultJson(value) {
 /***/ }),
 
 /***/ 13:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Top-level resolve-setup entry point. Owned by Agent 1.
-//
-// Full port of resolve_setup.py::main(). Reads INPUT_* / GITHUB_* env vars,
-// resolves the toolchain spec, derives all cache keys, computes the env
-// exports + outputs the orchestrator needs.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.pythonDefaultJson = exports.buildOutputs = exports.detectMuslCcEnv = exports.detectUserLinkerEnv = exports.parseRustBacktrace = exports.parseCacheShutdownOnIdleSeconds = exports.readRawInputs = void 0;
-exports.resolveRustupStrategy = resolveRustupStrategy;
-exports.detectZccachePrivateOverlap = detectZccachePrivateOverlap;
-exports.resolveSetup = resolveSetup;
-exports.applyResolveResult = applyResolveResult;
-const os = __importStar(__nccwpck_require__(393));
-const path = __importStar(__nccwpck_require__(522));
-const fs = __importStar(__nccwpck_require__(257));
-const core = __importStar(__nccwpck_require__(474));
-const cache_keys_js_1 = __nccwpck_require__(24);
-const blessed_cross_prepare_js_1 = __nccwpck_require__(435);
-const log_utils_js_1 = __nccwpck_require__(196);
-const cache_encrypt_js_1 = __nccwpck_require__(241);
-const dylint_nightly_js_1 = __nccwpck_require__(376);
-const detect_musl_cc_js_1 = __nccwpck_require__(477);
-Object.defineProperty(exports, "detectMuslCcEnv", ({ enumerable: true, get: function () { return detect_musl_cc_js_1.detectMuslCcEnv; } }));
-const build_outputs_js_1 = __nccwpck_require__(223);
-Object.defineProperty(exports, "buildOutputs", ({ enumerable: true, get: function () { return build_outputs_js_1.buildOutputs; } }));
-const raw_inputs_js_1 = __nccwpck_require__(465);
-Object.defineProperty(exports, "readRawInputs", ({ enumerable: true, get: function () { return raw_inputs_js_1.readRawInputs; } }));
-const phase_timing_js_1 = __nccwpck_require__(531);
-const input_parsers_js_1 = __nccwpck_require__(89);
-Object.defineProperty(exports, "detectUserLinkerEnv", ({ enumerable: true, get: function () { return input_parsers_js_1.detectUserLinkerEnv; } }));
-Object.defineProperty(exports, "parseCacheShutdownOnIdleSeconds", ({ enumerable: true, get: function () { return input_parsers_js_1.parseCacheShutdownOnIdleSeconds; } }));
-Object.defineProperty(exports, "parseRustBacktrace", ({ enumerable: true, get: function () { return input_parsers_js_1.parseRustBacktrace; } }));
-const fetch_release_js_1 = __nccwpck_require__(152);
-const python_json_js_1 = __nccwpck_require__(12);
-Object.defineProperty(exports, "pythonDefaultJson", ({ enumerable: true, get: function () { return python_json_js_1.pythonDefaultJson; } }));
-const toolchain_js_1 = __nccwpck_require__(310);
-const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
-const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
-const ALLOWED_LINKER_VALUES = [
-    "default",
-    "platform-default",
-    "ld",
-    "mold",
-    "rust-lld",
-    "fast",
-];
-// CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
-// FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
-// causes "failed to connect to jobserver" warnings in every downstream step.
-// See setup-soldr#71.
-const GITHUB_ENV_DENY_LIST = new Set(["CARGO_MAKEFLAGS", "MAKEFLAGS"]);
-function expanduser(p, env) {
-    if (!p)
-        return p;
-    if (p.startsWith("~")) {
-        const home = env["HOME"] || env["USERPROFILE"] || "";
-        if (p === "~")
-            return home;
-        if (p.startsWith("~/") || p.startsWith("~\\")) {
-            return path.join(home, p.slice(2));
-        }
-    }
-    return p;
-}
-function resolveAbsolute(p, env) {
-    return path.resolve(expanduser(p, env));
-}
-function isFalsy(value) {
-    return FALSY_VALUES.has(value.trim().toLowerCase());
-}
-function isTruthy(value) {
-    return TRUTHY_VALUES.has(value.trim().toLowerCase());
-}
-function defaultHomeDir(env, name) {
-    const home = env["HOME"] || env["USERPROFILE"] || os.homedir();
-    return path.resolve(path.join(home, name));
-}
-function parseOptInBool(inputName, value, defaultValue = false) {
-    const raw = value.trim().toLowerCase();
-    if (!raw)
-        return defaultValue;
-    if (TRUTHY_VALUES.has(raw))
-        return true;
-    if (FALSY_VALUES.has(raw))
-        return false;
-    throw new Error(`invalid '${inputName}' input: '${value}'. Allowed: true | false`);
-}
-function semverAtLeast(value, minimum) {
-    const parse = (v) => {
-        const m = v.trim().replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)/);
-        if (!m)
-            return null;
-        return [Number(m[1]), Number(m[2]), Number(m[3])];
-    };
-    const got = parse(value);
-    const want = parse(minimum);
-    if (!got || !want)
-        return false;
-    for (let i = 0; i < 3; i += 1) {
-        if (got[i] > want[i])
-            return true;
-        if (got[i] < want[i])
-            return false;
-    }
-    return true;
-}
-function rustHostTriple(runnerOs, runnerArch) {
-    const osName = runnerOs.trim().toLowerCase();
-    const archName = runnerArch.trim().toLowerCase();
-    const arch = archName === "x64" || archName === "amd64"
-        ? "x86_64"
-        : archName === "arm64" || archName === "aarch64"
-            ? "aarch64"
-            : archName === "x86" || archName === "ia32"
-                ? "i686"
-                : (0, cache_keys_js_1.sanitizeFragment)(archName || "unknown");
-    if (osName === "windows" || osName === "win32")
-        return `${arch}-pc-windows-msvc`;
-    if (osName === "macos" || osName === "darwin")
-        return `${arch}-apple-darwin`;
-    if (osName === "linux")
-        return `${arch}-unknown-linux-gnu`;
-    return `${arch}-${(0, cache_keys_js_1.sanitizeFragment)(osName || "unknown")}`;
-}
-function splitPathInput(value) {
-    return value
-        .split(/[\r\n,]+/g)
-        .map((item) => item.trim())
-        .filter((item) => item.length > 0);
-}
-function defaultDylintCachePaths(cargoHome, driverPath) {
-    return [
-        path.join(cargoHome, "bin", "cargo-dylint*"),
-        path.join(cargoHome, "bin", "dylint-link*"),
-        path.join(cargoHome, ".crates.toml"),
-        path.join(cargoHome, ".crates2.json"),
-        driverPath,
-    ];
-}
-function makeDirs(...paths) {
-    for (const p of paths) {
-        fs.mkdirSync(p, { recursive: true });
-    }
-}
-/**
- * Pure helper: decide the final rustup strategy from the requested one and
- * the host platform. On macOS we always override `system` to `managed` to
- * avoid the pre-installed rustup toolchain conflicts (see setup-soldr#105).
- *
- * GitHub-hosted `macos-15` (ARM) runners ship with a stable rustup toolchain
- * that already includes `clippy`. Downstream actions that try to install a
- * different toolchain with clippy hit
- *   detected conflict: 'bin/cargo-clippy'
- * because rustup component add refuses to overwrite the existing binary in
- * the shared rustup home. Forcing the managed strategy gives setup-soldr its
- * own private rustup home so the pre-installed components cannot collide.
- *
- * `explicit` (user-provided RUSTUP_HOME) is left untouched on every platform
- * — opting in to a specific home means accepting any conflicts that come
- * with it.
- */
-function resolveRustupStrategy(opts) {
-    const { requested, platform, warn } = opts;
-    if (platform === "darwin" && requested === "system") {
-        warn?.("setup-soldr: forcing rustup strategy to 'managed' on macOS to avoid " +
-            "pre-installed rustup toolchain component conflicts (e.g. " +
-            "\"detected conflict: 'bin/cargo-clippy'\" on macos-15 runners). " +
-            "See https://github.com/zackees/setup-soldr/issues/105 for context. " +
-            "This may change which setup-cache key is used compared to other " +
-            "platforms.");
-        return "managed";
-    }
-    return requested;
-}
-/**
- * Detect the `SOLDR_ZCCACHE_PRIVATE` ↔ `ZCCACHE_CACHE_DIR` overlap.
- *
- * soldr#807 added `SOLDR_ZCCACHE_PRIVATE` as an opt-in that reroutes the
- * managed zccache cache to `<cwd>/.zccache` — but only when
- * `ZCCACHE_CACHE_DIR` is *not* explicitly set. setup-soldr always sets
- * `ZCCACHE_CACHE_DIR` to `<soldr-root>/cache/zccache`, so when a workflow
- * also sets `SOLDR_ZCCACHE_PRIVATE=1` (truthy: `1`/`true`/`yes`/`on`)
- * the env var becomes a silent no-op. Return a warning string the caller
- * should surface via `core.warning`; return `null` otherwise.
- */
-function detectZccachePrivateOverlap(env) {
-    const raw = (env["SOLDR_ZCCACHE_PRIVATE"] ?? "").trim().toLowerCase();
-    if (!TRUTHY_VALUES.has(raw))
-        return null;
-    return ("setup-soldr: SOLDR_ZCCACHE_PRIVATE is set but will be ignored — " +
-        "setup-soldr pins ZCCACHE_CACHE_DIR=<soldr-root>/cache/zccache " +
-        "explicitly, and soldr#807 makes explicit ZCCACHE_CACHE_DIR take " +
-        "precedence over the private-session opt-in. The zccache cache " +
-        "will stay in setup-soldr's managed location, not <cwd>/.zccache. " +
-        "Unset ZCCACHE_CACHE_DIR (or run outside setup-soldr) to use the " +
-        "private cache path.");
-}
-// `fetchReleaseTagDefault` and `resolveSoldrReleaseVersion` live in
-// ./fetch-release.js — used directly from resolveSetup() below.
-/**
- * Resolve setup state. The orchestrator calls this once at the start of the
- * action and uses the returned ResolveResult to drive every subsequent step.
- */
-async function resolveSetup(ctx, inputs, deps) {
-    const env = { ...ctx.env };
-    // ---- timing seed ----
-    const logStart = String(Math.floor(Date.now() / 1000));
-    const timestamps = (inputs.timestamps && inputs.timestamps.trim()) || "true";
-    const timestampFormatRaw = (inputs.timestampFormat || "").trim().toLowerCase();
-    const VALID_TIMESTAMP_FORMATS = ["mmss", "seconds"];
-    if (timestampFormatRaw && !VALID_TIMESTAMP_FORMATS.includes(timestampFormatRaw)) {
-        throw new Error(`invalid timestamp-format '${inputs.timestampFormat}'; expected one of ${VALID_TIMESTAMP_FORMATS.join(", ")}`);
-    }
-    const timestampFormat = timestampFormatRaw || "mmss";
-    env["SETUP_SOLDR_LOG_START_EPOCH"] = logStart;
-    env["SETUP_SOLDR_TIMESTAMPS"] = timestamps;
-    env["SETUP_SOLDR_TIMESTAMP_FORMAT"] = timestampFormat;
-    // ---- #387 Feature 1: cache encryption ----
-    // Validate the key shape NOW (fail fast on a malformed key) and mark the
-    // raw value as a GitHub Actions secret so any incidental log line that
-    // captures it is auto-redacted. We do NOT keep the parsed Buffer in
-    // ResolveResult — downstream cache layers re-read SETUP_SOLDR_CACHE_ENCRYPT_KEY
-    // at the time of use and re-parse, so the key only exists in memory inside
-    // the closure that needs it.
-    const cacheEncryptKeyRaw = (inputs.cacheEncryptKey || "").trim();
-    if (cacheEncryptKeyRaw) {
-        core.setSecret(cacheEncryptKeyRaw);
-        // Throw early with a clean diagnostic when the key shape is wrong. The
-        // raw value is never echoed back in the error message.
-        (0, cache_encrypt_js_1.parseEncryptionKey)(cacheEncryptKeyRaw);
-    }
-    const cacheEncryptOnFailureRaw = (inputs.cacheEncryptOnFailure || "error")
-        .trim()
-        .toLowerCase();
-    if (cacheEncryptOnFailureRaw && !["error", "skip"].includes(cacheEncryptOnFailureRaw)) {
-        throw new Error(`invalid cache-encrypt-on-failure '${inputs.cacheEncryptOnFailure}'; expected 'error' or 'skip'`);
-    }
-    const cacheEncryptOnFailure = cacheEncryptOnFailureRaw === "skip" ? "skip" : "error";
-    if (cacheEncryptKeyRaw) {
-        env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] = cacheEncryptKeyRaw;
-        env["SETUP_SOLDR_CACHE_ENCRYPT_ON_FAILURE"] = cacheEncryptOnFailure;
-    }
-    const logger = ctx.logger ?? (0, log_utils_js_1.createLogger)(env);
-    const log = (msg) => logger.log(msg);
-    if (!ctx.workspace) {
-        throw new Error("ACTION_WORKSPACE / ctx.workspace must be set");
-    }
-    const workspace = path.resolve(ctx.workspace);
-    const runnerTemp = ctx.runnerTemp
-        ? path.resolve(ctx.runnerTemp)
-        : path.resolve(path.join(workspace, ".tmp"));
-    const dylintModeEnabled = parseOptInBool("dylint", inputs.dylint, false);
-    const explicitCargoRegistryCache = inputs.cargoRegistryCache.trim();
-    // ---- cache-preset resolution (#251) ----
-    // The umbrella `cache-preset` fills any cache-affecting input the consumer
-    // left unset; explicit fine-grained inputs always win. Resolved BEFORE the
-    // per-layer reads below so downstream logic only sees the post-preset
-    // values. The historical default of each input is the fallback when
-    // neither an explicit value nor a preset is set, which keeps behavior
-    // identical for consumers who never set `cache-preset`.
-    const cachePresetRaw = inputs.cachePreset.trim().toLowerCase();
-    const validCachePresets = ["minimal", "foundation", "full"];
-    if (cachePresetRaw && !validCachePresets.includes(cachePresetRaw)) {
-        throw new Error(`invalid cache-preset '${inputs.cachePreset}'; expected one of ${validCachePresets.join(", ")}`);
-    }
-    const cachePresetEffective = (cachePresetRaw || "");
-    const cachePresetMap = {
-        minimal: {
-            buildCache: "false",
-            targetCache: "false",
-            cargoRegistryCache: "false",
-            prebuildDeps: "soldr-cook",
-            buildCacheMode: "",
-        },
-        foundation: {
-            buildCache: "true",
-            targetCache: "false",
-            cargoRegistryCache: "false",
-            prebuildDeps: "soldr-cook",
-            buildCacheMode: "",
-        },
-        full: {
-            buildCache: "true",
-            targetCache: "true",
-            cargoRegistryCache: "true",
-            prebuildDeps: "soldr-cook",
-            buildCacheMode: "thin",
-        },
-    };
-    const cachePresetCfg = cachePresetEffective ? cachePresetMap[cachePresetEffective] : null;
-    // Explicit non-empty user value wins; else preset value when a preset is
-    // set; else leave empty so the existing downstream fall-through
-    // (`inputs.X.trim() || "<historical default>"`) applies as before. This
-    // preserves behavior for consumers who never set `cache-preset` — only
-    // unset inputs *under a preset* are filled here. Mutating `inputs` folds
-    // the resolution into the single source of truth that downstream code
-    // (here + main.ts + cook-cache.ts) reads from.
-    if (cachePresetCfg) {
-        const fillFromPreset = (explicit, presetValue) => {
-            const e = explicit.trim();
-            return e ? e : presetValue;
-        };
-        inputs.buildCache = fillFromPreset(inputs.buildCache, cachePresetCfg.buildCache);
-        inputs.targetCache = fillFromPreset(inputs.targetCache, cachePresetCfg.targetCache);
-        inputs.cargoRegistryCache = fillFromPreset(inputs.cargoRegistryCache, cachePresetCfg.cargoRegistryCache);
-        inputs.prebuildDeps = fillFromPreset(inputs.prebuildDeps, cachePresetCfg.prebuildDeps);
-        inputs.buildCacheMode = fillFromPreset(inputs.buildCacheMode, cachePresetCfg.buildCacheMode);
-    }
-    if (dylintModeEnabled) {
-        if (!explicitCargoRegistryCache)
-            inputs.cargoRegistryCache = "true";
-        // Ordinary cook is stable/build-shaped and cannot warm Dylint's isolated
-        // nightly/check-shaped tree. Dylint mode therefore always disables it.
-        inputs.prebuildDeps = "none";
-    }
-    // ---- cache roots ----
-    const requestedCacheDir = inputs.cacheDir.trim();
-    const cacheRoot = requestedCacheDir
-        ? resolveAbsolute(requestedCacheDir, env)
-        : path.resolve(path.join(runnerTemp, "setup-soldr"));
-    const soldrRoot = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-soldr`);
-    const cargoHomeInput = (env["CARGO_HOME"] ?? "").trim();
-    const cargoHome = cargoHomeInput
-        ? resolveAbsolute(cargoHomeInput, env)
-        : defaultHomeDir(env, ".cargo");
-    const binDir = path.join(cacheRoot, "bin");
-    const setupCachePath = cacheRoot;
-    const soldrBinCachePath = path.join(soldrRoot, "bin");
-    const zccacheCacheDir = path.join(soldrRoot, "cache", "zccache");
-    const thinTargetCacheBundlePath = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-target-thin`);
-    // When the action is disabled (`enable: false`), we write a script-based
-    // passthrough stub at soldrPath instead of installing the real binary.
-    // The stub is a bash script on Unix and a .cmd shim on Windows — Windows
-    // cannot spawn a script via the .exe extension without a real PE, so
-    // soldrPath must end in .cmd in passthrough mode.
-    const enableRaw = inputs.enable.trim() || "true";
-    if (!TRUTHY_VALUES.has(enableRaw.toLowerCase()) && !FALSY_VALUES.has(enableRaw.toLowerCase())) {
-        throw new Error(`invalid 'enable' input: '${enableRaw}'. Allowed: true | false`);
-    }
-    const enabled = !FALSY_VALUES.has(enableRaw.toLowerCase());
-    const soldrBinary = enabled
-        ? process.platform === "win32"
-            ? "soldr.exe"
-            : "soldr"
-        : process.platform === "win32"
-            ? "soldr.cmd"
-            : "soldr";
-    const soldrPath = path.join(binDir, soldrBinary);
-    // ---- toolchain ----
-    // #302: sub-phase timing on the awaits inside resolve so we can see
-    // which step is dominating (toolchain-spec / rustup-probe / hash walks
-    // / soldr-version fetch). Cheap finally-block bookkeeping; no behavior
-    // change for callers.
-    const toolchain = await (0, phase_timing_js_1.timeSubPhase)("resolve", "toolchain-spec", () => (0, toolchain_js_1.loadToolchainSpec)({
-        workspace,
-        toolchainFile: inputs.toolchainFile || "rust-toolchain.toml",
-        toolchainOverride: inputs.toolchain,
-        log,
-    }));
-    const crossTarget = (0, blessed_cross_prepare_js_1.parseSingleCrossTarget)(inputs.crossTargets);
-    toolchain.targets = (0, blessed_cross_prepare_js_1.mergeToolchainTargets)(toolchain.targets, crossTarget);
-    // ---- rustup home selection ----
-    const explicitRustupHome = (env["RUSTUP_HOME"] ?? "").trim();
-    let rustupHome;
-    let rustupStrategy;
-    if (explicitRustupHome) {
-        rustupHome = resolveAbsolute(explicitRustupHome, env);
-        rustupStrategy = "explicit";
-    }
-    else {
-        const runnerRustupHome = defaultHomeDir(env, ".rustup");
-        let satisfied = false;
-        if (deps?.systemRustupOverride) {
-            satisfied = await (0, phase_timing_js_1.timeSubPhase)("resolve", "rustup-probe", () => deps.systemRustupOverride(cargoHome, runnerRustupHome, toolchain));
-        }
-        else {
-            satisfied = await (0, phase_timing_js_1.timeSubPhase)("resolve", "rustup-probe", () => (0, toolchain_js_1.systemRustupSatisfiesRequest)({
-                cargoHome,
-                rustupHome: runnerRustupHome,
-                toolchain,
-                env,
-                logger,
-                deps: deps?.systemRustup,
-            }));
-        }
-        if (satisfied) {
-            rustupHome = runnerRustupHome;
-            rustupStrategy = "system";
-        }
-        else {
-            rustupHome = path.join(cacheRoot, "rustup-home");
-            rustupStrategy = "managed";
-        }
-        // Platform override: macOS pre-installed rustup toolchains conflict with
-        // downstream component adds (setup-soldr#105). Force `managed` when the
-        // initial selection landed on `system` so we get a private rustup home.
-        const overridden = resolveRustupStrategy({
-            requested: rustupStrategy,
-            platform: process.platform,
-            warn: (msg) => logger.warning(msg),
-        });
-        if (overridden !== rustupStrategy) {
-            rustupStrategy = overridden;
-            if (rustupStrategy === "managed") {
-                rustupHome = path.join(cacheRoot, "rustup-home");
-            }
-        }
-    }
-    let setupCachePathsList = (0, cache_keys_js_1.setupCachePaths)(setupCachePath, binDir, soldrBinCachePath, rustupHome);
-    let setupCacheLayoutValue = (0, cache_keys_js_1.setupCacheLayout)(setupCachePath, rustupHome);
-    if (dylintModeEnabled) {
-        // The Dylint foundation owns exact nightly toolchain paths. Do not let
-        // setup-cache's broad rustup directories overlap that layer or carry a
-        // Dylint nightly into a later non-Dylint job.
-        const rustupOwnedPaths = new Set([
-            path.normalize(path.join(rustupHome, "update-hashes")),
-            path.normalize(path.join(rustupHome, "settings.toml")),
-            path.normalize(path.join(rustupHome, "toolchains")),
-        ]);
-        setupCachePathsList = setupCachePathsList
-            .split(/\r?\n/)
-            .filter((candidate) => !rustupOwnedPaths.has(path.normalize(candidate)))
-            .join("\n");
-        setupCacheLayoutValue = "bin+soldr-bin";
-    }
-    for (const dir of [
-        cacheRoot,
-        soldrRoot,
-        path.join(soldrRoot, "cache"),
-        soldrBinCachePath,
-        cargoHome,
-        path.join(cargoHome, "bin"),
-        rustupHome,
-        binDir,
-        zccacheCacheDir,
-        thinTargetCacheBundlePath,
-    ]) {
-        makeDirs(dir);
-    }
-    const soldrRepo = inputs.repo.trim() || "zackees/soldr";
-    const soldrRef = inputs.ref.trim();
-    const soldrVersionRequested = inputs.version.trim();
-    const soldrVersionResolved = await (0, phase_timing_js_1.timeSubPhase)("resolve", "soldr-version", () => (0, fetch_release_js_1.resolveSoldrReleaseVersion)(soldrRepo, soldrVersionRequested, soldrRef, env, deps));
-    const toolchainSignature = {
-        channel: toolchain.cacheChannel,
-        profile: toolchain.profile,
-        components: toolchain.components,
-        targets: toolchain.targets,
-        source: toolchain.source,
-        file_hash: toolchain.fileHash,
-        setup_cache_layout: setupCacheLayoutValue,
-        soldr_repo: soldrRepo,
-        soldr_ref: soldrRef || "release",
-        soldr_version: soldrVersionResolved || soldrRef || "source-ref",
-    };
-    // Python uses json.dumps(sort_keys=True) without compact separators here,
-    // so canonical_json_stringify is wrong; mirror Python's default separators
-    // (", " and ": ") to match byte-for-byte.
-    const signatureString = (0, python_json_js_1.pythonDefaultJson)(toolchainSignature);
-    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 282, 23));
-    const digest = createHash("sha256").update(signatureString, "utf8").digest("hex").slice(0, 16);
-    const runnerOs = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_OS"] ?? process.platform).toLowerCase());
-    const runnerArch = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_ARCH"] ?? "unknown").toLowerCase());
-    const cachePrefix = `setup-soldr-v4-${runnerOs}-${runnerArch}`;
-    let cacheKey = `${cachePrefix}-${digest}`;
-    // #295-followup: parallelize the two independent workspace-wide hash
-    // walks. Both traverse different subsets of `workspace` (manifests
-    // vs .cargo/config.toml) and have no shared state, so running them
-    // sequentially just wastes resolve-phase wall clock. Cheap correctness
-    // improvement; no behavior change.
-    const [wsManifestHash, cargoConfigHashValue] = await (0, phase_timing_js_1.timeSubPhase)("resolve", "ws-hash", () => Promise.all([(0, cache_keys_js_1.workspaceManifestHash)(workspace), (0, cache_keys_js_1.cargoConfigHash)(workspace)]));
-    const suffix = inputs.cacheKeySuffix.trim();
-    const sanitizedSuffix = suffix ? (0, cache_keys_js_1.sanitizeFragment)(suffix) : "";
-    if (suffix) {
-        cacheKey = `${cacheKey}-${sanitizedSuffix}`;
-    }
-    // ---- build cache ----
-    const githubSha = (env["GITHUB_SHA"] ?? "").trim() || "nosha";
-    let parentSha = (env["ACTION_PARENT_SHA"] ?? "").trim();
-    if (parentSha === githubSha) {
-        parentSha = "";
-    }
-    const buildCachePrefix = `setup-soldr-buildcache-v2-${runnerOs}-${runnerArch}`;
-    const buildCacheToolchainPrefix = `${buildCachePrefix}-${digest}-`;
-    // Build-cache key (setup-soldr#237): platform + toolchain (digest) + per-job
-    // suffix + Cargo.lock — but NOT the commit SHA. Dropping the SHA is the fix:
-    // it made the key exact-miss on every commit, after which the fallback grabbed
-    // a *different* job's archive → 0 hits. We KEEP the per-job suffix (and scope
-    // the fallback to it, see the BuildCachePlan below) so each job restores its
-    // OWN store, warm across commits — sharing one store across jobs that compile
-    // different things (check vs doc vs test) was over-broad and still hit 0%.
-    // Assembled below once `cargoLockHash` is known.
-    // ---- target cache ----
-    const targetDirInput = inputs.targetDir.trim() || "target";
-    let targetCachePath = expanduser(targetDirInput, env);
-    if (!path.isAbsolute(targetCachePath)) {
-        targetCachePath = path.join(workspace, targetCachePath);
-    }
-    targetCachePath = path.resolve(targetCachePath);
-    makeDirs(targetCachePath);
-    const lockfilePath = (0, cache_keys_js_1.resolveLockfilePath)(workspace, targetCachePath, inputs.lockfile);
-    const cargoLockHash = lockfilePath
-        ? await (0, phase_timing_js_1.timeSubPhase)("resolve", "lock-hash", () => (0, cache_keys_js_1.shortFileHash)(lockfilePath, "no-lock"))
-        : "no-lock";
-    // setup-soldr#237: per-job, SHA-independent build-cache key. The per-job
-    // suffix keeps each job restoring its own store; dropping the SHA makes it
-    // warm across commits. The fallback (BuildCachePlan below) is scoped to this
-    // job prefix only, never another job's store.
-    const buildCacheJobPrefix = `${buildCacheToolchainPrefix}${sanitizedSuffix ? `${sanitizedSuffix}-` : ""}`;
-    const buildCacheKey = `${buildCacheJobPrefix}${cargoLockHash}`;
-    const buildCacheParentKey = "";
-    const legacyTargetCacheModeInput = inputs.targetCacheMode;
-    const legacyTargetCacheMode = (0, cache_keys_js_1.normalizeLegacyTargetCacheMode)(legacyTargetCacheModeInput, log);
-    const targetCacheProfile = (0, cache_keys_js_1.normalizeTargetCacheProfile)(inputs.targetCacheProfile);
-    // #418: thin-v3 may select a cook-partitioned durable slice only once Soldr
-    // can prove every Cargo fingerprint/build-script path's package owner. That
-    // closure is not available yet, so the action and Soldr deliberately agree
-    // on the safe zccache-all fallback. The policy+mode are part of the cache
-    // namespace; do not let a v1/v2 bundle restore into this contract.
-    const targetCachePolicyKey = targetCacheProfile === "thin-v3"
-        ? "thin-v3-lifetime-partition-v1-zccache-all-v1"
-        : targetCacheProfile;
-    // `cache: "false"` is the umbrella switch. It originally only gated the
-    // action-managed setup-cache (soldr binary + rustup state), but consumers
-    // reasonably expect it to mean "no caching at all" — so when the umbrella
-    // is off we force every per-layer flag off too AND tell soldr to skip its
-    // zccache build-cache wrapper. See zccache#307 / zackees/setup-soldr#118
-    // follow-up.
-    const cacheUmbrellaEnabled = !isFalsy(inputs.cache.trim() || "true");
-    const explicitTargetCacheInput = inputs.targetCache.trim();
-    const targetCacheInputRaw = explicitTargetCacheInput ||
-        (legacyTargetCacheMode && legacyTargetCacheMode !== "off" ? "true" : "false");
-    const targetCacheRequested = cacheUmbrellaEnabled &&
-        !isFalsy(targetCacheInputRaw) &&
-        legacyTargetCacheMode !== "off";
-    const explicitBuildCacheMode = inputs.buildCacheMode.trim();
-    const buildCacheMode = (0, cache_keys_js_1.normalizeBuildCacheMode)(inputs.buildCacheMode, legacyTargetCacheModeInput, !explicitBuildCacheMode && targetCacheRequested, log);
-    const buildCacheInputRaw = inputs.buildCache.trim() || "true";
-    const buildCacheEnabled = cacheUmbrellaEnabled && !isFalsy(buildCacheInputRaw);
-    const buildCacheRuntimeMode = buildCacheMode === "once" ? "full" : buildCacheMode;
-    let targetCacheEnabled = buildCacheEnabled && targetCacheRequested;
-    if (buildCacheMode === "thin" && cargoLockHash === "no-lock") {
-        log("build-cache-mode 'thin' requires Cargo.lock; target artifact cache disabled.");
-        targetCacheEnabled = false;
-    }
-    const [targetCacheBudgetBytes, targetCacheBudgetFiles] = (0, cache_keys_js_1.targetCacheSoftBudget)(targetCacheEnabled, buildCacheMode);
-    const targetShapeHash = (0, cache_keys_js_1.shortJsonHash)({
-        target_dir: targetCachePath,
-        target_dir_input: targetDirInput,
-        target_env: (0, cache_keys_js_1.targetEnvHash)(env),
-    });
-    const targetInputsHash = (0, cache_keys_js_1.shortJsonHash)({
-        cargo_config: cargoConfigHashValue,
-        cargo_lock: cargoLockHash,
-        manifest: wsManifestHash,
-        target_shape: targetShapeHash,
-        toolchain: digest,
-    });
-    const lockfileOnlyHash = (0, cache_keys_js_1.shortJsonHash)({
-        cargo_lock: cargoLockHash,
-        toolchain: digest,
-    });
-    const targetCacheBundlePath = thinTargetCacheBundlePath;
-    const targetTreeCacheEnabled = targetCacheEnabled && buildCacheMode === "full";
-    let targetCachePaths;
-    let targetCacheEffectiveMode;
-    let targetCachePrefix;
-    let targetCacheLockPrefix;
-    let targetCacheLockfilePrefix;
-    let targetCacheKey;
-    let targetCacheParentKey;
-    if (!targetCacheEnabled) {
-        targetCachePaths = "";
-        targetCacheEffectiveMode = "off";
-        targetCachePrefix = `setup-soldr-targetcache-off-v1-${runnerOs}-${runnerArch}`;
-        targetCacheLockPrefix = "";
-        targetCacheLockfilePrefix = "";
-        targetCacheKey = `${targetCachePrefix}-${targetInputsHash}`;
-        targetCacheParentKey = "";
-    }
-    else if (targetTreeCacheEnabled) {
-        targetCachePaths = [targetCachePath, targetCacheBundlePath].join("\n");
-        targetCacheEffectiveMode = buildCacheMode;
-        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v2-${runnerOs}-${runnerArch}-${targetCachePolicyKey}`;
-        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
-        targetCacheLockPrefix = `${targetCachePrefix}-${digest}-${cargoLockHash}-${targetShapeHash}-${sf}`;
-        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
-        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
-        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
-    }
-    else {
-        targetCachePaths = targetCacheBundlePath;
-        targetCacheEffectiveMode = buildCacheMode;
-        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v2-${runnerOs}-${runnerArch}-${targetCachePolicyKey}`;
-        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
-        targetCacheLockPrefix = `${targetCachePrefix}-${targetInputsHash}-${sf}`;
-        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
-        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
-        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
-    }
-    // setup-soldr#237: the build-cache key intentionally does NOT include
-    // `cache-key-suffix`. Per-job suffixes fragmented the cache and made the
-    // restore-key fallback land on another job's archive (→ ~0% hits). The
-    // suffix still scopes the action-managed setup-cache (`cacheKey` above) and
-    // the target-cache, just not the content-addressed zccache build-cache.
-    // ---- cargo registry cache ----
-    // #267: when prebuild-deps includes `soldr-cook` AND the user (or a
-    // preset they're using) has NOT explicitly set cargo-registry-cache,
-    // default it to `true`. Cook restores `target/` build artifacts but
-    // does NOT restore `$CARGO_HOME/registry`, so cargo re-downloads every
-    // crate source on the next build — the "I set cook, why is it still
-    // downloading?" trap. Presets that explicitly set
-    // `cargoRegistryCache: "false"` (minimal, foundation) survive because
-    // `inputs.cargoRegistryCache` is non-empty after `fillFromPreset`
-    // runs; the `||` short-circuits before reaching the implicit default.
-    const cookPrebuildEnabled = inputs.prebuildDeps.trim().includes("soldr-cook");
-    const cargoRegistryDefault = cookPrebuildEnabled ? "true" : "false";
-    const cargoRegistryCacheRawInput = inputs.cargoRegistryCache.trim();
-    const cargoRegistryCachePaired = cookPrebuildEnabled && cargoRegistryCacheRawInput === "";
-    if (cargoRegistryCachePaired) {
-        log("setup-soldr: defaulting cargo-registry-cache=true because prebuild-deps=soldr-cook " +
-            "(see setup-soldr#267 — pairs to avoid re-downloading every crate source on next " +
-            "build). Set cargo-registry-cache=false explicitly to opt out.");
-    }
-    const cargoRegistryCacheRequested = isTruthy(cargoRegistryCacheRawInput || cargoRegistryDefault);
-    const cargoRegistryCachePath = path.join(cargoHome, "registry");
-    // setup-soldr#102: bundle additional `$CARGO_HOME` siblings into the same
-    // cargo-registry archive so we close the cache-retention gaps without
-    // introducing a new top-level cache layer or changing the cache key shape.
-    //   - `.global-cache` — cargo's RFC-3413 GC sqlite database. Without it the
-    //     per-job `cargo gc` sees fresh access times and conservatively keeps
-    //     everything. Shared read-only dep between setup-soldr (persists) and
-    //     soldr (reads via zackees/soldr#323). One-line leverage win.
-    //   - `git`           — `$CARGO_HOME/git/{db,checkouts}/`. `db/` holds the
-    //     bare mirrors of git-source crate deps and `checkouts/` holds the
-    //     per-commit working trees derived from `db/`; both are required for
-    //     cargo to build from a restored `db/`. Caching the parent `git/` dir
-    //     covers both subtrees and any future siblings cargo introduces.
-    // Siblings that don't exist on disk at save time (e.g. workspaces with no
-    // git-source deps) are silently skipped by compressCache — see #102.
-    const cargoRegistryCacheExtras = [".global-cache", "git"];
-    const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-v1-${runnerOs}-${runnerArch}`;
-    const cargoRegistryCacheRestorePrefix = `${cargoRegistryCachePrefix}-${cargoLockHash}-`;
-    // #371: drop git SHA from the exact key, same anti-pattern fix as
-    // #237 did for build-cache. With SHA, every commit produced a new
-    // exact-key entry that no future probe could ever hit (only same-
-    // commit retries). The restore-key prefix (sans SHA) already does
-    // the actual work via FALLBACK — observed in production. Dropping
-    // SHA lifts exact-key hit rate from ~0% toward ~100% per
-    // (lockHash, digest) generation, eliminates redundant ~56 MB
-    // saves per run, and reduces cache-budget churn.
-    //
-    // #375: also drop per-job suffix from cargo-registry. Unlike
-    // build-cache (#237 KEPT suffix because target/ content differs
-    // per job), cargo-registry content is just `$CARGO_HOME/registry/`
-    // — downloaded crate sources keyed on Cargo.lock, identical
-    // across (check, test, doc, msrv) matrix jobs. Per-job suffix
-    // means N redundant saves per CI cycle (~56 MB × N for zccache's
-    // 9-job matrix = ~500 MB wasted bandwidth). Sharing the key
-    // across jobs means: first job saves, rest exact-HIT.
-    const cargoRegistryCacheKey = `${cargoRegistryCacheRestorePrefix}${digest}`;
-    const cargoRegistryCacheEnabled = cacheUmbrellaEnabled && cargoRegistryCacheRequested;
-    if (cargoRegistryCacheEnabled) {
-        makeDirs(cargoRegistryCachePath);
-    }
-    // ---- Dylint tool/driver cache (explicit opt-in, setup-soldr#221) ----
-    const dylintFoundationRequested = dylintModeEnabled
-        ? parseOptInBool("dylint-foundation-cache", inputs.dylintFoundationCache, true)
-        : parseOptInBool("dylint-cache", inputs.dylintCache, false);
-    const dylintOutputCacheEnabled = dylintModeEnabled &&
-        cacheUmbrellaEnabled &&
-        parseOptInBool("dylint-output-cache", inputs.dylintOutputCache, true);
-    if (dylintOutputCacheEnabled && targetTreeCacheEnabled) {
-        throw new Error("dylint-output-cache cannot overlap build-cache-mode=full target caching; " +
-            "disable target-cache/full mode for Dylint jobs");
-    }
-    const dylintCacheEnabled = cacheUmbrellaEnabled && dylintFoundationRequested;
-    const dylintDriverPath = path.join(runnerTemp, "dylint-drivers");
-    const dylintHostTriple = rustHostTriple(ctx.runnerOs || env["ACTION_OS"] || process.platform, ctx.runnerArch || env["ACTION_ARCH"] || process.arch);
-    const nightlyIdentity = dylintModeEnabled
-        ? await (0, phase_timing_js_1.timeSubPhase)("resolve", "dylint-nightly-map", () => (deps?.resolveDylintNightly ?? dylint_nightly_js_1.resolveDylintNightly)(inputs.dylintToolchain.trim() || toolchain.channel, env))
-        : null;
-    const dylintToolchain = nightlyIdentity?.channel || inputs.dylintToolchain.trim() || toolchain.channel;
-    const dylintRustcRelease = nightlyIdentity?.rustcRelease || "unmapped";
-    const dylintRustcCommitHash = nightlyIdentity?.rustcCommitHash || "unmapped";
-    const dylintCacheIdentity = `${dylintToolchain}|${dylintRustcRelease}|${dylintRustcCommitHash}`;
-    const dylintRequiredComponents = ["rustc-dev", "rust-src", "llvm-tools-preview"];
-    const dylintFoundationRevision = "foundation-v2";
-    const dylintRunScope = [
-        env["GITHUB_RUN_ID"],
-        env["GITHUB_RUN_ATTEMPT"],
-        env["GITHUB_JOB"],
-        env["GITHUB_ACTION"],
-    ]
-        .filter(Boolean)
-        .join("|") || `local-${process.pid}`;
-    const dylintSuccessMarker = path.join(runnerTemp, "dylint-foundation-success", (0, cache_keys_js_1.shortJsonHash)({
-        identity: dylintCacheIdentity,
-        components: dylintRequiredComponents,
-        revision: dylintFoundationRevision,
-        runScope: dylintRunScope,
-    }), "success.txt");
-    const dylintDriverRev = inputs.dylintDriverRev.trim() || "none";
-    const cargoDylintVersion = inputs.cargoDylintVersion.trim() || "6.0.1";
-    const dylintLinkVersion = inputs.dylintLinkVersion.trim() || "6.0.1";
-    const customDylintPaths = splitPathInput(inputs.dylintCachePaths).map((p) => path.isAbsolute(expanduser(p, env)) ? resolveAbsolute(p, env) : path.resolve(workspace, p));
-    const dylintToolchainPath = path.join(rustupHome, "toolchains", `${dylintToolchain}-${dylintHostTriple}`);
-    const dylintUpdateHashPath = path.join(rustupHome, "update-hashes", `${dylintToolchain}-${dylintHostTriple}`);
-    const dylintCachePaths = customDylintPaths.length > 0
-        ? customDylintPaths
-        : [
-            ...defaultDylintCachePaths(cargoHome, dylintDriverPath),
-            ...(dylintModeEnabled ? [dylintToolchainPath, dylintUpdateHashPath] : []),
-        ];
-    const dylintCacheHash = dylintModeEnabled
-        ? (0, cache_keys_js_1.shortJsonHash)({
-            host_triple: dylintHostTriple,
-            cargo_dylint_version: cargoDylintVersion,
-            dylint_link_version: dylintLinkVersion,
-            dylint_toolchain: dylintToolchain,
-            dylint_rustc_release: dylintRustcRelease,
-            dylint_rustc_commit_hash: dylintRustcCommitHash,
-            dylint_driver_rev: dylintDriverRev,
-            required_components: dylintRequiredComponents,
-            foundation_revision: dylintFoundationRevision,
-        })
-        : (0, cache_keys_js_1.shortJsonHash)({
-            host_triple: dylintHostTriple,
-            cargo_dylint_version: cargoDylintVersion,
-            dylint_link_version: dylintLinkVersion,
-            dylint_toolchain: dylintToolchain,
-            dylint_driver_rev: dylintDriverRev,
-            cargo_config: cargoConfigHashValue,
-            cargo_lock: cargoLockHash,
-            manifest: wsManifestHash,
-            setup_toolchain: digest,
-        });
-    const dylintCacheSchema = dylintModeEnabled ? "v2" : "v1";
-    let dylintCacheKey = `setup-soldr-dylint-${dylintCacheSchema}-${runnerOs}-${runnerArch}-${(0, cache_keys_js_1.sanitizeFragment)(dylintHostTriple)}-${dylintCacheHash}`;
-    if (suffix) {
-        dylintCacheKey = `${dylintCacheKey}-${sanitizedSuffix}`;
-    }
-    const dylintOutputPaths = [
-        path.join(targetCachePath, "dylint", "libraries", dylintToolchain, "release"),
-        path.join(targetCachePath, "dylint", "target", dylintToolchain),
-    ];
-    const dylintOutputHash = (0, cache_keys_js_1.shortJsonHash)({
-        compiler_identity: dylintCacheIdentity,
-        driver_revision: dylintDriverRev,
-        cargo_config: cargoConfigHashValue,
-        cargo_lock: cargoLockHash,
-        manifests: wsManifestHash,
-        target_shape: targetShapeHash,
-        source_revision: githubSha,
-        cache_suffix: sanitizedSuffix,
-    });
-    const dylintOutputKey = `setup-soldr-dylint-output-v1-${runnerOs}-${runnerArch}-${dylintOutputHash}`;
-    if (dylintCacheEnabled) {
-        makeDirs(dylintDriverPath);
-    }
-    // ---- env exports ----
-    const cacheShutdownOnIdleSeconds = (0, input_parsers_js_1.parseCacheShutdownOnIdleSeconds)(inputs.cacheShutdownOnIdle);
-    const rustBacktraceValue = (0, input_parsers_js_1.parseRustBacktrace)(inputs.rustBacktrace);
-    const envExports = {};
-    const setEnv = (name, value) => {
-        if (GITHUB_ENV_DENY_LIST.has(name))
-            return;
-        envExports[name] = value;
-    };
-    setEnv("SOLDR_CACHE_DIR", soldrRoot);
-    setEnv("CARGO_HOME", cargoHome);
-    setEnv("RUSTUP_HOME", rustupHome);
-    setEnv("ZCCACHE_CACHE_DIR", zccacheCacheDir);
-    // soldr#807: warn when SOLDR_ZCCACHE_PRIVATE is truthy because the
-    // explicit ZCCACHE_CACHE_DIR above will silently win and the opt-in
-    // private-session path under <cwd>/.zccache won't be used.
-    const zccachePrivateOverlap = detectZccachePrivateOverlap(env);
-    if (zccachePrivateOverlap)
-        core.warning(zccachePrivateOverlap);
-    setEnv("SETUP_SOLDR_BUILD_CACHE_MODE", cacheUmbrellaEnabled ? buildCacheMode : "off");
-    setEnv("SOLDR_BUILD_CACHE_MODE", cacheUmbrellaEnabled ? buildCacheRuntimeMode : "off");
-    setEnv("SOLDR_TARGET_CACHE_MODE", targetCacheEnabled ? buildCacheRuntimeMode : "off");
-    setEnv("SOLDR_TARGET_CACHE_DIR", targetCachePath);
-    setEnv("SOLDR_TARGET_CACHE_BUNDLE_DIR", targetCacheBundlePath);
-    setEnv("SOLDR_TARGET_CACHE_PROFILE", targetCacheProfile);
-    const stripDebug = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-strip-debuginfo", inputs.targetCacheStripDebuginfo);
-    if (stripDebug !== null) {
-        setEnv("SOLDR_TARGET_CACHE_STRIP_DEBUGINFO", stripDebug);
-    }
-    const includeIncremental = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-incremental", inputs.targetCacheIncludeIncremental);
-    if (includeIncremental !== null) {
-        setEnv("SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL", includeIncremental);
-    }
-    const includeBuildScripts = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-build-script-binaries", inputs.targetCacheIncludeBuildScriptBinaries);
-    if (includeBuildScripts !== null) {
-        setEnv("SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES", includeBuildScripts);
-    }
-    const targetCacheCompress = (0, cache_keys_js_1.normalizeTargetCacheCompress)(inputs.targetCacheCompress);
-    const targetCacheCompressLevel = (0, cache_keys_js_1.normalizeTargetCacheCompressLevel)(inputs.targetCacheCompressLevel);
-    setEnv("SOLDR_TARGET_CACHE_COMPRESS", targetCacheCompress);
-    setEnv("SOLDR_TARGET_CACHE_COMPRESS_LEVEL", targetCacheCompressLevel);
-    if (cargoRegistryCacheEnabled) {
-        setEnv("SOLDR_SKIP_CARGO_REGISTRY_SAVE", "1");
-    }
-    if (!soldrRef && semverAtLeast(soldrVersionResolved || soldrVersionRequested, "0.7.43")) {
-        setEnv("SOLDR_CARGO_CHEF_LOCAL_DIR", binDir);
-    }
-    if (dylintCacheEnabled) {
-        setEnv("DYLINT_DRIVER_PATH", dylintDriverPath);
-        setEnv("SETUP_SOLDR_DYLINT_CACHE_KEY", dylintCacheKey);
-        setEnv("SETUP_SOLDR_DYLINT_CACHE_PATHS", dylintCachePaths.join(path.delimiter));
-    }
-    if (dylintModeEnabled && nightlyIdentity) {
-        // These are configuration hints, not the active nested-Dylint scope.
-        // Soldr copies them to SOLDR_DYLINT_* only while launching cargo-dylint,
-        // so an ordinary stable `soldr cargo build` later in the job is unchanged.
-        setEnv("SOLDR_DYLINT_CONFIGURED_TOOLCHAIN", nightlyIdentity.channel);
-        setEnv("SOLDR_DYLINT_CONFIGURED_RUSTC_RELEASE", nightlyIdentity.rustcRelease);
-        setEnv("SOLDR_DYLINT_CONFIGURED_RUSTC_COMMIT_HASH", nightlyIdentity.rustcCommitHash);
-        setEnv("SOLDR_DYLINT_SUCCESS_MARKER", dylintSuccessMarker);
-    }
-    setEnv("SOLDR_TARGET_CACHE_BACKEND", "local");
-    setEnv("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain.channel);
-    setEnv("SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL", toolchain.cacheChannel);
-    setEnv("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain.profile);
-    setEnv("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", JSON.stringify(toolchain.components));
-    setEnv("SETUP_SOLDR_TOOLCHAIN_TARGETS", JSON.stringify(toolchain.targets));
-    setEnv("SETUP_SOLDR_LOG_START_EPOCH", logStart);
-    setEnv("SETUP_SOLDR_TIMESTAMPS", timestamps);
-    setEnv("SETUP_SOLDR_TIMESTAMP_FORMAT", timestampFormat);
-    if (cacheEncryptKeyRaw) {
-        // #387 Feature 1: propagate to GITHUB_ENV so the post-step (which loads
-        // a fresh process) and any subsequent setup-soldr-using steps see the
-        // same key. The key has already been core.setSecret-marked above so
-        // GitHub Actions auto-redacts it from logs.
-        setEnv("SETUP_SOLDR_CACHE_ENCRYPT_KEY", cacheEncryptKeyRaw);
-        setEnv("SETUP_SOLDR_CACHE_ENCRYPT_ON_FAILURE", cacheEncryptOnFailure);
-    }
-    if (!FALSY_VALUES.has(timestamps.toLowerCase()) && env["NO_COLOR"] === undefined) {
-        if (!env["CARGO_TERM_COLOR"])
-            setEnv("CARGO_TERM_COLOR", "always");
-        if (!env["CLICOLOR_FORCE"])
-            setEnv("CLICOLOR_FORCE", "1");
-        if (!env["FORCE_COLOR"])
-            setEnv("FORCE_COLOR", "1");
-    }
-    if (inputs.trustMode.trim()) {
-        setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
-    }
-    const linkerRaw = inputs.linker.trim();
-    if (linkerRaw === "") {
-        const preset = (0, input_parsers_js_1.detectUserLinkerEnv)(env);
-        if (preset.length > 0) {
-            logger.info(`setup-soldr: deferring to user-set ${preset.join(", ")}; skipping default SOLDR_LINKER=fast injection. See https://github.com/zackees/setup-soldr/issues/108`);
-        }
-        else {
-            setEnv("SOLDR_LINKER", "fast");
-            logger.notice("setup-soldr: defaulting SOLDR_LINKER=fast (mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows) for faster CI links. Soldr's native default is no injection, which produces a smaller build-cache and a slower link. Set `linker: platform-default` to opt out and keep cargo/rust-toolchain.toml in charge, or set `linker: <value>` to silence this notice.");
-        }
-    }
-    else if (!ALLOWED_LINKER_VALUES.includes(linkerRaw)) {
-        throw new Error(`invalid 'linker' input: '${linkerRaw}'. Allowed: default | platform-default | ld | mold | rust-lld | fast`);
-    }
-    else if (linkerRaw !== "default" && linkerRaw !== "platform-default") {
-        setEnv("SOLDR_LINKER", linkerRaw);
-    }
-    const compilePriorityRaw = inputs.compilePriority.trim();
-    if (compilePriorityRaw !== "") {
-        setEnv("ZCCACHE_COMPILE_PRIORITY", compilePriorityRaw);
-    }
-    if (cacheShutdownOnIdleSeconds !== null) {
-        // Set both env vars. zccache reads its own, sccache reads the
-        // SCCACHE_-prefixed one; exporting both means a zccache fork that
-        // still honors only the sccache name keeps working, and a vanilla
-        // sccache invoked via this action would too.
-        const seconds = String(cacheShutdownOnIdleSeconds);
-        setEnv("ZCCACHE_IDLE_TIMEOUT", seconds);
-        setEnv("SCCACHE_IDLE_TIMEOUT", seconds);
-    }
-    if (rustBacktraceValue !== null) {
-        setEnv("RUST_BACKTRACE", rustBacktraceValue);
-    }
-    // Auto-export cc-rs cross-compile env for *-unknown-linux-musl triples
-    // when the matching `<triple>-gcc/g++/ar` binaries are on PATH. cc-rs
-    // strips the "-unknown-" segment when looking up cross compilers, so
-    // archives that ship binaries with the full triple are missed without
-    // these per-target overrides. See setup-soldr#... and the cc-rs docs.
-    const muslCcHits = (0, detect_musl_cc_js_1.detectMuslCcEnv)(env);
-    for (const hit of muslCcHits) {
-        const suffix = (0, detect_musl_cc_js_1.tripleToCcRsSuffix)(hit.triple);
-        for (const [name, value] of Object.entries(hit.exports)) {
-            setEnv(name, value);
-        }
-        logger.warning(`setup-soldr: auto-exporting cc-rs cross-compile env for ${hit.triple} ` +
-            `(CC_${suffix}=${hit.exports[`CC_${suffix}`]}, ` +
-            `CXX_${suffix}=${hit.exports[`CXX_${suffix}`]}, ` +
-            `AR_${suffix}=${hit.exports[`AR_${suffix}`]}) ` +
-            "because cc-rs strips \"-unknown-\" from the triple when probing for a " +
-            "cross compiler and would otherwise fall back to the host gcc. " +
-            `Resolved: cc=${hit.resolvedPaths.cc}, cxx=${hit.resolvedPaths.cxx}, ar=${hit.resolvedPaths.ar}. ` +
-            `Pre-set CC_${suffix} yourself to opt out.`);
-    }
-    // ---- path additions ----
-    const pathAdditions = [binDir, path.join(cargoHome, "bin")];
-    // ---- logging summary ----
-    log("setup-soldr cache plan");
-    log(`cache key=${cacheKey}`);
-    log(`cache restore-key=${cachePrefix}-`);
-    log(`build-cache key=${buildCacheKey}`);
-    log(`build-cache mode=${buildCacheMode}`);
-    log(`build-cache soldr-mode=${buildCacheRuntimeMode}`);
-    if (buildCacheParentKey) {
-        log(`build-cache restore-key-parent=${buildCacheParentKey}`);
-    }
-    log(`build-cache restore-key-toolchain=${buildCacheToolchainPrefix}`);
-    log(`build-cache restore-key-os-arch=${buildCachePrefix}-`);
-    log(`target-cache key=${targetCacheKey}`);
-    log(`target-cache enabled=${targetCacheEnabled ? "true" : "false"}`);
-    log(`target-cache mode=${targetCacheEffectiveMode}`);
-    log("target-cache backend=local");
-    if (targetCacheEnabled) {
-        log(`target-cache soft-budget-bytes=${targetCacheBudgetBytes}`);
-        log(`target-cache soft-budget-files=${targetCacheBudgetFiles}`);
-    }
-    log(`soldr repo=${soldrRepo}`);
-    log(`soldr ref=${soldrRef || "release"}`);
-    if (soldrVersionResolved) {
-        log(`soldr version=${soldrVersionResolved}`);
-    }
-    log(`toolchain channel=${toolchain.channel}`);
-    log(`toolchain cache-channel=${toolchain.cacheChannel}`);
-    log(`rustup strategy=${rustupStrategy}`);
-    log(`setup-cache layout=${setupCacheLayoutValue}`);
-    if (targetCacheParentKey) {
-        log(`target-cache restore-key-parent=${targetCacheParentKey}`);
-    }
-    log(`target-cache restore-key-lock=${targetCacheLockPrefix}`);
-    log(`target-cache restore-key-lockfile=${targetCacheLockfilePrefix}`);
-    log(`target-cache paths=${targetCachePaths}`);
-    log(`target-cache bundle-dir=${targetCacheBundlePath}`);
-    log(`target-cache lockfile=${(0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath)}`);
-    log(`target-cache lockfile-hash=${cargoLockHash}`);
-    if (dylintCacheEnabled) {
-        log(`dylint-cache key=${dylintCacheKey}`);
-        log(`dylint-cache host-triple=${dylintHostTriple}`);
-        log(`dylint-cache toolchain=${dylintToolchain}`);
-        log(`dylint-cache cargo-dylint-version=${cargoDylintVersion}`);
-        log(`dylint-cache dylint-link-version=${dylintLinkVersion}`);
-        log(`dylint-cache driver-rev=${dylintDriverRev}`);
-        log(`dylint-cache driver-path=${dylintDriverPath}`);
-    }
-    // ---- assemble plans ----
-    const setupCache = {
-        key: cacheKey,
-        restorePrefix: `${cachePrefix}-`,
-        paths: setupCachePathsList ? setupCachePathsList.split("\n") : [],
-        setupCachePath,
-        layout: setupCacheLayoutValue,
-    };
-    const buildCache = {
-        enabled: buildCacheEnabled,
-        key: buildCacheKey,
-        restoreKeyParent: buildCacheParentKey,
-        // setup-soldr#237: job-scoped fallback only — newest entry for THIS job at
-        // any Cargo.lock, never another job's store. The old bare toolchain/os-arch
-        // restore-keys matched any job and caused cross-job restores → 0 hits.
-        restoreKeyToolchain: buildCacheJobPrefix,
-        restoreKeyOsArch: "",
-        path: zccacheCacheDir,
-        mode: buildCacheMode,
-    };
-    const targetCache = {
-        enabled: targetCacheEnabled,
-        key: targetCacheKey,
-        restoreKeyParent: targetCacheParentKey,
-        restoreKeyLock: targetCacheLockPrefix,
-        restoreKeyLockfile: targetCacheLockfilePrefix,
-        paths: targetCachePaths,
-        bundlePath: targetCacheBundlePath,
-        targetPath: targetCachePath,
-        effectiveMode: targetCacheEffectiveMode,
-        profile: targetCacheProfile,
-        budgetBytes: targetCacheBudgetBytes,
-        budgetFiles: targetCacheBudgetFiles,
-        lockfilePath: (0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath),
-        lockfileHash: cargoLockHash,
-    };
-    const cargoRegistryCachePlan = {
-        enabled: cargoRegistryCacheEnabled,
-        key: cargoRegistryCacheKey,
-        restorePrefix: cargoRegistryCacheRestorePrefix,
-        path: cargoRegistryCachePath,
-        extraBasenames: cargoRegistryCacheExtras,
-    };
-    const dylintCachePlan = {
-        enabled: dylintCacheEnabled,
-        outputCacheEnabled: dylintOutputCacheEnabled,
-        outputKey: dylintOutputCacheEnabled ? dylintOutputKey : "",
-        outputPaths: dylintOutputCacheEnabled ? dylintOutputPaths : [],
-        key: dylintCacheEnabled ? dylintCacheKey : "",
-        paths: dylintCacheEnabled ? dylintCachePaths : [],
-        driverPath: dylintCacheEnabled ? dylintDriverPath : "",
-        hostTriple: dylintCacheEnabled ? dylintHostTriple : "",
-        toolchain: dylintModeEnabled || dylintCacheEnabled ? dylintToolchain : "",
-        rustcRelease: dylintModeEnabled ? dylintRustcRelease : "",
-        rustcCommitHash: dylintModeEnabled ? dylintRustcCommitHash : "",
-        cacheIdentity: dylintModeEnabled ? dylintCacheIdentity : "",
-        successMarker: dylintModeEnabled ? dylintSuccessMarker : "",
-        driverRev: dylintCacheEnabled ? dylintDriverRev : "",
-        cargoDylintVersion: dylintCacheEnabled ? cargoDylintVersion : "",
-        dylintLinkVersion: dylintCacheEnabled ? dylintLinkVersion : "",
-    };
-    const blessedPrepareCache = (0, blessed_cross_prepare_js_1.planBlessedPrepareCache)({
-        enabled,
-        cacheEnabled: cacheUmbrellaEnabled,
-        ref: soldrRef,
-        runnerTemp,
-        runnerOs,
-        runnerArch,
-        target: crossTarget,
-        soldrRepo,
-        soldrVersion: soldrVersionResolved || soldrVersionRequested,
-    });
-    for (const archivePath of blessedPrepareCache.archivePaths)
-        makeDirs(path.dirname(archivePath));
-    // Avoid unused warnings on alias helper.
-    void toolchain_js_1.rollingToolchainAlias;
-    void cache_keys_js_1.canonicalJsonStringify;
-    const compileCacheStats = (0, input_parsers_js_1.normalizeCompileCacheStats)(inputs.compileCacheStats);
-    const stats = (0, input_parsers_js_1.normalizeStatsMode)(inputs.stats);
-    const debugMode = isTruthy(inputs.debugMode.trim() || "false");
-    // ---- shims ----
-    const shimsRaw = inputs.shims.trim() || "false";
-    const shimsEnabled = !isFalsy(shimsRaw);
-    const shimsDir = path.join(cacheRoot, "shims");
-    return {
-        enabled,
-        workspace,
-        cacheRoot,
-        soldrRoot,
-        binDir,
-        cargoHome,
-        rustupHome,
-        soldrPath,
-        soldrBinCachePath,
-        toolchain,
-        rustupStrategy,
-        soldrRepo,
-        soldrRef,
-        soldrVersionRequested,
-        soldrVersionResolved,
-        setupCache,
-        buildCache,
-        targetCache,
-        cargoRegistryCache: cargoRegistryCachePlan,
-        dylintCache: dylintCachePlan,
-        blessedPrepareCache,
-        targetCacheCompress,
-        targetCacheCompressLevel,
-        envExports,
-        pathAdditions,
-        logStartEpoch: logStart,
-        timestamps,
-        timestampFormat,
-        shimsEnabled,
-        shimsDir,
-        compileCacheStats,
-        stats,
-        debugMode,
-        cacheShutdownOnIdleSeconds,
-        cachePresetEffective,
-    };
-}
-/**
- * Apply ResolveResult to the runner: write $GITHUB_ENV, $GITHUB_PATH, and
- * $GITHUB_OUTPUT keys.
- */
-async function applyResolveResult(result) {
-    for (const [name, value] of Object.entries(result.envExports)) {
-        if (GITHUB_ENV_DENY_LIST.has(name))
-            continue;
-        core.exportVariable(name, value);
-    }
-    for (const p of result.pathAdditions) {
-        core.addPath(p);
-    }
-    const outputs = (0, build_outputs_js_1.buildOutputs)(result);
-    for (const [key, value] of Object.entries(outputs)) {
-        core.setOutput(key, value);
-    }
-}
-// `buildOutputs` and `pythonDefaultJson` are re-exported at the top of
-// this file from their dedicated submodules.
-
-
-/***/ }),
-
-/***/ 14:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(163)
-const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(84)
-const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(75)
-const { kHeadersList } = __nccwpck_require__(200)
-const { webidl } = __nccwpck_require__(470)
-const { Response, cloneResponse } = __nccwpck_require__(45)
-const { Request } = __nccwpck_require__(88)
-const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(17)
-const { fetching } = __nccwpck_require__(463)
-const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(532)
-const assert = __nccwpck_require__(542)
-const { getGlobalDispatcher } = __nccwpck_require__(386)
+const { kConstruct } = __nccwpck_require__(160)
+const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(81)
+const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(72)
+const { kHeadersList } = __nccwpck_require__(197)
+const { webidl } = __nccwpck_require__(471)
+const { Response, cloneResponse } = __nccwpck_require__(43)
+const { Request } = __nccwpck_require__(85)
+const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(16)
+const { fetching } = __nccwpck_require__(464)
+const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(533)
+const assert = __nccwpck_require__(543)
+const { getGlobalDispatcher } = __nccwpck_require__(385)
 
 /**
  * @see https://w3c.github.io/ServiceWorker/#dfn-cache-batch-operation
@@ -3883,19 +2749,19 @@ module.exports = {
 
 /***/ }),
 
-/***/ 15:
+/***/ 14:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(442).Writable)
-const inherits = (__nccwpck_require__(385).inherits)
+const WritableStream = (__nccwpck_require__(443).Writable)
+const inherits = (__nccwpck_require__(384).inherits)
 
-const StreamSearch = __nccwpck_require__(119)
+const StreamSearch = __nccwpck_require__(116)
 
-const PartStream = __nccwpck_require__(72)
-const HeaderParser = __nccwpck_require__(113)
+const PartStream = __nccwpck_require__(69)
+const HeaderParser = __nccwpck_require__(110)
 
 const DASH = 45
 const B_ONEDASH = Buffer.from('-')
@@ -4104,7 +2970,7 @@ module.exports = Dicer
 
 /***/ }),
 
-/***/ 16:
+/***/ 15:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4122,17 +2988,17 @@ exports.isObject = isObject;
 exports.randomUUID = randomUUID;
 exports.uint8ArrayToString = uint8ArrayToString;
 exports.stringToUint8Array = stringToUint8Array;
-const tslib_1 = __nccwpck_require__(220);
-const tspRuntime = tslib_1.__importStar(__nccwpck_require__(153));
-var aborterUtils_js_1 = __nccwpck_require__(106);
+const tslib_1 = __nccwpck_require__(219);
+const tspRuntime = tslib_1.__importStar(__nccwpck_require__(150));
+var aborterUtils_js_1 = __nccwpck_require__(103);
 Object.defineProperty(exports, "cancelablePromiseRace", ({ enumerable: true, get: function () { return aborterUtils_js_1.cancelablePromiseRace; } }));
-var createAbortablePromise_js_1 = __nccwpck_require__(268);
+var createAbortablePromise_js_1 = __nccwpck_require__(266);
 Object.defineProperty(exports, "createAbortablePromise", ({ enumerable: true, get: function () { return createAbortablePromise_js_1.createAbortablePromise; } }));
-var delay_js_1 = __nccwpck_require__(118);
+var delay_js_1 = __nccwpck_require__(115);
 Object.defineProperty(exports, "delay", ({ enumerable: true, get: function () { return delay_js_1.delay; } }));
-var error_js_1 = __nccwpck_require__(217);
+var error_js_1 = __nccwpck_require__(215);
 Object.defineProperty(exports, "getErrorMessage", ({ enumerable: true, get: function () { return error_js_1.getErrorMessage; } }));
-var typeGuards_js_1 = __nccwpck_require__(116);
+var typeGuards_js_1 = __nccwpck_require__(113);
 Object.defineProperty(exports, "isDefined", ({ enumerable: true, get: function () { return typeGuards_js_1.isDefined; } }));
 Object.defineProperty(exports, "isObjectWithProperties", ({ enumerable: true, get: function () { return typeGuards_js_1.isObjectWithProperties; } }));
 Object.defineProperty(exports, "objectHasProperty", ({ enumerable: true, get: function () { return typeGuards_js_1.objectHasProperty; } }));
@@ -4262,7 +3128,7 @@ function stringToUint8Array(value, format) {
 
 /***/ }),
 
-/***/ 17:
+/***/ 16:
 /***/ ((module) => {
 
 "use strict";
@@ -4280,7 +3146,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 18:
+/***/ 17:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -4305,11 +3171,11 @@ __export(retryPolicy_exports, {
   retryPolicy: () => retryPolicy
 });
 module.exports = __toCommonJS(retryPolicy_exports);
-var import_helpers = __nccwpck_require__(469);
-var import_restError = __nccwpck_require__(457);
+var import_helpers = __nccwpck_require__(470);
+var import_restError = __nccwpck_require__(458);
 var import_AbortError = __nccwpck_require__(11);
-var import_logger = __nccwpck_require__(253);
-var import_constants = __nccwpck_require__(52);
+var import_logger = __nccwpck_require__(251);
+var import_constants = __nccwpck_require__(50);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("ts-http-runtime retryPolicy");
 const retryPolicyName = "retryPolicy";
 function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAULT_RETRY_POLICY_COUNT }) {
@@ -4412,7 +3278,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 
 /***/ }),
 
-/***/ 19:
+/***/ 18:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4421,7 +3287,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = void 0;
-const logger_1 = __nccwpck_require__(48);
+const logger_1 = __nccwpck_require__(46);
 /**
  * The `@azure/logger` configuration for this package.
  */
@@ -4430,7 +3296,7 @@ exports.logger = (0, logger_1.createClientLogger)("storage-common");
 
 /***/ }),
 
-/***/ 20:
+/***/ 19:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4465,8 +3331,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
-const string_decoder_1 = __nccwpck_require__(156);
-const tr = __importStar(__nccwpck_require__(130));
+const string_decoder_1 = __nccwpck_require__(153);
+const tr = __importStar(__nccwpck_require__(127));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -4540,7 +3406,7 @@ exports.getExecOutput = getExecOutput;
 
 /***/ }),
 
-/***/ 21:
+/***/ 20:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4550,46 +3416,46 @@ exports.getExecOutput = getExecOutput;
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Convenience JSON typings and corresponding type guards
-var json_typings_1 = __nccwpck_require__(406);
+var json_typings_1 = __nccwpck_require__(407);
 Object.defineProperty(exports, "typeofJsonValue", ({ enumerable: true, get: function () { return json_typings_1.typeofJsonValue; } }));
 Object.defineProperty(exports, "isJsonObject", ({ enumerable: true, get: function () { return json_typings_1.isJsonObject; } }));
 // Base 64 encoding
-var base64_1 = __nccwpck_require__(312);
+var base64_1 = __nccwpck_require__(310);
 Object.defineProperty(exports, "base64decode", ({ enumerable: true, get: function () { return base64_1.base64decode; } }));
 Object.defineProperty(exports, "base64encode", ({ enumerable: true, get: function () { return base64_1.base64encode; } }));
 // UTF8 encoding
-var protobufjs_utf8_1 = __nccwpck_require__(354);
+var protobufjs_utf8_1 = __nccwpck_require__(352);
 Object.defineProperty(exports, "utf8read", ({ enumerable: true, get: function () { return protobufjs_utf8_1.utf8read; } }));
 // Binary format contracts, options for reading and writing, for example
-var binary_format_contract_1 = __nccwpck_require__(342);
+var binary_format_contract_1 = __nccwpck_require__(340);
 Object.defineProperty(exports, "WireType", ({ enumerable: true, get: function () { return binary_format_contract_1.WireType; } }));
 Object.defineProperty(exports, "mergeBinaryOptions", ({ enumerable: true, get: function () { return binary_format_contract_1.mergeBinaryOptions; } }));
 Object.defineProperty(exports, "UnknownFieldHandler", ({ enumerable: true, get: function () { return binary_format_contract_1.UnknownFieldHandler; } }));
 // Standard IBinaryReader implementation
-var binary_reader_1 = __nccwpck_require__(140);
+var binary_reader_1 = __nccwpck_require__(137);
 Object.defineProperty(exports, "BinaryReader", ({ enumerable: true, get: function () { return binary_reader_1.BinaryReader; } }));
 Object.defineProperty(exports, "binaryReadOptions", ({ enumerable: true, get: function () { return binary_reader_1.binaryReadOptions; } }));
 // Standard IBinaryWriter implementation
-var binary_writer_1 = __nccwpck_require__(259);
+var binary_writer_1 = __nccwpck_require__(257);
 Object.defineProperty(exports, "BinaryWriter", ({ enumerable: true, get: function () { return binary_writer_1.BinaryWriter; } }));
 Object.defineProperty(exports, "binaryWriteOptions", ({ enumerable: true, get: function () { return binary_writer_1.binaryWriteOptions; } }));
 // Int64 and UInt64 implementations required for the binary format
-var pb_long_1 = __nccwpck_require__(122);
+var pb_long_1 = __nccwpck_require__(119);
 Object.defineProperty(exports, "PbLong", ({ enumerable: true, get: function () { return pb_long_1.PbLong; } }));
 Object.defineProperty(exports, "PbULong", ({ enumerable: true, get: function () { return pb_long_1.PbULong; } }));
 // JSON format contracts, options for reading and writing, for example
-var json_format_contract_1 = __nccwpck_require__(247);
+var json_format_contract_1 = __nccwpck_require__(245);
 Object.defineProperty(exports, "jsonReadOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonReadOptions; } }));
 Object.defineProperty(exports, "jsonWriteOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonWriteOptions; } }));
 Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: function () { return json_format_contract_1.mergeJsonOptions; } }));
 // Message type contract
-var message_type_contract_1 = __nccwpck_require__(417);
+var message_type_contract_1 = __nccwpck_require__(418);
 Object.defineProperty(exports, "MESSAGE_TYPE", ({ enumerable: true, get: function () { return message_type_contract_1.MESSAGE_TYPE; } }));
 // Message type implementation via reflection
-var message_type_1 = __nccwpck_require__(545);
+var message_type_1 = __nccwpck_require__(546);
 Object.defineProperty(exports, "MessageType", ({ enumerable: true, get: function () { return message_type_1.MessageType; } }));
 // Reflection info, generated by the plugin, exposed to the user, used by reflection ops
-var reflection_info_1 = __nccwpck_require__(466);
+var reflection_info_1 = __nccwpck_require__(467);
 Object.defineProperty(exports, "ScalarType", ({ enumerable: true, get: function () { return reflection_info_1.ScalarType; } }));
 Object.defineProperty(exports, "LongType", ({ enumerable: true, get: function () { return reflection_info_1.LongType; } }));
 Object.defineProperty(exports, "RepeatType", ({ enumerable: true, get: function () { return reflection_info_1.RepeatType; } }));
@@ -4598,44 +3464,44 @@ Object.defineProperty(exports, "readFieldOptions", ({ enumerable: true, get: fun
 Object.defineProperty(exports, "readFieldOption", ({ enumerable: true, get: function () { return reflection_info_1.readFieldOption; } }));
 Object.defineProperty(exports, "readMessageOption", ({ enumerable: true, get: function () { return reflection_info_1.readMessageOption; } }));
 // Message operations via reflection
-var reflection_type_check_1 = __nccwpck_require__(298);
+var reflection_type_check_1 = __nccwpck_require__(296);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
-var reflection_create_1 = __nccwpck_require__(210);
+var reflection_create_1 = __nccwpck_require__(207);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
-var reflection_scalar_default_1 = __nccwpck_require__(478);
+var reflection_scalar_default_1 = __nccwpck_require__(479);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
-var reflection_merge_partial_1 = __nccwpck_require__(142);
+var reflection_merge_partial_1 = __nccwpck_require__(139);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
-var reflection_equals_1 = __nccwpck_require__(476);
+var reflection_equals_1 = __nccwpck_require__(477);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
-var reflection_binary_reader_1 = __nccwpck_require__(419);
+var reflection_binary_reader_1 = __nccwpck_require__(420);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
-var reflection_binary_writer_1 = __nccwpck_require__(190);
+var reflection_binary_writer_1 = __nccwpck_require__(187);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
-var reflection_json_reader_1 = __nccwpck_require__(352);
+var reflection_json_reader_1 = __nccwpck_require__(350);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
-var reflection_json_writer_1 = __nccwpck_require__(96);
+var reflection_json_writer_1 = __nccwpck_require__(93);
 Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get: function () { return reflection_json_writer_1.ReflectionJsonWriter; } }));
-var reflection_contains_message_type_1 = __nccwpck_require__(55);
+var reflection_contains_message_type_1 = __nccwpck_require__(52);
 Object.defineProperty(exports, "containsMessageType", ({ enumerable: true, get: function () { return reflection_contains_message_type_1.containsMessageType; } }));
 // Oneof helpers
-var oneof_1 = __nccwpck_require__(194);
+var oneof_1 = __nccwpck_require__(191);
 Object.defineProperty(exports, "isOneofGroup", ({ enumerable: true, get: function () { return oneof_1.isOneofGroup; } }));
 Object.defineProperty(exports, "setOneofValue", ({ enumerable: true, get: function () { return oneof_1.setOneofValue; } }));
 Object.defineProperty(exports, "getOneofValue", ({ enumerable: true, get: function () { return oneof_1.getOneofValue; } }));
 Object.defineProperty(exports, "clearOneofValue", ({ enumerable: true, get: function () { return oneof_1.clearOneofValue; } }));
 Object.defineProperty(exports, "getSelectedOneofValue", ({ enumerable: true, get: function () { return oneof_1.getSelectedOneofValue; } }));
 // Enum object type guard and reflection util, may be interesting to the user.
-var enum_object_1 = __nccwpck_require__(280);
+var enum_object_1 = __nccwpck_require__(279);
 Object.defineProperty(exports, "listEnumValues", ({ enumerable: true, get: function () { return enum_object_1.listEnumValues; } }));
 Object.defineProperty(exports, "listEnumNames", ({ enumerable: true, get: function () { return enum_object_1.listEnumNames; } }));
 Object.defineProperty(exports, "listEnumNumbers", ({ enumerable: true, get: function () { return enum_object_1.listEnumNumbers; } }));
 Object.defineProperty(exports, "isEnumObject", ({ enumerable: true, get: function () { return enum_object_1.isEnumObject; } }));
 // lowerCamelCase() is exported for plugin, rpc-runtime and other rpc packages
-var lower_camel_case_1 = __nccwpck_require__(467);
+var lower_camel_case_1 = __nccwpck_require__(468);
 Object.defineProperty(exports, "lowerCamelCase", ({ enumerable: true, get: function () { return lower_camel_case_1.lowerCamelCase; } }));
 // assertion functions are exported for plugin, may also be useful to user
-var assert_1 = __nccwpck_require__(500);
+var assert_1 = __nccwpck_require__(501);
 Object.defineProperty(exports, "assert", ({ enumerable: true, get: function () { return assert_1.assert; } }));
 Object.defineProperty(exports, "assertNever", ({ enumerable: true, get: function () { return assert_1.assertNever; } }));
 Object.defineProperty(exports, "assertInt32", ({ enumerable: true, get: function () { return assert_1.assertInt32; } }));
@@ -4645,7 +3511,7 @@ Object.defineProperty(exports, "assertFloat32", ({ enumerable: true, get: functi
 
 /***/ }),
 
-/***/ 22:
+/***/ 21:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -4670,7 +3536,7 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_ts_http_runtime = __nccwpck_require__(95);
+var import_ts_http_runtime = __nccwpck_require__(92);
 function createPipelineRequest(options) {
   return (0, import_ts_http_runtime.createPipelineRequest)(options);
 }
@@ -4680,7 +3546,7 @@ function createPipelineRequest(options) {
 
 /***/ }),
 
-/***/ 23:
+/***/ 22:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -4715,7 +3581,7 @@ const XML_CHARKEY = "_";
 
 /***/ }),
 
-/***/ 24:
+/***/ 23:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4794,9 +3660,9 @@ exports.setupCachePaths = setupCachePaths;
 exports.setupCacheLayout = setupCacheLayout;
 exports.crossToolCacheKeyFor = crossToolCacheKeyFor;
 exports.pathForOutput = pathForOutput;
-const node_crypto_1 = __nccwpck_require__(282);
-const fs = __importStar(__nccwpck_require__(257));
-const path = __importStar(__nccwpck_require__(522));
+const node_crypto_1 = __nccwpck_require__(281);
+const fs = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(523));
 const TARGET_CACHE_PROFILES = ["thin-v1", "thin-v2", "thin-v3"];
 const TARGET_CACHE_BOOL_TRUE = new Set(["true", "1", "yes", "on"]);
 const TARGET_CACHE_BOOL_FALSE = new Set(["false", "0", "no", "off"]);
@@ -5210,10 +4076,10 @@ function pathForOutput(workspace, p) {
 
 /***/ }),
 
-/***/ 25:
+/***/ 24:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(200)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(197)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -5251,7 +4117,7 @@ module.exports = PoolStats
 
 /***/ }),
 
-/***/ 26:
+/***/ 25:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -5277,7 +4143,7 @@ __export(throttlingRetryPolicy_exports, {
   throttlingRetryPolicyName: () => throttlingRetryPolicyName
 });
 module.exports = __toCommonJS(throttlingRetryPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(292);
 const throttlingRetryPolicyName = import_policies.throttlingRetryPolicyName;
 function throttlingRetryPolicy(options = {}) {
   return (0, import_policies.throttlingRetryPolicy)(options);
@@ -5288,14 +4154,14 @@ function throttlingRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 27:
+/***/ 26:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Busboy = __nccwpck_require__(427)
-const util = __nccwpck_require__(75)
+const Busboy = __nccwpck_require__(428)
+const util = __nccwpck_require__(72)
 const {
   ReadableStreamFrom,
   isBlobLike,
@@ -5303,22 +4169,22 @@ const {
   readableStreamClose,
   createDeferredPromise,
   fullyReadBody
-} = __nccwpck_require__(532)
-const { FormData } = __nccwpck_require__(212)
-const { kState } = __nccwpck_require__(17)
-const { webidl } = __nccwpck_require__(470)
-const { DOMException, structuredClone } = __nccwpck_require__(33)
-const { Blob, File: NativeFile } = __nccwpck_require__(124)
-const { kBodyUsed } = __nccwpck_require__(200)
-const assert = __nccwpck_require__(542)
-const { isErrored } = __nccwpck_require__(75)
-const { isUint8Array, isArrayBuffer } = __nccwpck_require__(203)
+} = __nccwpck_require__(533)
+const { FormData } = __nccwpck_require__(209)
+const { kState } = __nccwpck_require__(16)
+const { webidl } = __nccwpck_require__(471)
+const { DOMException, structuredClone } = __nccwpck_require__(32)
+const { Blob, File: NativeFile } = __nccwpck_require__(121)
+const { kBodyUsed } = __nccwpck_require__(197)
+const assert = __nccwpck_require__(543)
+const { isErrored } = __nccwpck_require__(72)
+const { isUint8Array, isArrayBuffer } = __nccwpck_require__(200)
 const { File: UndiciFile } = __nccwpck_require__(373)
-const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(28)
+const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(27)
 
 let random
 try {
-  const crypto = __nccwpck_require__(282)
+  const crypto = __nccwpck_require__(281)
   random = (max) => crypto.randomInt(0, max)
 } catch {
   random = (max) => Math.floor(Math.random(max))
@@ -5334,7 +4200,7 @@ const textDecoder = new TextDecoder()
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 function extractBody (object, keepalive = false) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(265).ReadableStream)
+    ReadableStream = (__nccwpck_require__(263).ReadableStream)
   }
 
   // 1. Let stream be null.
@@ -5555,7 +4421,7 @@ function extractBody (object, keepalive = false) {
 function safelyExtractBody (object, keepalive = false) {
   if (!ReadableStream) {
     // istanbul ignore next
-    ReadableStream = (__nccwpck_require__(265).ReadableStream)
+    ReadableStream = (__nccwpck_require__(263).ReadableStream)
   }
 
   // To safely extract a body and a `Content-Type` value from
@@ -5909,12 +4775,12 @@ module.exports = {
 
 /***/ }),
 
-/***/ 28:
+/***/ 27:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const assert = __nccwpck_require__(542)
-const { atob } = __nccwpck_require__(124)
-const { isomorphicDecode } = __nccwpck_require__(532)
+const assert = __nccwpck_require__(543)
+const { atob } = __nccwpck_require__(121)
+const { isomorphicDecode } = __nccwpck_require__(533)
 
 const encoder = new TextEncoder()
 
@@ -6543,7 +5409,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 29:
+/***/ 28:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -6557,10 +5423,10 @@ module.exports = {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(220);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(184));
-const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
+const tslib_1 = __nccwpck_require__(219);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const Parameters = tslib_1.__importStar(__nccwpck_require__(68));
 /** Class containing AppendBlob operations. */
 class AppendBlobImpl {
     client;
@@ -6778,7 +5644,7 @@ const sealOperationSpec = {
 
 /***/ }),
 
-/***/ 30:
+/***/ 29:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -6866,7 +5732,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 
 /***/ }),
 
-/***/ 31:
+/***/ 30:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -6892,9 +5758,9 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(407);
-var import_retryPolicy = __nccwpck_require__(18);
-var import_constants = __nccwpck_require__(52);
+var import_exponentialRetryStrategy = __nccwpck_require__(408);
+var import_retryPolicy = __nccwpck_require__(17);
+var import_constants = __nccwpck_require__(50);
 const systemErrorRetryPolicyName = "systemErrorRetryPolicy";
 function systemErrorRetryPolicy(options = {}) {
   return {
@@ -6919,7 +5785,7 @@ function systemErrorRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 32:
+/***/ 31:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -6960,13 +5826,13 @@ function rangeResponseFromModel(response) {
 
 /***/ }),
 
-/***/ 33:
+/***/ 32:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(328)
+const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(326)
 
 const corsSafeListedMethods = ['GET', 'HEAD', 'POST']
 const corsSafeListedMethodsSet = new Set(corsSafeListedMethods)
@@ -7119,266 +5985,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 34:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Wire `soldr load` into the cargo-registry-cache restore path on Windows
-// runners where Defender's per-CreateFile scan + NTFS overhead dominate
-// the wall clock for serial tar extraction. See zackees/setup-soldr#260
-// and zackees/soldr#575.
-//
-// Strategy:
-// - Detect the archive's first tar entry. If it's `SOLDR_MANIFEST.pb`,
-//   the archive was produced by `soldr save` and we can use `soldr load`
-//   for parallel extraction.
-// - Otherwise fall through to the existing tar/zstd path so legacy
-//   archives keep working.
-//
-// The detection avoids fully decompressing the archive — we only read
-// the first ~2 KiB of decompressed bytes (one tar block of 512 bytes
-// minimum, plus zstd frame slack).
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.CARGO_REGISTRY_VIA_SOLDR_ENV = exports.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP = exports.MIN_SOLDR_VERSION_FOR_LOAD = void 0;
-exports.cargoRegistryViaSoldrEnvOn = cargoRegistryViaSoldrEnvOn;
-exports.semverGte = semverGte;
-exports.detectSoldrManifest = detectSoldrManifest;
-exports.tryLoadViaSoldr = tryLoadViaSoldr;
-exports.trySaveViaSoldr = trySaveViaSoldr;
-const fs = __importStar(__nccwpck_require__(114));
-const exec = __importStar(__nccwpck_require__(20));
-/** Min soldr version with parallel-extract `soldr load`. Released in 0.7.46 alongside zackees/soldr#575. */
-exports.MIN_SOLDR_VERSION_FOR_LOAD = "0.7.46";
-/**
- * Min soldr version safe to use for `soldr save`/`soldr load` round-trip
- * on cargo-registry cache. 0.7.47 includes zackees/soldr#591 (+x bit
- * preservation); 0.7.46 alone would corrupt executable cache files
- * (cargo `build-script-build` failed `execve` with EACCES). (#263)
- */
-exports.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP = "0.7.47";
-/**
- * Env var that opts cargo-registry-cache into the `soldr save`/`soldr load`
- * round-trip. Default off so the v0.9.20 wire-in stays dormant and the
- * legacy tar+zstd path keeps running until #263's measurement validates
- * the Windows wall-clock improvement.
- */
-exports.CARGO_REGISTRY_VIA_SOLDR_ENV = "SOLDR_CARGO_REGISTRY_VIA_SOLDR";
-/** True when [[CARGO_REGISTRY_VIA_SOLDR_ENV]] is set to a truthy value. */
-function cargoRegistryViaSoldrEnvOn() {
-    const raw = (process.env[exports.CARGO_REGISTRY_VIA_SOLDR_ENV] ?? "").trim().toLowerCase();
-    return raw !== "" && raw !== "0" && raw !== "false" && raw !== "no" && raw !== "off";
-}
-/** Filename of the manifest at the root of every `soldr save` archive. */
-const SOLDR_MANIFEST_NAME = "SOLDR_MANIFEST.pb";
-/** Parse a `MAJOR.MINOR.PATCH` prefix from a version string. */
-function parseSemver(value) {
-    const m = value.trim().replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)/);
-    if (!m)
-        return null;
-    return [Number(m[1]), Number(m[2]), Number(m[3])];
-}
-/** Compare two semvers; `true` if `value >= minimum`. */
-function semverGte(value, minimum) {
-    const got = parseSemver(value);
-    const want = parseSemver(minimum);
-    if (!got || !want)
-        return false;
-    for (let i = 0; i < 3; i += 1) {
-        if (got[i] > want[i])
-            return true;
-        if (got[i] < want[i])
-            return false;
-    }
-    return true;
-}
-/**
- * Sniff whether the archive's first tar entry is `SOLDR_MANIFEST.pb`,
- * indicating a `soldr save` archive. Returns `false` on any read or
- * decode error — the caller should fall through to the legacy path.
- *
- * Uses synchronous `tar -tf` + `head -1` via `spawnSync` so the
- * subprocesses are guaranteed to be reaped before this function
- * returns (avoiding test-runner timeout from leaked descriptors).
- */
-async function detectSoldrManifest(archivePath) {
-    const { spawnSync } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 202, 23));
-    // We invoke tar with `-tf <archive>` directly — bsdtar (Windows) and
-    // GNU tar (Linux/macOS) both auto-detect zstd by magic byte on modern
-    // versions. Bounded by `timeout: 5000ms`; if tar takes longer than
-    // that on a single header read, we treat the archive as not-soldr.
-    let res;
-    try {
-        res = spawnSync("tar", ["-tf", archivePath], {
-            encoding: "utf8",
-            timeout: 5000,
-            maxBuffer: 1024 * 1024,
-        });
-    }
-    catch {
-        return false;
-    }
-    if (res.error || res.status !== 0)
-        return false;
-    const first = (res.stdout ?? "").split(/\r?\n/, 2)[0]?.trim();
-    return first === SOLDR_MANIFEST_NAME;
-}
-/**
- * Attempt to invoke `soldr load` for parallel extraction. Returns
- * `{ used: false }` when the binary isn't available, the version is
- * too old, or the archive isn't in soldr format. Throws only on a
- * genuine extraction failure (so the caller can decide to fall back).
- */
-async function tryLoadViaSoldr(opts) {
-    const t0 = Date.now();
-    const noOp = { used: false, durationMs: 0 };
-    const log = opts.log ?? (() => undefined);
-    if (!opts.soldrPath) {
-        if (opts.debug)
-            log(`[debug] soldr-load-shim: no soldr binary path supplied`);
-        return noOp;
-    }
-    if (!semverGte(opts.soldrVersion, exports.MIN_SOLDR_VERSION_FOR_LOAD)) {
-        if (opts.debug) {
-            log(`[debug] soldr-load-shim: soldr ${opts.soldrVersion} < ${exports.MIN_SOLDR_VERSION_FOR_LOAD}; falling back to tar+zstd`);
-        }
-        return noOp;
-    }
-    try {
-        const st = await fs.stat(opts.archivePath);
-        if (!st.isFile())
-            return noOp;
-    }
-    catch {
-        return noOp;
-    }
-    const isSoldrFormat = await detectSoldrManifest(opts.archivePath);
-    if (!isSoldrFormat) {
-        if (opts.debug) {
-            log(`[debug] soldr-load-shim: ${opts.archivePath} is not a soldr-format archive (no SOLDR_MANIFEST.pb); falling back to tar+zstd`);
-        }
-        return noOp;
-    }
-    const args = ["load", "--archive", opts.archivePath, "--cache-dir", opts.targetDir];
-    if (opts.autoDefenderExclude && process.platform === "win32") {
-        args.push("--auto-defender-exclude");
-    }
-    if (opts.profileExtract) {
-        args.push("--profile-extract");
-    }
-    if (opts.debug)
-        log(`[debug] soldr-load-shim: invoking ${opts.soldrPath} ${args.join(" ")}`);
-    await exec.exec(opts.soldrPath, args);
-    return { used: true, durationMs: Date.now() - t0 };
-}
-/**
- * Attempt to bundle the cache directory via `soldr save` so the matching
- * `soldr load` (in main.ts) can pick up the parallel-extract path. Returns
- * `{ used: false }` when gated off (env var, missing binary, too-old
- * version, extras present, or any throw). Produces a soldr-format archive
- * with `SOLDR_MANIFEST.pb` at the root + `cache/...` entries. (#263)
- */
-async function trySaveViaSoldr(opts) {
-    const t0 = Date.now();
-    const noOp = { used: false, archivePath: null, archiveBytes: 0, durationMs: 0 };
-    const log = opts.log ?? (() => undefined);
-    if (!cargoRegistryViaSoldrEnvOn()) {
-        if (opts.debug) {
-            log(`[debug] soldr-save-shim: ${exports.CARGO_REGISTRY_VIA_SOLDR_ENV} not set; deferring to legacy tar+zstd save`);
-        }
-        return noOp;
-    }
-    if (!opts.soldrPath) {
-        if (opts.debug)
-            log(`[debug] soldr-save-shim: no soldr binary path supplied`);
-        return noOp;
-    }
-    if (!semverGte(opts.soldrVersion, exports.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP)) {
-        if (opts.debug) {
-            log(`[debug] soldr-save-shim: soldr ${opts.soldrVersion} < ${exports.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP}; falling back to legacy save`);
-        }
-        return noOp;
-    }
-    if (opts.extraBasenames && opts.extraBasenames.length > 0) {
-        if (opts.debug) {
-            log(`[debug] soldr-save-shim: extraBasenames=[${opts.extraBasenames.join(",")}] not yet supported by soldr save; falling back to legacy`);
-        }
-        return noOp;
-    }
-    try {
-        const st = await fs.stat(opts.cacheDir);
-        if (!st.isDirectory())
-            return noOp;
-    }
-    catch {
-        return noOp;
-    }
-    const args = [
-        "save",
-        "--cache-dir",
-        opts.cacheDir,
-        "--out",
-        opts.archivePath,
-    ];
-    if (opts.debug)
-        log(`[debug] soldr-save-shim: invoking ${opts.soldrPath} ${args.join(" ")}`);
-    try {
-        await exec.exec(opts.soldrPath, args);
-    }
-    catch (err) {
-        if (opts.debug) {
-            log(`[debug] soldr-save-shim: invocation threw: ${err instanceof Error ? err.message : String(err)}`);
-        }
-        return noOp;
-    }
-    let archiveBytes = 0;
-    try {
-        archiveBytes = (await fs.stat(opts.archivePath)).size;
-    }
-    catch {
-        // Soldr save claimed success but archive vanished — fall back.
-        return noOp;
-    }
-    return { used: true, archivePath: opts.archivePath, archiveBytes, durationMs: Date.now() - t0 };
-}
-
-
-/***/ }),
-
-/***/ 35:
+/***/ 33:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7387,8 +5994,8 @@ async function trySaveViaSoldr(opts) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tracingClient = void 0;
-const core_tracing_1 = __nccwpck_require__(86);
-const constants_js_1 = __nccwpck_require__(155);
+const core_tracing_1 = __nccwpck_require__(83);
+const constants_js_1 = __nccwpck_require__(152);
 /**
  * Creates a span using the global tracer.
  * @internal
@@ -7402,7 +6009,7 @@ exports.tracingClient = (0, core_tracing_1.createTracingClient)({
 
 /***/ }),
 
-/***/ 36:
+/***/ 34:
 /***/ ((module) => {
 
 "use strict";
@@ -7410,7 +6017,7 @@ module.exports = require("console");
 
 /***/ }),
 
-/***/ 37:
+/***/ 35:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7420,7 +6027,7 @@ module.exports = require("console");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AzureSASCredential = void 0;
 exports.isSASCredential = isSASCredential;
-const core_util_1 = __nccwpck_require__(16);
+const core_util_1 = __nccwpck_require__(15);
 /**
  * A static-signature-based credential that supports updating
  * the underlying signature value.
@@ -7473,7 +6080,7 @@ function isSASCredential(credential) {
 
 /***/ }),
 
-/***/ 38:
+/***/ 36:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -7512,18 +6119,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.reserveCache = exports.downloadCache = exports.getCacheEntry = void 0;
-const core = __importStar(__nccwpck_require__(474));
-const http_client_1 = __nccwpck_require__(293);
-const auth_1 = __nccwpck_require__(30);
-const fs = __importStar(__nccwpck_require__(546));
-const url_1 = __nccwpck_require__(91);
-const utils = __importStar(__nccwpck_require__(81));
-const uploadUtils_1 = __nccwpck_require__(166);
+const core = __importStar(__nccwpck_require__(475));
+const http_client_1 = __nccwpck_require__(291);
+const auth_1 = __nccwpck_require__(29);
+const fs = __importStar(__nccwpck_require__(547));
+const url_1 = __nccwpck_require__(88);
+const utils = __importStar(__nccwpck_require__(78));
+const uploadUtils_1 = __nccwpck_require__(163);
 const downloadUtils_1 = __nccwpck_require__(3);
-const options_1 = __nccwpck_require__(273);
-const requestUtils_1 = __nccwpck_require__(269);
-const config_1 = __nccwpck_require__(41);
-const user_agent_1 = __nccwpck_require__(371);
+const options_1 = __nccwpck_require__(271);
+const requestUtils_1 = __nccwpck_require__(267);
+const config_1 = __nccwpck_require__(39);
+const user_agent_1 = __nccwpck_require__(370);
 function getCacheApiUrl(resource) {
     const baseUrl = (0, config_1.getCacheServiceURL)();
     if (!baseUrl) {
@@ -7736,7 +6343,7 @@ exports.saveCache = saveCache;
 
 /***/ }),
 
-/***/ 39:
+/***/ 37:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -7762,7 +6369,7 @@ __export(throttlingRetryStrategy_exports, {
   throttlingRetryStrategy: () => throttlingRetryStrategy
 });
 module.exports = __toCommonJS(throttlingRetryStrategy_exports);
-var import_helpers = __nccwpck_require__(469);
+var import_helpers = __nccwpck_require__(470);
 const RetryAfterHeader = "Retry-After";
 const AllRetryAfterHeaders = ["retry-after-ms", "x-ms-retry-after-ms", RetryAfterHeader];
 function getRetryAfterInMs(response) {
@@ -7808,7 +6415,7 @@ function throttlingRetryStrategy() {
 
 /***/ }),
 
-/***/ 40:
+/***/ 38:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7882,7 +6489,7 @@ exports.PathStylePorts = [
 
 /***/ }),
 
-/***/ 41:
+/***/ 39:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7926,7 +6533,7 @@ exports.getCacheServiceURL = getCacheServiceURL;
 
 /***/ }),
 
-/***/ 42:
+/***/ 40:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7935,7 +6542,7 @@ exports.getCacheServiceURL = getCacheServiceURL;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isKeyCredential = isKeyCredential;
-const core_util_1 = __nccwpck_require__(16);
+const core_util_1 = __nccwpck_require__(15);
 /**
  * Tests an object to determine whether it implements KeyCredential.
  *
@@ -7948,7 +6555,7 @@ function isKeyCredential(credential) {
 
 /***/ }),
 
-/***/ 43:
+/***/ 41:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -7977,9 +6584,9 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_https_proxy_agent = __nccwpck_require__(137);
-var import_http_proxy_agent = __nccwpck_require__(229);
-var import_log = __nccwpck_require__(158);
+var import_https_proxy_agent = __nccwpck_require__(134);
+var import_http_proxy_agent = __nccwpck_require__(227);
+var import_log = __nccwpck_require__(155);
 const HTTPS_PROXY = "HTTPS_PROXY";
 const HTTP_PROXY = "HTTP_PROXY";
 const ALL_PROXY = "ALL_PROXY";
@@ -8134,7 +6741,7 @@ function proxyPolicy(proxySettings, options) {
 
 /***/ }),
 
-/***/ 44:
+/***/ 42:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -8146,15 +6753,15 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 45:
+/***/ 43:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Headers, HeadersList, fill } = __nccwpck_require__(530)
-const { extractBody, cloneBody, mixinBody } = __nccwpck_require__(27)
-const util = __nccwpck_require__(75)
+const { Headers, HeadersList, fill } = __nccwpck_require__(531)
+const { extractBody, cloneBody, mixinBody } = __nccwpck_require__(26)
+const util = __nccwpck_require__(72)
 const { kEnumerableProperty } = util
 const {
   isValidReasonPhrase,
@@ -8164,22 +6771,22 @@ const {
   serializeJavascriptValueToJSONString,
   isErrorLike,
   isomorphicEncode
-} = __nccwpck_require__(532)
+} = __nccwpck_require__(533)
 const {
   redirectStatusSet,
   nullBodyStatus,
   DOMException
-} = __nccwpck_require__(33)
-const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(17)
-const { webidl } = __nccwpck_require__(470)
-const { FormData } = __nccwpck_require__(212)
-const { getGlobalOrigin } = __nccwpck_require__(145)
-const { URLSerializer } = __nccwpck_require__(28)
-const { kHeadersList, kConstruct } = __nccwpck_require__(200)
-const assert = __nccwpck_require__(542)
-const { types } = __nccwpck_require__(128)
+} = __nccwpck_require__(32)
+const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(16)
+const { webidl } = __nccwpck_require__(471)
+const { FormData } = __nccwpck_require__(209)
+const { getGlobalOrigin } = __nccwpck_require__(142)
+const { URLSerializer } = __nccwpck_require__(27)
+const { kHeadersList, kConstruct } = __nccwpck_require__(197)
+const assert = __nccwpck_require__(543)
+const { types } = __nccwpck_require__(125)
 
-const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(265).ReadableStream)
+const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(263).ReadableStream)
 const textEncoder = new TextEncoder('utf-8')
 
 // https://fetch.spec.whatwg.org/#response-class
@@ -8725,7 +7332,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 46:
+/***/ 44:
 /***/ ((module) => {
 
 "use strict";
@@ -8787,7 +7394,7 @@ module.exports = Decoder
 
 /***/ }),
 
-/***/ 47:
+/***/ 45:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -8813,8 +7420,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
-const pathHelper = __importStar(__nccwpck_require__(226));
-const internal_match_kind_1 = __nccwpck_require__(544);
+const pathHelper = __importStar(__nccwpck_require__(224));
+const internal_match_kind_1 = __nccwpck_require__(545);
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Given an array of patterns, returns an array of paths to search.
@@ -8888,7 +7495,7 @@ exports.partialMatch = partialMatch;
 
 /***/ }),
 
-/***/ 48:
+/***/ 46:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -8900,7 +7507,7 @@ exports.AzureLogger = void 0;
 exports.setLogLevel = setLogLevel;
 exports.getLogLevel = getLogLevel;
 exports.createClientLogger = createClientLogger;
-const logger_1 = __nccwpck_require__(154);
+const logger_1 = __nccwpck_require__(151);
 const context = (0, logger_1.createLoggerContext)({
     logLevelEnvVarName: "AZURE_LOG_LEVEL",
     namespace: "azure",
@@ -8941,7 +7548,7 @@ function createClientLogger(namespace) {
 
 /***/ }),
 
-/***/ 49:
+/***/ 47:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -8985,7 +7592,7 @@ exports.CacheFileSizeLimit = 10 * Math.pow(1024, 3); // 10GiB per repository
 
 /***/ }),
 
-/***/ 50:
+/***/ 48:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -9038,7 +7645,7 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
 
 /***/ }),
 
-/***/ 51:
+/***/ 49:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9052,10 +7659,10 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(220);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(184));
-const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
+const tslib_1 = __nccwpck_require__(219);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const Parameters = tslib_1.__importStar(__nccwpck_require__(68));
 /** Class containing Blob operations. */
 class BlobImpl {
     client;
@@ -10080,7 +8687,7 @@ const setTagsOperationSpec = {
 
 /***/ }),
 
-/***/ 52:
+/***/ 50:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -10115,398 +8722,7 @@ const DEFAULT_RETRY_POLICY_COUNT = 3;
 
 /***/ }),
 
-/***/ 53:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Verbose diagnostic dump emitted when the action receives `logging: true`.
-//
-// The goal is to make cache-behavior surprises trivially debuggable from a
-// single CI run. The dump bundles:
-//   - every observed INPUT_* env var (so the kebab-vs-underscore plumbing
-//     bug that motivated this module is visible without re-running)
-//   - the parsed RawInputs struct
-//   - every constructed cache key with restore-key fallbacks
-//   - resolved env exports (SOLDR_*, ZCCACHE_*, SETUP_SOLDR_*)
-//   - cache restore/save outcomes recorded so far
-//   - the final cache summary + compile-cache report in post phase
-//
-// Token-shaped values are redacted before printing.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.redactValue = redactValue;
-exports.captureProcessSnapshot = captureProcessSnapshot;
-exports.dumpDiagnostics = dumpDiagnostics;
-exports.loggingEnabled = loggingEnabled;
-const fs = __importStar(__nccwpck_require__(257));
-const node_child_process_1 = __nccwpck_require__(202);
-const compile_journal_js_1 = __nccwpck_require__(284);
-const ENV_KEY_PREFIXES = [
-    "INPUT_",
-    "SOLDR_",
-    "ZCCACHE_",
-    "SCCACHE_",
-    "SETUP_SOLDR_",
-    "GITHUB_",
-    "RUNNER_",
-    "ACTION_",
-    "CARGO_",
-    "RUSTUP_",
-    "RUSTC_",
-];
-const SECRET_KEY_PATTERN = /(token|secret|password|^.*_pass$|api[_-]?key|client[_-]?secret|webhook)/i;
-// Cache-key fields look secret-y but never are; never redact them.
-const NEVER_REDACT_PATTERN = /(_key$|cache[-_]key|cache[-_]keys$|key[-_]suffix$|public[-_]key)/i;
-// #387 Feature 1: cache-encrypt-key IS a secret even though its name
-// matches NEVER_REDACT_PATTERN's `_key$`. core.setSecret() in resolve-setup
-// already marks the value for runtime log redaction by the Actions runner,
-// but the diagnostics dump has its own writer — belt-and-suspenders here.
-const FORCE_REDACT_PATTERN = /(encrypt[-_]?key|cache[-_]encrypt[-_]key|cipher[-_]key|aes[-_]key)/i;
-function redactValue(key, value) {
-    if (FORCE_REDACT_PATTERN.test(key))
-        return value ? "<redacted>" : "";
-    if (NEVER_REDACT_PATTERN.test(key))
-        return value;
-    if (SECRET_KEY_PATTERN.test(key))
-        return value ? "<redacted>" : "";
-    return value;
-}
-function pickEnv(env) {
-    const pairs = [];
-    for (const [k, v] of Object.entries(env)) {
-        if (v === undefined)
-            continue;
-        if (!ENV_KEY_PREFIXES.some((p) => k.startsWith(p)))
-            continue;
-        pairs.push([k, redactValue(k, v)]);
-    }
-    pairs.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
-    return pairs;
-}
-function rawInputsLines(inputs) {
-    const lines = [];
-    const entries = Object.entries(inputs).sort((a, b) => (a[0] < b[0] ? -1 : 1));
-    for (const [k, v] of entries) {
-        // #387 Feature 1: parsed RawInputs needs the same redaction as raw env —
-        // otherwise `cacheEncryptKey` lands here verbatim.
-        const safe = typeof v === "string" ? redactValue(k, v) : v;
-        lines.push(`  ${k}=${JSON.stringify(safe)}`);
-    }
-    return lines;
-}
-function cachePlanLines(result) {
-    const lines = [];
-    lines.push("  setup_cache:");
-    lines.push(`    key=${result.setupCache.key}`);
-    lines.push(`    restore_prefix=${result.setupCache.restorePrefix}`);
-    lines.push(`    paths=${JSON.stringify(result.setupCache.paths)}`);
-    lines.push(`    layout=${result.setupCache.layout}`);
-    lines.push("  build_cache:");
-    lines.push(`    key=${result.buildCache.key}`);
-    lines.push(`    restore_key_parent=${result.buildCache.restoreKeyParent || "(none)"}`);
-    lines.push(`    restore_key_toolchain=${result.buildCache.restoreKeyToolchain}`);
-    lines.push(`    restore_key_os_arch=${result.buildCache.restoreKeyOsArch}`);
-    lines.push(`    path=${result.buildCache.path}`);
-    lines.push(`    mode=${result.buildCache.mode}`);
-    lines.push("  target_cache:");
-    lines.push(`    enabled=${result.targetCache.enabled}`);
-    lines.push(`    key=${result.targetCache.key}`);
-    lines.push(`    restore_key_parent=${result.targetCache.restoreKeyParent || "(none)"}`);
-    lines.push(`    restore_key_lock=${result.targetCache.restoreKeyLock || "(none)"}`);
-    lines.push(`    restore_key_lockfile=${result.targetCache.restoreKeyLockfile || "(none)"}`);
-    lines.push(`    paths=${result.targetCache.paths}`);
-    lines.push(`    bundle_path=${result.targetCache.bundlePath}`);
-    lines.push(`    target_path=${result.targetCache.targetPath}`);
-    lines.push(`    effective_mode=${result.targetCache.effectiveMode}`);
-    lines.push(`    profile=${result.targetCache.profile}`);
-    lines.push("  cargo_registry_cache:");
-    lines.push(`    enabled=${result.cargoRegistryCache.enabled}`);
-    lines.push(`    key=${result.cargoRegistryCache.key}`);
-    lines.push(`    restore_prefix=${result.cargoRegistryCache.restorePrefix}`);
-    lines.push(`    path=${result.cargoRegistryCache.path}`);
-    // setup-soldr#102: sibling basenames bundled into the same archive.
-    const extras = result.cargoRegistryCache.extraBasenames;
-    lines.push(`    extra_basenames=${extras.length > 0 ? extras.join(",") : "(none)"}`);
-    return lines;
-}
-function envExportLines(result) {
-    const entries = Object.entries(result.envExports).sort((a, b) => (a[0] < b[0] ? -1 : 1));
-    return entries.map(([k, v]) => `  ${k}=${redactValue(k, v)}`);
-}
-function cacheOutcomeLines(outcomes) {
-    if (outcomes.length === 0)
-        return ["  (no outcomes recorded yet)"];
-    const lines = [];
-    for (const o of outcomes) {
-        lines.push(`  [${o.operation}] ${o.label}: hit=${o.hit} matched=${o.matchedKey || "(none)"} ` +
-            `key=${o.key}${o.status ? ` status=${o.status}` : ""} duration_ms=${o.durationMs}`);
-        if (o.archiveBytes !== null) {
-            lines.push(`    archive_bytes=${o.archiveBytes} inflated_bytes=${o.inflatedBytes ?? "?"} files=${o.fileCount ?? "?"}`);
-        }
-        if (o.payload) {
-            lines.push(`    payload_bytes=${o.payload.bytes} payload_files=${o.payload.files} ` +
-                `symlinks=${o.payload.symlinks} dirs=${o.payload.directories}`);
-            if (o.payload.topFiles.length > 0) {
-                lines.push(`    top_files=${o.payload.topFiles.map((entry) => `${entry.path}:${entry.bytes}`).join(",")}`);
-            }
-            if (o.payload.skipped.length > 0) {
-                lines.push(`    skipped=${o.payload.skipped.map((entry) => `${entry.reason}:${entry.count}`).join(",")}`);
-            }
-        }
-    }
-    return lines;
-}
-/**
- * Capture a runtime process snapshot via `ps` (Unix) or `tasklist`
- * (Windows). Returns null only on an actual exec failure (binary
- * missing, etc.); a non-zero exit is reported in the result so the
- * stderr can be inspected.
- *
- * Why this lives here: the post step uses it to expose orphan daemons
- * (e.g. zccache-daemon processes that survive `soldr cache shutdown`
- * and get SIGKILL'd by the runner) so root-cause analysis doesn't
- * require another build.
- */
-function captureProcessSnapshot() {
-    const isWindows = process.platform === "win32";
-    const cmd = isWindows ? "tasklist" : "ps";
-    // Unix: print pid, ppid, user, state, command-name, full-args.
-    // BSD ps (macOS) supports the same -o keys but uses `command` instead
-    // of `args` — accept both via the column listing.
-    const args = isWindows
-        ? ["/V", "/FO", "CSV", "/NH"]
-        : ["-eo", "pid,ppid,user,stat,comm,args"];
-    try {
-        const result = (0, node_child_process_1.spawnSync)(cmd, args, {
-            encoding: "utf8",
-            maxBuffer: 8 * 1024 * 1024,
-            timeout: 15_000,
-        });
-        return {
-            cmd: `${cmd} ${args.join(" ")}`,
-            stdout: result.stdout ?? "",
-            stderr: result.stderr ?? "",
-            exitCode: result.status,
-        };
-    }
-    catch {
-        return null;
-    }
-}
-/**
- * Emit the full diagnostic dump to the logger and (optionally) the step summary.
- * Safe to call when `result`, `cacheOutcomes`, or `finalSummary` are missing —
- * each section is independent.
- */
-function dumpDiagnostics(opts) {
-    const lines = [];
-    const header = `=== DIAGNOSTIC DUMP (phase=${opts.phase}) ===`;
-    const footer = "=== END DIAGNOSTIC DUMP ===";
-    lines.push(header);
-    lines.push("[env: observed INPUT_/SOLDR_/ZCCACHE_/SETUP_SOLDR_/GITHUB_/RUNNER_/ACTION_/CARGO_/RUSTUP_/RUSTC_]");
-    const envPairs = pickEnv(opts.env);
-    if (envPairs.length === 0) {
-        lines.push("  (none observed)");
-    }
-    else {
-        for (const [k, v] of envPairs) {
-            lines.push(`  ${k}=${v}`);
-        }
-    }
-    if (opts.rawInputs) {
-        lines.push("[raw_inputs: parsed RawInputs after kebab-case lookup]");
-        lines.push(...rawInputsLines(opts.rawInputs));
-    }
-    if (opts.result) {
-        lines.push("[cache_plans: every constructed cache key + restore-key fallbacks]");
-        lines.push(...cachePlanLines(opts.result));
-        lines.push("[env_exports: resolved SOLDR_/ZCCACHE_/etc env exports]");
-        if (Object.keys(opts.result.envExports).length === 0) {
-            lines.push("  (none)");
-        }
-        else {
-            lines.push(...envExportLines(opts.result));
-        }
-        lines.push("[resolved_state]");
-        lines.push(`  enabled=${opts.result.enabled}`);
-        lines.push(`  workspace=${opts.result.workspace}`);
-        lines.push(`  cache_root=${opts.result.cacheRoot}`);
-        lines.push(`  soldr_root=${opts.result.soldrRoot}`);
-        lines.push(`  cargo_home=${opts.result.cargoHome}`);
-        lines.push(`  rustup_home=${opts.result.rustupHome}`);
-        lines.push(`  soldr_path=${opts.result.soldrPath}`);
-        lines.push(`  soldr_repo=${opts.result.soldrRepo}`);
-        lines.push(`  soldr_ref=${opts.result.soldrRef || "(release)"}`);
-        lines.push(`  soldr_version_requested=${opts.result.soldrVersionRequested}`);
-        lines.push(`  soldr_version_resolved=${opts.result.soldrVersionResolved}`);
-        lines.push(`  toolchain_channel=${opts.result.toolchain.channel}`);
-        lines.push(`  toolchain_cache_channel=${opts.result.toolchain.cacheChannel}`);
-        lines.push(`  rustup_strategy=${opts.result.rustupStrategy}`);
-        lines.push(`  shims_enabled=${opts.result.shimsEnabled}`);
-        lines.push(`  shims_dir=${opts.result.shimsDir}`);
-        lines.push(`  stats=${opts.result.stats}`);
-        lines.push(`  compile_cache_stats=${opts.result.compileCacheStats}`);
-        lines.push(`  debug_mode=${opts.result.debugMode}`);
-        lines.push(`  cache_shutdown_on_idle_seconds=${opts.result.cacheShutdownOnIdleSeconds ?? "(unset)"}`);
-    }
-    if (opts.cacheOutcomes !== undefined) {
-        lines.push("[cache_outcomes: per-layer restore/save results]");
-        lines.push(...cacheOutcomeLines(opts.cacheOutcomes));
-    }
-    if (opts.finalSummary) {
-        lines.push("[final_cache_summary]");
-        const json = JSON.stringify(opts.finalSummary, null, 2);
-        for (const line of json.split("\n")) {
-            lines.push(`  ${line}`);
-        }
-    }
-    // Per-compilation zccache journal — the answer to "warm reports
-    // hits=0; WHY did each lookup miss?". Reads the JSONL emitted by
-    // zccache for the just-finished session, summarizes it (outcome +
-    // miss_reason histograms, slowest misses with their miss_diff, a
-    // handful of verbatim records), and prints. Silently no-ops when
-    // the journal file isn't present.
-    if (opts.journalPath) {
-        try {
-            const records = (0, compile_journal_js_1.readJournal)(opts.journalPath);
-            if (records === null) {
-                lines.push(`[compile_journal]`);
-                lines.push(`  (journal file not found at ${opts.journalPath})`);
-            }
-            else if (records.length === 0) {
-                lines.push(`[compile_journal]`);
-                lines.push(`  (journal file empty at ${opts.journalPath})`);
-            }
-            else {
-                lines.push(...(0, compile_journal_js_1.formatJournalSection)((0, compile_journal_js_1.summarize)(records)));
-            }
-        }
-        catch (err) {
-            lines.push(`[compile_journal]`);
-            lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
-        }
-        // Raw JSONL dump — verbatim file contents under the summary. Only
-        // emitted when the caller opts in (debug=true) because it's huge
-        // (one record per rustc invocation, frequently MBs of output).
-        if (opts.journalPrintRaw) {
-            try {
-                const raw = fs.readFileSync(opts.journalPath, "utf8");
-                const rawLines = raw.split(/\r?\n/).filter((l) => l.length > 0);
-                lines.push(`[compile_journal_raw: verbatim JSONL from ${opts.journalPath} — ${rawLines.length} records]`);
-                for (const rawLine of rawLines) {
-                    lines.push(`  ${rawLine}`);
-                }
-            }
-            catch (err) {
-                const code = err.code;
-                if (code === "ENOENT") {
-                    // Already noted by the summary section above; no need to repeat.
-                }
-                else {
-                    lines.push(`[compile_journal_raw]`);
-                    lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
-                }
-            }
-        }
-    }
-    // Rollups (per-extension / per-crate) from `soldr cache report --json`.
-    // The raw report is already parsed into finalSummary's
-    // compile_cache_report.report; we accept it as a separate
-    // `cacheReport` so callers can pass it without rebuilding the
-    // FinalCacheSummary shape.
-    if (opts.cacheReport) {
-        lines.push(...(0, compile_journal_js_1.formatRollupsSection)(opts.cacheReport));
-    }
-    // Process snapshot — captured by the caller via captureProcessSnapshot()
-    // when debug mode is on. Useful for spotting orphan daemons (e.g.
-    // zccache-daemon survivors after `soldr cache shutdown`) that the runner
-    // SIGKILLs at job cleanup.
-    if (opts.processSnapshot) {
-        const snap = opts.processSnapshot;
-        lines.push(`[processes: snapshot via \`${snap.cmd}\` exit=${snap.exitCode ?? "null"}]`);
-        if (snap.stderr.trim().length > 0) {
-            lines.push(`  stderr: ${snap.stderr.trim().replace(/\n+/g, " | ")}`);
-        }
-        const trimmed = snap.stdout.replace(/\r\n/g, "\n").trimEnd();
-        if (trimmed.length === 0) {
-            lines.push("  (no stdout)");
-        }
-        else {
-            for (const line of trimmed.split("\n")) {
-                lines.push(`  ${line}`);
-            }
-        }
-    }
-    lines.push(footer);
-    for (const line of lines) {
-        opts.logger.log(line);
-    }
-    if (opts.stepSummaryPath) {
-        appendToStepSummary(opts.stepSummaryPath, opts.phase, lines, opts.logger);
-    }
-}
-function appendToStepSummary(summaryPath, phase, lines, logger) {
-    const block = [
-        `### setup-soldr diagnostic dump (phase=${phase})`,
-        "",
-        "```",
-        ...lines,
-        "```",
-        "",
-    ];
-    try {
-        fs.appendFileSync(summaryPath, block.join("\n") + "\n", "utf8");
-    }
-    catch (err) {
-        logger.log(`diagnostics: failed to append to step summary: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-/**
- * Truthy check matching the rest of the action: "1", "true", "yes", "on".
- * Empty / unset / anything else is false.
- */
-function loggingEnabled(value) {
-    const v = (value ?? "").trim().toLowerCase();
-    return v === "1" || v === "true" || v === "yes" || v === "on";
-}
-
-
-/***/ }),
-
-/***/ 54:
+/***/ 51:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10515,10 +8731,10 @@ function loggingEnabled(value) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageBrowserPolicy = void 0;
-const RequestPolicy_js_1 = __nccwpck_require__(50);
-const core_util_1 = __nccwpck_require__(16);
-const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(490);
+const RequestPolicy_js_1 = __nccwpck_require__(48);
+const core_util_1 = __nccwpck_require__(15);
+const constants_js_1 = __nccwpck_require__(38);
+const utils_common_js_1 = __nccwpck_require__(491);
 /**
  * StorageBrowserPolicy will handle differences between Node.js and browser runtime, including:
  *
@@ -10564,14 +8780,14 @@ exports.StorageBrowserPolicy = StorageBrowserPolicy;
 
 /***/ }),
 
-/***/ 55:
+/***/ 52:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.containsMessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(417);
+const message_type_contract_1 = __nccwpck_require__(418);
 /**
  * Check if the provided object is a proto message.
  *
@@ -10586,7 +8802,7 @@ exports.containsMessageType = containsMessageType;
 
 /***/ }),
 
-/***/ 56:
+/***/ 53:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10595,8 +8811,8 @@ exports.containsMessageType = containsMessageType;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollHttpOperation = exports.isOperationError = exports.getResourceLocation = exports.getOperationStatus = exports.getOperationLocation = exports.initHttpOperation = exports.getStatusFromInitialResponse = exports.getErrorFromResponse = exports.parseRetryAfter = exports.inferLroMode = void 0;
-const operation_js_1 = __nccwpck_require__(146);
-const logger_js_1 = __nccwpck_require__(195);
+const operation_js_1 = __nccwpck_require__(143);
+const logger_js_1 = __nccwpck_require__(192);
 function getOperationLocationPollingUrl(inputs) {
     const { azureAsyncOperation, operationLocation } = inputs;
     return operationLocation !== null && operationLocation !== void 0 ? operationLocation : azureAsyncOperation;
@@ -10888,7 +9104,7 @@ exports.pollHttpOperation = pollHttpOperation;
 
 /***/ }),
 
-/***/ 57:
+/***/ 54:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -10982,7 +9198,7 @@ exports.Deferred = Deferred;
 
 /***/ }),
 
-/***/ 58:
+/***/ 55:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10994,14 +9210,14 @@ const {
   kResult,
   kAborted,
   kLastProgressEventFired
-} = __nccwpck_require__(475)
-const { ProgressEvent } = __nccwpck_require__(455)
-const { getEncoding } = __nccwpck_require__(103)
-const { DOMException } = __nccwpck_require__(33)
-const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(28)
-const { types } = __nccwpck_require__(128)
-const { StringDecoder } = __nccwpck_require__(156)
-const { btoa } = __nccwpck_require__(124)
+} = __nccwpck_require__(476)
+const { ProgressEvent } = __nccwpck_require__(456)
+const { getEncoding } = __nccwpck_require__(100)
+const { DOMException } = __nccwpck_require__(32)
+const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(27)
+const { types } = __nccwpck_require__(125)
+const { StringDecoder } = __nccwpck_require__(153)
+const { btoa } = __nccwpck_require__(121)
 
 /** @type {PropertyDescriptor} */
 const staticPropertyDescriptors = {
@@ -11382,7 +9598,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 59:
+/***/ 56:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -11455,16 +9671,16 @@ exports.saveCookCache = saveCookCache;
 exports.saveLayeredCookCache = saveLayeredCookCache;
 exports.parseCookFlags = parseCookFlags;
 exports.canonicalizeCookFlags = canonicalizeCookFlags;
-const node_crypto_1 = __nccwpck_require__(282);
-const fs = __importStar(__nccwpck_require__(257));
-const fsp = __importStar(__nccwpck_require__(114));
-const path = __importStar(__nccwpck_require__(522));
-const core = __importStar(__nccwpck_require__(474));
-const exec = __importStar(__nccwpck_require__(20));
-const cache = __importStar(__nccwpck_require__(218));
-const cache_compress_js_1 = __nccwpck_require__(480);
-const log_utils_js_1 = __nccwpck_require__(196);
-const two_phase_actions_cache_js_1 = __nccwpck_require__(148);
+const node_crypto_1 = __nccwpck_require__(281);
+const fs = __importStar(__nccwpck_require__(255));
+const fsp = __importStar(__nccwpck_require__(111));
+const path = __importStar(__nccwpck_require__(523));
+const core = __importStar(__nccwpck_require__(475));
+const exec = __importStar(__nccwpck_require__(19));
+const cache = __importStar(__nccwpck_require__(217));
+const cache_compress_js_1 = __nccwpck_require__(481);
+const log_utils_js_1 = __nccwpck_require__(193);
+const two_phase_actions_cache_js_1 = __nccwpck_require__(145);
 function layeredCookBaseReady(restore, loaded) {
     return restore.base.hit && loaded.baseLoaded;
 }
@@ -12328,12 +10544,12 @@ function canonicalizeCookFlags(flags) {
 
 /***/ }),
 
-/***/ 60:
+/***/ 57:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(415)
+const f = __nccwpck_require__(416)
 const DateTime = global.Date
 
 class Date extends DateTime {
@@ -12359,7 +10575,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 61:
+/***/ 58:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -12385,7 +10601,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(292);
 const defaultRetryPolicyName = import_policies.defaultRetryPolicyName;
 function defaultRetryPolicy(options = {}) {
   return (0, import_policies.defaultRetryPolicy)(options);
@@ -12396,7 +10612,7 @@ function defaultRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 62:
+/***/ 59:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -12453,15 +10669,15 @@ exports.UnaryCall = UnaryCall;
 
 /***/ }),
 
-/***/ 63:
+/***/ 60:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(104)
-const { states, opcodes } = __nccwpck_require__(482)
-const { MessageEvent, ErrorEvent } = __nccwpck_require__(258)
+const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(101)
+const { states, opcodes } = __nccwpck_require__(483)
+const { MessageEvent, ErrorEvent } = __nccwpck_require__(256)
 
 /* globals Blob */
 
@@ -12661,7 +10877,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 64:
+/***/ 61:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -12897,7 +11113,7 @@ exports.AccountSASPermissions = AccountSASPermissions;
 
 /***/ }),
 
-/***/ 65:
+/***/ 62:
 /***/ ((module) => {
 
 "use strict";
@@ -12905,7 +11121,7 @@ module.exports = require("http2");
 
 /***/ }),
 
-/***/ 66:
+/***/ 63:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -12926,7 +11142,7 @@ exports.terminalStates = ["succeeded", "canceled", "failed"];
 
 /***/ }),
 
-/***/ 67:
+/***/ 64:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -12942,15 +11158,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.internalCacheTwirpClient = void 0;
-const core_1 = __nccwpck_require__(474);
-const user_agent_1 = __nccwpck_require__(371);
-const errors_1 = __nccwpck_require__(314);
-const config_1 = __nccwpck_require__(41);
-const cacheUtils_1 = __nccwpck_require__(81);
-const auth_1 = __nccwpck_require__(30);
-const http_client_1 = __nccwpck_require__(293);
-const cache_twirp_client_1 = __nccwpck_require__(448);
-const util_1 = __nccwpck_require__(303);
+const core_1 = __nccwpck_require__(475);
+const user_agent_1 = __nccwpck_require__(370);
+const errors_1 = __nccwpck_require__(312);
+const config_1 = __nccwpck_require__(39);
+const cacheUtils_1 = __nccwpck_require__(78);
+const auth_1 = __nccwpck_require__(29);
+const http_client_1 = __nccwpck_require__(291);
+const cache_twirp_client_1 = __nccwpck_require__(449);
+const util_1 = __nccwpck_require__(301);
 /**
  * This class is a wrapper around the CacheServiceClientJSON class generated by Twirp.
  *
@@ -13095,19 +11311,19 @@ exports.internalCacheTwirpClient = internalCacheTwirpClient;
 
 /***/ }),
 
-/***/ 68:
+/***/ 65:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Dispatcher = __nccwpck_require__(494)
+const Dispatcher = __nccwpck_require__(495)
 const {
   ClientDestroyedError,
   ClientClosedError,
   InvalidArgumentError
-} = __nccwpck_require__(504)
-const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(200)
+} = __nccwpck_require__(505)
+const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(197)
 
 const kDestroyed = Symbol('destroyed')
 const kClosed = Symbol('closed')
@@ -13295,7 +11511,7 @@ module.exports = DispatcherBase
 
 /***/ }),
 
-/***/ 69:
+/***/ 66:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -13322,8 +11538,8 @@ __export(requestPolicyFactoryPolicy_exports, {
   requestPolicyFactoryPolicyName: () => requestPolicyFactoryPolicyName
 });
 module.exports = __toCommonJS(requestPolicyFactoryPolicy_exports);
-var import_util = __nccwpck_require__(115);
-var import_response = __nccwpck_require__(423);
+var import_util = __nccwpck_require__(112);
+var import_response = __nccwpck_require__(424);
 var HttpPipelineLogLevel = /* @__PURE__ */ ((HttpPipelineLogLevel2) => {
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["ERROR"] = 1] = "ERROR";
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["INFO"] = 3] = "INFO";
@@ -13366,25 +11582,25 @@ function createRequestPolicyFactoryPolicy(factories) {
 
 /***/ }),
 
-/***/ 70:
+/***/ 67:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const core_util_1 = __nccwpck_require__(16);
-const core_auth_1 = __nccwpck_require__(528);
-const storage_common_1 = __nccwpck_require__(285);
-const Pipeline_js_1 = __nccwpck_require__(187);
-const StorageClient_js_1 = __nccwpck_require__(468);
-const tracing_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(161);
-const BlobSASSignatureValues_js_1 = __nccwpck_require__(74);
-const BlobLeaseClient_js_1 = __nccwpck_require__(209);
-const Clients_js_1 = __nccwpck_require__(189);
-const BlobBatchClient_js_1 = __nccwpck_require__(414);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const core_util_1 = __nccwpck_require__(15);
+const core_auth_1 = __nccwpck_require__(529);
+const storage_common_1 = __nccwpck_require__(283);
+const Pipeline_js_1 = __nccwpck_require__(184);
+const StorageClient_js_1 = __nccwpck_require__(469);
+const tracing_js_1 = __nccwpck_require__(33);
+const utils_common_js_1 = __nccwpck_require__(158);
+const BlobSASSignatureValues_js_1 = __nccwpck_require__(71);
+const BlobLeaseClient_js_1 = __nccwpck_require__(206);
+const Clients_js_1 = __nccwpck_require__(186);
+const BlobBatchClient_js_1 = __nccwpck_require__(415);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
  */
@@ -14670,7 +12886,7 @@ exports.ContainerClient = ContainerClient;
 
 /***/ }),
 
-/***/ 71:
+/***/ 68:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -14686,7 +12902,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.action3 = exports.action2 = exports.leaseId1 = exports.action1 = exports.proposedLeaseId = exports.duration = exports.action = exports.comp10 = exports.sourceLeaseId = exports.sourceContainerName = exports.comp9 = exports.deletedContainerVersion = exports.deletedContainerName = exports.comp8 = exports.containerAcl = exports.comp7 = exports.comp6 = exports.ifUnmodifiedSince = exports.ifModifiedSince = exports.leaseId = exports.preventEncryptionScopeOverride = exports.defaultEncryptionScope = exports.access = exports.metadata = exports.restype2 = exports.where = exports.comp5 = exports.multipartContentType = exports.contentLength = exports.comp4 = exports.body = exports.restype1 = exports.comp3 = exports.keyInfo = exports.include = exports.maxPageSize = exports.marker = exports.prefix = exports.comp2 = exports.comp1 = exports.accept1 = exports.requestId = exports.version = exports.timeoutInSeconds = exports.comp = exports.restype = exports.url = exports.accept = exports.blobServiceProperties = exports.contentType = void 0;
 exports.copySourceTags = exports.copySourceAuthorization = exports.sourceContentMD5 = exports.xMsRequiresSync = exports.legalHold1 = exports.sealBlob = exports.blobTagsString = exports.copySource = exports.sourceIfTags = exports.sourceIfNoneMatch = exports.sourceIfMatch = exports.sourceIfUnmodifiedSince = exports.sourceIfModifiedSince = exports.rehydratePriority = exports.tier = exports.comp14 = exports.encryptionScope = exports.legalHold = exports.comp13 = exports.immutabilityPolicyMode = exports.immutabilityPolicyExpiry = exports.comp12 = exports.blobContentDisposition = exports.blobContentLanguage = exports.blobContentEncoding = exports.blobContentMD5 = exports.blobContentType = exports.blobCacheControl = exports.expiresOn = exports.expiryOptions = exports.comp11 = exports.blobDeleteType = exports.deleteSnapshots = exports.ifTags = exports.ifNoneMatch = exports.ifMatch = exports.encryptionAlgorithm = exports.encryptionKeySha256 = exports.encryptionKey = exports.rangeGetContentCRC64 = exports.rangeGetContentMD5 = exports.range = exports.versionId = exports.snapshot = exports.delimiter = exports.startFrom = exports.include1 = exports.proposedLeaseId1 = exports.action4 = exports.breakPeriod = void 0;
 exports.listType = exports.comp25 = exports.blocks = exports.blockId = exports.comp24 = exports.copySourceBlobProperties = exports.blobType2 = exports.comp23 = exports.sourceRange1 = exports.appendPosition = exports.maxSize = exports.comp22 = exports.blobType1 = exports.comp21 = exports.sequenceNumberAction = exports.prevSnapshotUrl = exports.prevsnapshot = exports.comp20 = exports.range1 = exports.sourceContentCrc64 = exports.sourceRange = exports.sourceUrl = exports.pageWrite1 = exports.ifSequenceNumberEqualTo = exports.ifSequenceNumberLessThan = exports.ifSequenceNumberLessThanOrEqualTo = exports.pageWrite = exports.comp19 = exports.accept2 = exports.body1 = exports.contentType1 = exports.blobSequenceNumber = exports.blobContentLength = exports.blobType = exports.transactionalContentCrc64 = exports.transactionalContentMD5 = exports.tags = exports.ifNoneMatch1 = exports.ifMatch1 = exports.ifUnmodifiedSince1 = exports.ifModifiedSince1 = exports.comp18 = exports.comp17 = exports.queryRequest = exports.tier1 = exports.comp16 = exports.copyId = exports.copyActionAbortConstant = exports.comp15 = exports.fileRequestIntent = void 0;
-const mappers_js_1 = __nccwpck_require__(184);
+const mappers_js_1 = __nccwpck_require__(181);
 exports.contentType = {
     parameterPath: ["options", "contentType"],
     mapper: {
@@ -16356,14 +14572,14 @@ exports.listType = {
 
 /***/ }),
 
-/***/ 72:
+/***/ 69:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const inherits = (__nccwpck_require__(385).inherits)
-const ReadableStream = (__nccwpck_require__(442).Readable)
+const inherits = (__nccwpck_require__(384).inherits)
+const ReadableStream = (__nccwpck_require__(443).Readable)
 
 function PartStream (opts) {
   ReadableStream.call(this, opts)
@@ -16377,7 +14593,7 @@ module.exports = PartStream
 
 /***/ }),
 
-/***/ 73:
+/***/ 70:
 /***/ ((module) => {
 
 module.exports = 'AGFzbQEAAAABMAhgAX8Bf2ADf39/AX9gBH9/f38Bf2AAAGADf39/AGABfwBgAn9/AGAGf39/f39/AALLAQgDZW52GHdhc21fb25faGVhZGVyc19jb21wbGV0ZQACA2VudhV3YXNtX29uX21lc3NhZ2VfYmVnaW4AAANlbnYLd2FzbV9vbl91cmwAAQNlbnYOd2FzbV9vbl9zdGF0dXMAAQNlbnYUd2FzbV9vbl9oZWFkZXJfZmllbGQAAQNlbnYUd2FzbV9vbl9oZWFkZXJfdmFsdWUAAQNlbnYMd2FzbV9vbl9ib2R5AAEDZW52GHdhc21fb25fbWVzc2FnZV9jb21wbGV0ZQAAA0ZFAwMEAAAFAAAAAAAABQEFAAUFBQAABgAAAAAGBgYGAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQABAAABAQcAAAUFAwABBAUBcAESEgUDAQACBggBfwFBgNQECwfRBSIGbWVtb3J5AgALX2luaXRpYWxpemUACRlfX2luZGlyZWN0X2Z1bmN0aW9uX3RhYmxlAQALbGxodHRwX2luaXQAChhsbGh0dHBfc2hvdWxkX2tlZXBfYWxpdmUAQQxsbGh0dHBfYWxsb2MADAZtYWxsb2MARgtsbGh0dHBfZnJlZQANBGZyZWUASA9sbGh0dHBfZ2V0X3R5cGUADhVsbGh0dHBfZ2V0X2h0dHBfbWFqb3IADxVsbGh0dHBfZ2V0X2h0dHBfbWlub3IAEBFsbGh0dHBfZ2V0X21ldGhvZAARFmxsaHR0cF9nZXRfc3RhdHVzX2NvZGUAEhJsbGh0dHBfZ2V0X3VwZ3JhZGUAEwxsbGh0dHBfcmVzZXQAFA5sbGh0dHBfZXhlY3V0ZQAVFGxsaHR0cF9zZXR0aW5nc19pbml0ABYNbGxodHRwX2ZpbmlzaAAXDGxsaHR0cF9wYXVzZQAYDWxsaHR0cF9yZXN1bWUAGRtsbGh0dHBfcmVzdW1lX2FmdGVyX3VwZ3JhZGUAGhBsbGh0dHBfZ2V0X2Vycm5vABsXbGxodHRwX2dldF9lcnJvcl9yZWFzb24AHBdsbGh0dHBfc2V0X2Vycm9yX3JlYXNvbgAdFGxsaHR0cF9nZXRfZXJyb3JfcG9zAB4RbGxodHRwX2Vycm5vX25hbWUAHxJsbGh0dHBfbWV0aG9kX25hbWUAIBJsbGh0dHBfc3RhdHVzX25hbWUAIRpsbGh0dHBfc2V0X2xlbmllbnRfaGVhZGVycwAiIWxsaHR0cF9zZXRfbGVuaWVudF9jaHVua2VkX2xlbmd0aAAjHWxsaHR0cF9zZXRfbGVuaWVudF9rZWVwX2FsaXZlACQkbGxodHRwX3NldF9sZW5pZW50X3RyYW5zZmVyX2VuY29kaW5nACUYbGxodHRwX21lc3NhZ2VfbmVlZHNfZW9mAD8JFwEAQQELEQECAwQFCwYHNTk3MS8tJyspCrLgAkUCAAsIABCIgICAAAsZACAAEMKAgIAAGiAAIAI2AjggACABOgAoCxwAIAAgAC8BMiAALQAuIAAQwYCAgAAQgICAgAALKgEBf0HAABDGgICAACIBEMKAgIAAGiABQYCIgIAANgI4IAEgADoAKCABCwoAIAAQyICAgAALBwAgAC0AKAsHACAALQAqCwcAIAAtACsLBwAgAC0AKQsHACAALwEyCwcAIAAtAC4LRQEEfyAAKAIYIQEgAC0ALSECIAAtACghAyAAKAI4IQQgABDCgICAABogACAENgI4IAAgAzoAKCAAIAI6AC0gACABNgIYCxEAIAAgASABIAJqEMOAgIAACxAAIABBAEHcABDMgICAABoLZwEBf0EAIQECQCAAKAIMDQACQAJAAkACQCAALQAvDgMBAAMCCyAAKAI4IgFFDQAgASgCLCIBRQ0AIAAgARGAgICAAAAiAQ0DC0EADwsQyoCAgAAACyAAQcOWgIAANgIQQQ4hAQsgAQseAAJAIAAoAgwNACAAQdGbgIAANgIQIABBFTYCDAsLFgACQCAAKAIMQRVHDQAgAEEANgIMCwsWAAJAIAAoAgxBFkcNACAAQQA2AgwLCwcAIAAoAgwLBwAgACgCEAsJACAAIAE2AhALBwAgACgCFAsiAAJAIABBJEkNABDKgICAAAALIABBAnRBoLOAgABqKAIACyIAAkAgAEEuSQ0AEMqAgIAAAAsgAEECdEGwtICAAGooAgAL7gsBAX9B66iAgAAhAQJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAIABBnH9qDvQDY2IAAWFhYWFhYQIDBAVhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhBgcICQoLDA0OD2FhYWFhEGFhYWFhYWFhYWFhEWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYRITFBUWFxgZGhthYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2YTc4OTphYWFhYWFhYTthYWE8YWFhYT0+P2FhYWFhYWFhQGFhQWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYUJDREVGR0hJSktMTU5PUFFSU2FhYWFhYWFhVFVWV1hZWlthXF1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFeYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhX2BhC0Hhp4CAAA8LQaShgIAADwtBy6yAgAAPC0H+sYCAAA8LQcCkgIAADwtBq6SAgAAPC0GNqICAAA8LQeKmgIAADwtBgLCAgAAPC0G5r4CAAA8LQdekgIAADwtB75+AgAAPC0Hhn4CAAA8LQfqfgIAADwtB8qCAgAAPC0Gor4CAAA8LQa6ygIAADwtBiLCAgAAPC0Hsp4CAAA8LQYKigIAADwtBjp2AgAAPC0HQroCAAA8LQcqjgIAADwtBxbKAgAAPC0HfnICAAA8LQdKcgIAADwtBxKCAgAAPC0HXoICAAA8LQaKfgIAADwtB7a6AgAAPC0GrsICAAA8LQdSlgIAADwtBzK6AgAAPC0H6roCAAA8LQfyrgIAADwtB0rCAgAAPC0HxnYCAAA8LQbuggIAADwtB96uAgAAPC0GQsYCAAA8LQdexgIAADwtBoq2AgAAPC0HUp4CAAA8LQeCrgIAADwtBn6yAgAAPC0HrsYCAAA8LQdWfgIAADwtByrGAgAAPC0HepYCAAA8LQdSegIAADwtB9JyAgAAPC0GnsoCAAA8LQbGdgIAADwtBoJ2AgAAPC0G5sYCAAA8LQbywgIAADwtBkqGAgAAPC0GzpoCAAA8LQemsgIAADwtBrJ6AgAAPC0HUq4CAAA8LQfemgIAADwtBgKaAgAAPC0GwoYCAAA8LQf6egIAADwtBjaOAgAAPC0GJrYCAAA8LQfeigIAADwtBoLGAgAAPC0Gun4CAAA8LQcalgIAADwtB6J6AgAAPC0GTooCAAA8LQcKvgIAADwtBw52AgAAPC0GLrICAAA8LQeGdgIAADwtBja+AgAAPC0HqoYCAAA8LQbStgIAADwtB0q+AgAAPC0HfsoCAAA8LQdKygIAADwtB8LCAgAAPC0GpooCAAA8LQfmjgIAADwtBmZ6AgAAPC0G1rICAAA8LQZuwgIAADwtBkrKAgAAPC0G2q4CAAA8LQcKigIAADwtB+LKAgAAPC0GepYCAAA8LQdCigIAADwtBup6AgAAPC0GBnoCAAA8LEMqAgIAAAAtB1qGAgAAhAQsgAQsWACAAIAAtAC1B/gFxIAFBAEdyOgAtCxkAIAAgAC0ALUH9AXEgAUEAR0EBdHI6AC0LGQAgACAALQAtQfsBcSABQQBHQQJ0cjoALQsZACAAIAAtAC1B9wFxIAFBAEdBA3RyOgAtCy4BAn9BACEDAkAgACgCOCIERQ0AIAQoAgAiBEUNACAAIAQRgICAgAAAIQMLIAMLSQECf0EAIQMCQCAAKAI4IgRFDQAgBCgCBCIERQ0AIAAgASACIAFrIAQRgYCAgAAAIgNBf0cNACAAQcaRgIAANgIQQRghAwsgAwsuAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAIwIgRFDQAgACAEEYCAgIAAACEDCyADC0kBAn9BACEDAkAgACgCOCIERQ0AIAQoAggiBEUNACAAIAEgAiABayAEEYGAgIAAACIDQX9HDQAgAEH2ioCAADYCEEEYIQMLIAMLLgECf0EAIQMCQCAAKAI4IgRFDQAgBCgCNCIERQ0AIAAgBBGAgICAAAAhAwsgAwtJAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAIMIgRFDQAgACABIAIgAWsgBBGBgICAAAAiA0F/Rw0AIABB7ZqAgAA2AhBBGCEDCyADCy4BAn9BACEDAkAgACgCOCIERQ0AIAQoAjgiBEUNACAAIAQRgICAgAAAIQMLIAMLSQECf0EAIQMCQCAAKAI4IgRFDQAgBCgCECIERQ0AIAAgASACIAFrIAQRgYCAgAAAIgNBf0cNACAAQZWQgIAANgIQQRghAwsgAwsuAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAI8IgRFDQAgACAEEYCAgIAAACEDCyADC0kBAn9BACEDAkAgACgCOCIERQ0AIAQoAhQiBEUNACAAIAEgAiABayAEEYGAgIAAACIDQX9HDQAgAEGqm4CAADYCEEEYIQMLIAMLLgECf0EAIQMCQCAAKAI4IgRFDQAgBCgCQCIERQ0AIAAgBBGAgICAAAAhAwsgAwtJAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAIYIgRFDQAgACABIAIgAWsgBBGBgICAAAAiA0F/Rw0AIABB7ZOAgAA2AhBBGCEDCyADCy4BAn9BACEDAkAgACgCOCIERQ0AIAQoAkQiBEUNACAAIAQRgICAgAAAIQMLIAMLLgECf0EAIQMCQCAAKAI4IgRFDQAgBCgCJCIERQ0AIAAgBBGAgICAAAAhAwsgAwsuAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAIsIgRFDQAgACAEEYCAgIAAACEDCyADC0kBAn9BACEDAkAgACgCOCIERQ0AIAQoAigiBEUNACAAIAEgAiABayAEEYGAgIAAACIDQX9HDQAgAEH2iICAADYCEEEYIQMLIAMLLgECf0EAIQMCQCAAKAI4IgRFDQAgBCgCUCIERQ0AIAAgBBGAgICAAAAhAwsgAwtJAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAIcIgRFDQAgACABIAIgAWsgBBGBgICAAAAiA0F/Rw0AIABBwpmAgAA2AhBBGCEDCyADCy4BAn9BACEDAkAgACgCOCIERQ0AIAQoAkgiBEUNACAAIAQRgICAgAAAIQMLIAMLSQECf0EAIQMCQCAAKAI4IgRFDQAgBCgCICIERQ0AIAAgASACIAFrIAQRgYCAgAAAIgNBf0cNACAAQZSUgIAANgIQQRghAwsgAwsuAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAJMIgRFDQAgACAEEYCAgIAAACEDCyADCy4BAn9BACEDAkAgACgCOCIERQ0AIAQoAlQiBEUNACAAIAQRgICAgAAAIQMLIAMLLgECf0EAIQMCQCAAKAI4IgRFDQAgBCgCWCIERQ0AIAAgBBGAgICAAAAhAwsgAwtFAQF/AkACQCAALwEwQRRxQRRHDQBBASEDIAAtAChBAUYNASAALwEyQeUARiEDDAELIAAtAClBBUYhAwsgACADOgAuQQAL/gEBA39BASEDAkAgAC8BMCIEQQhxDQAgACkDIEIAUiEDCwJAAkAgAC0ALkUNAEEBIQUgAC0AKUEFRg0BQQEhBSAEQcAAcUUgA3FBAUcNAQtBACEFIARBwABxDQBBAiEFIARB//8DcSIDQQhxDQACQCADQYAEcUUNAAJAIAAtAChBAUcNACAALQAtQQpxDQBBBQ8LQQQPCwJAIANBIHENAAJAIAAtAChBAUYNACAALwEyQf//A3EiAEGcf2pB5ABJDQAgAEHMAUYNACAAQbACRg0AQQQhBSAEQShxRQ0CIANBiARxQYAERg0CC0EADwtBAEEDIAApAyBQGyEFCyAFC2IBAn9BACEBAkAgAC0AKEEBRg0AIAAvATJB//8DcSICQZx/akHkAEkNACACQcwBRg0AIAJBsAJGDQAgAC8BMCIAQcAAcQ0AQQEhASAAQYgEcUGABEYNACAAQShxRSEBCyABC6cBAQN/AkACQAJAIAAtACpFDQAgAC0AK0UNAEEAIQMgAC8BMCIEQQJxRQ0BDAILQQAhAyAALwEwIgRBAXFFDQELQQEhAyAALQAoQQFGDQAgAC8BMkH//wNxIgVBnH9qQeQASQ0AIAVBzAFGDQAgBUGwAkYNACAEQcAAcQ0AQQAhAyAEQYgEcUGABEYNACAEQShxQQBHIQMLIABBADsBMCAAQQA6AC8gAwuZAQECfwJAAkACQCAALQAqRQ0AIAAtACtFDQBBACEBIAAvATAiAkECcUUNAQwCC0EAIQEgAC8BMCICQQFxRQ0BC0EBIQEgAC0AKEEBRg0AIAAvATJB//8DcSIAQZx/akHkAEkNACAAQcwBRg0AIABBsAJGDQAgAkHAAHENAEEAIQEgAkGIBHFBgARGDQAgAkEocUEARyEBCyABC0kBAXsgAEEQav0MAAAAAAAAAAAAAAAAAAAAACIB/QsDACAAIAH9CwMAIABBMGogAf0LAwAgAEEgaiAB/QsDACAAQd0BNgIcQQALewEBfwJAIAAoAgwiAw0AAkAgACgCBEUNACAAIAE2AgQLAkAgACABIAIQxICAgAAiAw0AIAAoAgwPCyAAIAM2AhxBACEDIAAoAgQiAUUNACAAIAEgAiAAKAIIEYGAgIAAACIBRQ0AIAAgAjYCFCAAIAE2AgwgASEDCyADC+TzAQMOfwN+BH8jgICAgABBEGsiAySAgICAACABIQQgASEFIAEhBiABIQcgASEIIAEhCSABIQogASELIAEhDCABIQ0gASEOIAEhDwJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQCAAKAIcIhBBf2oO3QHaAQHZAQIDBAUGBwgJCgsMDQ7YAQ8Q1wEREtYBExQVFhcYGRob4AHfARwdHtUBHyAhIiMkJdQBJicoKSorLNMB0gEtLtEB0AEvMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUbbAUdISUrPAc4BS80BTMwBTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gAGBAYIBgwGEAYUBhgGHAYgBiQGKAYsBjAGNAY4BjwGQAZEBkgGTAZQBlQGWAZcBmAGZAZoBmwGcAZ0BngGfAaABoQGiAaMBpAGlAaYBpwGoAakBqgGrAawBrQGuAa8BsAGxAbIBswG0AbUBtgG3AcsBygG4AckBuQHIAboBuwG8Ab0BvgG/AcABwQHCAcMBxAHFAcYBANwBC0EAIRAMxgELQQ4hEAzFAQtBDSEQDMQBC0EPIRAMwwELQRAhEAzCAQtBEyEQDMEBC0EUIRAMwAELQRUhEAy/AQtBFiEQDL4BC0EXIRAMvQELQRghEAy8AQtBGSEQDLsBC0EaIRAMugELQRshEAy5AQtBHCEQDLgBC0EIIRAMtwELQR0hEAy2AQtBICEQDLUBC0EfIRAMtAELQQchEAyzAQtBISEQDLIBC0EiIRAMsQELQR4hEAywAQtBIyEQDK8BC0ESIRAMrgELQREhEAytAQtBJCEQDKwBC0ElIRAMqwELQSYhEAyqAQtBJyEQDKkBC0HDASEQDKgBC0EpIRAMpwELQSshEAymAQtBLCEQDKUBC0EtIRAMpAELQS4hEAyjAQtBLyEQDKIBC0HEASEQDKEBC0EwIRAMoAELQTQhEAyfAQtBDCEQDJ4BC0ExIRAMnQELQTIhEAycAQtBMyEQDJsBC0E5IRAMmgELQTUhEAyZAQtBxQEhEAyYAQtBCyEQDJcBC0E6IRAMlgELQTYhEAyVAQtBCiEQDJQBC0E3IRAMkwELQTghEAySAQtBPCEQDJEBC0E7IRAMkAELQT0hEAyPAQtBCSEQDI4BC0EoIRAMjQELQT4hEAyMAQtBPyEQDIsBC0HAACEQDIoBC0HBACEQDIkBC0HCACEQDIgBC0HDACEQDIcBC0HEACEQDIYBC0HFACEQDIUBC0HGACEQDIQBC0EqIRAMgwELQccAIRAMggELQcgAIRAMgQELQckAIRAMgAELQcoAIRAMfwtBywAhEAx+C0HNACEQDH0LQcwAIRAMfAtBzgAhEAx7C0HPACEQDHoLQdAAIRAMeQtB0QAhEAx4C0HSACEQDHcLQdMAIRAMdgtB1AAhEAx1C0HWACEQDHQLQdUAIRAMcwtBBiEQDHILQdcAIRAMcQtBBSEQDHALQdgAIRAMbwtBBCEQDG4LQdkAIRAMbQtB2gAhEAxsC0HbACEQDGsLQdwAIRAMagtBAyEQDGkLQd0AIRAMaAtB3gAhEAxnC0HfACEQDGYLQeEAIRAMZQtB4AAhEAxkC0HiACEQDGMLQeMAIRAMYgtBAiEQDGELQeQAIRAMYAtB5QAhEAxfC0HmACEQDF4LQecAIRAMXQtB6AAhEAxcC0HpACEQDFsLQeoAIRAMWgtB6wAhEAxZC0HsACEQDFgLQe0AIRAMVwtB7gAhEAxWC0HvACEQDFULQfAAIRAMVAtB8QAhEAxTC0HyACEQDFILQfMAIRAMUQtB9AAhEAxQC0H1ACEQDE8LQfYAIRAMTgtB9wAhEAxNC0H4ACEQDEwLQfkAIRAMSwtB+gAhEAxKC0H7ACEQDEkLQfwAIRAMSAtB/QAhEAxHC0H+ACEQDEYLQf8AIRAMRQtBgAEhEAxEC0GBASEQDEMLQYIBIRAMQgtBgwEhEAxBC0GEASEQDEALQYUBIRAMPwtBhgEhEAw+C0GHASEQDD0LQYgBIRAMPAtBiQEhEAw7C0GKASEQDDoLQYsBIRAMOQtBjAEhEAw4C0GNASEQDDcLQY4BIRAMNgtBjwEhEAw1C0GQASEQDDQLQZEBIRAMMwtBkgEhEAwyC0GTASEQDDELQZQBIRAMMAtBlQEhEAwvC0GWASEQDC4LQZcBIRAMLQtBmAEhEAwsC0GZASEQDCsLQZoBIRAMKgtBmwEhEAwpC0GcASEQDCgLQZ0BIRAMJwtBngEhEAwmC0GfASEQDCULQaABIRAMJAtBoQEhEAwjC0GiASEQDCILQaMBIRAMIQtBpAEhEAwgC0GlASEQDB8LQaYBIRAMHgtBpwEhEAwdC0GoASEQDBwLQakBIRAMGwtBqgEhEAwaC0GrASEQDBkLQawBIRAMGAtBrQEhEAwXC0GuASEQDBYLQQEhEAwVC0GvASEQDBQLQbABIRAMEwtBsQEhEAwSC0GzASEQDBELQbIBIRAMEAtBtAEhEAwPC0G1ASEQDA4LQbYBIRAMDQtBtwEhEAwMC0G4ASEQDAsLQbkBIRAMCgtBugEhEAwJC0G7ASEQDAgLQcYBIRAMBwtBvAEhEAwGC0G9ASEQDAULQb4BIRAMBAtBvwEhEAwDC0HAASEQDAILQcIBIRAMAQtBwQEhEAsDQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAIBAOxwEAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB4fICEjJSg/QEFERUZHSElKS0xNT1BRUlPeA1dZW1xdYGJlZmdoaWprbG1vcHFyc3R1dnd4eXp7fH1+gAGCAYUBhgGHAYkBiwGMAY0BjgGPAZABkQGUAZUBlgGXAZgBmQGaAZsBnAGdAZ4BnwGgAaEBogGjAaQBpQGmAacBqAGpAaoBqwGsAa0BrgGvAbABsQGyAbMBtAG1AbYBtwG4AbkBugG7AbwBvQG+Ab8BwAHBAcIBwwHEAcUBxgHHAcgByQHKAcsBzAHNAc4BzwHQAdEB0gHTAdQB1QHWAdcB2AHZAdoB2wHcAd0B3gHgAeEB4gHjAeQB5QHmAecB6AHpAeoB6wHsAe0B7gHvAfAB8QHyAfMBmQKkArAC/gL+AgsgASIEIAJHDfMBQd0BIRAM/wMLIAEiECACRw3dAUHDASEQDP4DCyABIgEgAkcNkAFB9wAhEAz9AwsgASIBIAJHDYYBQe8AIRAM/AMLIAEiASACRw1/QeoAIRAM+wMLIAEiASACRw17QegAIRAM+gMLIAEiASACRw14QeYAIRAM+QMLIAEiASACRw0aQRghEAz4AwsgASIBIAJHDRRBEiEQDPcDCyABIgEgAkcNWUHFACEQDPYDCyABIgEgAkcNSkE/IRAM9QMLIAEiASACRw1IQTwhEAz0AwsgASIBIAJHDUFBMSEQDPMDCyAALQAuQQFGDesDDIcCCyAAIAEiASACEMCAgIAAQQFHDeYBIABCADcDIAznAQsgACABIgEgAhC0gICAACIQDecBIAEhAQz1AgsCQCABIgEgAkcNAEEGIRAM8AMLIAAgAUEBaiIBIAIQu4CAgAAiEA3oASABIQEMMQsgAEIANwMgQRIhEAzVAwsgASIQIAJHDStBHSEQDO0DCwJAIAEiASACRg0AIAFBAWohAUEQIRAM1AMLQQchEAzsAwsgAEIAIAApAyAiESACIAEiEGutIhJ9IhMgEyARVhs3AyAgESASViIURQ3lAUEIIRAM6wMLAkAgASIBIAJGDQAgAEGJgICAADYCCCAAIAE2AgQgASEBQRQhEAzSAwtBCSEQDOoDCyABIQEgACkDIFAN5AEgASEBDPICCwJAIAEiASACRw0AQQshEAzpAwsgACABQQFqIgEgAhC2gICAACIQDeUBIAEhAQzyAgsgACABIgEgAhC4gICAACIQDeUBIAEhAQzyAgsgACABIgEgAhC4gICAACIQDeYBIAEhAQwNCyAAIAEiASACELqAgIAAIhAN5wEgASEBDPACCwJAIAEiASACRw0AQQ8hEAzlAwsgAS0AACIQQTtGDQggEEENRw3oASABQQFqIQEM7wILIAAgASIBIAIQuoCAgAAiEA3oASABIQEM8gILA0ACQCABLQAAQfC1gIAAai0AACIQQQFGDQAgEEECRw3rASAAKAIEIRAgAEEANgIEIAAgECABQQFqIgEQuYCAgAAiEA3qASABIQEM9AILIAFBAWoiASACRw0AC0ESIRAM4gMLIAAgASIBIAIQuoCAgAAiEA3pASABIQEMCgsgASIBIAJHDQZBGyEQDOADCwJAIAEiASACRw0AQRYhEAzgAwsgAEGKgICAADYCCCAAIAE2AgQgACABIAIQuICAgAAiEA3qASABIQFBICEQDMYDCwJAIAEiASACRg0AA0ACQCABLQAAQfC3gIAAai0AACIQQQJGDQACQCAQQX9qDgTlAewBAOsB7AELIAFBAWohAUEIIRAMyAMLIAFBAWoiASACRw0AC0EVIRAM3wMLQRUhEAzeAwsDQAJAIAEtAABB8LmAgABqLQAAIhBBAkYNACAQQX9qDgTeAewB4AHrAewBCyABQQFqIgEgAkcNAAtBGCEQDN0DCwJAIAEiASACRg0AIABBi4CAgAA2AgggACABNgIEIAEhAUEHIRAMxAMLQRkhEAzcAwsgAUEBaiEBDAILAkAgASIUIAJHDQBBGiEQDNsDCyAUIQECQCAULQAAQXNqDhTdAu4C7gLuAu4C7gLuAu4C7gLuAu4C7gLuAu4C7gLuAu4C7gLuAgDuAgtBACEQIABBADYCHCAAQa+LgIAANgIQIABBAjYCDCAAIBRBAWo2AhQM2gMLAkAgAS0AACIQQTtGDQAgEEENRw3oASABQQFqIQEM5QILIAFBAWohAQtBIiEQDL8DCwJAIAEiECACRw0AQRwhEAzYAwtCACERIBAhASAQLQAAQVBqDjfnAeYBAQIDBAUGBwgAAAAAAAAACQoLDA0OAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPEBESExQAC0EeIRAMvQMLQgIhEQzlAQtCAyERDOQBC0IEIREM4wELQgUhEQziAQtCBiERDOEBC0IHIREM4AELQgghEQzfAQtCCSERDN4BC0IKIREM3QELQgshEQzcAQtCDCERDNsBC0INIREM2gELQg4hEQzZAQtCDyERDNgBC0IKIREM1wELQgshEQzWAQtCDCERDNUBC0INIREM1AELQg4hEQzTAQtCDyERDNIBC0IAIRECQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAIBAtAABBUGoON+UB5AEAAQIDBAUGB+YB5gHmAeYB5gHmAeYBCAkKCwwN5gHmAeYB5gHmAeYB5gHmAeYB5gHmAeYB5gHmAeYB5gHmAeYB5gHmAeYB5gHmAeYB5gHmAQ4PEBESE+YBC0ICIREM5AELQgMhEQzjAQtCBCERDOIBC0IFIREM4QELQgYhEQzgAQtCByERDN8BC0IIIREM3gELQgkhEQzdAQtCCiERDNwBC0ILIREM2wELQgwhEQzaAQtCDSERDNkBC0IOIREM2AELQg8hEQzXAQtCCiERDNYBC0ILIREM1QELQgwhEQzUAQtCDSERDNMBC0IOIREM0gELQg8hEQzRAQsgAEIAIAApAyAiESACIAEiEGutIhJ9IhMgEyARVhs3AyAgESASViIURQ3SAUEfIRAMwAMLAkAgASIBIAJGDQAgAEGJgICAADYCCCAAIAE2AgQgASEBQSQhEAynAwtBICEQDL8DCyAAIAEiECACEL6AgIAAQX9qDgW2AQDFAgHRAdIBC0ERIRAMpAMLIABBAToALyAQIQEMuwMLIAEiASACRw3SAUEkIRAMuwMLIAEiDSACRw0eQcYAIRAMugMLIAAgASIBIAIQsoCAgAAiEA3UASABIQEMtQELIAEiECACRw0mQdAAIRAMuAMLAkAgASIBIAJHDQBBKCEQDLgDCyAAQQA2AgQgAEGMgICAADYCCCAAIAEgARCxgICAACIQDdMBIAEhAQzYAQsCQCABIhAgAkcNAEEpIRAMtwMLIBAtAAAiAUEgRg0UIAFBCUcN0wEgEEEBaiEBDBULAkAgASIBIAJGDQAgAUEBaiEBDBcLQSohEAy1AwsCQCABIhAgAkcNAEErIRAMtQMLAkAgEC0AACIBQQlGDQAgAUEgRw3VAQsgAC0ALEEIRg3TASAQIQEMkQMLAkAgASIBIAJHDQBBLCEQDLQDCyABLQAAQQpHDdUBIAFBAWohAQzJAgsgASIOIAJHDdUBQS8hEAyyAwsDQAJAIAEtAAAiEEEgRg0AAkAgEEF2ag4EANwB3AEA2gELIAEhAQzgAQsgAUEBaiIBIAJHDQALQTEhEAyxAwtBMiEQIAEiFCACRg2wAyACIBRrIAAoAgAiAWohFSAUIAFrQQNqIRYCQANAIBQtAAAiF0EgciAXIBdBv39qQf8BcUEaSRtB/wFxIAFB8LuAgABqLQAARw0BAkAgAUEDRw0AQQYhAQyWAwsgAUEBaiEBIBRBAWoiFCACRw0ACyAAIBU2AgAMsQMLIABBADYCACAUIQEM2QELQTMhECABIhQgAkYNrwMgAiAUayAAKAIAIgFqIRUgFCABa0EIaiEWAkADQCAULQAAIhdBIHIgFyAXQb9/akH/AXFBGkkbQf8BcSABQfS7gIAAai0AAEcNAQJAIAFBCEcNAEEFIQEMlQMLIAFBAWohASAUQQFqIhQgAkcNAAsgACAVNgIADLADCyAAQQA2AgAgFCEBDNgBC0E0IRAgASIUIAJGDa4DIAIgFGsgACgCACIBaiEVIBQgAWtBBWohFgJAA0AgFC0AACIXQSByIBcgF0G/f2pB/wFxQRpJG0H/AXEgAUHQwoCAAGotAABHDQECQCABQQVHDQBBByEBDJQDCyABQQFqIQEgFEEBaiIUIAJHDQALIAAgFTYCAAyvAwsgAEEANgIAIBQhAQzXAQsCQCABIgEgAkYNAANAAkAgAS0AAEGAvoCAAGotAAAiEEEBRg0AIBBBAkYNCiABIQEM3QELIAFBAWoiASACRw0AC0EwIRAMrgMLQTAhEAytAwsCQCABIgEgAkYNAANAAkAgAS0AACIQQSBGDQAgEEF2ag4E2QHaAdoB2QHaAQsgAUEBaiIBIAJHDQALQTghEAytAwtBOCEQDKwDCwNAAkAgAS0AACIQQSBGDQAgEEEJRw0DCyABQQFqIgEgAkcNAAtBPCEQDKsDCwNAAkAgAS0AACIQQSBGDQACQAJAIBBBdmoOBNoBAQHaAQALIBBBLEYN2wELIAEhAQwECyABQQFqIgEgAkcNAAtBPyEQDKoDCyABIQEM2wELQcAAIRAgASIUIAJGDagDIAIgFGsgACgCACIBaiEWIBQgAWtBBmohFwJAA0AgFC0AAEEgciABQYDAgIAAai0AAEcNASABQQZGDY4DIAFBAWohASAUQQFqIhQgAkcNAAsgACAWNgIADKkDCyAAQQA2AgAgFCEBC0E2IRAMjgMLAkAgASIPIAJHDQBBwQAhEAynAwsgAEGMgICAADYCCCAAIA82AgQgDyEBIAAtACxBf2oOBM0B1QHXAdkBhwMLIAFBAWohAQzMAQsCQCABIgEgAkYNAANAAkAgAS0AACIQQSByIBAgEEG/f2pB/wFxQRpJG0H/AXEiEEEJRg0AIBBBIEYNAAJAAkACQAJAIBBBnX9qDhMAAwMDAwMDAwEDAwMDAwMDAwMCAwsgAUEBaiEBQTEhEAyRAwsgAUEBaiEBQTIhEAyQAwsgAUEBaiEBQTMhEAyPAwsgASEBDNABCyABQQFqIgEgAkcNAAtBNSEQDKUDC0E1IRAMpAMLAkAgASIBIAJGDQADQAJAIAEtAABBgLyAgABqLQAAQQFGDQAgASEBDNMBCyABQQFqIgEgAkcNAAtBPSEQDKQDC0E9IRAMowMLIAAgASIBIAIQsICAgAAiEA3WASABIQEMAQsgEEEBaiEBC0E8IRAMhwMLAkAgASIBIAJHDQBBwgAhEAygAwsCQANAAkAgAS0AAEF3ag4YAAL+Av4ChAP+Av4C/gL+Av4C/gL+Av4C/gL+Av4C/gL+Av4C/gL+Av4C/gIA/gILIAFBAWoiASACRw0AC0HCACEQDKADCyABQQFqIQEgAC0ALUEBcUUNvQEgASEBC0EsIRAMhQMLIAEiASACRw3TAUHEACEQDJ0DCwNAAkAgAS0AAEGQwICAAGotAABBAUYNACABIQEMtwILIAFBAWoiASACRw0AC0HFACEQDJwDCyANLQAAIhBBIEYNswEgEEE6Rw2BAyAAKAIEIQEgAEEANgIEIAAgASANEK+AgIAAIgEN0AEgDUEBaiEBDLMCC0HHACEQIAEiDSACRg2aAyACIA1rIAAoAgAiAWohFiANIAFrQQVqIRcDQCANLQAAIhRBIHIgFCAUQb9/akH/AXFBGkkbQf8BcSABQZDCgIAAai0AAEcNgAMgAUEFRg30AiABQQFqIQEgDUEBaiINIAJHDQALIAAgFjYCAAyaAwtByAAhECABIg0gAkYNmQMgAiANayAAKAIAIgFqIRYgDSABa0EJaiEXA0AgDS0AACIUQSByIBQgFEG/f2pB/wFxQRpJG0H/AXEgAUGWwoCAAGotAABHDf8CAkAgAUEJRw0AQQIhAQz1AgsgAUEBaiEBIA1BAWoiDSACRw0ACyAAIBY2AgAMmQMLAkAgASINIAJHDQBByQAhEAyZAwsCQAJAIA0tAAAiAUEgciABIAFBv39qQf8BcUEaSRtB/wFxQZJ/ag4HAIADgAOAA4ADgAMBgAMLIA1BAWohAUE+IRAMgAMLIA1BAWohAUE/IRAM/wILQcoAIRAgASINIAJGDZcDIAIgDWsgACgCACIBaiEWIA0gAWtBAWohFwNAIA0tAAAiFEEgciAUIBRBv39qQf8BcUEaSRtB/wFxIAFBoMKAgABqLQAARw39AiABQQFGDfACIAFBAWohASANQQFqIg0gAkcNAAsgACAWNgIADJcDC0HLACEQIAEiDSACRg2WAyACIA1rIAAoAgAiAWohFiANIAFrQQ5qIRcDQCANLQAAIhRBIHIgFCAUQb9/akH/AXFBGkkbQf8BcSABQaLCgIAAai0AAEcN/AIgAUEORg3wAiABQQFqIQEgDUEBaiINIAJHDQALIAAgFjYCAAyWAwtBzAAhECABIg0gAkYNlQMgAiANayAAKAIAIgFqIRYgDSABa0EPaiEXA0AgDS0AACIUQSByIBQgFEG/f2pB/wFxQRpJG0H/AXEgAUHAwoCAAGotAABHDfsCAkAgAUEPRw0AQQMhAQzxAgsgAUEBaiEBIA1BAWoiDSACRw0ACyAAIBY2AgAMlQMLQc0AIRAgASINIAJGDZQDIAIgDWsgACgCACIBaiEWIA0gAWtBBWohFwNAIA0tAAAiFEEgciAUIBRBv39qQf8BcUEaSRtB/wFxIAFB0MKAgABqLQAARw36AgJAIAFBBUcNAEEEIQEM8AILIAFBAWohASANQQFqIg0gAkcNAAsgACAWNgIADJQDCwJAIAEiDSACRw0AQc4AIRAMlAMLAkACQAJAAkAgDS0AACIBQSByIAEgAUG/f2pB/wFxQRpJG0H/AXFBnX9qDhMA/QL9Av0C/QL9Av0C/QL9Av0C/QL9Av0CAf0C/QL9AgID/QILIA1BAWohAUHBACEQDP0CCyANQQFqIQFBwgAhEAz8AgsgDUEBaiEBQcMAIRAM+wILIA1BAWohAUHEACEQDPoCCwJAIAEiASACRg0AIABBjYCAgAA2AgggACABNgIEIAEhAUHFACEQDPoCC0HPACEQDJIDCyAQIQECQAJAIBAtAABBdmoOBAGoAqgCAKgCCyAQQQFqIQELQSchEAz4AgsCQCABIgEgAkcNAEHRACEQDJEDCwJAIAEtAABBIEYNACABIQEMjQELIAFBAWohASAALQAtQQFxRQ3HASABIQEMjAELIAEiFyACRw3IAUHSACEQDI8DC0HTACEQIAEiFCACRg2OAyACIBRrIAAoAgAiAWohFiAUIAFrQQFqIRcDQCAULQAAIAFB1sKAgABqLQAARw3MASABQQFGDccBIAFBAWohASAUQQFqIhQgAkcNAAsgACAWNgIADI4DCwJAIAEiASACRw0AQdUAIRAMjgMLIAEtAABBCkcNzAEgAUEBaiEBDMcBCwJAIAEiASACRw0AQdYAIRAMjQMLAkACQCABLQAAQXZqDgQAzQHNAQHNAQsgAUEBaiEBDMcBCyABQQFqIQFBygAhEAzzAgsgACABIgEgAhCugICAACIQDcsBIAEhAUHNACEQDPICCyAALQApQSJGDYUDDKYCCwJAIAEiASACRw0AQdsAIRAMigMLQQAhFEEBIRdBASEWQQAhEAJAAkACQAJAAkACQAJAAkACQCABLQAAQVBqDgrUAdMBAAECAwQFBgjVAQtBAiEQDAYLQQMhEAwFC0EEIRAMBAtBBSEQDAMLQQYhEAwCC0EHIRAMAQtBCCEQC0EAIRdBACEWQQAhFAzMAQtBCSEQQQEhFEEAIRdBACEWDMsBCwJAIAEiASACRw0AQd0AIRAMiQMLIAEtAABBLkcNzAEgAUEBaiEBDKYCCyABIgEgAkcNzAFB3wAhEAyHAwsCQCABIgEgAkYNACAAQY6AgIAANgIIIAAgATYCBCABIQFB0AAhEAzuAgtB4AAhEAyGAwtB4QAhECABIgEgAkYNhQMgAiABayAAKAIAIhRqIRYgASAUa0EDaiEXA0AgAS0AACAUQeLCgIAAai0AAEcNzQEgFEEDRg3MASAUQQFqIRQgAUEBaiIBIAJHDQALIAAgFjYCAAyFAwtB4gAhECABIgEgAkYNhAMgAiABayAAKAIAIhRqIRYgASAUa0ECaiEXA0AgAS0AACAUQebCgIAAai0AAEcNzAEgFEECRg3OASAUQQFqIRQgAUEBaiIBIAJHDQALIAAgFjYCAAyEAwtB4wAhECABIgEgAkYNgwMgAiABayAAKAIAIhRqIRYgASAUa0EDaiEXA0AgAS0AACAUQenCgIAAai0AAEcNywEgFEEDRg3OASAUQQFqIRQgAUEBaiIBIAJHDQALIAAgFjYCAAyDAwsCQCABIgEgAkcNAEHlACEQDIMDCyAAIAFBAWoiASACEKiAgIAAIhANzQEgASEBQdYAIRAM6QILAkAgASIBIAJGDQADQAJAIAEtAAAiEEEgRg0AAkACQAJAIBBBuH9qDgsAAc8BzwHPAc8BzwHPAc8BzwECzwELIAFBAWohAUHSACEQDO0CCyABQQFqIQFB0wAhEAzsAgsgAUEBaiEBQdQAIRAM6wILIAFBAWoiASACRw0AC0HkACEQDIIDC0HkACEQDIEDCwNAAkAgAS0AAEHwwoCAAGotAAAiEEEBRg0AIBBBfmoOA88B0AHRAdIBCyABQQFqIgEgAkcNAAtB5gAhEAyAAwsCQCABIgEgAkYNACABQQFqIQEMAwtB5wAhEAz/AgsDQAJAIAEtAABB8MSAgABqLQAAIhBBAUYNAAJAIBBBfmoOBNIB0wHUAQDVAQsgASEBQdcAIRAM5wILIAFBAWoiASACRw0AC0HoACEQDP4CCwJAIAEiASACRw0AQekAIRAM/gILAkAgAS0AACIQQXZqDhq6AdUB1QG8AdUB1QHVAdUB1QHVAdUB1QHVAdUB1QHVAdUB1QHVAdUB1QHVAcoB1QHVAQDTAQsgAUEBaiEBC0EGIRAM4wILA0ACQCABLQAAQfDGgIAAai0AAEEBRg0AIAEhAQyeAgsgAUEBaiIBIAJHDQALQeoAIRAM+wILAkAgASIBIAJGDQAgAUEBaiEBDAMLQesAIRAM+gILAkAgASIBIAJHDQBB7AAhEAz6AgsgAUEBaiEBDAELAkAgASIBIAJHDQBB7QAhEAz5AgsgAUEBaiEBC0EEIRAM3gILAkAgASIUIAJHDQBB7gAhEAz3AgsgFCEBAkACQAJAIBQtAABB8MiAgABqLQAAQX9qDgfUAdUB1gEAnAIBAtcBCyAUQQFqIQEMCgsgFEEBaiEBDM0BC0EAIRAgAEEANgIcIABBm5KAgAA2AhAgAEEHNgIMIAAgFEEBajYCFAz2AgsCQANAAkAgAS0AAEHwyICAAGotAAAiEEEERg0AAkACQCAQQX9qDgfSAdMB1AHZAQAEAdkBCyABIQFB2gAhEAzgAgsgAUEBaiEBQdwAIRAM3wILIAFBAWoiASACRw0AC0HvACEQDPYCCyABQQFqIQEMywELAkAgASIUIAJHDQBB8AAhEAz1AgsgFC0AAEEvRw3UASAUQQFqIQEMBgsCQCABIhQgAkcNAEHxACEQDPQCCwJAIBQtAAAiAUEvRw0AIBRBAWohAUHdACEQDNsCCyABQXZqIgRBFksN0wFBASAEdEGJgIACcUUN0wEMygILAkAgASIBIAJGDQAgAUEBaiEBQd4AIRAM2gILQfIAIRAM8gILAkAgASIUIAJHDQBB9AAhEAzyAgsgFCEBAkAgFC0AAEHwzICAAGotAABBf2oOA8kClAIA1AELQeEAIRAM2AILAkAgASIUIAJGDQADQAJAIBQtAABB8MqAgABqLQAAIgFBA0YNAAJAIAFBf2oOAssCANUBCyAUIQFB3wAhEAzaAgsgFEEBaiIUIAJHDQALQfMAIRAM8QILQfMAIRAM8AILAkAgASIBIAJGDQAgAEGPgICAADYCCCAAIAE2AgQgASEBQeAAIRAM1wILQfUAIRAM7wILAkAgASIBIAJHDQBB9gAhEAzvAgsgAEGPgICAADYCCCAAIAE2AgQgASEBC0EDIRAM1AILA0AgAS0AAEEgRw3DAiABQQFqIgEgAkcNAAtB9wAhEAzsAgsCQCABIgEgAkcNAEH4ACEQDOwCCyABLQAAQSBHDc4BIAFBAWohAQzvAQsgACABIgEgAhCsgICAACIQDc4BIAEhAQyOAgsCQCABIgQgAkcNAEH6ACEQDOoCCyAELQAAQcwARw3RASAEQQFqIQFBEyEQDM8BCwJAIAEiBCACRw0AQfsAIRAM6QILIAIgBGsgACgCACIBaiEUIAQgAWtBBWohEANAIAQtAAAgAUHwzoCAAGotAABHDdABIAFBBUYNzgEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBB+wAhEAzoAgsCQCABIgQgAkcNAEH8ACEQDOgCCwJAAkAgBC0AAEG9f2oODADRAdEB0QHRAdEB0QHRAdEB0QHRAQHRAQsgBEEBaiEBQeYAIRAMzwILIARBAWohAUHnACEQDM4CCwJAIAEiBCACRw0AQf0AIRAM5wILIAIgBGsgACgCACIBaiEUIAQgAWtBAmohEAJAA0AgBC0AACABQe3PgIAAai0AAEcNzwEgAUECRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQf0AIRAM5wILIABBADYCACAQQQFqIQFBECEQDMwBCwJAIAEiBCACRw0AQf4AIRAM5gILIAIgBGsgACgCACIBaiEUIAQgAWtBBWohEAJAA0AgBC0AACABQfbOgIAAai0AAEcNzgEgAUEFRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQf4AIRAM5gILIABBADYCACAQQQFqIQFBFiEQDMsBCwJAIAEiBCACRw0AQf8AIRAM5QILIAIgBGsgACgCACIBaiEUIAQgAWtBA2ohEAJAA0AgBC0AACABQfzOgIAAai0AAEcNzQEgAUEDRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQf8AIRAM5QILIABBADYCACAQQQFqIQFBBSEQDMoBCwJAIAEiBCACRw0AQYABIRAM5AILIAQtAABB2QBHDcsBIARBAWohAUEIIRAMyQELAkAgASIEIAJHDQBBgQEhEAzjAgsCQAJAIAQtAABBsn9qDgMAzAEBzAELIARBAWohAUHrACEQDMoCCyAEQQFqIQFB7AAhEAzJAgsCQCABIgQgAkcNAEGCASEQDOICCwJAAkAgBC0AAEG4f2oOCADLAcsBywHLAcsBywEBywELIARBAWohAUHqACEQDMkCCyAEQQFqIQFB7QAhEAzIAgsCQCABIgQgAkcNAEGDASEQDOECCyACIARrIAAoAgAiAWohECAEIAFrQQJqIRQCQANAIAQtAAAgAUGAz4CAAGotAABHDckBIAFBAkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgEDYCAEGDASEQDOECC0EAIRAgAEEANgIAIBRBAWohAQzGAQsCQCABIgQgAkcNAEGEASEQDOACCyACIARrIAAoAgAiAWohFCAEIAFrQQRqIRACQANAIAQtAAAgAUGDz4CAAGotAABHDcgBIAFBBEYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGEASEQDOACCyAAQQA2AgAgEEEBaiEBQSMhEAzFAQsCQCABIgQgAkcNAEGFASEQDN8CCwJAAkAgBC0AAEG0f2oOCADIAcgByAHIAcgByAEByAELIARBAWohAUHvACEQDMYCCyAEQQFqIQFB8AAhEAzFAgsCQCABIgQgAkcNAEGGASEQDN4CCyAELQAAQcUARw3FASAEQQFqIQEMgwILAkAgASIEIAJHDQBBhwEhEAzdAgsgAiAEayAAKAIAIgFqIRQgBCABa0EDaiEQAkADQCAELQAAIAFBiM+AgABqLQAARw3FASABQQNGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBhwEhEAzdAgsgAEEANgIAIBBBAWohAUEtIRAMwgELAkAgASIEIAJHDQBBiAEhEAzcAgsgAiAEayAAKAIAIgFqIRQgBCABa0EIaiEQAkADQCAELQAAIAFB0M+AgABqLQAARw3EASABQQhGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBiAEhEAzcAgsgAEEANgIAIBBBAWohAUEpIRAMwQELAkAgASIBIAJHDQBBiQEhEAzbAgtBASEQIAEtAABB3wBHDcABIAFBAWohAQyBAgsCQCABIgQgAkcNAEGKASEQDNoCCyACIARrIAAoAgAiAWohFCAEIAFrQQFqIRADQCAELQAAIAFBjM+AgABqLQAARw3BASABQQFGDa8CIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQYoBIRAM2QILAkAgASIEIAJHDQBBiwEhEAzZAgsgAiAEayAAKAIAIgFqIRQgBCABa0ECaiEQAkADQCAELQAAIAFBjs+AgABqLQAARw3BASABQQJGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBiwEhEAzZAgsgAEEANgIAIBBBAWohAUECIRAMvgELAkAgASIEIAJHDQBBjAEhEAzYAgsgAiAEayAAKAIAIgFqIRQgBCABa0EBaiEQAkADQCAELQAAIAFB8M+AgABqLQAARw3AASABQQFGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBjAEhEAzYAgsgAEEANgIAIBBBAWohAUEfIRAMvQELAkAgASIEIAJHDQBBjQEhEAzXAgsgAiAEayAAKAIAIgFqIRQgBCABa0EBaiEQAkADQCAELQAAIAFB8s+AgABqLQAARw2/ASABQQFGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBjQEhEAzXAgsgAEEANgIAIBBBAWohAUEJIRAMvAELAkAgASIEIAJHDQBBjgEhEAzWAgsCQAJAIAQtAABBt39qDgcAvwG/Ab8BvwG/AQG/AQsgBEEBaiEBQfgAIRAMvQILIARBAWohAUH5ACEQDLwCCwJAIAEiBCACRw0AQY8BIRAM1QILIAIgBGsgACgCACIBaiEUIAQgAWtBBWohEAJAA0AgBC0AACABQZHPgIAAai0AAEcNvQEgAUEFRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQY8BIRAM1QILIABBADYCACAQQQFqIQFBGCEQDLoBCwJAIAEiBCACRw0AQZABIRAM1AILIAIgBGsgACgCACIBaiEUIAQgAWtBAmohEAJAA0AgBC0AACABQZfPgIAAai0AAEcNvAEgAUECRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQZABIRAM1AILIABBADYCACAQQQFqIQFBFyEQDLkBCwJAIAEiBCACRw0AQZEBIRAM0wILIAIgBGsgACgCACIBaiEUIAQgAWtBBmohEAJAA0AgBC0AACABQZrPgIAAai0AAEcNuwEgAUEGRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQZEBIRAM0wILIABBADYCACAQQQFqIQFBFSEQDLgBCwJAIAEiBCACRw0AQZIBIRAM0gILIAIgBGsgACgCACIBaiEUIAQgAWtBBWohEAJAA0AgBC0AACABQaHPgIAAai0AAEcNugEgAUEFRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQZIBIRAM0gILIABBADYCACAQQQFqIQFBHiEQDLcBCwJAIAEiBCACRw0AQZMBIRAM0QILIAQtAABBzABHDbgBIARBAWohAUEKIRAMtgELAkAgBCACRw0AQZQBIRAM0AILAkACQCAELQAAQb9/ag4PALkBuQG5AbkBuQG5AbkBuQG5AbkBuQG5AbkBAbkBCyAEQQFqIQFB/gAhEAy3AgsgBEEBaiEBQf8AIRAMtgILAkAgBCACRw0AQZUBIRAMzwILAkACQCAELQAAQb9/ag4DALgBAbgBCyAEQQFqIQFB/QAhEAy2AgsgBEEBaiEEQYABIRAMtQILAkAgBCACRw0AQZYBIRAMzgILIAIgBGsgACgCACIBaiEUIAQgAWtBAWohEAJAA0AgBC0AACABQafPgIAAai0AAEcNtgEgAUEBRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQZYBIRAMzgILIABBADYCACAQQQFqIQFBCyEQDLMBCwJAIAQgAkcNAEGXASEQDM0CCwJAAkACQAJAIAQtAABBU2oOIwC4AbgBuAG4AbgBuAG4AbgBuAG4AbgBuAG4AbgBuAG4AbgBuAG4AbgBuAG4AbgBAbgBuAG4AbgBuAECuAG4AbgBA7gBCyAEQQFqIQFB+wAhEAy2AgsgBEEBaiEBQfwAIRAMtQILIARBAWohBEGBASEQDLQCCyAEQQFqIQRBggEhEAyzAgsCQCAEIAJHDQBBmAEhEAzMAgsgAiAEayAAKAIAIgFqIRQgBCABa0EEaiEQAkADQCAELQAAIAFBqc+AgABqLQAARw20ASABQQRGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBmAEhEAzMAgsgAEEANgIAIBBBAWohAUEZIRAMsQELAkAgBCACRw0AQZkBIRAMywILIAIgBGsgACgCACIBaiEUIAQgAWtBBWohEAJAA0AgBC0AACABQa7PgIAAai0AAEcNswEgAUEFRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQZkBIRAMywILIABBADYCACAQQQFqIQFBBiEQDLABCwJAIAQgAkcNAEGaASEQDMoCCyACIARrIAAoAgAiAWohFCAEIAFrQQFqIRACQANAIAQtAAAgAUG0z4CAAGotAABHDbIBIAFBAUYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGaASEQDMoCCyAAQQA2AgAgEEEBaiEBQRwhEAyvAQsCQCAEIAJHDQBBmwEhEAzJAgsgAiAEayAAKAIAIgFqIRQgBCABa0EBaiEQAkADQCAELQAAIAFBts+AgABqLQAARw2xASABQQFGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBmwEhEAzJAgsgAEEANgIAIBBBAWohAUEnIRAMrgELAkAgBCACRw0AQZwBIRAMyAILAkACQCAELQAAQax/ag4CAAGxAQsgBEEBaiEEQYYBIRAMrwILIARBAWohBEGHASEQDK4CCwJAIAQgAkcNAEGdASEQDMcCCyACIARrIAAoAgAiAWohFCAEIAFrQQFqIRACQANAIAQtAAAgAUG4z4CAAGotAABHDa8BIAFBAUYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGdASEQDMcCCyAAQQA2AgAgEEEBaiEBQSYhEAysAQsCQCAEIAJHDQBBngEhEAzGAgsgAiAEayAAKAIAIgFqIRQgBCABa0EBaiEQAkADQCAELQAAIAFBus+AgABqLQAARw2uASABQQFGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBngEhEAzGAgsgAEEANgIAIBBBAWohAUEDIRAMqwELAkAgBCACRw0AQZ8BIRAMxQILIAIgBGsgACgCACIBaiEUIAQgAWtBAmohEAJAA0AgBC0AACABQe3PgIAAai0AAEcNrQEgAUECRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQZ8BIRAMxQILIABBADYCACAQQQFqIQFBDCEQDKoBCwJAIAQgAkcNAEGgASEQDMQCCyACIARrIAAoAgAiAWohFCAEIAFrQQNqIRACQANAIAQtAAAgAUG8z4CAAGotAABHDawBIAFBA0YNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGgASEQDMQCCyAAQQA2AgAgEEEBaiEBQQ0hEAypAQsCQCAEIAJHDQBBoQEhEAzDAgsCQAJAIAQtAABBun9qDgsArAGsAawBrAGsAawBrAGsAawBAawBCyAEQQFqIQRBiwEhEAyqAgsgBEEBaiEEQYwBIRAMqQILAkAgBCACRw0AQaIBIRAMwgILIAQtAABB0ABHDakBIARBAWohBAzpAQsCQCAEIAJHDQBBowEhEAzBAgsCQAJAIAQtAABBt39qDgcBqgGqAaoBqgGqAQCqAQsgBEEBaiEEQY4BIRAMqAILIARBAWohAUEiIRAMpgELAkAgBCACRw0AQaQBIRAMwAILIAIgBGsgACgCACIBaiEUIAQgAWtBAWohEAJAA0AgBC0AACABQcDPgIAAai0AAEcNqAEgAUEBRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQaQBIRAMwAILIABBADYCACAQQQFqIQFBHSEQDKUBCwJAIAQgAkcNAEGlASEQDL8CCwJAAkAgBC0AAEGuf2oOAwCoAQGoAQsgBEEBaiEEQZABIRAMpgILIARBAWohAUEEIRAMpAELAkAgBCACRw0AQaYBIRAMvgILAkACQAJAAkACQCAELQAAQb9/ag4VAKoBqgGqAaoBqgGqAaoBqgGqAaoBAaoBqgECqgGqAQOqAaoBBKoBCyAEQQFqIQRBiAEhEAyoAgsgBEEBaiEEQYkBIRAMpwILIARBAWohBEGKASEQDKYCCyAEQQFqIQRBjwEhEAylAgsgBEEBaiEEQZEBIRAMpAILAkAgBCACRw0AQacBIRAMvQILIAIgBGsgACgCACIBaiEUIAQgAWtBAmohEAJAA0AgBC0AACABQe3PgIAAai0AAEcNpQEgAUECRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQacBIRAMvQILIABBADYCACAQQQFqIQFBESEQDKIBCwJAIAQgAkcNAEGoASEQDLwCCyACIARrIAAoAgAiAWohFCAEIAFrQQJqIRACQANAIAQtAAAgAUHCz4CAAGotAABHDaQBIAFBAkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGoASEQDLwCCyAAQQA2AgAgEEEBaiEBQSwhEAyhAQsCQCAEIAJHDQBBqQEhEAy7AgsgAiAEayAAKAIAIgFqIRQgBCABa0EEaiEQAkADQCAELQAAIAFBxc+AgABqLQAARw2jASABQQRGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBqQEhEAy7AgsgAEEANgIAIBBBAWohAUErIRAMoAELAkAgBCACRw0AQaoBIRAMugILIAIgBGsgACgCACIBaiEUIAQgAWtBAmohEAJAA0AgBC0AACABQcrPgIAAai0AAEcNogEgAUECRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQaoBIRAMugILIABBADYCACAQQQFqIQFBFCEQDJ8BCwJAIAQgAkcNAEGrASEQDLkCCwJAAkACQAJAIAQtAABBvn9qDg8AAQKkAaQBpAGkAaQBpAGkAaQBpAGkAaQBA6QBCyAEQQFqIQRBkwEhEAyiAgsgBEEBaiEEQZQBIRAMoQILIARBAWohBEGVASEQDKACCyAEQQFqIQRBlgEhEAyfAgsCQCAEIAJHDQBBrAEhEAy4AgsgBC0AAEHFAEcNnwEgBEEBaiEEDOABCwJAIAQgAkcNAEGtASEQDLcCCyACIARrIAAoAgAiAWohFCAEIAFrQQJqIRACQANAIAQtAAAgAUHNz4CAAGotAABHDZ8BIAFBAkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGtASEQDLcCCyAAQQA2AgAgEEEBaiEBQQ4hEAycAQsCQCAEIAJHDQBBrgEhEAy2AgsgBC0AAEHQAEcNnQEgBEEBaiEBQSUhEAybAQsCQCAEIAJHDQBBrwEhEAy1AgsgAiAEayAAKAIAIgFqIRQgBCABa0EIaiEQAkADQCAELQAAIAFB0M+AgABqLQAARw2dASABQQhGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBrwEhEAy1AgsgAEEANgIAIBBBAWohAUEqIRAMmgELAkAgBCACRw0AQbABIRAMtAILAkACQCAELQAAQat/ag4LAJ0BnQGdAZ0BnQGdAZ0BnQGdAQGdAQsgBEEBaiEEQZoBIRAMmwILIARBAWohBEGbASEQDJoCCwJAIAQgAkcNAEGxASEQDLMCCwJAAkAgBC0AAEG/f2oOFACcAZwBnAGcAZwBnAGcAZwBnAGcAZwBnAGcAZwBnAGcAZwBnAEBnAELIARBAWohBEGZASEQDJoCCyAEQQFqIQRBnAEhEAyZAgsCQCAEIAJHDQBBsgEhEAyyAgsgAiAEayAAKAIAIgFqIRQgBCABa0EDaiEQAkADQCAELQAAIAFB2c+AgABqLQAARw2aASABQQNGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBsgEhEAyyAgsgAEEANgIAIBBBAWohAUEhIRAMlwELAkAgBCACRw0AQbMBIRAMsQILIAIgBGsgACgCACIBaiEUIAQgAWtBBmohEAJAA0AgBC0AACABQd3PgIAAai0AAEcNmQEgAUEGRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQbMBIRAMsQILIABBADYCACAQQQFqIQFBGiEQDJYBCwJAIAQgAkcNAEG0ASEQDLACCwJAAkACQCAELQAAQbt/ag4RAJoBmgGaAZoBmgGaAZoBmgGaAQGaAZoBmgGaAZoBApoBCyAEQQFqIQRBnQEhEAyYAgsgBEEBaiEEQZ4BIRAMlwILIARBAWohBEGfASEQDJYCCwJAIAQgAkcNAEG1ASEQDK8CCyACIARrIAAoAgAiAWohFCAEIAFrQQVqIRACQANAIAQtAAAgAUHkz4CAAGotAABHDZcBIAFBBUYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEG1ASEQDK8CCyAAQQA2AgAgEEEBaiEBQSghEAyUAQsCQCAEIAJHDQBBtgEhEAyuAgsgAiAEayAAKAIAIgFqIRQgBCABa0ECaiEQAkADQCAELQAAIAFB6s+AgABqLQAARw2WASABQQJGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBtgEhEAyuAgsgAEEANgIAIBBBAWohAUEHIRAMkwELAkAgBCACRw0AQbcBIRAMrQILAkACQCAELQAAQbt/ag4OAJYBlgGWAZYBlgGWAZYBlgGWAZYBlgGWAQGWAQsgBEEBaiEEQaEBIRAMlAILIARBAWohBEGiASEQDJMCCwJAIAQgAkcNAEG4ASEQDKwCCyACIARrIAAoAgAiAWohFCAEIAFrQQJqIRACQANAIAQtAAAgAUHtz4CAAGotAABHDZQBIAFBAkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEG4ASEQDKwCCyAAQQA2AgAgEEEBaiEBQRIhEAyRAQsCQCAEIAJHDQBBuQEhEAyrAgsgAiAEayAAKAIAIgFqIRQgBCABa0EBaiEQAkADQCAELQAAIAFB8M+AgABqLQAARw2TASABQQFGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBuQEhEAyrAgsgAEEANgIAIBBBAWohAUEgIRAMkAELAkAgBCACRw0AQboBIRAMqgILIAIgBGsgACgCACIBaiEUIAQgAWtBAWohEAJAA0AgBC0AACABQfLPgIAAai0AAEcNkgEgAUEBRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQboBIRAMqgILIABBADYCACAQQQFqIQFBDyEQDI8BCwJAIAQgAkcNAEG7ASEQDKkCCwJAAkAgBC0AAEG3f2oOBwCSAZIBkgGSAZIBAZIBCyAEQQFqIQRBpQEhEAyQAgsgBEEBaiEEQaYBIRAMjwILAkAgBCACRw0AQbwBIRAMqAILIAIgBGsgACgCACIBaiEUIAQgAWtBB2ohEAJAA0AgBC0AACABQfTPgIAAai0AAEcNkAEgAUEHRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQbwBIRAMqAILIABBADYCACAQQQFqIQFBGyEQDI0BCwJAIAQgAkcNAEG9ASEQDKcCCwJAAkACQCAELQAAQb5/ag4SAJEBkQGRAZEBkQGRAZEBkQGRAQGRAZEBkQGRAZEBkQECkQELIARBAWohBEGkASEQDI8CCyAEQQFqIQRBpwEhEAyOAgsgBEEBaiEEQagBIRAMjQILAkAgBCACRw0AQb4BIRAMpgILIAQtAABBzgBHDY0BIARBAWohBAzPAQsCQCAEIAJHDQBBvwEhEAylAgsCQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQCAELQAAQb9/ag4VAAECA5wBBAUGnAGcAZwBBwgJCgucAQwNDg+cAQsgBEEBaiEBQegAIRAMmgILIARBAWohAUHpACEQDJkCCyAEQQFqIQFB7gAhEAyYAgsgBEEBaiEBQfIAIRAMlwILIARBAWohAUHzACEQDJYCCyAEQQFqIQFB9gAhEAyVAgsgBEEBaiEBQfcAIRAMlAILIARBAWohAUH6ACEQDJMCCyAEQQFqIQRBgwEhEAySAgsgBEEBaiEEQYQBIRAMkQILIARBAWohBEGFASEQDJACCyAEQQFqIQRBkgEhEAyPAgsgBEEBaiEEQZgBIRAMjgILIARBAWohBEGgASEQDI0CCyAEQQFqIQRBowEhEAyMAgsgBEEBaiEEQaoBIRAMiwILAkAgBCACRg0AIABBkICAgAA2AgggACAENgIEQasBIRAMiwILQcABIRAMowILIAAgBSACEKqAgIAAIgENiwEgBSEBDFwLAkAgBiACRg0AIAZBAWohBQyNAQtBwgEhEAyhAgsDQAJAIBAtAABBdmoOBIwBAACPAQALIBBBAWoiECACRw0AC0HDASEQDKACCwJAIAcgAkYNACAAQZGAgIAANgIIIAAgBzYCBCAHIQFBASEQDIcCC0HEASEQDJ8CCwJAIAcgAkcNAEHFASEQDJ8CCwJAAkAgBy0AAEF2ag4EAc4BzgEAzgELIAdBAWohBgyNAQsgB0EBaiEFDIkBCwJAIAcgAkcNAEHGASEQDJ4CCwJAAkAgBy0AAEF2ag4XAY8BjwEBjwGPAY8BjwGPAY8BjwGPAY8BjwGPAY8BjwGPAY8BjwGPAY8BAI8BCyAHQQFqIQcLQbABIRAMhAILAkAgCCACRw0AQcgBIRAMnQILIAgtAABBIEcNjQEgAEEAOwEyIAhBAWohAUGzASEQDIMCCyABIRcCQANAIBciByACRg0BIActAABBUGpB/wFxIhBBCk8NzAECQCAALwEyIhRBmTNLDQAgACAUQQpsIhQ7ATIgEEH//wNzIBRB/v8DcUkNACAHQQFqIRcgACAUIBBqIhA7ATIgEEH//wNxQegHSQ0BCwtBACEQIABBADYCHCAAQcGJgIAANgIQIABBDTYCDCAAIAdBAWo2AhQMnAILQccBIRAMmwILIAAgCCACEK6AgIAAIhBFDcoBIBBBFUcNjAEgAEHIATYCHCAAIAg2AhQgAEHJl4CAADYCECAAQRU2AgxBACEQDJoCCwJAIAkgAkcNAEHMASEQDJoCC0EAIRRBASEXQQEhFkEAIRACQAJAAkACQAJAAkACQAJAAkAgCS0AAEFQag4KlgGVAQABAgMEBQYIlwELQQIhEAwGC0EDIRAMBQtBBCEQDAQLQQUhEAwDC0EGIRAMAgtBByEQDAELQQghEAtBACEXQQAhFkEAIRQMjgELQQkhEEEBIRRBACEXQQAhFgyNAQsCQCAKIAJHDQBBzgEhEAyZAgsgCi0AAEEuRw2OASAKQQFqIQkMygELIAsgAkcNjgFB0AEhEAyXAgsCQCALIAJGDQAgAEGOgICAADYCCCAAIAs2AgRBtwEhEAz+AQtB0QEhEAyWAgsCQCAEIAJHDQBB0gEhEAyWAgsgAiAEayAAKAIAIhBqIRQgBCAQa0EEaiELA0AgBC0AACAQQfzPgIAAai0AAEcNjgEgEEEERg3pASAQQQFqIRAgBEEBaiIEIAJHDQALIAAgFDYCAEHSASEQDJUCCyAAIAwgAhCsgICAACIBDY0BIAwhAQy4AQsCQCAEIAJHDQBB1AEhEAyUAgsgAiAEayAAKAIAIhBqIRQgBCAQa0EBaiEMA0AgBC0AACAQQYHQgIAAai0AAEcNjwEgEEEBRg2OASAQQQFqIRAgBEEBaiIEIAJHDQALIAAgFDYCAEHUASEQDJMCCwJAIAQgAkcNAEHWASEQDJMCCyACIARrIAAoAgAiEGohFCAEIBBrQQJqIQsDQCAELQAAIBBBg9CAgABqLQAARw2OASAQQQJGDZABIBBBAWohECAEQQFqIgQgAkcNAAsgACAUNgIAQdYBIRAMkgILAkAgBCACRw0AQdcBIRAMkgILAkACQCAELQAAQbt/ag4QAI8BjwGPAY8BjwGPAY8BjwGPAY8BjwGPAY8BjwEBjwELIARBAWohBEG7ASEQDPkBCyAEQQFqIQRBvAEhEAz4AQsCQCAEIAJHDQBB2AEhEAyRAgsgBC0AAEHIAEcNjAEgBEEBaiEEDMQBCwJAIAQgAkYNACAAQZCAgIAANgIIIAAgBDYCBEG+ASEQDPcBC0HZASEQDI8CCwJAIAQgAkcNAEHaASEQDI8CCyAELQAAQcgARg3DASAAQQE6ACgMuQELIABBAjoALyAAIAQgAhCmgICAACIQDY0BQcIBIRAM9AELIAAtAChBf2oOArcBuQG4AQsDQAJAIAQtAABBdmoOBACOAY4BAI4BCyAEQQFqIgQgAkcNAAtB3QEhEAyLAgsgAEEAOgAvIAAtAC1BBHFFDYQCCyAAQQA6AC8gAEEBOgA0IAEhAQyMAQsgEEEVRg3aASAAQQA2AhwgACABNgIUIABBp46AgAA2AhAgAEESNgIMQQAhEAyIAgsCQCAAIBAgAhC0gICAACIEDQAgECEBDIECCwJAIARBFUcNACAAQQM2AhwgACAQNgIUIABBsJiAgAA2AhAgAEEVNgIMQQAhEAyIAgsgAEEANgIcIAAgEDYCFCAAQaeOgIAANgIQIABBEjYCDEEAIRAMhwILIBBBFUYN1gEgAEEANgIcIAAgATYCFCAAQdqNgIAANgIQIABBFDYCDEEAIRAMhgILIAAoAgQhFyAAQQA2AgQgECARp2oiFiEBIAAgFyAQIBYgFBsiEBC1gICAACIURQ2NASAAQQc2AhwgACAQNgIUIAAgFDYCDEEAIRAMhQILIAAgAC8BMEGAAXI7ATAgASEBC0EqIRAM6gELIBBBFUYN0QEgAEEANgIcIAAgATYCFCAAQYOMgIAANgIQIABBEzYCDEEAIRAMggILIBBBFUYNzwEgAEEANgIcIAAgATYCFCAAQZqPgIAANgIQIABBIjYCDEEAIRAMgQILIAAoAgQhECAAQQA2AgQCQCAAIBAgARC3gICAACIQDQAgAUEBaiEBDI0BCyAAQQw2AhwgACAQNgIMIAAgAUEBajYCFEEAIRAMgAILIBBBFUYNzAEgAEEANgIcIAAgATYCFCAAQZqPgIAANgIQIABBIjYCDEEAIRAM/wELIAAoAgQhECAAQQA2AgQCQCAAIBAgARC3gICAACIQDQAgAUEBaiEBDIwBCyAAQQ02AhwgACAQNgIMIAAgAUEBajYCFEEAIRAM/gELIBBBFUYNyQEgAEEANgIcIAAgATYCFCAAQcaMgIAANgIQIABBIzYCDEEAIRAM/QELIAAoAgQhECAAQQA2AgQCQCAAIBAgARC5gICAACIQDQAgAUEBaiEBDIsBCyAAQQ42AhwgACAQNgIMIAAgAUEBajYCFEEAIRAM/AELIABBADYCHCAAIAE2AhQgAEHAlYCAADYCECAAQQI2AgxBACEQDPsBCyAQQRVGDcUBIABBADYCHCAAIAE2AhQgAEHGjICAADYCECAAQSM2AgxBACEQDPoBCyAAQRA2AhwgACABNgIUIAAgEDYCDEEAIRAM+QELIAAoAgQhBCAAQQA2AgQCQCAAIAQgARC5gICAACIEDQAgAUEBaiEBDPEBCyAAQRE2AhwgACAENgIMIAAgAUEBajYCFEEAIRAM+AELIBBBFUYNwQEgAEEANgIcIAAgATYCFCAAQcaMgIAANgIQIABBIzYCDEEAIRAM9wELIAAoAgQhECAAQQA2AgQCQCAAIBAgARC5gICAACIQDQAgAUEBaiEBDIgBCyAAQRM2AhwgACAQNgIMIAAgAUEBajYCFEEAIRAM9gELIAAoAgQhBCAAQQA2AgQCQCAAIAQgARC5gICAACIEDQAgAUEBaiEBDO0BCyAAQRQ2AhwgACAENgIMIAAgAUEBajYCFEEAIRAM9QELIBBBFUYNvQEgAEEANgIcIAAgATYCFCAAQZqPgIAANgIQIABBIjYCDEEAIRAM9AELIAAoAgQhECAAQQA2AgQCQCAAIBAgARC3gICAACIQDQAgAUEBaiEBDIYBCyAAQRY2AhwgACAQNgIMIAAgAUEBajYCFEEAIRAM8wELIAAoAgQhBCAAQQA2AgQCQCAAIAQgARC3gICAACIEDQAgAUEBaiEBDOkBCyAAQRc2AhwgACAENgIMIAAgAUEBajYCFEEAIRAM8gELIABBADYCHCAAIAE2AhQgAEHNk4CAADYCECAAQQw2AgxBACEQDPEBC0IBIRELIBBBAWohAQJAIAApAyAiEkL//////////w9WDQAgACASQgSGIBGENwMgIAEhAQyEAQsgAEEANgIcIAAgATYCFCAAQa2JgIAANgIQIABBDDYCDEEAIRAM7wELIABBADYCHCAAIBA2AhQgAEHNk4CAADYCECAAQQw2AgxBACEQDO4BCyAAKAIEIRcgAEEANgIEIBAgEadqIhYhASAAIBcgECAWIBQbIhAQtYCAgAAiFEUNcyAAQQU2AhwgACAQNgIUIAAgFDYCDEEAIRAM7QELIABBADYCHCAAIBA2AhQgAEGqnICAADYCECAAQQ82AgxBACEQDOwBCyAAIBAgAhC0gICAACIBDQEgECEBC0EOIRAM0QELAkAgAUEVRw0AIABBAjYCHCAAIBA2AhQgAEGwmICAADYCECAAQRU2AgxBACEQDOoBCyAAQQA2AhwgACAQNgIUIABBp46AgAA2AhAgAEESNgIMQQAhEAzpAQsgAUEBaiEQAkAgAC8BMCIBQYABcUUNAAJAIAAgECACELuAgIAAIgENACAQIQEMcAsgAUEVRw26ASAAQQU2AhwgACAQNgIUIABB+ZeAgAA2AhAgAEEVNgIMQQAhEAzpAQsCQCABQaAEcUGgBEcNACAALQAtQQJxDQAgAEEANgIcIAAgEDYCFCAAQZaTgIAANgIQIABBBDYCDEEAIRAM6QELIAAgECACEL2AgIAAGiAQIQECQAJAAkACQAJAIAAgECACELOAgIAADhYCAQAEBAQEBAQEBAQEBAQEBAQEBAQDBAsgAEEBOgAuCyAAIAAvATBBwAByOwEwIBAhAQtBJiEQDNEBCyAAQSM2AhwgACAQNgIUIABBpZaAgAA2AhAgAEEVNgIMQQAhEAzpAQsgAEEANgIcIAAgEDYCFCAAQdWLgIAANgIQIABBETYCDEEAIRAM6AELIAAtAC1BAXFFDQFBwwEhEAzOAQsCQCANIAJGDQADQAJAIA0tAABBIEYNACANIQEMxAELIA1BAWoiDSACRw0AC0ElIRAM5wELQSUhEAzmAQsgACgCBCEEIABBADYCBCAAIAQgDRCvgICAACIERQ2tASAAQSY2AhwgACAENgIMIAAgDUEBajYCFEEAIRAM5QELIBBBFUYNqwEgAEEANgIcIAAgATYCFCAAQf2NgIAANgIQIABBHTYCDEEAIRAM5AELIABBJzYCHCAAIAE2AhQgACAQNgIMQQAhEAzjAQsgECEBQQEhFAJAAkACQAJAAkACQAJAIAAtACxBfmoOBwYFBQMBAgAFCyAAIAAvATBBCHI7ATAMAwtBAiEUDAELQQQhFAsgAEEBOgAsIAAgAC8BMCAUcjsBMAsgECEBC0ErIRAMygELIABBADYCHCAAIBA2AhQgAEGrkoCAADYCECAAQQs2AgxBACEQDOIBCyAAQQA2AhwgACABNgIUIABB4Y+AgAA2AhAgAEEKNgIMQQAhEAzhAQsgAEEAOgAsIBAhAQy9AQsgECEBQQEhFAJAAkACQAJAAkAgAC0ALEF7ag4EAwECAAULIAAgAC8BMEEIcjsBMAwDC0ECIRQMAQtBBCEUCyAAQQE6ACwgACAALwEwIBRyOwEwCyAQIQELQSkhEAzFAQsgAEEANgIcIAAgATYCFCAAQfCUgIAANgIQIABBAzYCDEEAIRAM3QELAkAgDi0AAEENRw0AIAAoAgQhASAAQQA2AgQCQCAAIAEgDhCxgICAACIBDQAgDkEBaiEBDHULIABBLDYCHCAAIAE2AgwgACAOQQFqNgIUQQAhEAzdAQsgAC0ALUEBcUUNAUHEASEQDMMBCwJAIA4gAkcNAEEtIRAM3AELAkACQANAAkAgDi0AAEF2ag4EAgAAAwALIA5BAWoiDiACRw0AC0EtIRAM3QELIAAoAgQhASAAQQA2AgQCQCAAIAEgDhCxgICAACIBDQAgDiEBDHQLIABBLDYCHCAAIA42AhQgACABNgIMQQAhEAzcAQsgACgCBCEBIABBADYCBAJAIAAgASAOELGAgIAAIgENACAOQQFqIQEMcwsgAEEsNgIcIAAgATYCDCAAIA5BAWo2AhRBACEQDNsBCyAAKAIEIQQgAEEANgIEIAAgBCAOELGAgIAAIgQNoAEgDiEBDM4BCyAQQSxHDQEgAUEBaiEQQQEhAQJAAkACQAJAAkAgAC0ALEF7ag4EAwECBAALIBAhAQwEC0ECIQEMAQtBBCEBCyAAQQE6ACwgACAALwEwIAFyOwEwIBAhAQwBCyAAIAAvATBBCHI7ATAgECEBC0E5IRAMvwELIABBADoALCABIQELQTQhEAy9AQsgACAALwEwQSByOwEwIAEhAQwCCyAAKAIEIQQgAEEANgIEAkAgACAEIAEQsYCAgAAiBA0AIAEhAQzHAQsgAEE3NgIcIAAgATYCFCAAIAQ2AgxBACEQDNQBCyAAQQg6ACwgASEBC0EwIRAMuQELAkAgAC0AKEEBRg0AIAEhAQwECyAALQAtQQhxRQ2TASABIQEMAwsgAC0AMEEgcQ2UAUHFASEQDLcBCwJAIA8gAkYNAAJAA0ACQCAPLQAAQVBqIgFB/wFxQQpJDQAgDyEBQTUhEAy6AQsgACkDICIRQpmz5syZs+bMGVYNASAAIBFCCn4iETcDICARIAGtQv8BgyISQn+FVg0BIAAgESASfDcDICAPQQFqIg8gAkcNAAtBOSEQDNEBCyAAKAIEIQIgAEEANgIEIAAgAiAPQQFqIgQQsYCAgAAiAg2VASAEIQEMwwELQTkhEAzPAQsCQCAALwEwIgFBCHFFDQAgAC0AKEEBRw0AIAAtAC1BCHFFDZABCyAAIAFB9/sDcUGABHI7ATAgDyEBC0E3IRAMtAELIAAgAC8BMEEQcjsBMAyrAQsgEEEVRg2LASAAQQA2AhwgACABNgIUIABB8I6AgAA2AhAgAEEcNgIMQQAhEAzLAQsgAEHDADYCHCAAIAE2AgwgACANQQFqNgIUQQAhEAzKAQsCQCABLQAAQTpHDQAgACgCBCEQIABBADYCBAJAIAAgECABEK+AgIAAIhANACABQQFqIQEMYwsgAEHDADYCHCAAIBA2AgwgACABQQFqNgIUQQAhEAzKAQsgAEEANgIcIAAgATYCFCAAQbGRgIAANgIQIABBCjYCDEEAIRAMyQELIABBADYCHCAAIAE2AhQgAEGgmYCAADYCECAAQR42AgxBACEQDMgBCyAAQQA2AgALIABBgBI7ASogACAXQQFqIgEgAhCogICAACIQDQEgASEBC0HHACEQDKwBCyAQQRVHDYMBIABB0QA2AhwgACABNgIUIABB45eAgAA2AhAgAEEVNgIMQQAhEAzEAQsgACgCBCEQIABBADYCBAJAIAAgECABEKeAgIAAIhANACABIQEMXgsgAEHSADYCHCAAIAE2AhQgACAQNgIMQQAhEAzDAQsgAEEANgIcIAAgFDYCFCAAQcGogIAANgIQIABBBzYCDCAAQQA2AgBBACEQDMIBCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQp4CAgAAiEA0AIAEhAQxdCyAAQdMANgIcIAAgATYCFCAAIBA2AgxBACEQDMEBC0EAIRAgAEEANgIcIAAgATYCFCAAQYCRgIAANgIQIABBCTYCDAzAAQsgEEEVRg19IABBADYCHCAAIAE2AhQgAEGUjYCAADYCECAAQSE2AgxBACEQDL8BC0EBIRZBACEXQQAhFEEBIRALIAAgEDoAKyABQQFqIQECQAJAIAAtAC1BEHENAAJAAkACQCAALQAqDgMBAAIECyAWRQ0DDAILIBQNAQwCCyAXRQ0BCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQrYCAgAAiEA0AIAEhAQxcCyAAQdgANgIcIAAgATYCFCAAIBA2AgxBACEQDL4BCyAAKAIEIQQgAEEANgIEAkAgACAEIAEQrYCAgAAiBA0AIAEhAQytAQsgAEHZADYCHCAAIAE2AhQgACAENgIMQQAhEAy9AQsgACgCBCEEIABBADYCBAJAIAAgBCABEK2AgIAAIgQNACABIQEMqwELIABB2gA2AhwgACABNgIUIAAgBDYCDEEAIRAMvAELIAAoAgQhBCAAQQA2AgQCQCAAIAQgARCtgICAACIEDQAgASEBDKkBCyAAQdwANgIcIAAgATYCFCAAIAQ2AgxBACEQDLsBCwJAIAEtAABBUGoiEEH/AXFBCk8NACAAIBA6ACogAUEBaiEBQc8AIRAMogELIAAoAgQhBCAAQQA2AgQCQCAAIAQgARCtgICAACIEDQAgASEBDKcBCyAAQd4ANgIcIAAgATYCFCAAIAQ2AgxBACEQDLoBCyAAQQA2AgAgF0EBaiEBAkAgAC0AKUEjTw0AIAEhAQxZCyAAQQA2AhwgACABNgIUIABB04mAgAA2AhAgAEEINgIMQQAhEAy5AQsgAEEANgIAC0EAIRAgAEEANgIcIAAgATYCFCAAQZCzgIAANgIQIABBCDYCDAy3AQsgAEEANgIAIBdBAWohAQJAIAAtAClBIUcNACABIQEMVgsgAEEANgIcIAAgATYCFCAAQZuKgIAANgIQIABBCDYCDEEAIRAMtgELIABBADYCACAXQQFqIQECQCAALQApIhBBXWpBC08NACABIQEMVQsCQCAQQQZLDQBBASAQdEHKAHFFDQAgASEBDFULQQAhECAAQQA2AhwgACABNgIUIABB94mAgAA2AhAgAEEINgIMDLUBCyAQQRVGDXEgAEEANgIcIAAgATYCFCAAQbmNgIAANgIQIABBGjYCDEEAIRAMtAELIAAoAgQhECAAQQA2AgQCQCAAIBAgARCngICAACIQDQAgASEBDFQLIABB5QA2AhwgACABNgIUIAAgEDYCDEEAIRAMswELIAAoAgQhECAAQQA2AgQCQCAAIBAgARCngICAACIQDQAgASEBDE0LIABB0gA2AhwgACABNgIUIAAgEDYCDEEAIRAMsgELIAAoAgQhECAAQQA2AgQCQCAAIBAgARCngICAACIQDQAgASEBDE0LIABB0wA2AhwgACABNgIUIAAgEDYCDEEAIRAMsQELIAAoAgQhECAAQQA2AgQCQCAAIBAgARCngICAACIQDQAgASEBDFELIABB5QA2AhwgACABNgIUIAAgEDYCDEEAIRAMsAELIABBADYCHCAAIAE2AhQgAEHGioCAADYCECAAQQc2AgxBACEQDK8BCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQp4CAgAAiEA0AIAEhAQxJCyAAQdIANgIcIAAgATYCFCAAIBA2AgxBACEQDK4BCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQp4CAgAAiEA0AIAEhAQxJCyAAQdMANgIcIAAgATYCFCAAIBA2AgxBACEQDK0BCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQp4CAgAAiEA0AIAEhAQxNCyAAQeUANgIcIAAgATYCFCAAIBA2AgxBACEQDKwBCyAAQQA2AhwgACABNgIUIABB3IiAgAA2AhAgAEEHNgIMQQAhEAyrAQsgEEE/Rw0BIAFBAWohAQtBBSEQDJABC0EAIRAgAEEANgIcIAAgATYCFCAAQf2SgIAANgIQIABBBzYCDAyoAQsgACgCBCEQIABBADYCBAJAIAAgECABEKeAgIAAIhANACABIQEMQgsgAEHSADYCHCAAIAE2AhQgACAQNgIMQQAhEAynAQsgACgCBCEQIABBADYCBAJAIAAgECABEKeAgIAAIhANACABIQEMQgsgAEHTADYCHCAAIAE2AhQgACAQNgIMQQAhEAymAQsgACgCBCEQIABBADYCBAJAIAAgECABEKeAgIAAIhANACABIQEMRgsgAEHlADYCHCAAIAE2AhQgACAQNgIMQQAhEAylAQsgACgCBCEBIABBADYCBAJAIAAgASAUEKeAgIAAIgENACAUIQEMPwsgAEHSADYCHCAAIBQ2AhQgACABNgIMQQAhEAykAQsgACgCBCEBIABBADYCBAJAIAAgASAUEKeAgIAAIgENACAUIQEMPwsgAEHTADYCHCAAIBQ2AhQgACABNgIMQQAhEAyjAQsgACgCBCEBIABBADYCBAJAIAAgASAUEKeAgIAAIgENACAUIQEMQwsgAEHlADYCHCAAIBQ2AhQgACABNgIMQQAhEAyiAQsgAEEANgIcIAAgFDYCFCAAQcOPgIAANgIQIABBBzYCDEEAIRAMoQELIABBADYCHCAAIAE2AhQgAEHDj4CAADYCECAAQQc2AgxBACEQDKABC0EAIRAgAEEANgIcIAAgFDYCFCAAQYycgIAANgIQIABBBzYCDAyfAQsgAEEANgIcIAAgFDYCFCAAQYycgIAANgIQIABBBzYCDEEAIRAMngELIABBADYCHCAAIBQ2AhQgAEH+kYCAADYCECAAQQc2AgxBACEQDJ0BCyAAQQA2AhwgACABNgIUIABBjpuAgAA2AhAgAEEGNgIMQQAhEAycAQsgEEEVRg1XIABBADYCHCAAIAE2AhQgAEHMjoCAADYCECAAQSA2AgxBACEQDJsBCyAAQQA2AgAgEEEBaiEBQSQhEAsgACAQOgApIAAoAgQhECAAQQA2AgQgACAQIAEQq4CAgAAiEA1UIAEhAQw+CyAAQQA2AgALQQAhECAAQQA2AhwgACAENgIUIABB8ZuAgAA2AhAgAEEGNgIMDJcBCyABQRVGDVAgAEEANgIcIAAgBTYCFCAAQfCMgIAANgIQIABBGzYCDEEAIRAMlgELIAAoAgQhBSAAQQA2AgQgACAFIBAQqYCAgAAiBQ0BIBBBAWohBQtBrQEhEAx7CyAAQcEBNgIcIAAgBTYCDCAAIBBBAWo2AhRBACEQDJMBCyAAKAIEIQYgAEEANgIEIAAgBiAQEKmAgIAAIgYNASAQQQFqIQYLQa4BIRAMeAsgAEHCATYCHCAAIAY2AgwgACAQQQFqNgIUQQAhEAyQAQsgAEEANgIcIAAgBzYCFCAAQZeLgIAANgIQIABBDTYCDEEAIRAMjwELIABBADYCHCAAIAg2AhQgAEHjkICAADYCECAAQQk2AgxBACEQDI4BCyAAQQA2AhwgACAINgIUIABBlI2AgAA2AhAgAEEhNgIMQQAhEAyNAQtBASEWQQAhF0EAIRRBASEQCyAAIBA6ACsgCUEBaiEIAkACQCAALQAtQRBxDQACQAJAAkAgAC0AKg4DAQACBAsgFkUNAwwCCyAUDQEMAgsgF0UNAQsgACgCBCEQIABBADYCBCAAIBAgCBCtgICAACIQRQ09IABByQE2AhwgACAINgIUIAAgEDYCDEEAIRAMjAELIAAoAgQhBCAAQQA2AgQgACAEIAgQrYCAgAAiBEUNdiAAQcoBNgIcIAAgCDYCFCAAIAQ2AgxBACEQDIsBCyAAKAIEIQQgAEEANgIEIAAgBCAJEK2AgIAAIgRFDXQgAEHLATYCHCAAIAk2AhQgACAENgIMQQAhEAyKAQsgACgCBCEEIABBADYCBCAAIAQgChCtgICAACIERQ1yIABBzQE2AhwgACAKNgIUIAAgBDYCDEEAIRAMiQELAkAgCy0AAEFQaiIQQf8BcUEKTw0AIAAgEDoAKiALQQFqIQpBtgEhEAxwCyAAKAIEIQQgAEEANgIEIAAgBCALEK2AgIAAIgRFDXAgAEHPATYCHCAAIAs2AhQgACAENgIMQQAhEAyIAQsgAEEANgIcIAAgBDYCFCAAQZCzgIAANgIQIABBCDYCDCAAQQA2AgBBACEQDIcBCyABQRVGDT8gAEEANgIcIAAgDDYCFCAAQcyOgIAANgIQIABBIDYCDEEAIRAMhgELIABBgQQ7ASggACgCBCEQIABCADcDACAAIBAgDEEBaiIMEKuAgIAAIhBFDTggAEHTATYCHCAAIAw2AhQgACAQNgIMQQAhEAyFAQsgAEEANgIAC0EAIRAgAEEANgIcIAAgBDYCFCAAQdibgIAANgIQIABBCDYCDAyDAQsgACgCBCEQIABCADcDACAAIBAgC0EBaiILEKuAgIAAIhANAUHGASEQDGkLIABBAjoAKAxVCyAAQdUBNgIcIAAgCzYCFCAAIBA2AgxBACEQDIABCyAQQRVGDTcgAEEANgIcIAAgBDYCFCAAQaSMgIAANgIQIABBEDYCDEEAIRAMfwsgAC0ANEEBRw00IAAgBCACELyAgIAAIhBFDTQgEEEVRw01IABB3AE2AhwgACAENgIUIABB1ZaAgAA2AhAgAEEVNgIMQQAhEAx+C0EAIRAgAEEANgIcIABBr4uAgAA2AhAgAEECNgIMIAAgFEEBajYCFAx9C0EAIRAMYwtBAiEQDGILQQ0hEAxhC0EPIRAMYAtBJSEQDF8LQRMhEAxeC0EVIRAMXQtBFiEQDFwLQRchEAxbC0EYIRAMWgtBGSEQDFkLQRohEAxYC0EbIRAMVwtBHCEQDFYLQR0hEAxVC0EfIRAMVAtBISEQDFMLQSMhEAxSC0HGACEQDFELQS4hEAxQC0EvIRAMTwtBOyEQDE4LQT0hEAxNC0HIACEQDEwLQckAIRAMSwtBywAhEAxKC0HMACEQDEkLQc4AIRAMSAtB0QAhEAxHC0HVACEQDEYLQdgAIRAMRQtB2QAhEAxEC0HbACEQDEMLQeQAIRAMQgtB5QAhEAxBC0HxACEQDEALQfQAIRAMPwtBjQEhEAw+C0GXASEQDD0LQakBIRAMPAtBrAEhEAw7C0HAASEQDDoLQbkBIRAMOQtBrwEhEAw4C0GxASEQDDcLQbIBIRAMNgtBtAEhEAw1C0G1ASEQDDQLQboBIRAMMwtBvQEhEAwyC0G/ASEQDDELQcEBIRAMMAsgAEEANgIcIAAgBDYCFCAAQemLgIAANgIQIABBHzYCDEEAIRAMSAsgAEHbATYCHCAAIAQ2AhQgAEH6loCAADYCECAAQRU2AgxBACEQDEcLIABB+AA2AhwgACAMNgIUIABBypiAgAA2AhAgAEEVNgIMQQAhEAxGCyAAQdEANgIcIAAgBTYCFCAAQbCXgIAANgIQIABBFTYCDEEAIRAMRQsgAEH5ADYCHCAAIAE2AhQgACAQNgIMQQAhEAxECyAAQfgANgIcIAAgATYCFCAAQcqYgIAANgIQIABBFTYCDEEAIRAMQwsgAEHkADYCHCAAIAE2AhQgAEHjl4CAADYCECAAQRU2AgxBACEQDEILIABB1wA2AhwgACABNgIUIABByZeAgAA2AhAgAEEVNgIMQQAhEAxBCyAAQQA2AhwgACABNgIUIABBuY2AgAA2AhAgAEEaNgIMQQAhEAxACyAAQcIANgIcIAAgATYCFCAAQeOYgIAANgIQIABBFTYCDEEAIRAMPwsgAEEANgIEIAAgDyAPELGAgIAAIgRFDQEgAEE6NgIcIAAgBDYCDCAAIA9BAWo2AhRBACEQDD4LIAAoAgQhBCAAQQA2AgQCQCAAIAQgARCxgICAACIERQ0AIABBOzYCHCAAIAQ2AgwgACABQQFqNgIUQQAhEAw+CyABQQFqIQEMLQsgD0EBaiEBDC0LIABBADYCHCAAIA82AhQgAEHkkoCAADYCECAAQQQ2AgxBACEQDDsLIABBNjYCHCAAIAQ2AhQgACACNgIMQQAhEAw6CyAAQS42AhwgACAONgIUIAAgBDYCDEEAIRAMOQsgAEHQADYCHCAAIAE2AhQgAEGRmICAADYCECAAQRU2AgxBACEQDDgLIA1BAWohAQwsCyAAQRU2AhwgACABNgIUIABBgpmAgAA2AhAgAEEVNgIMQQAhEAw2CyAAQRs2AhwgACABNgIUIABBkZeAgAA2AhAgAEEVNgIMQQAhEAw1CyAAQQ82AhwgACABNgIUIABBkZeAgAA2AhAgAEEVNgIMQQAhEAw0CyAAQQs2AhwgACABNgIUIABBkZeAgAA2AhAgAEEVNgIMQQAhEAwzCyAAQRo2AhwgACABNgIUIABBgpmAgAA2AhAgAEEVNgIMQQAhEAwyCyAAQQs2AhwgACABNgIUIABBgpmAgAA2AhAgAEEVNgIMQQAhEAwxCyAAQQo2AhwgACABNgIUIABB5JaAgAA2AhAgAEEVNgIMQQAhEAwwCyAAQR42AhwgACABNgIUIABB+ZeAgAA2AhAgAEEVNgIMQQAhEAwvCyAAQQA2AhwgACAQNgIUIABB2o2AgAA2AhAgAEEUNgIMQQAhEAwuCyAAQQQ2AhwgACABNgIUIABBsJiAgAA2AhAgAEEVNgIMQQAhEAwtCyAAQQA2AgAgC0EBaiELC0G4ASEQDBILIABBADYCACAQQQFqIQFB9QAhEAwRCyABIQECQCAALQApQQVHDQBB4wAhEAwRC0HiACEQDBALQQAhECAAQQA2AhwgAEHkkYCAADYCECAAQQc2AgwgACAUQQFqNgIUDCgLIABBADYCACAXQQFqIQFBwAAhEAwOC0EBIQELIAAgAToALCAAQQA2AgAgF0EBaiEBC0EoIRAMCwsgASEBC0E4IRAMCQsCQCABIg8gAkYNAANAAkAgDy0AAEGAvoCAAGotAAAiAUEBRg0AIAFBAkcNAyAPQQFqIQEMBAsgD0EBaiIPIAJHDQALQT4hEAwiC0E+IRAMIQsgAEEAOgAsIA8hAQwBC0ELIRAMBgtBOiEQDAULIAFBAWohAUEtIRAMBAsgACABOgAsIABBADYCACAWQQFqIQFBDCEQDAMLIABBADYCACAXQQFqIQFBCiEQDAILIABBADYCAAsgAEEAOgAsIA0hAUEJIRAMAAsLQQAhECAAQQA2AhwgACALNgIUIABBzZCAgAA2AhAgAEEJNgIMDBcLQQAhECAAQQA2AhwgACAKNgIUIABB6YqAgAA2AhAgAEEJNgIMDBYLQQAhECAAQQA2AhwgACAJNgIUIABBt5CAgAA2AhAgAEEJNgIMDBULQQAhECAAQQA2AhwgACAINgIUIABBnJGAgAA2AhAgAEEJNgIMDBQLQQAhECAAQQA2AhwgACABNgIUIABBzZCAgAA2AhAgAEEJNgIMDBMLQQAhECAAQQA2AhwgACABNgIUIABB6YqAgAA2AhAgAEEJNgIMDBILQQAhECAAQQA2AhwgACABNgIUIABBt5CAgAA2AhAgAEEJNgIMDBELQQAhECAAQQA2AhwgACABNgIUIABBnJGAgAA2AhAgAEEJNgIMDBALQQAhECAAQQA2AhwgACABNgIUIABBl5WAgAA2AhAgAEEPNgIMDA8LQQAhECAAQQA2AhwgACABNgIUIABBl5WAgAA2AhAgAEEPNgIMDA4LQQAhECAAQQA2AhwgACABNgIUIABBwJKAgAA2AhAgAEELNgIMDA0LQQAhECAAQQA2AhwgACABNgIUIABBlYmAgAA2AhAgAEELNgIMDAwLQQAhECAAQQA2AhwgACABNgIUIABB4Y+AgAA2AhAgAEEKNgIMDAsLQQAhECAAQQA2AhwgACABNgIUIABB+4+AgAA2AhAgAEEKNgIMDAoLQQAhECAAQQA2AhwgACABNgIUIABB8ZmAgAA2AhAgAEECNgIMDAkLQQAhECAAQQA2AhwgACABNgIUIABBxJSAgAA2AhAgAEECNgIMDAgLQQAhECAAQQA2AhwgACABNgIUIABB8pWAgAA2AhAgAEECNgIMDAcLIABBAjYCHCAAIAE2AhQgAEGcmoCAADYCECAAQRY2AgxBACEQDAYLQQEhEAwFC0HUACEQIAEiBCACRg0EIANBCGogACAEIAJB2MKAgABBChDFgICAACADKAIMIQQgAygCCA4DAQQCAAsQyoCAgAAACyAAQQA2AhwgAEG1moCAADYCECAAQRc2AgwgACAEQQFqNgIUQQAhEAwCCyAAQQA2AhwgACAENgIUIABBypqAgAA2AhAgAEEJNgIMQQAhEAwBCwJAIAEiBCACRw0AQSIhEAwBCyAAQYmAgIAANgIIIAAgBDYCBEEhIRALIANBEGokgICAgAAgEAuvAQECfyABKAIAIQYCQAJAIAIgA0YNACAEIAZqIQQgBiADaiACayEHIAIgBkF/cyAFaiIGaiEFA0ACQCACLQAAIAQtAABGDQBBAiEEDAMLAkAgBg0AQQAhBCAFIQIMAwsgBkF/aiEGIARBAWohBCACQQFqIgIgA0cNAAsgByEGIAMhAgsgAEEBNgIAIAEgBjYCACAAIAI2AgQPCyABQQA2AgAgACAENgIAIAAgAjYCBAsKACAAEMeAgIAAC/I2AQt/I4CAgIAAQRBrIgEkgICAgAACQEEAKAKg0ICAAA0AQQAQy4CAgABBgNSEgABrIgJB2QBJDQBBACEDAkBBACgC4NOAgAAiBA0AQQBCfzcC7NOAgABBAEKAgISAgIDAADcC5NOAgABBACABQQhqQXBxQdiq1aoFcyIENgLg04CAAEEAQQA2AvTTgIAAQQBBADYCxNOAgAALQQAgAjYCzNOAgABBAEGA1ISAADYCyNOAgABBAEGA1ISAADYCmNCAgABBACAENgKs0ICAAEEAQX82AqjQgIAAA0AgA0HE0ICAAGogA0G40ICAAGoiBDYCACAEIANBsNCAgABqIgU2AgAgA0G80ICAAGogBTYCACADQczQgIAAaiADQcDQgIAAaiIFNgIAIAUgBDYCACADQdTQgIAAaiADQcjQgIAAaiIENgIAIAQgBTYCACADQdDQgIAAaiAENgIAIANBIGoiA0GAAkcNAAtBgNSEgABBeEGA1ISAAGtBD3FBAEGA1ISAAEEIakEPcRsiA2oiBEEEaiACQUhqIgUgA2siA0EBcjYCAEEAQQAoAvDTgIAANgKk0ICAAEEAIAM2ApTQgIAAQQAgBDYCoNCAgABBgNSEgAAgBWpBODYCBAsCQAJAAkACQAJAAkACQAJAAkACQAJAAkAgAEHsAUsNAAJAQQAoAojQgIAAIgZBECAAQRNqQXBxIABBC0kbIgJBA3YiBHYiA0EDcUUNAAJAAkAgA0EBcSAEckEBcyIFQQN0IgRBsNCAgABqIgMgBEG40ICAAGooAgAiBCgCCCICRw0AQQAgBkF+IAV3cTYCiNCAgAAMAQsgAyACNgIIIAIgAzYCDAsgBEEIaiEDIAQgBUEDdCIFQQNyNgIEIAQgBWoiBCAEKAIEQQFyNgIEDAwLIAJBACgCkNCAgAAiB00NAQJAIANFDQACQAJAIAMgBHRBAiAEdCIDQQAgA2tycSIDQQAgA2txQX9qIgMgA0EMdkEQcSIDdiIEQQV2QQhxIgUgA3IgBCAFdiIDQQJ2QQRxIgRyIAMgBHYiA0EBdkECcSIEciADIAR2IgNBAXZBAXEiBHIgAyAEdmoiBEEDdCIDQbDQgIAAaiIFIANBuNCAgABqKAIAIgMoAggiAEcNAEEAIAZBfiAEd3EiBjYCiNCAgAAMAQsgBSAANgIIIAAgBTYCDAsgAyACQQNyNgIEIAMgBEEDdCIEaiAEIAJrIgU2AgAgAyACaiIAIAVBAXI2AgQCQCAHRQ0AIAdBeHFBsNCAgABqIQJBACgCnNCAgAAhBAJAAkAgBkEBIAdBA3Z0IghxDQBBACAGIAhyNgKI0ICAACACIQgMAQsgAigCCCEICyAIIAQ2AgwgAiAENgIIIAQgAjYCDCAEIAg2AggLIANBCGohA0EAIAA2ApzQgIAAQQAgBTYCkNCAgAAMDAtBACgCjNCAgAAiCUUNASAJQQAgCWtxQX9qIgMgA0EMdkEQcSIDdiIEQQV2QQhxIgUgA3IgBCAFdiIDQQJ2QQRxIgRyIAMgBHYiA0EBdkECcSIEciADIAR2IgNBAXZBAXEiBHIgAyAEdmpBAnRBuNKAgABqKAIAIgAoAgRBeHEgAmshBCAAIQUCQANAAkAgBSgCECIDDQAgBUEUaigCACIDRQ0CCyADKAIEQXhxIAJrIgUgBCAFIARJIgUbIQQgAyAAIAUbIQAgAyEFDAALCyAAKAIYIQoCQCAAKAIMIgggAEYNACAAKAIIIgNBACgCmNCAgABJGiAIIAM2AgggAyAINgIMDAsLAkAgAEEUaiIFKAIAIgMNACAAKAIQIgNFDQMgAEEQaiEFCwNAIAUhCyADIghBFGoiBSgCACIDDQAgCEEQaiEFIAgoAhAiAw0ACyALQQA2AgAMCgtBfyECIABBv39LDQAgAEETaiIDQXBxIQJBACgCjNCAgAAiB0UNAEEAIQsCQCACQYACSQ0AQR8hCyACQf///wdLDQAgA0EIdiIDIANBgP4/akEQdkEIcSIDdCIEIARBgOAfakEQdkEEcSIEdCIFIAVBgIAPakEQdkECcSIFdEEPdiADIARyIAVyayIDQQF0IAIgA0EVanZBAXFyQRxqIQsLQQAgAmshBAJAAkACQAJAIAtBAnRBuNKAgABqKAIAIgUNAEEAIQNBACEIDAELQQAhAyACQQBBGSALQQF2ayALQR9GG3QhAEEAIQgDQAJAIAUoAgRBeHEgAmsiBiAETw0AIAYhBCAFIQggBg0AQQAhBCAFIQggBSEDDAMLIAMgBUEUaigCACIGIAYgBSAAQR12QQRxakEQaigCACIFRhsgAyAGGyEDIABBAXQhACAFDQALCwJAIAMgCHINAEEAIQhBAiALdCIDQQAgA2tyIAdxIgNFDQMgA0EAIANrcUF/aiIDIANBDHZBEHEiA3YiBUEFdkEIcSIAIANyIAUgAHYiA0ECdkEEcSIFciADIAV2IgNBAXZBAnEiBXIgAyAFdiIDQQF2QQFxIgVyIAMgBXZqQQJ0QbjSgIAAaigCACEDCyADRQ0BCwNAIAMoAgRBeHEgAmsiBiAESSEAAkAgAygCECIFDQAgA0EUaigCACEFCyAGIAQgABshBCADIAggABshCCAFIQMgBQ0ACwsgCEUNACAEQQAoApDQgIAAIAJrTw0AIAgoAhghCwJAIAgoAgwiACAIRg0AIAgoAggiA0EAKAKY0ICAAEkaIAAgAzYCCCADIAA2AgwMCQsCQCAIQRRqIgUoAgAiAw0AIAgoAhAiA0UNAyAIQRBqIQULA0AgBSEGIAMiAEEUaiIFKAIAIgMNACAAQRBqIQUgACgCECIDDQALIAZBADYCAAwICwJAQQAoApDQgIAAIgMgAkkNAEEAKAKc0ICAACEEAkACQCADIAJrIgVBEEkNACAEIAJqIgAgBUEBcjYCBEEAIAU2ApDQgIAAQQAgADYCnNCAgAAgBCADaiAFNgIAIAQgAkEDcjYCBAwBCyAEIANBA3I2AgQgBCADaiIDIAMoAgRBAXI2AgRBAEEANgKc0ICAAEEAQQA2ApDQgIAACyAEQQhqIQMMCgsCQEEAKAKU0ICAACIAIAJNDQBBACgCoNCAgAAiAyACaiIEIAAgAmsiBUEBcjYCBEEAIAU2ApTQgIAAQQAgBDYCoNCAgAAgAyACQQNyNgIEIANBCGohAwwKCwJAAkBBACgC4NOAgABFDQBBACgC6NOAgAAhBAwBC0EAQn83AuzTgIAAQQBCgICEgICAwAA3AuTTgIAAQQAgAUEMakFwcUHYqtWqBXM2AuDTgIAAQQBBADYC9NOAgABBAEEANgLE04CAAEGAgAQhBAtBACEDAkAgBCACQccAaiIHaiIGQQAgBGsiC3EiCCACSw0AQQBBMDYC+NOAgAAMCgsCQEEAKALA04CAACIDRQ0AAkBBACgCuNOAgAAiBCAIaiIFIARNDQAgBSADTQ0BC0EAIQNBAEEwNgL404CAAAwKC0EALQDE04CAAEEEcQ0EAkACQAJAQQAoAqDQgIAAIgRFDQBByNOAgAAhAwNAAkAgAygCACIFIARLDQAgBSADKAIEaiAESw0DCyADKAIIIgMNAAsLQQAQy4CAgAAiAEF/Rg0FIAghBgJAQQAoAuTTgIAAIgNBf2oiBCAAcUUNACAIIABrIAQgAGpBACADa3FqIQYLIAYgAk0NBSAGQf7///8HSw0FAkBBACgCwNOAgAAiA0UNAEEAKAK404CAACIEIAZqIgUgBE0NBiAFIANLDQYLIAYQy4CAgAAiAyAARw0BDAcLIAYgAGsgC3EiBkH+////B0sNBCAGEMuAgIAAIgAgAygCACADKAIEakYNAyAAIQMLAkAgA0F/Rg0AIAJByABqIAZNDQACQCAHIAZrQQAoAujTgIAAIgRqQQAgBGtxIgRB/v///wdNDQAgAyEADAcLAkAgBBDLgICAAEF/Rg0AIAQgBmohBiADIQAMBwtBACAGaxDLgICAABoMBAsgAyEAIANBf0cNBQwDC0EAIQgMBwtBACEADAULIABBf0cNAgtBAEEAKALE04CAAEEEcjYCxNOAgAALIAhB/v///wdLDQEgCBDLgICAACEAQQAQy4CAgAAhAyAAQX9GDQEgA0F/Rg0BIAAgA08NASADIABrIgYgAkE4ak0NAQtBAEEAKAK404CAACAGaiIDNgK404CAAAJAIANBACgCvNOAgABNDQBBACADNgK804CAAAsCQAJAAkACQEEAKAKg0ICAACIERQ0AQcjTgIAAIQMDQCAAIAMoAgAiBSADKAIEIghqRg0CIAMoAggiAw0ADAMLCwJAAkBBACgCmNCAgAAiA0UNACAAIANPDQELQQAgADYCmNCAgAALQQAhA0EAIAY2AszTgIAAQQAgADYCyNOAgABBAEF/NgKo0ICAAEEAQQAoAuDTgIAANgKs0ICAAEEAQQA2AtTTgIAAA0AgA0HE0ICAAGogA0G40ICAAGoiBDYCACAEIANBsNCAgABqIgU2AgAgA0G80ICAAGogBTYCACADQczQgIAAaiADQcDQgIAAaiIFNgIAIAUgBDYCACADQdTQgIAAaiADQcjQgIAAaiIENgIAIAQgBTYCACADQdDQgIAAaiAENgIAIANBIGoiA0GAAkcNAAsgAEF4IABrQQ9xQQAgAEEIakEPcRsiA2oiBCAGQUhqIgUgA2siA0EBcjYCBEEAQQAoAvDTgIAANgKk0ICAAEEAIAM2ApTQgIAAQQAgBDYCoNCAgAAgACAFakE4NgIEDAILIAMtAAxBCHENACAEIAVJDQAgBCAATw0AIARBeCAEa0EPcUEAIARBCGpBD3EbIgVqIgBBACgClNCAgAAgBmoiCyAFayIFQQFyNgIEIAMgCCAGajYCBEEAQQAoAvDTgIAANgKk0ICAAEEAIAU2ApTQgIAAQQAgADYCoNCAgAAgBCALakE4NgIEDAELAkAgAEEAKAKY0ICAACIITw0AQQAgADYCmNCAgAAgACEICyAAIAZqIQVByNOAgAAhAwJAAkACQAJAAkACQAJAA0AgAygCACAFRg0BIAMoAggiAw0ADAILCyADLQAMQQhxRQ0BC0HI04CAACEDA0ACQCADKAIAIgUgBEsNACAFIAMoAgRqIgUgBEsNAwsgAygCCCEDDAALCyADIAA2AgAgAyADKAIEIAZqNgIEIABBeCAAa0EPcUEAIABBCGpBD3EbaiILIAJBA3I2AgQgBUF4IAVrQQ9xQQAgBUEIakEPcRtqIgYgCyACaiICayEDAkAgBiAERw0AQQAgAjYCoNCAgABBAEEAKAKU0ICAACADaiIDNgKU0ICAACACIANBAXI2AgQMAwsCQCAGQQAoApzQgIAARw0AQQAgAjYCnNCAgABBAEEAKAKQ0ICAACADaiIDNgKQ0ICAACACIANBAXI2AgQgAiADaiADNgIADAMLAkAgBigCBCIEQQNxQQFHDQAgBEF4cSEHAkACQCAEQf8BSw0AIAYoAggiBSAEQQN2IghBA3RBsNCAgABqIgBGGgJAIAYoAgwiBCAFRw0AQQBBACgCiNCAgABBfiAId3E2AojQgIAADAILIAQgAEYaIAQgBTYCCCAFIAQ2AgwMAQsgBigCGCEJAkACQCAGKAIMIgAgBkYNACAGKAIIIgQgCEkaIAAgBDYCCCAEIAA2AgwMAQsCQCAGQRRqIgQoAgAiBQ0AIAZBEGoiBCgCACIFDQBBACEADAELA0AgBCEIIAUiAEEUaiIEKAIAIgUNACAAQRBqIQQgACgCECIFDQALIAhBADYCAAsgCUUNAAJAAkAgBiAGKAIcIgVBAnRBuNKAgABqIgQoAgBHDQAgBCAANgIAIAANAUEAQQAoAozQgIAAQX4gBXdxNgKM0ICAAAwCCyAJQRBBFCAJKAIQIAZGG2ogADYCACAARQ0BCyAAIAk2AhgCQCAGKAIQIgRFDQAgACAENgIQIAQgADYCGAsgBigCFCIERQ0AIABBFGogBDYCACAEIAA2AhgLIAcgA2ohAyAGIAdqIgYoAgQhBAsgBiAEQX5xNgIEIAIgA2ogAzYCACACIANBAXI2AgQCQCADQf8BSw0AIANBeHFBsNCAgABqIQQCQAJAQQAoAojQgIAAIgVBASADQQN2dCIDcQ0AQQAgBSADcjYCiNCAgAAgBCEDDAELIAQoAgghAwsgAyACNgIMIAQgAjYCCCACIAQ2AgwgAiADNgIIDAMLQR8hBAJAIANB////B0sNACADQQh2IgQgBEGA/j9qQRB2QQhxIgR0IgUgBUGA4B9qQRB2QQRxIgV0IgAgAEGAgA9qQRB2QQJxIgB0QQ92IAQgBXIgAHJrIgRBAXQgAyAEQRVqdkEBcXJBHGohBAsgAiAENgIcIAJCADcCECAEQQJ0QbjSgIAAaiEFAkBBACgCjNCAgAAiAEEBIAR0IghxDQAgBSACNgIAQQAgACAIcjYCjNCAgAAgAiAFNgIYIAIgAjYCCCACIAI2AgwMAwsgA0EAQRkgBEEBdmsgBEEfRht0IQQgBSgCACEAA0AgACIFKAIEQXhxIANGDQIgBEEddiEAIARBAXQhBCAFIABBBHFqQRBqIggoAgAiAA0ACyAIIAI2AgAgAiAFNgIYIAIgAjYCDCACIAI2AggMAgsgAEF4IABrQQ9xQQAgAEEIakEPcRsiA2oiCyAGQUhqIgggA2siA0EBcjYCBCAAIAhqQTg2AgQgBCAFQTcgBWtBD3FBACAFQUlqQQ9xG2pBQWoiCCAIIARBEGpJGyIIQSM2AgRBAEEAKALw04CAADYCpNCAgABBACADNgKU0ICAAEEAIAs2AqDQgIAAIAhBEGpBACkC0NOAgAA3AgAgCEEAKQLI04CAADcCCEEAIAhBCGo2AtDTgIAAQQAgBjYCzNOAgABBACAANgLI04CAAEEAQQA2AtTTgIAAIAhBJGohAwNAIANBBzYCACADQQRqIgMgBUkNAAsgCCAERg0DIAggCCgCBEF+cTYCBCAIIAggBGsiADYCACAEIABBAXI2AgQCQCAAQf8BSw0AIABBeHFBsNCAgABqIQMCQAJAQQAoAojQgIAAIgVBASAAQQN2dCIAcQ0AQQAgBSAAcjYCiNCAgAAgAyEFDAELIAMoAgghBQsgBSAENgIMIAMgBDYCCCAEIAM2AgwgBCAFNgIIDAQLQR8hAwJAIABB////B0sNACAAQQh2IgMgA0GA/j9qQRB2QQhxIgN0IgUgBUGA4B9qQRB2QQRxIgV0IgggCEGAgA9qQRB2QQJxIgh0QQ92IAMgBXIgCHJrIgNBAXQgACADQRVqdkEBcXJBHGohAwsgBCADNgIcIARCADcCECADQQJ0QbjSgIAAaiEFAkBBACgCjNCAgAAiCEEBIAN0IgZxDQAgBSAENgIAQQAgCCAGcjYCjNCAgAAgBCAFNgIYIAQgBDYCCCAEIAQ2AgwMBAsgAEEAQRkgA0EBdmsgA0EfRht0IQMgBSgCACEIA0AgCCIFKAIEQXhxIABGDQMgA0EddiEIIANBAXQhAyAFIAhBBHFqQRBqIgYoAgAiCA0ACyAGIAQ2AgAgBCAFNgIYIAQgBDYCDCAEIAQ2AggMAwsgBSgCCCIDIAI2AgwgBSACNgIIIAJBADYCGCACIAU2AgwgAiADNgIICyALQQhqIQMMBQsgBSgCCCIDIAQ2AgwgBSAENgIIIARBADYCGCAEIAU2AgwgBCADNgIIC0EAKAKU0ICAACIDIAJNDQBBACgCoNCAgAAiBCACaiIFIAMgAmsiA0EBcjYCBEEAIAM2ApTQgIAAQQAgBTYCoNCAgAAgBCACQQNyNgIEIARBCGohAwwDC0EAIQNBAEEwNgL404CAAAwCCwJAIAtFDQACQAJAIAggCCgCHCIFQQJ0QbjSgIAAaiIDKAIARw0AIAMgADYCACAADQFBACAHQX4gBXdxIgc2AozQgIAADAILIAtBEEEUIAsoAhAgCEYbaiAANgIAIABFDQELIAAgCzYCGAJAIAgoAhAiA0UNACAAIAM2AhAgAyAANgIYCyAIQRRqKAIAIgNFDQAgAEEUaiADNgIAIAMgADYCGAsCQAJAIARBD0sNACAIIAQgAmoiA0EDcjYCBCAIIANqIgMgAygCBEEBcjYCBAwBCyAIIAJqIgAgBEEBcjYCBCAIIAJBA3I2AgQgACAEaiAENgIAAkAgBEH/AUsNACAEQXhxQbDQgIAAaiEDAkACQEEAKAKI0ICAACIFQQEgBEEDdnQiBHENAEEAIAUgBHI2AojQgIAAIAMhBAwBCyADKAIIIQQLIAQgADYCDCADIAA2AgggACADNgIMIAAgBDYCCAwBC0EfIQMCQCAEQf///wdLDQAgBEEIdiIDIANBgP4/akEQdkEIcSIDdCIFIAVBgOAfakEQdkEEcSIFdCICIAJBgIAPakEQdkECcSICdEEPdiADIAVyIAJyayIDQQF0IAQgA0EVanZBAXFyQRxqIQMLIAAgAzYCHCAAQgA3AhAgA0ECdEG40oCAAGohBQJAIAdBASADdCICcQ0AIAUgADYCAEEAIAcgAnI2AozQgIAAIAAgBTYCGCAAIAA2AgggACAANgIMDAELIARBAEEZIANBAXZrIANBH0YbdCEDIAUoAgAhAgJAA0AgAiIFKAIEQXhxIARGDQEgA0EddiECIANBAXQhAyAFIAJBBHFqQRBqIgYoAgAiAg0ACyAGIAA2AgAgACAFNgIYIAAgADYCDCAAIAA2AggMAQsgBSgCCCIDIAA2AgwgBSAANgIIIABBADYCGCAAIAU2AgwgACADNgIICyAIQQhqIQMMAQsCQCAKRQ0AAkACQCAAIAAoAhwiBUECdEG40oCAAGoiAygCAEcNACADIAg2AgAgCA0BQQAgCUF+IAV3cTYCjNCAgAAMAgsgCkEQQRQgCigCECAARhtqIAg2AgAgCEUNAQsgCCAKNgIYAkAgACgCECIDRQ0AIAggAzYCECADIAg2AhgLIABBFGooAgAiA0UNACAIQRRqIAM2AgAgAyAINgIYCwJAAkAgBEEPSw0AIAAgBCACaiIDQQNyNgIEIAAgA2oiAyADKAIEQQFyNgIEDAELIAAgAmoiBSAEQQFyNgIEIAAgAkEDcjYCBCAFIARqIAQ2AgACQCAHRQ0AIAdBeHFBsNCAgABqIQJBACgCnNCAgAAhAwJAAkBBASAHQQN2dCIIIAZxDQBBACAIIAZyNgKI0ICAACACIQgMAQsgAigCCCEICyAIIAM2AgwgAiADNgIIIAMgAjYCDCADIAg2AggLQQAgBTYCnNCAgABBACAENgKQ0ICAAAsgAEEIaiEDCyABQRBqJICAgIAAIAMLCgAgABDJgICAAAviDQEHfwJAIABFDQAgAEF4aiIBIABBfGooAgAiAkF4cSIAaiEDAkAgAkEBcQ0AIAJBA3FFDQEgASABKAIAIgJrIgFBACgCmNCAgAAiBEkNASACIABqIQACQCABQQAoApzQgIAARg0AAkAgAkH/AUsNACABKAIIIgQgAkEDdiIFQQN0QbDQgIAAaiIGRhoCQCABKAIMIgIgBEcNAEEAQQAoAojQgIAAQX4gBXdxNgKI0ICAAAwDCyACIAZGGiACIAQ2AgggBCACNgIMDAILIAEoAhghBwJAAkAgASgCDCIGIAFGDQAgASgCCCICIARJGiAGIAI2AgggAiAGNgIMDAELAkAgAUEUaiICKAIAIgQNACABQRBqIgIoAgAiBA0AQQAhBgwBCwNAIAIhBSAEIgZBFGoiAigCACIEDQAgBkEQaiECIAYoAhAiBA0ACyAFQQA2AgALIAdFDQECQAJAIAEgASgCHCIEQQJ0QbjSgIAAaiICKAIARw0AIAIgBjYCACAGDQFBAEEAKAKM0ICAAEF+IAR3cTYCjNCAgAAMAwsgB0EQQRQgBygCECABRhtqIAY2AgAgBkUNAgsgBiAHNgIYAkAgASgCECICRQ0AIAYgAjYCECACIAY2AhgLIAEoAhQiAkUNASAGQRRqIAI2AgAgAiAGNgIYDAELIAMoAgQiAkEDcUEDRw0AIAMgAkF+cTYCBEEAIAA2ApDQgIAAIAEgAGogADYCACABIABBAXI2AgQPCyABIANPDQAgAygCBCICQQFxRQ0AAkACQCACQQJxDQACQCADQQAoAqDQgIAARw0AQQAgATYCoNCAgABBAEEAKAKU0ICAACAAaiIANgKU0ICAACABIABBAXI2AgQgAUEAKAKc0ICAAEcNA0EAQQA2ApDQgIAAQQBBADYCnNCAgAAPCwJAIANBACgCnNCAgABHDQBBACABNgKc0ICAAEEAQQAoApDQgIAAIABqIgA2ApDQgIAAIAEgAEEBcjYCBCABIABqIAA2AgAPCyACQXhxIABqIQACQAJAIAJB/wFLDQAgAygCCCIEIAJBA3YiBUEDdEGw0ICAAGoiBkYaAkAgAygCDCICIARHDQBBAEEAKAKI0ICAAEF+IAV3cTYCiNCAgAAMAgsgAiAGRhogAiAENgIIIAQgAjYCDAwBCyADKAIYIQcCQAJAIAMoAgwiBiADRg0AIAMoAggiAkEAKAKY0ICAAEkaIAYgAjYCCCACIAY2AgwMAQsCQCADQRRqIgIoAgAiBA0AIANBEGoiAigCACIEDQBBACEGDAELA0AgAiEFIAQiBkEUaiICKAIAIgQNACAGQRBqIQIgBigCECIEDQALIAVBADYCAAsgB0UNAAJAAkAgAyADKAIcIgRBAnRBuNKAgABqIgIoAgBHDQAgAiAGNgIAIAYNAUEAQQAoAozQgIAAQX4gBHdxNgKM0ICAAAwCCyAHQRBBFCAHKAIQIANGG2ogBjYCACAGRQ0BCyAGIAc2AhgCQCADKAIQIgJFDQAgBiACNgIQIAIgBjYCGAsgAygCFCICRQ0AIAZBFGogAjYCACACIAY2AhgLIAEgAGogADYCACABIABBAXI2AgQgAUEAKAKc0ICAAEcNAUEAIAA2ApDQgIAADwsgAyACQX5xNgIEIAEgAGogADYCACABIABBAXI2AgQLAkAgAEH/AUsNACAAQXhxQbDQgIAAaiECAkACQEEAKAKI0ICAACIEQQEgAEEDdnQiAHENAEEAIAQgAHI2AojQgIAAIAIhAAwBCyACKAIIIQALIAAgATYCDCACIAE2AgggASACNgIMIAEgADYCCA8LQR8hAgJAIABB////B0sNACAAQQh2IgIgAkGA/j9qQRB2QQhxIgJ0IgQgBEGA4B9qQRB2QQRxIgR0IgYgBkGAgA9qQRB2QQJxIgZ0QQ92IAIgBHIgBnJrIgJBAXQgACACQRVqdkEBcXJBHGohAgsgASACNgIcIAFCADcCECACQQJ0QbjSgIAAaiEEAkACQEEAKAKM0ICAACIGQQEgAnQiA3ENACAEIAE2AgBBACAGIANyNgKM0ICAACABIAQ2AhggASABNgIIIAEgATYCDAwBCyAAQQBBGSACQQF2ayACQR9GG3QhAiAEKAIAIQYCQANAIAYiBCgCBEF4cSAARg0BIAJBHXYhBiACQQF0IQIgBCAGQQRxakEQaiIDKAIAIgYNAAsgAyABNgIAIAEgBDYCGCABIAE2AgwgASABNgIIDAELIAQoAggiACABNgIMIAQgATYCCCABQQA2AhggASAENgIMIAEgADYCCAtBAEEAKAKo0ICAAEF/aiIBQX8gARs2AqjQgIAACwsEAAAAC04AAkAgAA0APwBBEHQPCwJAIABB//8DcQ0AIABBf0wNAAJAIABBEHZAACIAQX9HDQBBAEEwNgL404CAAEF/DwsgAEEQdA8LEMqAgIAAAAvyAgIDfwF+AkAgAkUNACAAIAE6AAAgAiAAaiIDQX9qIAE6AAAgAkEDSQ0AIAAgAToAAiAAIAE6AAEgA0F9aiABOgAAIANBfmogAToAACACQQdJDQAgACABOgADIANBfGogAToAACACQQlJDQAgAEEAIABrQQNxIgRqIgMgAUH/AXFBgYKECGwiATYCACADIAIgBGtBfHEiBGoiAkF8aiABNgIAIARBCUkNACADIAE2AgggAyABNgIEIAJBeGogATYCACACQXRqIAE2AgAgBEEZSQ0AIAMgATYCGCADIAE2AhQgAyABNgIQIAMgATYCDCACQXBqIAE2AgAgAkFsaiABNgIAIAJBaGogATYCACACQWRqIAE2AgAgBCADQQRxQRhyIgVrIgJBIEkNACABrUKBgICAEH4hBiADIAVqIQEDQCABIAY3AxggASAGNwMQIAEgBjcDCCABIAY3AwAgAUEgaiEBIAJBYGoiAkEfSw0ACwsgAAsLjkgBAEGACAuGSAEAAAACAAAAAwAAAAAAAAAAAAAABAAAAAUAAAAAAAAAAAAAAAYAAAAHAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASW52YWxpZCBjaGFyIGluIHVybCBxdWVyeQBTcGFuIGNhbGxiYWNrIGVycm9yIGluIG9uX2JvZHkAQ29udGVudC1MZW5ndGggb3ZlcmZsb3cAQ2h1bmsgc2l6ZSBvdmVyZmxvdwBSZXNwb25zZSBvdmVyZmxvdwBJbnZhbGlkIG1ldGhvZCBmb3IgSFRUUC94LnggcmVxdWVzdABJbnZhbGlkIG1ldGhvZCBmb3IgUlRTUC94LnggcmVxdWVzdABFeHBlY3RlZCBTT1VSQ0UgbWV0aG9kIGZvciBJQ0UveC54IHJlcXVlc3QASW52YWxpZCBjaGFyIGluIHVybCBmcmFnbWVudCBzdGFydABFeHBlY3RlZCBkb3QAU3BhbiBjYWxsYmFjayBlcnJvciBpbiBvbl9zdGF0dXMASW52YWxpZCByZXNwb25zZSBzdGF0dXMASW52YWxpZCBjaGFyYWN0ZXIgaW4gY2h1bmsgZXh0ZW5zaW9ucwBVc2VyIGNhbGxiYWNrIGVycm9yAGBvbl9yZXNldGAgY2FsbGJhY2sgZXJyb3IAYG9uX2NodW5rX2hlYWRlcmAgY2FsbGJhY2sgZXJyb3IAYG9uX21lc3NhZ2VfYmVnaW5gIGNhbGxiYWNrIGVycm9yAGBvbl9jaHVua19leHRlbnNpb25fdmFsdWVgIGNhbGxiYWNrIGVycm9yAGBvbl9zdGF0dXNfY29tcGxldGVgIGNhbGxiYWNrIGVycm9yAGBvbl92ZXJzaW9uX2NvbXBsZXRlYCBjYWxsYmFjayBlcnJvcgBgb25fdXJsX2NvbXBsZXRlYCBjYWxsYmFjayBlcnJvcgBgb25fY2h1bmtfY29tcGxldGVgIGNhbGxiYWNrIGVycm9yAGBvbl9oZWFkZXJfdmFsdWVfY29tcGxldGVgIGNhbGxiYWNrIGVycm9yAGBvbl9tZXNzYWdlX2NvbXBsZXRlYCBjYWxsYmFjayBlcnJvcgBgb25fbWV0aG9kX2NvbXBsZXRlYCBjYWxsYmFjayBlcnJvcgBgb25faGVhZGVyX2ZpZWxkX2NvbXBsZXRlYCBjYWxsYmFjayBlcnJvcgBgb25fY2h1bmtfZXh0ZW5zaW9uX25hbWVgIGNhbGxiYWNrIGVycm9yAFVuZXhwZWN0ZWQgY2hhciBpbiB1cmwgc2VydmVyAEludmFsaWQgaGVhZGVyIHZhbHVlIGNoYXIASW52YWxpZCBoZWFkZXIgZmllbGQgY2hhcgBTcGFuIGNhbGxiYWNrIGVycm9yIGluIG9uX3ZlcnNpb24ASW52YWxpZCBtaW5vciB2ZXJzaW9uAEludmFsaWQgbWFqb3IgdmVyc2lvbgBFeHBlY3RlZCBzcGFjZSBhZnRlciB2ZXJzaW9uAEV4cGVjdGVkIENSTEYgYWZ0ZXIgdmVyc2lvbgBJbnZhbGlkIEhUVFAgdmVyc2lvbgBJbnZhbGlkIGhlYWRlciB0b2tlbgBTcGFuIGNhbGxiYWNrIGVycm9yIGluIG9uX3VybABJbnZhbGlkIGNoYXJhY3RlcnMgaW4gdXJsAFVuZXhwZWN0ZWQgc3RhcnQgY2hhciBpbiB1cmwARG91YmxlIEAgaW4gdXJsAEVtcHR5IENvbnRlbnQtTGVuZ3RoAEludmFsaWQgY2hhcmFjdGVyIGluIENvbnRlbnQtTGVuZ3RoAER1cGxpY2F0ZSBDb250ZW50LUxlbmd0aABJbnZhbGlkIGNoYXIgaW4gdXJsIHBhdGgAQ29udGVudC1MZW5ndGggY2FuJ3QgYmUgcHJlc2VudCB3aXRoIFRyYW5zZmVyLUVuY29kaW5nAEludmFsaWQgY2hhcmFjdGVyIGluIGNodW5rIHNpemUAU3BhbiBjYWxsYmFjayBlcnJvciBpbiBvbl9oZWFkZXJfdmFsdWUAU3BhbiBjYWxsYmFjayBlcnJvciBpbiBvbl9jaHVua19leHRlbnNpb25fdmFsdWUASW52YWxpZCBjaGFyYWN0ZXIgaW4gY2h1bmsgZXh0ZW5zaW9ucyB2YWx1ZQBNaXNzaW5nIGV4cGVjdGVkIExGIGFmdGVyIGhlYWRlciB2YWx1ZQBJbnZhbGlkIGBUcmFuc2Zlci1FbmNvZGluZ2AgaGVhZGVyIHZhbHVlAEludmFsaWQgY2hhcmFjdGVyIGluIGNodW5rIGV4dGVuc2lvbnMgcXVvdGUgdmFsdWUASW52YWxpZCBjaGFyYWN0ZXIgaW4gY2h1bmsgZXh0ZW5zaW9ucyBxdW90ZWQgdmFsdWUAUGF1c2VkIGJ5IG9uX2hlYWRlcnNfY29tcGxldGUASW52YWxpZCBFT0Ygc3RhdGUAb25fcmVzZXQgcGF1c2UAb25fY2h1bmtfaGVhZGVyIHBhdXNlAG9uX21lc3NhZ2VfYmVnaW4gcGF1c2UAb25fY2h1bmtfZXh0ZW5zaW9uX3ZhbHVlIHBhdXNlAG9uX3N0YXR1c19jb21wbGV0ZSBwYXVzZQBvbl92ZXJzaW9uX2NvbXBsZXRlIHBhdXNlAG9uX3VybF9jb21wbGV0ZSBwYXVzZQBvbl9jaHVua19jb21wbGV0ZSBwYXVzZQBvbl9oZWFkZXJfdmFsdWVfY29tcGxldGUgcGF1c2UAb25fbWVzc2FnZV9jb21wbGV0ZSBwYXVzZQBvbl9tZXRob2RfY29tcGxldGUgcGF1c2UAb25faGVhZGVyX2ZpZWxkX2NvbXBsZXRlIHBhdXNlAG9uX2NodW5rX2V4dGVuc2lvbl9uYW1lIHBhdXNlAFVuZXhwZWN0ZWQgc3BhY2UgYWZ0ZXIgc3RhcnQgbGluZQBTcGFuIGNhbGxiYWNrIGVycm9yIGluIG9uX2NodW5rX2V4dGVuc2lvbl9uYW1lAEludmFsaWQgY2hhcmFjdGVyIGluIGNodW5rIGV4dGVuc2lvbnMgbmFtZQBQYXVzZSBvbiBDT05ORUNUL1VwZ3JhZGUAUGF1c2Ugb24gUFJJL1VwZ3JhZGUARXhwZWN0ZWQgSFRUUC8yIENvbm5lY3Rpb24gUHJlZmFjZQBTcGFuIGNhbGxiYWNrIGVycm9yIGluIG9uX21ldGhvZABFeHBlY3RlZCBzcGFjZSBhZnRlciBtZXRob2QAU3BhbiBjYWxsYmFjayBlcnJvciBpbiBvbl9oZWFkZXJfZmllbGQAUGF1c2VkAEludmFsaWQgd29yZCBlbmNvdW50ZXJlZABJbnZhbGlkIG1ldGhvZCBlbmNvdW50ZXJlZABVbmV4cGVjdGVkIGNoYXIgaW4gdXJsIHNjaGVtYQBSZXF1ZXN0IGhhcyBpbnZhbGlkIGBUcmFuc2Zlci1FbmNvZGluZ2AAU1dJVENIX1BST1hZAFVTRV9QUk9YWQBNS0FDVElWSVRZAFVOUFJPQ0VTU0FCTEVfRU5USVRZAENPUFkATU9WRURfUEVSTUFORU5UTFkAVE9PX0VBUkxZAE5PVElGWQBGQUlMRURfREVQRU5ERU5DWQBCQURfR0FURVdBWQBQTEFZAFBVVABDSEVDS09VVABHQVRFV0FZX1RJTUVPVVQAUkVRVUVTVF9USU1FT1VUAE5FVFdPUktfQ09OTkVDVF9USU1FT1VUAENPTk5FQ1RJT05fVElNRU9VVABMT0dJTl9USU1FT1VUAE5FVFdPUktfUkVBRF9USU1FT1VUAFBPU1QATUlTRElSRUNURURfUkVRVUVTVABDTElFTlRfQ0xPU0VEX1JFUVVFU1QAQ0xJRU5UX0NMT1NFRF9MT0FEX0JBTEFOQ0VEX1JFUVVFU1QAQkFEX1JFUVVFU1QASFRUUF9SRVFVRVNUX1NFTlRfVE9fSFRUUFNfUE9SVABSRVBPUlQASU1fQV9URUFQT1QAUkVTRVRfQ09OVEVOVABOT19DT05URU5UAFBBUlRJQUxfQ09OVEVOVABIUEVfSU5WQUxJRF9DT05TVEFOVABIUEVfQ0JfUkVTRVQAR0VUAEhQRV9TVFJJQ1QAQ09ORkxJQ1QAVEVNUE9SQVJZX1JFRElSRUNUAFBFUk1BTkVOVF9SRURJUkVDVABDT05ORUNUAE1VTFRJX1NUQVRVUwBIUEVfSU5WQUxJRF9TVEFUVVMAVE9PX01BTllfUkVRVUVTVFMARUFSTFlfSElOVFMAVU5BVkFJTEFCTEVfRk9SX0xFR0FMX1JFQVNPTlMAT1BUSU9OUwBTV0lUQ0hJTkdfUFJPVE9DT0xTAFZBUklBTlRfQUxTT19ORUdPVElBVEVTAE1VTFRJUExFX0NIT0lDRVMASU5URVJOQUxfU0VSVkVSX0VSUk9SAFdFQl9TRVJWRVJfVU5LTk9XTl9FUlJPUgBSQUlMR1VOX0VSUk9SAElERU5USVRZX1BST1ZJREVSX0FVVEhFTlRJQ0FUSU9OX0VSUk9SAFNTTF9DRVJUSUZJQ0FURV9FUlJPUgBJTlZBTElEX1hfRk9SV0FSREVEX0ZPUgBTRVRfUEFSQU1FVEVSAEdFVF9QQVJBTUVURVIASFBFX1VTRVIAU0VFX09USEVSAEhQRV9DQl9DSFVOS19IRUFERVIATUtDQUxFTkRBUgBTRVRVUABXRUJfU0VSVkVSX0lTX0RPV04AVEVBUkRPV04ASFBFX0NMT1NFRF9DT05ORUNUSU9OAEhFVVJJU1RJQ19FWFBJUkFUSU9OAERJU0NPTk5FQ1RFRF9PUEVSQVRJT04ATk9OX0FVVEhPUklUQVRJVkVfSU5GT1JNQVRJT04ASFBFX0lOVkFMSURfVkVSU0lPTgBIUEVfQ0JfTUVTU0FHRV9CRUdJTgBTSVRFX0lTX0ZST1pFTgBIUEVfSU5WQUxJRF9IRUFERVJfVE9LRU4ASU5WQUxJRF9UT0tFTgBGT1JCSURERU4ARU5IQU5DRV9ZT1VSX0NBTE0ASFBFX0lOVkFMSURfVVJMAEJMT0NLRURfQllfUEFSRU5UQUxfQ09OVFJPTABNS0NPTABBQ0wASFBFX0lOVEVSTkFMAFJFUVVFU1RfSEVBREVSX0ZJRUxEU19UT09fTEFSR0VfVU5PRkZJQ0lBTABIUEVfT0sAVU5MSU5LAFVOTE9DSwBQUkkAUkVUUllfV0lUSABIUEVfSU5WQUxJRF9DT05URU5UX0xFTkdUSABIUEVfVU5FWFBFQ1RFRF9DT05URU5UX0xFTkdUSABGTFVTSABQUk9QUEFUQ0gATS1TRUFSQ0gAVVJJX1RPT19MT05HAFBST0NFU1NJTkcATUlTQ0VMTEFORU9VU19QRVJTSVNURU5UX1dBUk5JTkcATUlTQ0VMTEFORU9VU19XQVJOSU5HAEhQRV9JTlZBTElEX1RSQU5TRkVSX0VOQ09ESU5HAEV4cGVjdGVkIENSTEYASFBFX0lOVkFMSURfQ0hVTktfU0laRQBNT1ZFAENPTlRJTlVFAEhQRV9DQl9TVEFUVVNfQ09NUExFVEUASFBFX0NCX0hFQURFUlNfQ09NUExFVEUASFBFX0NCX1ZFUlNJT05fQ09NUExFVEUASFBFX0NCX1VSTF9DT01QTEVURQBIUEVfQ0JfQ0hVTktfQ09NUExFVEUASFBFX0NCX0hFQURFUl9WQUxVRV9DT01QTEVURQBIUEVfQ0JfQ0hVTktfRVhURU5TSU9OX1ZBTFVFX0NPTVBMRVRFAEhQRV9DQl9DSFVOS19FWFRFTlNJT05fTkFNRV9DT01QTEVURQBIUEVfQ0JfTUVTU0FHRV9DT01QTEVURQBIUEVfQ0JfTUVUSE9EX0NPTVBMRVRFAEhQRV9DQl9IRUFERVJfRklFTERfQ09NUExFVEUAREVMRVRFAEhQRV9JTlZBTElEX0VPRl9TVEFURQBJTlZBTElEX1NTTF9DRVJUSUZJQ0FURQBQQVVTRQBOT19SRVNQT05TRQBVTlNVUFBPUlRFRF9NRURJQV9UWVBFAEdPTkUATk9UX0FDQ0VQVEFCTEUAU0VSVklDRV9VTkFWQUlMQUJMRQBSQU5HRV9OT1RfU0FUSVNGSUFCTEUAT1JJR0lOX0lTX1VOUkVBQ0hBQkxFAFJFU1BPTlNFX0lTX1NUQUxFAFBVUkdFAE1FUkdFAFJFUVVFU1RfSEVBREVSX0ZJRUxEU19UT09fTEFSR0UAUkVRVUVTVF9IRUFERVJfVE9PX0xBUkdFAFBBWUxPQURfVE9PX0xBUkdFAElOU1VGRklDSUVOVF9TVE9SQUdFAEhQRV9QQVVTRURfVVBHUkFERQBIUEVfUEFVU0VEX0gyX1VQR1JBREUAU09VUkNFAEFOTk9VTkNFAFRSQUNFAEhQRV9VTkVYUEVDVEVEX1NQQUNFAERFU0NSSUJFAFVOU1VCU0NSSUJFAFJFQ09SRABIUEVfSU5WQUxJRF9NRVRIT0QATk9UX0ZPVU5EAFBST1BGSU5EAFVOQklORABSRUJJTkQAVU5BVVRIT1JJWkVEAE1FVEhPRF9OT1RfQUxMT1dFRABIVFRQX1ZFUlNJT05fTk9UX1NVUFBPUlRFRABBTFJFQURZX1JFUE9SVEVEAEFDQ0VQVEVEAE5PVF9JTVBMRU1FTlRFRABMT09QX0RFVEVDVEVEAEhQRV9DUl9FWFBFQ1RFRABIUEVfTEZfRVhQRUNURUQAQ1JFQVRFRABJTV9VU0VEAEhQRV9QQVVTRUQAVElNRU9VVF9PQ0NVUkVEAFBBWU1FTlRfUkVRVUlSRUQAUFJFQ09ORElUSU9OX1JFUVVJUkVEAFBST1hZX0FVVEhFTlRJQ0FUSU9OX1JFUVVJUkVEAE5FVFdPUktfQVVUSEVOVElDQVRJT05fUkVRVUlSRUQATEVOR1RIX1JFUVVJUkVEAFNTTF9DRVJUSUZJQ0FURV9SRVFVSVJFRABVUEdSQURFX1JFUVVJUkVEAFBBR0VfRVhQSVJFRABQUkVDT05ESVRJT05fRkFJTEVEAEVYUEVDVEFUSU9OX0ZBSUxFRABSRVZBTElEQVRJT05fRkFJTEVEAFNTTF9IQU5EU0hBS0VfRkFJTEVEAExPQ0tFRABUUkFOU0ZPUk1BVElPTl9BUFBMSUVEAE5PVF9NT0RJRklFRABOT1RfRVhURU5ERUQAQkFORFdJRFRIX0xJTUlUX0VYQ0VFREVEAFNJVEVfSVNfT1ZFUkxPQURFRABIRUFEAEV4cGVjdGVkIEhUVFAvAABeEwAAJhMAADAQAADwFwAAnRMAABUSAAA5FwAA8BIAAAoQAAB1EgAArRIAAIITAABPFAAAfxAAAKAVAAAjFAAAiRIAAIsUAABNFQAA1BEAAM8UAAAQGAAAyRYAANwWAADBEQAA4BcAALsUAAB0FAAAfBUAAOUUAAAIFwAAHxAAAGUVAACjFAAAKBUAAAIVAACZFQAALBAAAIsZAABPDwAA1A4AAGoQAADOEAAAAhcAAIkOAABuEwAAHBMAAGYUAABWFwAAwRMAAM0TAABsEwAAaBcAAGYXAABfFwAAIhMAAM4PAABpDgAA2A4AAGMWAADLEwAAqg4AACgXAAAmFwAAxRMAAF0WAADoEQAAZxMAAGUTAADyFgAAcxMAAB0XAAD5FgAA8xEAAM8OAADOFQAADBIAALMRAAClEQAAYRAAADIXAAC7EwAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAgEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgMCAgICAgAAAgIAAgIAAgICAgICAgICAgAEAAAAAAACAgICAgICAgICAgICAgICAgICAgICAgICAgAAAAICAgICAgICAgICAgICAgICAgICAgICAgICAgICAAIAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAgICAgIAAAICAAICAAICAgICAgICAgIAAwAEAAAAAgICAgICAgICAgICAgICAgICAgICAgICAgIAAAACAgICAgICAgICAgICAgICAgICAgICAgICAgICAgACAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABsb3NlZWVwLWFsaXZlAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEBAQEBAQEBAQEBAgEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQFjaHVua2VkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQABAQEBAQAAAQEAAQEAAQEBAQEBAQEBAQAAAAAAAAABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQAAAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAEAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGVjdGlvbmVudC1sZW5ndGhvbnJveHktY29ubmVjdGlvbgAAAAAAAAAAAAAAAAAAAHJhbnNmZXItZW5jb2RpbmdwZ3JhZGUNCg0KDQpTTQ0KDQpUVFAvQ0UvVFNQLwAAAAAAAAAAAAAAAAECAAEDAAAAAAAAAAAAAAAAAAAAAAAABAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAAAAAAAAAAABAgABAwAAAAAAAAAAAAAAAAAAAAAAAAQBAQUBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAAAAAAAAAAAAQAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAQEAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAAAAAAABAAACAAAAAAAAAAAAAAAAAAAAAAAAAwQAAAQEBAQEBAQEBAQEBQQEBAQEBAQEBAQEBAAEAAYHBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAQABAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAAAAAAAAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAgAAAAACAAAAAAAAAAAAAAAAAAAAAAADAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAAAAAAAAMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE5PVU5DRUVDS09VVE5FQ1RFVEVDUklCRUxVU0hFVEVBRFNFQVJDSFJHRUNUSVZJVFlMRU5EQVJWRU9USUZZUFRJT05TQ0hTRUFZU1RBVENIR0VPUkRJUkVDVE9SVFJDSFBBUkFNRVRFUlVSQ0VCU0NSSUJFQVJET1dOQUNFSU5ETktDS1VCU0NSSUJFSFRUUC9BRFRQLw=='
@@ -16385,7 +14601,7 @@ module.exports = 'AGFzbQEAAAABMAhgAX8Bf2ADf39/AX9gBH9/f38Bf2AAAGADf39/AGABfwBgAn
 
 /***/ }),
 
-/***/ 74:
+/***/ 71:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16395,14 +14611,14 @@ exports.generateBlobSASQueryParameters = generateBlobSASQueryParameters;
 exports.generateBlobSASQueryParametersInternal = generateBlobSASQueryParametersInternal;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const BlobSASPermissions_js_1 = __nccwpck_require__(518);
-const ContainerSASPermissions_js_1 = __nccwpck_require__(288);
-const storage_common_1 = __nccwpck_require__(285);
-const SasIPRange_js_1 = __nccwpck_require__(369);
-const SASQueryParameters_js_1 = __nccwpck_require__(541);
-const constants_js_1 = __nccwpck_require__(155);
-const utils_common_js_1 = __nccwpck_require__(161);
-const storage_common_2 = __nccwpck_require__(285);
+const BlobSASPermissions_js_1 = __nccwpck_require__(519);
+const ContainerSASPermissions_js_1 = __nccwpck_require__(286);
+const storage_common_1 = __nccwpck_require__(283);
+const SasIPRange_js_1 = __nccwpck_require__(368);
+const SASQueryParameters_js_1 = __nccwpck_require__(542);
+const constants_js_1 = __nccwpck_require__(152);
+const utils_common_js_1 = __nccwpck_require__(158);
+const storage_common_2 = __nccwpck_require__(283);
 function generateBlobSASQueryParameters(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName) {
     return generateBlobSASQueryParametersInternal(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName).sasQueryParameters;
 }
@@ -17062,22 +15278,22 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 
 /***/ }),
 
-/***/ 75:
+/***/ 72:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const assert = __nccwpck_require__(542)
-const { kDestroyed, kBodyUsed } = __nccwpck_require__(200)
-const { IncomingMessage } = __nccwpck_require__(338)
-const stream = __nccwpck_require__(135)
-const net = __nccwpck_require__(523)
-const { InvalidArgumentError } = __nccwpck_require__(504)
-const { Blob } = __nccwpck_require__(124)
-const nodeUtil = __nccwpck_require__(128)
-const { stringify } = __nccwpck_require__(134)
-const { headerNameLowerCasedRecord } = __nccwpck_require__(79)
+const assert = __nccwpck_require__(543)
+const { kDestroyed, kBodyUsed } = __nccwpck_require__(197)
+const { IncomingMessage } = __nccwpck_require__(336)
+const stream = __nccwpck_require__(132)
+const net = __nccwpck_require__(524)
+const { InvalidArgumentError } = __nccwpck_require__(505)
+const { Blob } = __nccwpck_require__(121)
+const nodeUtil = __nccwpck_require__(125)
+const { stringify } = __nccwpck_require__(131)
+const { headerNameLowerCasedRecord } = __nccwpck_require__(76)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
 
@@ -17446,7 +15662,7 @@ async function * convertIterableToBuffer (iterable) {
 let ReadableStream
 function ReadableStreamFrom (iterable) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(265).ReadableStream)
+    ReadableStream = (__nccwpck_require__(263).ReadableStream)
   }
 
   if (ReadableStream.from) {
@@ -17592,7 +15808,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 76:
+/***/ 73:
 /***/ ((module) => {
 
 "use strict";
@@ -17600,7 +15816,7 @@ module.exports = require("https");
 
 /***/ }),
 
-/***/ 77:
+/***/ 74:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -17626,8 +15842,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(188);
-var import_policies = __nccwpck_require__(294);
+var import_log = __nccwpck_require__(185);
+var import_policies = __nccwpck_require__(292);
 const logPolicyName = import_policies.logPolicyName;
 function logPolicy(options = {}) {
   return (0, import_policies.logPolicy)({
@@ -17641,7 +15857,7 @@ function logPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 78:
+/***/ 75:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -17673,12 +15889,12 @@ __export(src_exports, {
   toHttpHeadersLike: () => import_util.toHttpHeadersLike
 });
 module.exports = __toCommonJS(src_exports);
-var import_extendedClient = __nccwpck_require__(219);
-var import_response = __nccwpck_require__(423);
-var import_requestPolicyFactoryPolicy = __nccwpck_require__(69);
+var import_extendedClient = __nccwpck_require__(218);
+var import_response = __nccwpck_require__(424);
+var import_requestPolicyFactoryPolicy = __nccwpck_require__(66);
 var import_disableKeepAlivePolicy = __nccwpck_require__(9);
-var import_httpClientAdapter = __nccwpck_require__(215);
-var import_util = __nccwpck_require__(115);
+var import_httpClientAdapter = __nccwpck_require__(213);
+var import_util = __nccwpck_require__(112);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -17686,7 +15902,7 @@ var import_util = __nccwpck_require__(115);
 
 /***/ }),
 
-/***/ 79:
+/***/ 76:
 /***/ ((module) => {
 
 "use strict";
@@ -17812,7 +16028,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 80:
+/***/ 77:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -18222,7 +16438,7 @@ exports.Poller = Poller;
 
 /***/ }),
 
-/***/ 81:
+/***/ 78:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -18268,16 +16484,16 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
-const core = __importStar(__nccwpck_require__(474));
-const exec = __importStar(__nccwpck_require__(20));
-const glob = __importStar(__nccwpck_require__(173));
-const io = __importStar(__nccwpck_require__(302));
-const crypto = __importStar(__nccwpck_require__(299));
-const fs = __importStar(__nccwpck_require__(546));
-const path = __importStar(__nccwpck_require__(256));
-const semver = __importStar(__nccwpck_require__(183));
-const util = __importStar(__nccwpck_require__(128));
-const constants_1 = __nccwpck_require__(49);
+const core = __importStar(__nccwpck_require__(475));
+const exec = __importStar(__nccwpck_require__(19));
+const glob = __importStar(__nccwpck_require__(170));
+const io = __importStar(__nccwpck_require__(300));
+const crypto = __importStar(__nccwpck_require__(297));
+const fs = __importStar(__nccwpck_require__(547));
+const path = __importStar(__nccwpck_require__(254));
+const semver = __importStar(__nccwpck_require__(180));
+const util = __importStar(__nccwpck_require__(125));
+const constants_1 = __nccwpck_require__(47);
 const versionSalt = '1.0';
 // From https://github.com/actions/toolkit/blob/main/packages/tool-cache/src/tool-cache.ts#L23
 function createTempDirectory() {
@@ -18445,7 +16661,7 @@ exports.getRuntimeToken = getRuntimeToken;
 
 /***/ }),
 
-/***/ 82:
+/***/ 79:
 /***/ ((module) => {
 
 module.exports = 'AGFzbQEAAAABMAhgAX8Bf2ADf39/AX9gBH9/f38Bf2AAAGADf39/AGABfwBgAn9/AGAGf39/f39/AALLAQgDZW52GHdhc21fb25faGVhZGVyc19jb21wbGV0ZQACA2VudhV3YXNtX29uX21lc3NhZ2VfYmVnaW4AAANlbnYLd2FzbV9vbl91cmwAAQNlbnYOd2FzbV9vbl9zdGF0dXMAAQNlbnYUd2FzbV9vbl9oZWFkZXJfZmllbGQAAQNlbnYUd2FzbV9vbl9oZWFkZXJfdmFsdWUAAQNlbnYMd2FzbV9vbl9ib2R5AAEDZW52GHdhc21fb25fbWVzc2FnZV9jb21wbGV0ZQAAA0ZFAwMEAAAFAAAAAAAABQEFAAUFBQAABgAAAAAGBgYGAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQABAAABAQcAAAUFAwABBAUBcAESEgUDAQACBggBfwFBgNQECwfRBSIGbWVtb3J5AgALX2luaXRpYWxpemUACRlfX2luZGlyZWN0X2Z1bmN0aW9uX3RhYmxlAQALbGxodHRwX2luaXQAChhsbGh0dHBfc2hvdWxkX2tlZXBfYWxpdmUAQQxsbGh0dHBfYWxsb2MADAZtYWxsb2MARgtsbGh0dHBfZnJlZQANBGZyZWUASA9sbGh0dHBfZ2V0X3R5cGUADhVsbGh0dHBfZ2V0X2h0dHBfbWFqb3IADxVsbGh0dHBfZ2V0X2h0dHBfbWlub3IAEBFsbGh0dHBfZ2V0X21ldGhvZAARFmxsaHR0cF9nZXRfc3RhdHVzX2NvZGUAEhJsbGh0dHBfZ2V0X3VwZ3JhZGUAEwxsbGh0dHBfcmVzZXQAFA5sbGh0dHBfZXhlY3V0ZQAVFGxsaHR0cF9zZXR0aW5nc19pbml0ABYNbGxodHRwX2ZpbmlzaAAXDGxsaHR0cF9wYXVzZQAYDWxsaHR0cF9yZXN1bWUAGRtsbGh0dHBfcmVzdW1lX2FmdGVyX3VwZ3JhZGUAGhBsbGh0dHBfZ2V0X2Vycm5vABsXbGxodHRwX2dldF9lcnJvcl9yZWFzb24AHBdsbGh0dHBfc2V0X2Vycm9yX3JlYXNvbgAdFGxsaHR0cF9nZXRfZXJyb3JfcG9zAB4RbGxodHRwX2Vycm5vX25hbWUAHxJsbGh0dHBfbWV0aG9kX25hbWUAIBJsbGh0dHBfc3RhdHVzX25hbWUAIRpsbGh0dHBfc2V0X2xlbmllbnRfaGVhZGVycwAiIWxsaHR0cF9zZXRfbGVuaWVudF9jaHVua2VkX2xlbmd0aAAjHWxsaHR0cF9zZXRfbGVuaWVudF9rZWVwX2FsaXZlACQkbGxodHRwX3NldF9sZW5pZW50X3RyYW5zZmVyX2VuY29kaW5nACUYbGxodHRwX21lc3NhZ2VfbmVlZHNfZW9mAD8JFwEAQQELEQECAwQFCwYHNTk3MS8tJyspCsLgAkUCAAsIABCIgICAAAsZACAAEMKAgIAAGiAAIAI2AjggACABOgAoCxwAIAAgAC8BMiAALQAuIAAQwYCAgAAQgICAgAALKgEBf0HAABDGgICAACIBEMKAgIAAGiABQYCIgIAANgI4IAEgADoAKCABCwoAIAAQyICAgAALBwAgAC0AKAsHACAALQAqCwcAIAAtACsLBwAgAC0AKQsHACAALwEyCwcAIAAtAC4LRQEEfyAAKAIYIQEgAC0ALSECIAAtACghAyAAKAI4IQQgABDCgICAABogACAENgI4IAAgAzoAKCAAIAI6AC0gACABNgIYCxEAIAAgASABIAJqEMOAgIAACxAAIABBAEHcABDMgICAABoLZwEBf0EAIQECQCAAKAIMDQACQAJAAkACQCAALQAvDgMBAAMCCyAAKAI4IgFFDQAgASgCLCIBRQ0AIAAgARGAgICAAAAiAQ0DC0EADwsQyoCAgAAACyAAQcOWgIAANgIQQQ4hAQsgAQseAAJAIAAoAgwNACAAQdGbgIAANgIQIABBFTYCDAsLFgACQCAAKAIMQRVHDQAgAEEANgIMCwsWAAJAIAAoAgxBFkcNACAAQQA2AgwLCwcAIAAoAgwLBwAgACgCEAsJACAAIAE2AhALBwAgACgCFAsiAAJAIABBJEkNABDKgICAAAALIABBAnRBoLOAgABqKAIACyIAAkAgAEEuSQ0AEMqAgIAAAAsgAEECdEGwtICAAGooAgAL7gsBAX9B66iAgAAhAQJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAIABBnH9qDvQDY2IAAWFhYWFhYQIDBAVhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhBgcICQoLDA0OD2FhYWFhEGFhYWFhYWFhYWFhEWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYRITFBUWFxgZGhthYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2YTc4OTphYWFhYWFhYTthYWE8YWFhYT0+P2FhYWFhYWFhQGFhQWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYUJDREVGR0hJSktMTU5PUFFSU2FhYWFhYWFhVFVWV1hZWlthXF1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFeYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhX2BhC0Hhp4CAAA8LQaShgIAADwtBy6yAgAAPC0H+sYCAAA8LQcCkgIAADwtBq6SAgAAPC0GNqICAAA8LQeKmgIAADwtBgLCAgAAPC0G5r4CAAA8LQdekgIAADwtB75+AgAAPC0Hhn4CAAA8LQfqfgIAADwtB8qCAgAAPC0Gor4CAAA8LQa6ygIAADwtBiLCAgAAPC0Hsp4CAAA8LQYKigIAADwtBjp2AgAAPC0HQroCAAA8LQcqjgIAADwtBxbKAgAAPC0HfnICAAA8LQdKcgIAADwtBxKCAgAAPC0HXoICAAA8LQaKfgIAADwtB7a6AgAAPC0GrsICAAA8LQdSlgIAADwtBzK6AgAAPC0H6roCAAA8LQfyrgIAADwtB0rCAgAAPC0HxnYCAAA8LQbuggIAADwtB96uAgAAPC0GQsYCAAA8LQdexgIAADwtBoq2AgAAPC0HUp4CAAA8LQeCrgIAADwtBn6yAgAAPC0HrsYCAAA8LQdWfgIAADwtByrGAgAAPC0HepYCAAA8LQdSegIAADwtB9JyAgAAPC0GnsoCAAA8LQbGdgIAADwtBoJ2AgAAPC0G5sYCAAA8LQbywgIAADwtBkqGAgAAPC0GzpoCAAA8LQemsgIAADwtBrJ6AgAAPC0HUq4CAAA8LQfemgIAADwtBgKaAgAAPC0GwoYCAAA8LQf6egIAADwtBjaOAgAAPC0GJrYCAAA8LQfeigIAADwtBoLGAgAAPC0Gun4CAAA8LQcalgIAADwtB6J6AgAAPC0GTooCAAA8LQcKvgIAADwtBw52AgAAPC0GLrICAAA8LQeGdgIAADwtBja+AgAAPC0HqoYCAAA8LQbStgIAADwtB0q+AgAAPC0HfsoCAAA8LQdKygIAADwtB8LCAgAAPC0GpooCAAA8LQfmjgIAADwtBmZ6AgAAPC0G1rICAAA8LQZuwgIAADwtBkrKAgAAPC0G2q4CAAA8LQcKigIAADwtB+LKAgAAPC0GepYCAAA8LQdCigIAADwtBup6AgAAPC0GBnoCAAA8LEMqAgIAAAAtB1qGAgAAhAQsgAQsWACAAIAAtAC1B/gFxIAFBAEdyOgAtCxkAIAAgAC0ALUH9AXEgAUEAR0EBdHI6AC0LGQAgACAALQAtQfsBcSABQQBHQQJ0cjoALQsZACAAIAAtAC1B9wFxIAFBAEdBA3RyOgAtCy4BAn9BACEDAkAgACgCOCIERQ0AIAQoAgAiBEUNACAAIAQRgICAgAAAIQMLIAMLSQECf0EAIQMCQCAAKAI4IgRFDQAgBCgCBCIERQ0AIAAgASACIAFrIAQRgYCAgAAAIgNBf0cNACAAQcaRgIAANgIQQRghAwsgAwsuAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAIwIgRFDQAgACAEEYCAgIAAACEDCyADC0kBAn9BACEDAkAgACgCOCIERQ0AIAQoAggiBEUNACAAIAEgAiABayAEEYGAgIAAACIDQX9HDQAgAEH2ioCAADYCEEEYIQMLIAMLLgECf0EAIQMCQCAAKAI4IgRFDQAgBCgCNCIERQ0AIAAgBBGAgICAAAAhAwsgAwtJAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAIMIgRFDQAgACABIAIgAWsgBBGBgICAAAAiA0F/Rw0AIABB7ZqAgAA2AhBBGCEDCyADCy4BAn9BACEDAkAgACgCOCIERQ0AIAQoAjgiBEUNACAAIAQRgICAgAAAIQMLIAMLSQECf0EAIQMCQCAAKAI4IgRFDQAgBCgCECIERQ0AIAAgASACIAFrIAQRgYCAgAAAIgNBf0cNACAAQZWQgIAANgIQQRghAwsgAwsuAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAI8IgRFDQAgACAEEYCAgIAAACEDCyADC0kBAn9BACEDAkAgACgCOCIERQ0AIAQoAhQiBEUNACAAIAEgAiABayAEEYGAgIAAACIDQX9HDQAgAEGqm4CAADYCEEEYIQMLIAMLLgECf0EAIQMCQCAAKAI4IgRFDQAgBCgCQCIERQ0AIAAgBBGAgICAAAAhAwsgAwtJAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAIYIgRFDQAgACABIAIgAWsgBBGBgICAAAAiA0F/Rw0AIABB7ZOAgAA2AhBBGCEDCyADCy4BAn9BACEDAkAgACgCOCIERQ0AIAQoAkQiBEUNACAAIAQRgICAgAAAIQMLIAMLLgECf0EAIQMCQCAAKAI4IgRFDQAgBCgCJCIERQ0AIAAgBBGAgICAAAAhAwsgAwsuAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAIsIgRFDQAgACAEEYCAgIAAACEDCyADC0kBAn9BACEDAkAgACgCOCIERQ0AIAQoAigiBEUNACAAIAEgAiABayAEEYGAgIAAACIDQX9HDQAgAEH2iICAADYCEEEYIQMLIAMLLgECf0EAIQMCQCAAKAI4IgRFDQAgBCgCUCIERQ0AIAAgBBGAgICAAAAhAwsgAwtJAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAIcIgRFDQAgACABIAIgAWsgBBGBgICAAAAiA0F/Rw0AIABBwpmAgAA2AhBBGCEDCyADCy4BAn9BACEDAkAgACgCOCIERQ0AIAQoAkgiBEUNACAAIAQRgICAgAAAIQMLIAMLSQECf0EAIQMCQCAAKAI4IgRFDQAgBCgCICIERQ0AIAAgASACIAFrIAQRgYCAgAAAIgNBf0cNACAAQZSUgIAANgIQQRghAwsgAwsuAQJ/QQAhAwJAIAAoAjgiBEUNACAEKAJMIgRFDQAgACAEEYCAgIAAACEDCyADCy4BAn9BACEDAkAgACgCOCIERQ0AIAQoAlQiBEUNACAAIAQRgICAgAAAIQMLIAMLLgECf0EAIQMCQCAAKAI4IgRFDQAgBCgCWCIERQ0AIAAgBBGAgICAAAAhAwsgAwtFAQF/AkACQCAALwEwQRRxQRRHDQBBASEDIAAtAChBAUYNASAALwEyQeUARiEDDAELIAAtAClBBUYhAwsgACADOgAuQQAL/gEBA39BASEDAkAgAC8BMCIEQQhxDQAgACkDIEIAUiEDCwJAAkAgAC0ALkUNAEEBIQUgAC0AKUEFRg0BQQEhBSAEQcAAcUUgA3FBAUcNAQtBACEFIARBwABxDQBBAiEFIARB//8DcSIDQQhxDQACQCADQYAEcUUNAAJAIAAtAChBAUcNACAALQAtQQpxDQBBBQ8LQQQPCwJAIANBIHENAAJAIAAtAChBAUYNACAALwEyQf//A3EiAEGcf2pB5ABJDQAgAEHMAUYNACAAQbACRg0AQQQhBSAEQShxRQ0CIANBiARxQYAERg0CC0EADwtBAEEDIAApAyBQGyEFCyAFC2IBAn9BACEBAkAgAC0AKEEBRg0AIAAvATJB//8DcSICQZx/akHkAEkNACACQcwBRg0AIAJBsAJGDQAgAC8BMCIAQcAAcQ0AQQEhASAAQYgEcUGABEYNACAAQShxRSEBCyABC6cBAQN/AkACQAJAIAAtACpFDQAgAC0AK0UNAEEAIQMgAC8BMCIEQQJxRQ0BDAILQQAhAyAALwEwIgRBAXFFDQELQQEhAyAALQAoQQFGDQAgAC8BMkH//wNxIgVBnH9qQeQASQ0AIAVBzAFGDQAgBUGwAkYNACAEQcAAcQ0AQQAhAyAEQYgEcUGABEYNACAEQShxQQBHIQMLIABBADsBMCAAQQA6AC8gAwuZAQECfwJAAkACQCAALQAqRQ0AIAAtACtFDQBBACEBIAAvATAiAkECcUUNAQwCC0EAIQEgAC8BMCICQQFxRQ0BC0EBIQEgAC0AKEEBRg0AIAAvATJB//8DcSIAQZx/akHkAEkNACAAQcwBRg0AIABBsAJGDQAgAkHAAHENAEEAIQEgAkGIBHFBgARGDQAgAkEocUEARyEBCyABC1kAIABBGGpCADcDACAAQgA3AwAgAEE4akIANwMAIABBMGpCADcDACAAQShqQgA3AwAgAEEgakIANwMAIABBEGpCADcDACAAQQhqQgA3AwAgAEHdATYCHEEAC3sBAX8CQCAAKAIMIgMNAAJAIAAoAgRFDQAgACABNgIECwJAIAAgASACEMSAgIAAIgMNACAAKAIMDwsgACADNgIcQQAhAyAAKAIEIgFFDQAgACABIAIgACgCCBGBgICAAAAiAUUNACAAIAI2AhQgACABNgIMIAEhAwsgAwvk8wEDDn8DfgR/I4CAgIAAQRBrIgMkgICAgAAgASEEIAEhBSABIQYgASEHIAEhCCABIQkgASEKIAEhCyABIQwgASENIAEhDiABIQ8CQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkAgACgCHCIQQX9qDt0B2gEB2QECAwQFBgcICQoLDA0O2AEPENcBERLWARMUFRYXGBkaG+AB3wEcHR7VAR8gISIjJCXUASYnKCkqKyzTAdIBLS7RAdABLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVG2wFHSElKzwHOAUvNAUzMAU1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4ABgQGCAYMBhAGFAYYBhwGIAYkBigGLAYwBjQGOAY8BkAGRAZIBkwGUAZUBlgGXAZgBmQGaAZsBnAGdAZ4BnwGgAaEBogGjAaQBpQGmAacBqAGpAaoBqwGsAa0BrgGvAbABsQGyAbMBtAG1AbYBtwHLAcoBuAHJAbkByAG6AbsBvAG9Ab4BvwHAAcEBwgHDAcQBxQHGAQDcAQtBACEQDMYBC0EOIRAMxQELQQ0hEAzEAQtBDyEQDMMBC0EQIRAMwgELQRMhEAzBAQtBFCEQDMABC0EVIRAMvwELQRYhEAy+AQtBFyEQDL0BC0EYIRAMvAELQRkhEAy7AQtBGiEQDLoBC0EbIRAMuQELQRwhEAy4AQtBCCEQDLcBC0EdIRAMtgELQSAhEAy1AQtBHyEQDLQBC0EHIRAMswELQSEhEAyyAQtBIiEQDLEBC0EeIRAMsAELQSMhEAyvAQtBEiEQDK4BC0ERIRAMrQELQSQhEAysAQtBJSEQDKsBC0EmIRAMqgELQSchEAypAQtBwwEhEAyoAQtBKSEQDKcBC0ErIRAMpgELQSwhEAylAQtBLSEQDKQBC0EuIRAMowELQS8hEAyiAQtBxAEhEAyhAQtBMCEQDKABC0E0IRAMnwELQQwhEAyeAQtBMSEQDJ0BC0EyIRAMnAELQTMhEAybAQtBOSEQDJoBC0E1IRAMmQELQcUBIRAMmAELQQshEAyXAQtBOiEQDJYBC0E2IRAMlQELQQohEAyUAQtBNyEQDJMBC0E4IRAMkgELQTwhEAyRAQtBOyEQDJABC0E9IRAMjwELQQkhEAyOAQtBKCEQDI0BC0E+IRAMjAELQT8hEAyLAQtBwAAhEAyKAQtBwQAhEAyJAQtBwgAhEAyIAQtBwwAhEAyHAQtBxAAhEAyGAQtBxQAhEAyFAQtBxgAhEAyEAQtBKiEQDIMBC0HHACEQDIIBC0HIACEQDIEBC0HJACEQDIABC0HKACEQDH8LQcsAIRAMfgtBzQAhEAx9C0HMACEQDHwLQc4AIRAMewtBzwAhEAx6C0HQACEQDHkLQdEAIRAMeAtB0gAhEAx3C0HTACEQDHYLQdQAIRAMdQtB1gAhEAx0C0HVACEQDHMLQQYhEAxyC0HXACEQDHELQQUhEAxwC0HYACEQDG8LQQQhEAxuC0HZACEQDG0LQdoAIRAMbAtB2wAhEAxrC0HcACEQDGoLQQMhEAxpC0HdACEQDGgLQd4AIRAMZwtB3wAhEAxmC0HhACEQDGULQeAAIRAMZAtB4gAhEAxjC0HjACEQDGILQQIhEAxhC0HkACEQDGALQeUAIRAMXwtB5gAhEAxeC0HnACEQDF0LQegAIRAMXAtB6QAhEAxbC0HqACEQDFoLQesAIRAMWQtB7AAhEAxYC0HtACEQDFcLQe4AIRAMVgtB7wAhEAxVC0HwACEQDFQLQfEAIRAMUwtB8gAhEAxSC0HzACEQDFELQfQAIRAMUAtB9QAhEAxPC0H2ACEQDE4LQfcAIRAMTQtB+AAhEAxMC0H5ACEQDEsLQfoAIRAMSgtB+wAhEAxJC0H8ACEQDEgLQf0AIRAMRwtB/gAhEAxGC0H/ACEQDEULQYABIRAMRAtBgQEhEAxDC0GCASEQDEILQYMBIRAMQQtBhAEhEAxAC0GFASEQDD8LQYYBIRAMPgtBhwEhEAw9C0GIASEQDDwLQYkBIRAMOwtBigEhEAw6C0GLASEQDDkLQYwBIRAMOAtBjQEhEAw3C0GOASEQDDYLQY8BIRAMNQtBkAEhEAw0C0GRASEQDDMLQZIBIRAMMgtBkwEhEAwxC0GUASEQDDALQZUBIRAMLwtBlgEhEAwuC0GXASEQDC0LQZgBIRAMLAtBmQEhEAwrC0GaASEQDCoLQZsBIRAMKQtBnAEhEAwoC0GdASEQDCcLQZ4BIRAMJgtBnwEhEAwlC0GgASEQDCQLQaEBIRAMIwtBogEhEAwiC0GjASEQDCELQaQBIRAMIAtBpQEhEAwfC0GmASEQDB4LQacBIRAMHQtBqAEhEAwcC0GpASEQDBsLQaoBIRAMGgtBqwEhEAwZC0GsASEQDBgLQa0BIRAMFwtBrgEhEAwWC0EBIRAMFQtBrwEhEAwUC0GwASEQDBMLQbEBIRAMEgtBswEhEAwRC0GyASEQDBALQbQBIRAMDwtBtQEhEAwOC0G2ASEQDA0LQbcBIRAMDAtBuAEhEAwLC0G5ASEQDAoLQboBIRAMCQtBuwEhEAwIC0HGASEQDAcLQbwBIRAMBgtBvQEhEAwFC0G+ASEQDAQLQb8BIRAMAwtBwAEhEAwCC0HCASEQDAELQcEBIRALA0ACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQCAQDscBAAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxweHyAhIyUoP0BBREVGR0hJSktMTU9QUVJT3gNXWVtcXWBiZWZnaGlqa2xtb3BxcnN0dXZ3eHl6e3x9foABggGFAYYBhwGJAYsBjAGNAY4BjwGQAZEBlAGVAZYBlwGYAZkBmgGbAZwBnQGeAZ8BoAGhAaIBowGkAaUBpgGnAagBqQGqAasBrAGtAa4BrwGwAbEBsgGzAbQBtQG2AbcBuAG5AboBuwG8Ab0BvgG/AcABwQHCAcMBxAHFAcYBxwHIAckBygHLAcwBzQHOAc8B0AHRAdIB0wHUAdUB1gHXAdgB2QHaAdsB3AHdAd4B4AHhAeIB4wHkAeUB5gHnAegB6QHqAesB7AHtAe4B7wHwAfEB8gHzAZkCpAKwAv4C/gILIAEiBCACRw3zAUHdASEQDP8DCyABIhAgAkcN3QFBwwEhEAz+AwsgASIBIAJHDZABQfcAIRAM/QMLIAEiASACRw2GAUHvACEQDPwDCyABIgEgAkcNf0HqACEQDPsDCyABIgEgAkcNe0HoACEQDPoDCyABIgEgAkcNeEHmACEQDPkDCyABIgEgAkcNGkEYIRAM+AMLIAEiASACRw0UQRIhEAz3AwsgASIBIAJHDVlBxQAhEAz2AwsgASIBIAJHDUpBPyEQDPUDCyABIgEgAkcNSEE8IRAM9AMLIAEiASACRw1BQTEhEAzzAwsgAC0ALkEBRg3rAwyHAgsgACABIgEgAhDAgICAAEEBRw3mASAAQgA3AyAM5wELIAAgASIBIAIQtICAgAAiEA3nASABIQEM9QILAkAgASIBIAJHDQBBBiEQDPADCyAAIAFBAWoiASACELuAgIAAIhAN6AEgASEBDDELIABCADcDIEESIRAM1QMLIAEiECACRw0rQR0hEAztAwsCQCABIgEgAkYNACABQQFqIQFBECEQDNQDC0EHIRAM7AMLIABCACAAKQMgIhEgAiABIhBrrSISfSITIBMgEVYbNwMgIBEgElYiFEUN5QFBCCEQDOsDCwJAIAEiASACRg0AIABBiYCAgAA2AgggACABNgIEIAEhAUEUIRAM0gMLQQkhEAzqAwsgASEBIAApAyBQDeQBIAEhAQzyAgsCQCABIgEgAkcNAEELIRAM6QMLIAAgAUEBaiIBIAIQtoCAgAAiEA3lASABIQEM8gILIAAgASIBIAIQuICAgAAiEA3lASABIQEM8gILIAAgASIBIAIQuICAgAAiEA3mASABIQEMDQsgACABIgEgAhC6gICAACIQDecBIAEhAQzwAgsCQCABIgEgAkcNAEEPIRAM5QMLIAEtAAAiEEE7Rg0IIBBBDUcN6AEgAUEBaiEBDO8CCyAAIAEiASACELqAgIAAIhAN6AEgASEBDPICCwNAAkAgAS0AAEHwtYCAAGotAAAiEEEBRg0AIBBBAkcN6wEgACgCBCEQIABBADYCBCAAIBAgAUEBaiIBELmAgIAAIhAN6gEgASEBDPQCCyABQQFqIgEgAkcNAAtBEiEQDOIDCyAAIAEiASACELqAgIAAIhAN6QEgASEBDAoLIAEiASACRw0GQRshEAzgAwsCQCABIgEgAkcNAEEWIRAM4AMLIABBioCAgAA2AgggACABNgIEIAAgASACELiAgIAAIhAN6gEgASEBQSAhEAzGAwsCQCABIgEgAkYNAANAAkAgAS0AAEHwt4CAAGotAAAiEEECRg0AAkAgEEF/ag4E5QHsAQDrAewBCyABQQFqIQFBCCEQDMgDCyABQQFqIgEgAkcNAAtBFSEQDN8DC0EVIRAM3gMLA0ACQCABLQAAQfC5gIAAai0AACIQQQJGDQAgEEF/ag4E3gHsAeAB6wHsAQsgAUEBaiIBIAJHDQALQRghEAzdAwsCQCABIgEgAkYNACAAQYuAgIAANgIIIAAgATYCBCABIQFBByEQDMQDC0EZIRAM3AMLIAFBAWohAQwCCwJAIAEiFCACRw0AQRohEAzbAwsgFCEBAkAgFC0AAEFzag4U3QLuAu4C7gLuAu4C7gLuAu4C7gLuAu4C7gLuAu4C7gLuAu4C7gIA7gILQQAhECAAQQA2AhwgAEGvi4CAADYCECAAQQI2AgwgACAUQQFqNgIUDNoDCwJAIAEtAAAiEEE7Rg0AIBBBDUcN6AEgAUEBaiEBDOUCCyABQQFqIQELQSIhEAy/AwsCQCABIhAgAkcNAEEcIRAM2AMLQgAhESAQIQEgEC0AAEFQag435wHmAQECAwQFBgcIAAAAAAAAAAkKCwwNDgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADxAREhMUAAtBHiEQDL0DC0ICIREM5QELQgMhEQzkAQtCBCERDOMBC0IFIREM4gELQgYhEQzhAQtCByERDOABC0IIIREM3wELQgkhEQzeAQtCCiERDN0BC0ILIREM3AELQgwhEQzbAQtCDSERDNoBC0IOIREM2QELQg8hEQzYAQtCCiERDNcBC0ILIREM1gELQgwhEQzVAQtCDSERDNQBC0IOIREM0wELQg8hEQzSAQtCACERAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQCAQLQAAQVBqDjflAeQBAAECAwQFBgfmAeYB5gHmAeYB5gHmAQgJCgsMDeYB5gHmAeYB5gHmAeYB5gHmAeYB5gHmAeYB5gHmAeYB5gHmAeYB5gHmAeYB5gHmAeYB5gEODxAREhPmAQtCAiERDOQBC0IDIREM4wELQgQhEQziAQtCBSERDOEBC0IGIREM4AELQgchEQzfAQtCCCERDN4BC0IJIREM3QELQgohEQzcAQtCCyERDNsBC0IMIREM2gELQg0hEQzZAQtCDiERDNgBC0IPIREM1wELQgohEQzWAQtCCyERDNUBC0IMIREM1AELQg0hEQzTAQtCDiERDNIBC0IPIREM0QELIABCACAAKQMgIhEgAiABIhBrrSISfSITIBMgEVYbNwMgIBEgElYiFEUN0gFBHyEQDMADCwJAIAEiASACRg0AIABBiYCAgAA2AgggACABNgIEIAEhAUEkIRAMpwMLQSAhEAy/AwsgACABIhAgAhC+gICAAEF/ag4FtgEAxQIB0QHSAQtBESEQDKQDCyAAQQE6AC8gECEBDLsDCyABIgEgAkcN0gFBJCEQDLsDCyABIg0gAkcNHkHGACEQDLoDCyAAIAEiASACELKAgIAAIhAN1AEgASEBDLUBCyABIhAgAkcNJkHQACEQDLgDCwJAIAEiASACRw0AQSghEAy4AwsgAEEANgIEIABBjICAgAA2AgggACABIAEQsYCAgAAiEA3TASABIQEM2AELAkAgASIQIAJHDQBBKSEQDLcDCyAQLQAAIgFBIEYNFCABQQlHDdMBIBBBAWohAQwVCwJAIAEiASACRg0AIAFBAWohAQwXC0EqIRAMtQMLAkAgASIQIAJHDQBBKyEQDLUDCwJAIBAtAAAiAUEJRg0AIAFBIEcN1QELIAAtACxBCEYN0wEgECEBDJEDCwJAIAEiASACRw0AQSwhEAy0AwsgAS0AAEEKRw3VASABQQFqIQEMyQILIAEiDiACRw3VAUEvIRAMsgMLA0ACQCABLQAAIhBBIEYNAAJAIBBBdmoOBADcAdwBANoBCyABIQEM4AELIAFBAWoiASACRw0AC0ExIRAMsQMLQTIhECABIhQgAkYNsAMgAiAUayAAKAIAIgFqIRUgFCABa0EDaiEWAkADQCAULQAAIhdBIHIgFyAXQb9/akH/AXFBGkkbQf8BcSABQfC7gIAAai0AAEcNAQJAIAFBA0cNAEEGIQEMlgMLIAFBAWohASAUQQFqIhQgAkcNAAsgACAVNgIADLEDCyAAQQA2AgAgFCEBDNkBC0EzIRAgASIUIAJGDa8DIAIgFGsgACgCACIBaiEVIBQgAWtBCGohFgJAA0AgFC0AACIXQSByIBcgF0G/f2pB/wFxQRpJG0H/AXEgAUH0u4CAAGotAABHDQECQCABQQhHDQBBBSEBDJUDCyABQQFqIQEgFEEBaiIUIAJHDQALIAAgFTYCAAywAwsgAEEANgIAIBQhAQzYAQtBNCEQIAEiFCACRg2uAyACIBRrIAAoAgAiAWohFSAUIAFrQQVqIRYCQANAIBQtAAAiF0EgciAXIBdBv39qQf8BcUEaSRtB/wFxIAFB0MKAgABqLQAARw0BAkAgAUEFRw0AQQchAQyUAwsgAUEBaiEBIBRBAWoiFCACRw0ACyAAIBU2AgAMrwMLIABBADYCACAUIQEM1wELAkAgASIBIAJGDQADQAJAIAEtAABBgL6AgABqLQAAIhBBAUYNACAQQQJGDQogASEBDN0BCyABQQFqIgEgAkcNAAtBMCEQDK4DC0EwIRAMrQMLAkAgASIBIAJGDQADQAJAIAEtAAAiEEEgRg0AIBBBdmoOBNkB2gHaAdkB2gELIAFBAWoiASACRw0AC0E4IRAMrQMLQTghEAysAwsDQAJAIAEtAAAiEEEgRg0AIBBBCUcNAwsgAUEBaiIBIAJHDQALQTwhEAyrAwsDQAJAIAEtAAAiEEEgRg0AAkACQCAQQXZqDgTaAQEB2gEACyAQQSxGDdsBCyABIQEMBAsgAUEBaiIBIAJHDQALQT8hEAyqAwsgASEBDNsBC0HAACEQIAEiFCACRg2oAyACIBRrIAAoAgAiAWohFiAUIAFrQQZqIRcCQANAIBQtAABBIHIgAUGAwICAAGotAABHDQEgAUEGRg2OAyABQQFqIQEgFEEBaiIUIAJHDQALIAAgFjYCAAypAwsgAEEANgIAIBQhAQtBNiEQDI4DCwJAIAEiDyACRw0AQcEAIRAMpwMLIABBjICAgAA2AgggACAPNgIEIA8hASAALQAsQX9qDgTNAdUB1wHZAYcDCyABQQFqIQEMzAELAkAgASIBIAJGDQADQAJAIAEtAAAiEEEgciAQIBBBv39qQf8BcUEaSRtB/wFxIhBBCUYNACAQQSBGDQACQAJAAkACQCAQQZ1/ag4TAAMDAwMDAwMBAwMDAwMDAwMDAgMLIAFBAWohAUExIRAMkQMLIAFBAWohAUEyIRAMkAMLIAFBAWohAUEzIRAMjwMLIAEhAQzQAQsgAUEBaiIBIAJHDQALQTUhEAylAwtBNSEQDKQDCwJAIAEiASACRg0AA0ACQCABLQAAQYC8gIAAai0AAEEBRg0AIAEhAQzTAQsgAUEBaiIBIAJHDQALQT0hEAykAwtBPSEQDKMDCyAAIAEiASACELCAgIAAIhAN1gEgASEBDAELIBBBAWohAQtBPCEQDIcDCwJAIAEiASACRw0AQcIAIRAMoAMLAkADQAJAIAEtAABBd2oOGAAC/gL+AoQD/gL+Av4C/gL+Av4C/gL+Av4C/gL+Av4C/gL+Av4C/gL+Av4CAP4CCyABQQFqIgEgAkcNAAtBwgAhEAygAwsgAUEBaiEBIAAtAC1BAXFFDb0BIAEhAQtBLCEQDIUDCyABIgEgAkcN0wFBxAAhEAydAwsDQAJAIAEtAABBkMCAgABqLQAAQQFGDQAgASEBDLcCCyABQQFqIgEgAkcNAAtBxQAhEAycAwsgDS0AACIQQSBGDbMBIBBBOkcNgQMgACgCBCEBIABBADYCBCAAIAEgDRCvgICAACIBDdABIA1BAWohAQyzAgtBxwAhECABIg0gAkYNmgMgAiANayAAKAIAIgFqIRYgDSABa0EFaiEXA0AgDS0AACIUQSByIBQgFEG/f2pB/wFxQRpJG0H/AXEgAUGQwoCAAGotAABHDYADIAFBBUYN9AIgAUEBaiEBIA1BAWoiDSACRw0ACyAAIBY2AgAMmgMLQcgAIRAgASINIAJGDZkDIAIgDWsgACgCACIBaiEWIA0gAWtBCWohFwNAIA0tAAAiFEEgciAUIBRBv39qQf8BcUEaSRtB/wFxIAFBlsKAgABqLQAARw3/AgJAIAFBCUcNAEECIQEM9QILIAFBAWohASANQQFqIg0gAkcNAAsgACAWNgIADJkDCwJAIAEiDSACRw0AQckAIRAMmQMLAkACQCANLQAAIgFBIHIgASABQb9/akH/AXFBGkkbQf8BcUGSf2oOBwCAA4ADgAOAA4ADAYADCyANQQFqIQFBPiEQDIADCyANQQFqIQFBPyEQDP8CC0HKACEQIAEiDSACRg2XAyACIA1rIAAoAgAiAWohFiANIAFrQQFqIRcDQCANLQAAIhRBIHIgFCAUQb9/akH/AXFBGkkbQf8BcSABQaDCgIAAai0AAEcN/QIgAUEBRg3wAiABQQFqIQEgDUEBaiINIAJHDQALIAAgFjYCAAyXAwtBywAhECABIg0gAkYNlgMgAiANayAAKAIAIgFqIRYgDSABa0EOaiEXA0AgDS0AACIUQSByIBQgFEG/f2pB/wFxQRpJG0H/AXEgAUGiwoCAAGotAABHDfwCIAFBDkYN8AIgAUEBaiEBIA1BAWoiDSACRw0ACyAAIBY2AgAMlgMLQcwAIRAgASINIAJGDZUDIAIgDWsgACgCACIBaiEWIA0gAWtBD2ohFwNAIA0tAAAiFEEgciAUIBRBv39qQf8BcUEaSRtB/wFxIAFBwMKAgABqLQAARw37AgJAIAFBD0cNAEEDIQEM8QILIAFBAWohASANQQFqIg0gAkcNAAsgACAWNgIADJUDC0HNACEQIAEiDSACRg2UAyACIA1rIAAoAgAiAWohFiANIAFrQQVqIRcDQCANLQAAIhRBIHIgFCAUQb9/akH/AXFBGkkbQf8BcSABQdDCgIAAai0AAEcN+gICQCABQQVHDQBBBCEBDPACCyABQQFqIQEgDUEBaiINIAJHDQALIAAgFjYCAAyUAwsCQCABIg0gAkcNAEHOACEQDJQDCwJAAkACQAJAIA0tAAAiAUEgciABIAFBv39qQf8BcUEaSRtB/wFxQZ1/ag4TAP0C/QL9Av0C/QL9Av0C/QL9Av0C/QL9AgH9Av0C/QICA/0CCyANQQFqIQFBwQAhEAz9AgsgDUEBaiEBQcIAIRAM/AILIA1BAWohAUHDACEQDPsCCyANQQFqIQFBxAAhEAz6AgsCQCABIgEgAkYNACAAQY2AgIAANgIIIAAgATYCBCABIQFBxQAhEAz6AgtBzwAhEAySAwsgECEBAkACQCAQLQAAQXZqDgQBqAKoAgCoAgsgEEEBaiEBC0EnIRAM+AILAkAgASIBIAJHDQBB0QAhEAyRAwsCQCABLQAAQSBGDQAgASEBDI0BCyABQQFqIQEgAC0ALUEBcUUNxwEgASEBDIwBCyABIhcgAkcNyAFB0gAhEAyPAwtB0wAhECABIhQgAkYNjgMgAiAUayAAKAIAIgFqIRYgFCABa0EBaiEXA0AgFC0AACABQdbCgIAAai0AAEcNzAEgAUEBRg3HASABQQFqIQEgFEEBaiIUIAJHDQALIAAgFjYCAAyOAwsCQCABIgEgAkcNAEHVACEQDI4DCyABLQAAQQpHDcwBIAFBAWohAQzHAQsCQCABIgEgAkcNAEHWACEQDI0DCwJAAkAgAS0AAEF2ag4EAM0BzQEBzQELIAFBAWohAQzHAQsgAUEBaiEBQcoAIRAM8wILIAAgASIBIAIQroCAgAAiEA3LASABIQFBzQAhEAzyAgsgAC0AKUEiRg2FAwymAgsCQCABIgEgAkcNAEHbACEQDIoDC0EAIRRBASEXQQEhFkEAIRACQAJAAkACQAJAAkACQAJAAkAgAS0AAEFQag4K1AHTAQABAgMEBQYI1QELQQIhEAwGC0EDIRAMBQtBBCEQDAQLQQUhEAwDC0EGIRAMAgtBByEQDAELQQghEAtBACEXQQAhFkEAIRQMzAELQQkhEEEBIRRBACEXQQAhFgzLAQsCQCABIgEgAkcNAEHdACEQDIkDCyABLQAAQS5HDcwBIAFBAWohAQymAgsgASIBIAJHDcwBQd8AIRAMhwMLAkAgASIBIAJGDQAgAEGOgICAADYCCCAAIAE2AgQgASEBQdAAIRAM7gILQeAAIRAMhgMLQeEAIRAgASIBIAJGDYUDIAIgAWsgACgCACIUaiEWIAEgFGtBA2ohFwNAIAEtAAAgFEHiwoCAAGotAABHDc0BIBRBA0YNzAEgFEEBaiEUIAFBAWoiASACRw0ACyAAIBY2AgAMhQMLQeIAIRAgASIBIAJGDYQDIAIgAWsgACgCACIUaiEWIAEgFGtBAmohFwNAIAEtAAAgFEHmwoCAAGotAABHDcwBIBRBAkYNzgEgFEEBaiEUIAFBAWoiASACRw0ACyAAIBY2AgAMhAMLQeMAIRAgASIBIAJGDYMDIAIgAWsgACgCACIUaiEWIAEgFGtBA2ohFwNAIAEtAAAgFEHpwoCAAGotAABHDcsBIBRBA0YNzgEgFEEBaiEUIAFBAWoiASACRw0ACyAAIBY2AgAMgwMLAkAgASIBIAJHDQBB5QAhEAyDAwsgACABQQFqIgEgAhCogICAACIQDc0BIAEhAUHWACEQDOkCCwJAIAEiASACRg0AA0ACQCABLQAAIhBBIEYNAAJAAkACQCAQQbh/ag4LAAHPAc8BzwHPAc8BzwHPAc8BAs8BCyABQQFqIQFB0gAhEAztAgsgAUEBaiEBQdMAIRAM7AILIAFBAWohAUHUACEQDOsCCyABQQFqIgEgAkcNAAtB5AAhEAyCAwtB5AAhEAyBAwsDQAJAIAEtAABB8MKAgABqLQAAIhBBAUYNACAQQX5qDgPPAdAB0QHSAQsgAUEBaiIBIAJHDQALQeYAIRAMgAMLAkAgASIBIAJGDQAgAUEBaiEBDAMLQecAIRAM/wILA0ACQCABLQAAQfDEgIAAai0AACIQQQFGDQACQCAQQX5qDgTSAdMB1AEA1QELIAEhAUHXACEQDOcCCyABQQFqIgEgAkcNAAtB6AAhEAz+AgsCQCABIgEgAkcNAEHpACEQDP4CCwJAIAEtAAAiEEF2ag4augHVAdUBvAHVAdUB1QHVAdUB1QHVAdUB1QHVAdUB1QHVAdUB1QHVAdUB1QHKAdUB1QEA0wELIAFBAWohAQtBBiEQDOMCCwNAAkAgAS0AAEHwxoCAAGotAABBAUYNACABIQEMngILIAFBAWoiASACRw0AC0HqACEQDPsCCwJAIAEiASACRg0AIAFBAWohAQwDC0HrACEQDPoCCwJAIAEiASACRw0AQewAIRAM+gILIAFBAWohAQwBCwJAIAEiASACRw0AQe0AIRAM+QILIAFBAWohAQtBBCEQDN4CCwJAIAEiFCACRw0AQe4AIRAM9wILIBQhAQJAAkACQCAULQAAQfDIgIAAai0AAEF/ag4H1AHVAdYBAJwCAQLXAQsgFEEBaiEBDAoLIBRBAWohAQzNAQtBACEQIABBADYCHCAAQZuSgIAANgIQIABBBzYCDCAAIBRBAWo2AhQM9gILAkADQAJAIAEtAABB8MiAgABqLQAAIhBBBEYNAAJAAkAgEEF/ag4H0gHTAdQB2QEABAHZAQsgASEBQdoAIRAM4AILIAFBAWohAUHcACEQDN8CCyABQQFqIgEgAkcNAAtB7wAhEAz2AgsgAUEBaiEBDMsBCwJAIAEiFCACRw0AQfAAIRAM9QILIBQtAABBL0cN1AEgFEEBaiEBDAYLAkAgASIUIAJHDQBB8QAhEAz0AgsCQCAULQAAIgFBL0cNACAUQQFqIQFB3QAhEAzbAgsgAUF2aiIEQRZLDdMBQQEgBHRBiYCAAnFFDdMBDMoCCwJAIAEiASACRg0AIAFBAWohAUHeACEQDNoCC0HyACEQDPICCwJAIAEiFCACRw0AQfQAIRAM8gILIBQhAQJAIBQtAABB8MyAgABqLQAAQX9qDgPJApQCANQBC0HhACEQDNgCCwJAIAEiFCACRg0AA0ACQCAULQAAQfDKgIAAai0AACIBQQNGDQACQCABQX9qDgLLAgDVAQsgFCEBQd8AIRAM2gILIBRBAWoiFCACRw0AC0HzACEQDPECC0HzACEQDPACCwJAIAEiASACRg0AIABBj4CAgAA2AgggACABNgIEIAEhAUHgACEQDNcCC0H1ACEQDO8CCwJAIAEiASACRw0AQfYAIRAM7wILIABBj4CAgAA2AgggACABNgIEIAEhAQtBAyEQDNQCCwNAIAEtAABBIEcNwwIgAUEBaiIBIAJHDQALQfcAIRAM7AILAkAgASIBIAJHDQBB+AAhEAzsAgsgAS0AAEEgRw3OASABQQFqIQEM7wELIAAgASIBIAIQrICAgAAiEA3OASABIQEMjgILAkAgASIEIAJHDQBB+gAhEAzqAgsgBC0AAEHMAEcN0QEgBEEBaiEBQRMhEAzPAQsCQCABIgQgAkcNAEH7ACEQDOkCCyACIARrIAAoAgAiAWohFCAEIAFrQQVqIRADQCAELQAAIAFB8M6AgABqLQAARw3QASABQQVGDc4BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQfsAIRAM6AILAkAgASIEIAJHDQBB/AAhEAzoAgsCQAJAIAQtAABBvX9qDgwA0QHRAdEB0QHRAdEB0QHRAdEB0QEB0QELIARBAWohAUHmACEQDM8CCyAEQQFqIQFB5wAhEAzOAgsCQCABIgQgAkcNAEH9ACEQDOcCCyACIARrIAAoAgAiAWohFCAEIAFrQQJqIRACQANAIAQtAAAgAUHtz4CAAGotAABHDc8BIAFBAkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEH9ACEQDOcCCyAAQQA2AgAgEEEBaiEBQRAhEAzMAQsCQCABIgQgAkcNAEH+ACEQDOYCCyACIARrIAAoAgAiAWohFCAEIAFrQQVqIRACQANAIAQtAAAgAUH2zoCAAGotAABHDc4BIAFBBUYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEH+ACEQDOYCCyAAQQA2AgAgEEEBaiEBQRYhEAzLAQsCQCABIgQgAkcNAEH/ACEQDOUCCyACIARrIAAoAgAiAWohFCAEIAFrQQNqIRACQANAIAQtAAAgAUH8zoCAAGotAABHDc0BIAFBA0YNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEH/ACEQDOUCCyAAQQA2AgAgEEEBaiEBQQUhEAzKAQsCQCABIgQgAkcNAEGAASEQDOQCCyAELQAAQdkARw3LASAEQQFqIQFBCCEQDMkBCwJAIAEiBCACRw0AQYEBIRAM4wILAkACQCAELQAAQbJ/ag4DAMwBAcwBCyAEQQFqIQFB6wAhEAzKAgsgBEEBaiEBQewAIRAMyQILAkAgASIEIAJHDQBBggEhEAziAgsCQAJAIAQtAABBuH9qDggAywHLAcsBywHLAcsBAcsBCyAEQQFqIQFB6gAhEAzJAgsgBEEBaiEBQe0AIRAMyAILAkAgASIEIAJHDQBBgwEhEAzhAgsgAiAEayAAKAIAIgFqIRAgBCABa0ECaiEUAkADQCAELQAAIAFBgM+AgABqLQAARw3JASABQQJGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBA2AgBBgwEhEAzhAgtBACEQIABBADYCACAUQQFqIQEMxgELAkAgASIEIAJHDQBBhAEhEAzgAgsgAiAEayAAKAIAIgFqIRQgBCABa0EEaiEQAkADQCAELQAAIAFBg8+AgABqLQAARw3IASABQQRGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBhAEhEAzgAgsgAEEANgIAIBBBAWohAUEjIRAMxQELAkAgASIEIAJHDQBBhQEhEAzfAgsCQAJAIAQtAABBtH9qDggAyAHIAcgByAHIAcgBAcgBCyAEQQFqIQFB7wAhEAzGAgsgBEEBaiEBQfAAIRAMxQILAkAgASIEIAJHDQBBhgEhEAzeAgsgBC0AAEHFAEcNxQEgBEEBaiEBDIMCCwJAIAEiBCACRw0AQYcBIRAM3QILIAIgBGsgACgCACIBaiEUIAQgAWtBA2ohEAJAA0AgBC0AACABQYjPgIAAai0AAEcNxQEgAUEDRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQYcBIRAM3QILIABBADYCACAQQQFqIQFBLSEQDMIBCwJAIAEiBCACRw0AQYgBIRAM3AILIAIgBGsgACgCACIBaiEUIAQgAWtBCGohEAJAA0AgBC0AACABQdDPgIAAai0AAEcNxAEgAUEIRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQYgBIRAM3AILIABBADYCACAQQQFqIQFBKSEQDMEBCwJAIAEiASACRw0AQYkBIRAM2wILQQEhECABLQAAQd8ARw3AASABQQFqIQEMgQILAkAgASIEIAJHDQBBigEhEAzaAgsgAiAEayAAKAIAIgFqIRQgBCABa0EBaiEQA0AgBC0AACABQYzPgIAAai0AAEcNwQEgAUEBRg2vAiABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGKASEQDNkCCwJAIAEiBCACRw0AQYsBIRAM2QILIAIgBGsgACgCACIBaiEUIAQgAWtBAmohEAJAA0AgBC0AACABQY7PgIAAai0AAEcNwQEgAUECRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQYsBIRAM2QILIABBADYCACAQQQFqIQFBAiEQDL4BCwJAIAEiBCACRw0AQYwBIRAM2AILIAIgBGsgACgCACIBaiEUIAQgAWtBAWohEAJAA0AgBC0AACABQfDPgIAAai0AAEcNwAEgAUEBRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQYwBIRAM2AILIABBADYCACAQQQFqIQFBHyEQDL0BCwJAIAEiBCACRw0AQY0BIRAM1wILIAIgBGsgACgCACIBaiEUIAQgAWtBAWohEAJAA0AgBC0AACABQfLPgIAAai0AAEcNvwEgAUEBRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQY0BIRAM1wILIABBADYCACAQQQFqIQFBCSEQDLwBCwJAIAEiBCACRw0AQY4BIRAM1gILAkACQCAELQAAQbd/ag4HAL8BvwG/Ab8BvwEBvwELIARBAWohAUH4ACEQDL0CCyAEQQFqIQFB+QAhEAy8AgsCQCABIgQgAkcNAEGPASEQDNUCCyACIARrIAAoAgAiAWohFCAEIAFrQQVqIRACQANAIAQtAAAgAUGRz4CAAGotAABHDb0BIAFBBUYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGPASEQDNUCCyAAQQA2AgAgEEEBaiEBQRghEAy6AQsCQCABIgQgAkcNAEGQASEQDNQCCyACIARrIAAoAgAiAWohFCAEIAFrQQJqIRACQANAIAQtAAAgAUGXz4CAAGotAABHDbwBIAFBAkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGQASEQDNQCCyAAQQA2AgAgEEEBaiEBQRchEAy5AQsCQCABIgQgAkcNAEGRASEQDNMCCyACIARrIAAoAgAiAWohFCAEIAFrQQZqIRACQANAIAQtAAAgAUGaz4CAAGotAABHDbsBIAFBBkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGRASEQDNMCCyAAQQA2AgAgEEEBaiEBQRUhEAy4AQsCQCABIgQgAkcNAEGSASEQDNICCyACIARrIAAoAgAiAWohFCAEIAFrQQVqIRACQANAIAQtAAAgAUGhz4CAAGotAABHDboBIAFBBUYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGSASEQDNICCyAAQQA2AgAgEEEBaiEBQR4hEAy3AQsCQCABIgQgAkcNAEGTASEQDNECCyAELQAAQcwARw24ASAEQQFqIQFBCiEQDLYBCwJAIAQgAkcNAEGUASEQDNACCwJAAkAgBC0AAEG/f2oODwC5AbkBuQG5AbkBuQG5AbkBuQG5AbkBuQG5AQG5AQsgBEEBaiEBQf4AIRAMtwILIARBAWohAUH/ACEQDLYCCwJAIAQgAkcNAEGVASEQDM8CCwJAAkAgBC0AAEG/f2oOAwC4AQG4AQsgBEEBaiEBQf0AIRAMtgILIARBAWohBEGAASEQDLUCCwJAIAQgAkcNAEGWASEQDM4CCyACIARrIAAoAgAiAWohFCAEIAFrQQFqIRACQANAIAQtAAAgAUGnz4CAAGotAABHDbYBIAFBAUYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGWASEQDM4CCyAAQQA2AgAgEEEBaiEBQQshEAyzAQsCQCAEIAJHDQBBlwEhEAzNAgsCQAJAAkACQCAELQAAQVNqDiMAuAG4AbgBuAG4AbgBuAG4AbgBuAG4AbgBuAG4AbgBuAG4AbgBuAG4AbgBuAG4AQG4AbgBuAG4AbgBArgBuAG4AQO4AQsgBEEBaiEBQfsAIRAMtgILIARBAWohAUH8ACEQDLUCCyAEQQFqIQRBgQEhEAy0AgsgBEEBaiEEQYIBIRAMswILAkAgBCACRw0AQZgBIRAMzAILIAIgBGsgACgCACIBaiEUIAQgAWtBBGohEAJAA0AgBC0AACABQanPgIAAai0AAEcNtAEgAUEERg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQZgBIRAMzAILIABBADYCACAQQQFqIQFBGSEQDLEBCwJAIAQgAkcNAEGZASEQDMsCCyACIARrIAAoAgAiAWohFCAEIAFrQQVqIRACQANAIAQtAAAgAUGuz4CAAGotAABHDbMBIAFBBUYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGZASEQDMsCCyAAQQA2AgAgEEEBaiEBQQYhEAywAQsCQCAEIAJHDQBBmgEhEAzKAgsgAiAEayAAKAIAIgFqIRQgBCABa0EBaiEQAkADQCAELQAAIAFBtM+AgABqLQAARw2yASABQQFGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBmgEhEAzKAgsgAEEANgIAIBBBAWohAUEcIRAMrwELAkAgBCACRw0AQZsBIRAMyQILIAIgBGsgACgCACIBaiEUIAQgAWtBAWohEAJAA0AgBC0AACABQbbPgIAAai0AAEcNsQEgAUEBRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQZsBIRAMyQILIABBADYCACAQQQFqIQFBJyEQDK4BCwJAIAQgAkcNAEGcASEQDMgCCwJAAkAgBC0AAEGsf2oOAgABsQELIARBAWohBEGGASEQDK8CCyAEQQFqIQRBhwEhEAyuAgsCQCAEIAJHDQBBnQEhEAzHAgsgAiAEayAAKAIAIgFqIRQgBCABa0EBaiEQAkADQCAELQAAIAFBuM+AgABqLQAARw2vASABQQFGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBnQEhEAzHAgsgAEEANgIAIBBBAWohAUEmIRAMrAELAkAgBCACRw0AQZ4BIRAMxgILIAIgBGsgACgCACIBaiEUIAQgAWtBAWohEAJAA0AgBC0AACABQbrPgIAAai0AAEcNrgEgAUEBRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQZ4BIRAMxgILIABBADYCACAQQQFqIQFBAyEQDKsBCwJAIAQgAkcNAEGfASEQDMUCCyACIARrIAAoAgAiAWohFCAEIAFrQQJqIRACQANAIAQtAAAgAUHtz4CAAGotAABHDa0BIAFBAkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGfASEQDMUCCyAAQQA2AgAgEEEBaiEBQQwhEAyqAQsCQCAEIAJHDQBBoAEhEAzEAgsgAiAEayAAKAIAIgFqIRQgBCABa0EDaiEQAkADQCAELQAAIAFBvM+AgABqLQAARw2sASABQQNGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBoAEhEAzEAgsgAEEANgIAIBBBAWohAUENIRAMqQELAkAgBCACRw0AQaEBIRAMwwILAkACQCAELQAAQbp/ag4LAKwBrAGsAawBrAGsAawBrAGsAQGsAQsgBEEBaiEEQYsBIRAMqgILIARBAWohBEGMASEQDKkCCwJAIAQgAkcNAEGiASEQDMICCyAELQAAQdAARw2pASAEQQFqIQQM6QELAkAgBCACRw0AQaMBIRAMwQILAkACQCAELQAAQbd/ag4HAaoBqgGqAaoBqgEAqgELIARBAWohBEGOASEQDKgCCyAEQQFqIQFBIiEQDKYBCwJAIAQgAkcNAEGkASEQDMACCyACIARrIAAoAgAiAWohFCAEIAFrQQFqIRACQANAIAQtAAAgAUHAz4CAAGotAABHDagBIAFBAUYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGkASEQDMACCyAAQQA2AgAgEEEBaiEBQR0hEAylAQsCQCAEIAJHDQBBpQEhEAy/AgsCQAJAIAQtAABBrn9qDgMAqAEBqAELIARBAWohBEGQASEQDKYCCyAEQQFqIQFBBCEQDKQBCwJAIAQgAkcNAEGmASEQDL4CCwJAAkACQAJAAkAgBC0AAEG/f2oOFQCqAaoBqgGqAaoBqgGqAaoBqgGqAQGqAaoBAqoBqgEDqgGqAQSqAQsgBEEBaiEEQYgBIRAMqAILIARBAWohBEGJASEQDKcCCyAEQQFqIQRBigEhEAymAgsgBEEBaiEEQY8BIRAMpQILIARBAWohBEGRASEQDKQCCwJAIAQgAkcNAEGnASEQDL0CCyACIARrIAAoAgAiAWohFCAEIAFrQQJqIRACQANAIAQtAAAgAUHtz4CAAGotAABHDaUBIAFBAkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGnASEQDL0CCyAAQQA2AgAgEEEBaiEBQREhEAyiAQsCQCAEIAJHDQBBqAEhEAy8AgsgAiAEayAAKAIAIgFqIRQgBCABa0ECaiEQAkADQCAELQAAIAFBws+AgABqLQAARw2kASABQQJGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBqAEhEAy8AgsgAEEANgIAIBBBAWohAUEsIRAMoQELAkAgBCACRw0AQakBIRAMuwILIAIgBGsgACgCACIBaiEUIAQgAWtBBGohEAJAA0AgBC0AACABQcXPgIAAai0AAEcNowEgAUEERg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQakBIRAMuwILIABBADYCACAQQQFqIQFBKyEQDKABCwJAIAQgAkcNAEGqASEQDLoCCyACIARrIAAoAgAiAWohFCAEIAFrQQJqIRACQANAIAQtAAAgAUHKz4CAAGotAABHDaIBIAFBAkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGqASEQDLoCCyAAQQA2AgAgEEEBaiEBQRQhEAyfAQsCQCAEIAJHDQBBqwEhEAy5AgsCQAJAAkACQCAELQAAQb5/ag4PAAECpAGkAaQBpAGkAaQBpAGkAaQBpAGkAQOkAQsgBEEBaiEEQZMBIRAMogILIARBAWohBEGUASEQDKECCyAEQQFqIQRBlQEhEAygAgsgBEEBaiEEQZYBIRAMnwILAkAgBCACRw0AQawBIRAMuAILIAQtAABBxQBHDZ8BIARBAWohBAzgAQsCQCAEIAJHDQBBrQEhEAy3AgsgAiAEayAAKAIAIgFqIRQgBCABa0ECaiEQAkADQCAELQAAIAFBzc+AgABqLQAARw2fASABQQJGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBrQEhEAy3AgsgAEEANgIAIBBBAWohAUEOIRAMnAELAkAgBCACRw0AQa4BIRAMtgILIAQtAABB0ABHDZ0BIARBAWohAUElIRAMmwELAkAgBCACRw0AQa8BIRAMtQILIAIgBGsgACgCACIBaiEUIAQgAWtBCGohEAJAA0AgBC0AACABQdDPgIAAai0AAEcNnQEgAUEIRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQa8BIRAMtQILIABBADYCACAQQQFqIQFBKiEQDJoBCwJAIAQgAkcNAEGwASEQDLQCCwJAAkAgBC0AAEGrf2oOCwCdAZ0BnQGdAZ0BnQGdAZ0BnQEBnQELIARBAWohBEGaASEQDJsCCyAEQQFqIQRBmwEhEAyaAgsCQCAEIAJHDQBBsQEhEAyzAgsCQAJAIAQtAABBv39qDhQAnAGcAZwBnAGcAZwBnAGcAZwBnAGcAZwBnAGcAZwBnAGcAZwBAZwBCyAEQQFqIQRBmQEhEAyaAgsgBEEBaiEEQZwBIRAMmQILAkAgBCACRw0AQbIBIRAMsgILIAIgBGsgACgCACIBaiEUIAQgAWtBA2ohEAJAA0AgBC0AACABQdnPgIAAai0AAEcNmgEgAUEDRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQbIBIRAMsgILIABBADYCACAQQQFqIQFBISEQDJcBCwJAIAQgAkcNAEGzASEQDLECCyACIARrIAAoAgAiAWohFCAEIAFrQQZqIRACQANAIAQtAAAgAUHdz4CAAGotAABHDZkBIAFBBkYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEGzASEQDLECCyAAQQA2AgAgEEEBaiEBQRohEAyWAQsCQCAEIAJHDQBBtAEhEAywAgsCQAJAAkAgBC0AAEG7f2oOEQCaAZoBmgGaAZoBmgGaAZoBmgEBmgGaAZoBmgGaAQKaAQsgBEEBaiEEQZ0BIRAMmAILIARBAWohBEGeASEQDJcCCyAEQQFqIQRBnwEhEAyWAgsCQCAEIAJHDQBBtQEhEAyvAgsgAiAEayAAKAIAIgFqIRQgBCABa0EFaiEQAkADQCAELQAAIAFB5M+AgABqLQAARw2XASABQQVGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBtQEhEAyvAgsgAEEANgIAIBBBAWohAUEoIRAMlAELAkAgBCACRw0AQbYBIRAMrgILIAIgBGsgACgCACIBaiEUIAQgAWtBAmohEAJAA0AgBC0AACABQerPgIAAai0AAEcNlgEgAUECRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQbYBIRAMrgILIABBADYCACAQQQFqIQFBByEQDJMBCwJAIAQgAkcNAEG3ASEQDK0CCwJAAkAgBC0AAEG7f2oODgCWAZYBlgGWAZYBlgGWAZYBlgGWAZYBlgEBlgELIARBAWohBEGhASEQDJQCCyAEQQFqIQRBogEhEAyTAgsCQCAEIAJHDQBBuAEhEAysAgsgAiAEayAAKAIAIgFqIRQgBCABa0ECaiEQAkADQCAELQAAIAFB7c+AgABqLQAARw2UASABQQJGDQEgAUEBaiEBIARBAWoiBCACRw0ACyAAIBQ2AgBBuAEhEAysAgsgAEEANgIAIBBBAWohAUESIRAMkQELAkAgBCACRw0AQbkBIRAMqwILIAIgBGsgACgCACIBaiEUIAQgAWtBAWohEAJAA0AgBC0AACABQfDPgIAAai0AAEcNkwEgAUEBRg0BIAFBAWohASAEQQFqIgQgAkcNAAsgACAUNgIAQbkBIRAMqwILIABBADYCACAQQQFqIQFBICEQDJABCwJAIAQgAkcNAEG6ASEQDKoCCyACIARrIAAoAgAiAWohFCAEIAFrQQFqIRACQANAIAQtAAAgAUHyz4CAAGotAABHDZIBIAFBAUYNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEG6ASEQDKoCCyAAQQA2AgAgEEEBaiEBQQ8hEAyPAQsCQCAEIAJHDQBBuwEhEAypAgsCQAJAIAQtAABBt39qDgcAkgGSAZIBkgGSAQGSAQsgBEEBaiEEQaUBIRAMkAILIARBAWohBEGmASEQDI8CCwJAIAQgAkcNAEG8ASEQDKgCCyACIARrIAAoAgAiAWohFCAEIAFrQQdqIRACQANAIAQtAAAgAUH0z4CAAGotAABHDZABIAFBB0YNASABQQFqIQEgBEEBaiIEIAJHDQALIAAgFDYCAEG8ASEQDKgCCyAAQQA2AgAgEEEBaiEBQRshEAyNAQsCQCAEIAJHDQBBvQEhEAynAgsCQAJAAkAgBC0AAEG+f2oOEgCRAZEBkQGRAZEBkQGRAZEBkQEBkQGRAZEBkQGRAZEBApEBCyAEQQFqIQRBpAEhEAyPAgsgBEEBaiEEQacBIRAMjgILIARBAWohBEGoASEQDI0CCwJAIAQgAkcNAEG+ASEQDKYCCyAELQAAQc4ARw2NASAEQQFqIQQMzwELAkAgBCACRw0AQb8BIRAMpQILAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkAgBC0AAEG/f2oOFQABAgOcAQQFBpwBnAGcAQcICQoLnAEMDQ4PnAELIARBAWohAUHoACEQDJoCCyAEQQFqIQFB6QAhEAyZAgsgBEEBaiEBQe4AIRAMmAILIARBAWohAUHyACEQDJcCCyAEQQFqIQFB8wAhEAyWAgsgBEEBaiEBQfYAIRAMlQILIARBAWohAUH3ACEQDJQCCyAEQQFqIQFB+gAhEAyTAgsgBEEBaiEEQYMBIRAMkgILIARBAWohBEGEASEQDJECCyAEQQFqIQRBhQEhEAyQAgsgBEEBaiEEQZIBIRAMjwILIARBAWohBEGYASEQDI4CCyAEQQFqIQRBoAEhEAyNAgsgBEEBaiEEQaMBIRAMjAILIARBAWohBEGqASEQDIsCCwJAIAQgAkYNACAAQZCAgIAANgIIIAAgBDYCBEGrASEQDIsCC0HAASEQDKMCCyAAIAUgAhCqgICAACIBDYsBIAUhAQxcCwJAIAYgAkYNACAGQQFqIQUMjQELQcIBIRAMoQILA0ACQCAQLQAAQXZqDgSMAQAAjwEACyAQQQFqIhAgAkcNAAtBwwEhEAygAgsCQCAHIAJGDQAgAEGRgICAADYCCCAAIAc2AgQgByEBQQEhEAyHAgtBxAEhEAyfAgsCQCAHIAJHDQBBxQEhEAyfAgsCQAJAIActAABBdmoOBAHOAc4BAM4BCyAHQQFqIQYMjQELIAdBAWohBQyJAQsCQCAHIAJHDQBBxgEhEAyeAgsCQAJAIActAABBdmoOFwGPAY8BAY8BjwGPAY8BjwGPAY8BjwGPAY8BjwGPAY8BjwGPAY8BjwGPAQCPAQsgB0EBaiEHC0GwASEQDIQCCwJAIAggAkcNAEHIASEQDJ0CCyAILQAAQSBHDY0BIABBADsBMiAIQQFqIQFBswEhEAyDAgsgASEXAkADQCAXIgcgAkYNASAHLQAAQVBqQf8BcSIQQQpPDcwBAkAgAC8BMiIUQZkzSw0AIAAgFEEKbCIUOwEyIBBB//8DcyAUQf7/A3FJDQAgB0EBaiEXIAAgFCAQaiIQOwEyIBBB//8DcUHoB0kNAQsLQQAhECAAQQA2AhwgAEHBiYCAADYCECAAQQ02AgwgACAHQQFqNgIUDJwCC0HHASEQDJsCCyAAIAggAhCugICAACIQRQ3KASAQQRVHDYwBIABByAE2AhwgACAINgIUIABByZeAgAA2AhAgAEEVNgIMQQAhEAyaAgsCQCAJIAJHDQBBzAEhEAyaAgtBACEUQQEhF0EBIRZBACEQAkACQAJAAkACQAJAAkACQAJAIAktAABBUGoOCpYBlQEAAQIDBAUGCJcBC0ECIRAMBgtBAyEQDAULQQQhEAwEC0EFIRAMAwtBBiEQDAILQQchEAwBC0EIIRALQQAhF0EAIRZBACEUDI4BC0EJIRBBASEUQQAhF0EAIRYMjQELAkAgCiACRw0AQc4BIRAMmQILIAotAABBLkcNjgEgCkEBaiEJDMoBCyALIAJHDY4BQdABIRAMlwILAkAgCyACRg0AIABBjoCAgAA2AgggACALNgIEQbcBIRAM/gELQdEBIRAMlgILAkAgBCACRw0AQdIBIRAMlgILIAIgBGsgACgCACIQaiEUIAQgEGtBBGohCwNAIAQtAAAgEEH8z4CAAGotAABHDY4BIBBBBEYN6QEgEEEBaiEQIARBAWoiBCACRw0ACyAAIBQ2AgBB0gEhEAyVAgsgACAMIAIQrICAgAAiAQ2NASAMIQEMuAELAkAgBCACRw0AQdQBIRAMlAILIAIgBGsgACgCACIQaiEUIAQgEGtBAWohDANAIAQtAAAgEEGB0ICAAGotAABHDY8BIBBBAUYNjgEgEEEBaiEQIARBAWoiBCACRw0ACyAAIBQ2AgBB1AEhEAyTAgsCQCAEIAJHDQBB1gEhEAyTAgsgAiAEayAAKAIAIhBqIRQgBCAQa0ECaiELA0AgBC0AACAQQYPQgIAAai0AAEcNjgEgEEECRg2QASAQQQFqIRAgBEEBaiIEIAJHDQALIAAgFDYCAEHWASEQDJICCwJAIAQgAkcNAEHXASEQDJICCwJAAkAgBC0AAEG7f2oOEACPAY8BjwGPAY8BjwGPAY8BjwGPAY8BjwGPAY8BAY8BCyAEQQFqIQRBuwEhEAz5AQsgBEEBaiEEQbwBIRAM+AELAkAgBCACRw0AQdgBIRAMkQILIAQtAABByABHDYwBIARBAWohBAzEAQsCQCAEIAJGDQAgAEGQgICAADYCCCAAIAQ2AgRBvgEhEAz3AQtB2QEhEAyPAgsCQCAEIAJHDQBB2gEhEAyPAgsgBC0AAEHIAEYNwwEgAEEBOgAoDLkBCyAAQQI6AC8gACAEIAIQpoCAgAAiEA2NAUHCASEQDPQBCyAALQAoQX9qDgK3AbkBuAELA0ACQCAELQAAQXZqDgQAjgGOAQCOAQsgBEEBaiIEIAJHDQALQd0BIRAMiwILIABBADoALyAALQAtQQRxRQ2EAgsgAEEAOgAvIABBAToANCABIQEMjAELIBBBFUYN2gEgAEEANgIcIAAgATYCFCAAQaeOgIAANgIQIABBEjYCDEEAIRAMiAILAkAgACAQIAIQtICAgAAiBA0AIBAhAQyBAgsCQCAEQRVHDQAgAEEDNgIcIAAgEDYCFCAAQbCYgIAANgIQIABBFTYCDEEAIRAMiAILIABBADYCHCAAIBA2AhQgAEGnjoCAADYCECAAQRI2AgxBACEQDIcCCyAQQRVGDdYBIABBADYCHCAAIAE2AhQgAEHajYCAADYCECAAQRQ2AgxBACEQDIYCCyAAKAIEIRcgAEEANgIEIBAgEadqIhYhASAAIBcgECAWIBQbIhAQtYCAgAAiFEUNjQEgAEEHNgIcIAAgEDYCFCAAIBQ2AgxBACEQDIUCCyAAIAAvATBBgAFyOwEwIAEhAQtBKiEQDOoBCyAQQRVGDdEBIABBADYCHCAAIAE2AhQgAEGDjICAADYCECAAQRM2AgxBACEQDIICCyAQQRVGDc8BIABBADYCHCAAIAE2AhQgAEGaj4CAADYCECAAQSI2AgxBACEQDIECCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQt4CAgAAiEA0AIAFBAWohAQyNAQsgAEEMNgIcIAAgEDYCDCAAIAFBAWo2AhRBACEQDIACCyAQQRVGDcwBIABBADYCHCAAIAE2AhQgAEGaj4CAADYCECAAQSI2AgxBACEQDP8BCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQt4CAgAAiEA0AIAFBAWohAQyMAQsgAEENNgIcIAAgEDYCDCAAIAFBAWo2AhRBACEQDP4BCyAQQRVGDckBIABBADYCHCAAIAE2AhQgAEHGjICAADYCECAAQSM2AgxBACEQDP0BCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQuYCAgAAiEA0AIAFBAWohAQyLAQsgAEEONgIcIAAgEDYCDCAAIAFBAWo2AhRBACEQDPwBCyAAQQA2AhwgACABNgIUIABBwJWAgAA2AhAgAEECNgIMQQAhEAz7AQsgEEEVRg3FASAAQQA2AhwgACABNgIUIABBxoyAgAA2AhAgAEEjNgIMQQAhEAz6AQsgAEEQNgIcIAAgATYCFCAAIBA2AgxBACEQDPkBCyAAKAIEIQQgAEEANgIEAkAgACAEIAEQuYCAgAAiBA0AIAFBAWohAQzxAQsgAEERNgIcIAAgBDYCDCAAIAFBAWo2AhRBACEQDPgBCyAQQRVGDcEBIABBADYCHCAAIAE2AhQgAEHGjICAADYCECAAQSM2AgxBACEQDPcBCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQuYCAgAAiEA0AIAFBAWohAQyIAQsgAEETNgIcIAAgEDYCDCAAIAFBAWo2AhRBACEQDPYBCyAAKAIEIQQgAEEANgIEAkAgACAEIAEQuYCAgAAiBA0AIAFBAWohAQztAQsgAEEUNgIcIAAgBDYCDCAAIAFBAWo2AhRBACEQDPUBCyAQQRVGDb0BIABBADYCHCAAIAE2AhQgAEGaj4CAADYCECAAQSI2AgxBACEQDPQBCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQt4CAgAAiEA0AIAFBAWohAQyGAQsgAEEWNgIcIAAgEDYCDCAAIAFBAWo2AhRBACEQDPMBCyAAKAIEIQQgAEEANgIEAkAgACAEIAEQt4CAgAAiBA0AIAFBAWohAQzpAQsgAEEXNgIcIAAgBDYCDCAAIAFBAWo2AhRBACEQDPIBCyAAQQA2AhwgACABNgIUIABBzZOAgAA2AhAgAEEMNgIMQQAhEAzxAQtCASERCyAQQQFqIQECQCAAKQMgIhJC//////////8PVg0AIAAgEkIEhiARhDcDICABIQEMhAELIABBADYCHCAAIAE2AhQgAEGtiYCAADYCECAAQQw2AgxBACEQDO8BCyAAQQA2AhwgACAQNgIUIABBzZOAgAA2AhAgAEEMNgIMQQAhEAzuAQsgACgCBCEXIABBADYCBCAQIBGnaiIWIQEgACAXIBAgFiAUGyIQELWAgIAAIhRFDXMgAEEFNgIcIAAgEDYCFCAAIBQ2AgxBACEQDO0BCyAAQQA2AhwgACAQNgIUIABBqpyAgAA2AhAgAEEPNgIMQQAhEAzsAQsgACAQIAIQtICAgAAiAQ0BIBAhAQtBDiEQDNEBCwJAIAFBFUcNACAAQQI2AhwgACAQNgIUIABBsJiAgAA2AhAgAEEVNgIMQQAhEAzqAQsgAEEANgIcIAAgEDYCFCAAQaeOgIAANgIQIABBEjYCDEEAIRAM6QELIAFBAWohEAJAIAAvATAiAUGAAXFFDQACQCAAIBAgAhC7gICAACIBDQAgECEBDHALIAFBFUcNugEgAEEFNgIcIAAgEDYCFCAAQfmXgIAANgIQIABBFTYCDEEAIRAM6QELAkAgAUGgBHFBoARHDQAgAC0ALUECcQ0AIABBADYCHCAAIBA2AhQgAEGWk4CAADYCECAAQQQ2AgxBACEQDOkBCyAAIBAgAhC9gICAABogECEBAkACQAJAAkACQCAAIBAgAhCzgICAAA4WAgEABAQEBAQEBAQEBAQEBAQEBAQEAwQLIABBAToALgsgACAALwEwQcAAcjsBMCAQIQELQSYhEAzRAQsgAEEjNgIcIAAgEDYCFCAAQaWWgIAANgIQIABBFTYCDEEAIRAM6QELIABBADYCHCAAIBA2AhQgAEHVi4CAADYCECAAQRE2AgxBACEQDOgBCyAALQAtQQFxRQ0BQcMBIRAMzgELAkAgDSACRg0AA0ACQCANLQAAQSBGDQAgDSEBDMQBCyANQQFqIg0gAkcNAAtBJSEQDOcBC0ElIRAM5gELIAAoAgQhBCAAQQA2AgQgACAEIA0Qr4CAgAAiBEUNrQEgAEEmNgIcIAAgBDYCDCAAIA1BAWo2AhRBACEQDOUBCyAQQRVGDasBIABBADYCHCAAIAE2AhQgAEH9jYCAADYCECAAQR02AgxBACEQDOQBCyAAQSc2AhwgACABNgIUIAAgEDYCDEEAIRAM4wELIBAhAUEBIRQCQAJAAkACQAJAAkACQCAALQAsQX5qDgcGBQUDAQIABQsgACAALwEwQQhyOwEwDAMLQQIhFAwBC0EEIRQLIABBAToALCAAIAAvATAgFHI7ATALIBAhAQtBKyEQDMoBCyAAQQA2AhwgACAQNgIUIABBq5KAgAA2AhAgAEELNgIMQQAhEAziAQsgAEEANgIcIAAgATYCFCAAQeGPgIAANgIQIABBCjYCDEEAIRAM4QELIABBADoALCAQIQEMvQELIBAhAUEBIRQCQAJAAkACQAJAIAAtACxBe2oOBAMBAgAFCyAAIAAvATBBCHI7ATAMAwtBAiEUDAELQQQhFAsgAEEBOgAsIAAgAC8BMCAUcjsBMAsgECEBC0EpIRAMxQELIABBADYCHCAAIAE2AhQgAEHwlICAADYCECAAQQM2AgxBACEQDN0BCwJAIA4tAABBDUcNACAAKAIEIQEgAEEANgIEAkAgACABIA4QsYCAgAAiAQ0AIA5BAWohAQx1CyAAQSw2AhwgACABNgIMIAAgDkEBajYCFEEAIRAM3QELIAAtAC1BAXFFDQFBxAEhEAzDAQsCQCAOIAJHDQBBLSEQDNwBCwJAAkADQAJAIA4tAABBdmoOBAIAAAMACyAOQQFqIg4gAkcNAAtBLSEQDN0BCyAAKAIEIQEgAEEANgIEAkAgACABIA4QsYCAgAAiAQ0AIA4hAQx0CyAAQSw2AhwgACAONgIUIAAgATYCDEEAIRAM3AELIAAoAgQhASAAQQA2AgQCQCAAIAEgDhCxgICAACIBDQAgDkEBaiEBDHMLIABBLDYCHCAAIAE2AgwgACAOQQFqNgIUQQAhEAzbAQsgACgCBCEEIABBADYCBCAAIAQgDhCxgICAACIEDaABIA4hAQzOAQsgEEEsRw0BIAFBAWohEEEBIQECQAJAAkACQAJAIAAtACxBe2oOBAMBAgQACyAQIQEMBAtBAiEBDAELQQQhAQsgAEEBOgAsIAAgAC8BMCABcjsBMCAQIQEMAQsgACAALwEwQQhyOwEwIBAhAQtBOSEQDL8BCyAAQQA6ACwgASEBC0E0IRAMvQELIAAgAC8BMEEgcjsBMCABIQEMAgsgACgCBCEEIABBADYCBAJAIAAgBCABELGAgIAAIgQNACABIQEMxwELIABBNzYCHCAAIAE2AhQgACAENgIMQQAhEAzUAQsgAEEIOgAsIAEhAQtBMCEQDLkBCwJAIAAtAChBAUYNACABIQEMBAsgAC0ALUEIcUUNkwEgASEBDAMLIAAtADBBIHENlAFBxQEhEAy3AQsCQCAPIAJGDQACQANAAkAgDy0AAEFQaiIBQf8BcUEKSQ0AIA8hAUE1IRAMugELIAApAyAiEUKZs+bMmbPmzBlWDQEgACARQgp+IhE3AyAgESABrUL/AYMiEkJ/hVYNASAAIBEgEnw3AyAgD0EBaiIPIAJHDQALQTkhEAzRAQsgACgCBCECIABBADYCBCAAIAIgD0EBaiIEELGAgIAAIgINlQEgBCEBDMMBC0E5IRAMzwELAkAgAC8BMCIBQQhxRQ0AIAAtAChBAUcNACAALQAtQQhxRQ2QAQsgACABQff7A3FBgARyOwEwIA8hAQtBNyEQDLQBCyAAIAAvATBBEHI7ATAMqwELIBBBFUYNiwEgAEEANgIcIAAgATYCFCAAQfCOgIAANgIQIABBHDYCDEEAIRAMywELIABBwwA2AhwgACABNgIMIAAgDUEBajYCFEEAIRAMygELAkAgAS0AAEE6Rw0AIAAoAgQhECAAQQA2AgQCQCAAIBAgARCvgICAACIQDQAgAUEBaiEBDGMLIABBwwA2AhwgACAQNgIMIAAgAUEBajYCFEEAIRAMygELIABBADYCHCAAIAE2AhQgAEGxkYCAADYCECAAQQo2AgxBACEQDMkBCyAAQQA2AhwgACABNgIUIABBoJmAgAA2AhAgAEEeNgIMQQAhEAzIAQsgAEEANgIACyAAQYASOwEqIAAgF0EBaiIBIAIQqICAgAAiEA0BIAEhAQtBxwAhEAysAQsgEEEVRw2DASAAQdEANgIcIAAgATYCFCAAQeOXgIAANgIQIABBFTYCDEEAIRAMxAELIAAoAgQhECAAQQA2AgQCQCAAIBAgARCngICAACIQDQAgASEBDF4LIABB0gA2AhwgACABNgIUIAAgEDYCDEEAIRAMwwELIABBADYCHCAAIBQ2AhQgAEHBqICAADYCECAAQQc2AgwgAEEANgIAQQAhEAzCAQsgACgCBCEQIABBADYCBAJAIAAgECABEKeAgIAAIhANACABIQEMXQsgAEHTADYCHCAAIAE2AhQgACAQNgIMQQAhEAzBAQtBACEQIABBADYCHCAAIAE2AhQgAEGAkYCAADYCECAAQQk2AgwMwAELIBBBFUYNfSAAQQA2AhwgACABNgIUIABBlI2AgAA2AhAgAEEhNgIMQQAhEAy/AQtBASEWQQAhF0EAIRRBASEQCyAAIBA6ACsgAUEBaiEBAkACQCAALQAtQRBxDQACQAJAAkAgAC0AKg4DAQACBAsgFkUNAwwCCyAUDQEMAgsgF0UNAQsgACgCBCEQIABBADYCBAJAIAAgECABEK2AgIAAIhANACABIQEMXAsgAEHYADYCHCAAIAE2AhQgACAQNgIMQQAhEAy+AQsgACgCBCEEIABBADYCBAJAIAAgBCABEK2AgIAAIgQNACABIQEMrQELIABB2QA2AhwgACABNgIUIAAgBDYCDEEAIRAMvQELIAAoAgQhBCAAQQA2AgQCQCAAIAQgARCtgICAACIEDQAgASEBDKsBCyAAQdoANgIcIAAgATYCFCAAIAQ2AgxBACEQDLwBCyAAKAIEIQQgAEEANgIEAkAgACAEIAEQrYCAgAAiBA0AIAEhAQypAQsgAEHcADYCHCAAIAE2AhQgACAENgIMQQAhEAy7AQsCQCABLQAAQVBqIhBB/wFxQQpPDQAgACAQOgAqIAFBAWohAUHPACEQDKIBCyAAKAIEIQQgAEEANgIEAkAgACAEIAEQrYCAgAAiBA0AIAEhAQynAQsgAEHeADYCHCAAIAE2AhQgACAENgIMQQAhEAy6AQsgAEEANgIAIBdBAWohAQJAIAAtAClBI08NACABIQEMWQsgAEEANgIcIAAgATYCFCAAQdOJgIAANgIQIABBCDYCDEEAIRAMuQELIABBADYCAAtBACEQIABBADYCHCAAIAE2AhQgAEGQs4CAADYCECAAQQg2AgwMtwELIABBADYCACAXQQFqIQECQCAALQApQSFHDQAgASEBDFYLIABBADYCHCAAIAE2AhQgAEGbioCAADYCECAAQQg2AgxBACEQDLYBCyAAQQA2AgAgF0EBaiEBAkAgAC0AKSIQQV1qQQtPDQAgASEBDFULAkAgEEEGSw0AQQEgEHRBygBxRQ0AIAEhAQxVC0EAIRAgAEEANgIcIAAgATYCFCAAQfeJgIAANgIQIABBCDYCDAy1AQsgEEEVRg1xIABBADYCHCAAIAE2AhQgAEG5jYCAADYCECAAQRo2AgxBACEQDLQBCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQp4CAgAAiEA0AIAEhAQxUCyAAQeUANgIcIAAgATYCFCAAIBA2AgxBACEQDLMBCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQp4CAgAAiEA0AIAEhAQxNCyAAQdIANgIcIAAgATYCFCAAIBA2AgxBACEQDLIBCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQp4CAgAAiEA0AIAEhAQxNCyAAQdMANgIcIAAgATYCFCAAIBA2AgxBACEQDLEBCyAAKAIEIRAgAEEANgIEAkAgACAQIAEQp4CAgAAiEA0AIAEhAQxRCyAAQeUANgIcIAAgATYCFCAAIBA2AgxBACEQDLABCyAAQQA2AhwgACABNgIUIABBxoqAgAA2AhAgAEEHNgIMQQAhEAyvAQsgACgCBCEQIABBADYCBAJAIAAgECABEKeAgIAAIhANACABIQEMSQsgAEHSADYCHCAAIAE2AhQgACAQNgIMQQAhEAyuAQsgACgCBCEQIABBADYCBAJAIAAgECABEKeAgIAAIhANACABIQEMSQsgAEHTADYCHCAAIAE2AhQgACAQNgIMQQAhEAytAQsgACgCBCEQIABBADYCBAJAIAAgECABEKeAgIAAIhANACABIQEMTQsgAEHlADYCHCAAIAE2AhQgACAQNgIMQQAhEAysAQsgAEEANgIcIAAgATYCFCAAQdyIgIAANgIQIABBBzYCDEEAIRAMqwELIBBBP0cNASABQQFqIQELQQUhEAyQAQtBACEQIABBADYCHCAAIAE2AhQgAEH9koCAADYCECAAQQc2AgwMqAELIAAoAgQhECAAQQA2AgQCQCAAIBAgARCngICAACIQDQAgASEBDEILIABB0gA2AhwgACABNgIUIAAgEDYCDEEAIRAMpwELIAAoAgQhECAAQQA2AgQCQCAAIBAgARCngICAACIQDQAgASEBDEILIABB0wA2AhwgACABNgIUIAAgEDYCDEEAIRAMpgELIAAoAgQhECAAQQA2AgQCQCAAIBAgARCngICAACIQDQAgASEBDEYLIABB5QA2AhwgACABNgIUIAAgEDYCDEEAIRAMpQELIAAoAgQhASAAQQA2AgQCQCAAIAEgFBCngICAACIBDQAgFCEBDD8LIABB0gA2AhwgACAUNgIUIAAgATYCDEEAIRAMpAELIAAoAgQhASAAQQA2AgQCQCAAIAEgFBCngICAACIBDQAgFCEBDD8LIABB0wA2AhwgACAUNgIUIAAgATYCDEEAIRAMowELIAAoAgQhASAAQQA2AgQCQCAAIAEgFBCngICAACIBDQAgFCEBDEMLIABB5QA2AhwgACAUNgIUIAAgATYCDEEAIRAMogELIABBADYCHCAAIBQ2AhQgAEHDj4CAADYCECAAQQc2AgxBACEQDKEBCyAAQQA2AhwgACABNgIUIABBw4+AgAA2AhAgAEEHNgIMQQAhEAygAQtBACEQIABBADYCHCAAIBQ2AhQgAEGMnICAADYCECAAQQc2AgwMnwELIABBADYCHCAAIBQ2AhQgAEGMnICAADYCECAAQQc2AgxBACEQDJ4BCyAAQQA2AhwgACAUNgIUIABB/pGAgAA2AhAgAEEHNgIMQQAhEAydAQsgAEEANgIcIAAgATYCFCAAQY6bgIAANgIQIABBBjYCDEEAIRAMnAELIBBBFUYNVyAAQQA2AhwgACABNgIUIABBzI6AgAA2AhAgAEEgNgIMQQAhEAybAQsgAEEANgIAIBBBAWohAUEkIRALIAAgEDoAKSAAKAIEIRAgAEEANgIEIAAgECABEKuAgIAAIhANVCABIQEMPgsgAEEANgIAC0EAIRAgAEEANgIcIAAgBDYCFCAAQfGbgIAANgIQIABBBjYCDAyXAQsgAUEVRg1QIABBADYCHCAAIAU2AhQgAEHwjICAADYCECAAQRs2AgxBACEQDJYBCyAAKAIEIQUgAEEANgIEIAAgBSAQEKmAgIAAIgUNASAQQQFqIQULQa0BIRAMewsgAEHBATYCHCAAIAU2AgwgACAQQQFqNgIUQQAhEAyTAQsgACgCBCEGIABBADYCBCAAIAYgEBCpgICAACIGDQEgEEEBaiEGC0GuASEQDHgLIABBwgE2AhwgACAGNgIMIAAgEEEBajYCFEEAIRAMkAELIABBADYCHCAAIAc2AhQgAEGXi4CAADYCECAAQQ02AgxBACEQDI8BCyAAQQA2AhwgACAINgIUIABB45CAgAA2AhAgAEEJNgIMQQAhEAyOAQsgAEEANgIcIAAgCDYCFCAAQZSNgIAANgIQIABBITYCDEEAIRAMjQELQQEhFkEAIRdBACEUQQEhEAsgACAQOgArIAlBAWohCAJAAkAgAC0ALUEQcQ0AAkACQAJAIAAtACoOAwEAAgQLIBZFDQMMAgsgFA0BDAILIBdFDQELIAAoAgQhECAAQQA2AgQgACAQIAgQrYCAgAAiEEUNPSAAQckBNgIcIAAgCDYCFCAAIBA2AgxBACEQDIwBCyAAKAIEIQQgAEEANgIEIAAgBCAIEK2AgIAAIgRFDXYgAEHKATYCHCAAIAg2AhQgACAENgIMQQAhEAyLAQsgACgCBCEEIABBADYCBCAAIAQgCRCtgICAACIERQ10IABBywE2AhwgACAJNgIUIAAgBDYCDEEAIRAMigELIAAoAgQhBCAAQQA2AgQgACAEIAoQrYCAgAAiBEUNciAAQc0BNgIcIAAgCjYCFCAAIAQ2AgxBACEQDIkBCwJAIAstAABBUGoiEEH/AXFBCk8NACAAIBA6ACogC0EBaiEKQbYBIRAMcAsgACgCBCEEIABBADYCBCAAIAQgCxCtgICAACIERQ1wIABBzwE2AhwgACALNgIUIAAgBDYCDEEAIRAMiAELIABBADYCHCAAIAQ2AhQgAEGQs4CAADYCECAAQQg2AgwgAEEANgIAQQAhEAyHAQsgAUEVRg0/IABBADYCHCAAIAw2AhQgAEHMjoCAADYCECAAQSA2AgxBACEQDIYBCyAAQYEEOwEoIAAoAgQhECAAQgA3AwAgACAQIAxBAWoiDBCrgICAACIQRQ04IABB0wE2AhwgACAMNgIUIAAgEDYCDEEAIRAMhQELIABBADYCAAtBACEQIABBADYCHCAAIAQ2AhQgAEHYm4CAADYCECAAQQg2AgwMgwELIAAoAgQhECAAQgA3AwAgACAQIAtBAWoiCxCrgICAACIQDQFBxgEhEAxpCyAAQQI6ACgMVQsgAEHVATYCHCAAIAs2AhQgACAQNgIMQQAhEAyAAQsgEEEVRg03IABBADYCHCAAIAQ2AhQgAEGkjICAADYCECAAQRA2AgxBACEQDH8LIAAtADRBAUcNNCAAIAQgAhC8gICAACIQRQ00IBBBFUcNNSAAQdwBNgIcIAAgBDYCFCAAQdWWgIAANgIQIABBFTYCDEEAIRAMfgtBACEQIABBADYCHCAAQa+LgIAANgIQIABBAjYCDCAAIBRBAWo2AhQMfQtBACEQDGMLQQIhEAxiC0ENIRAMYQtBDyEQDGALQSUhEAxfC0ETIRAMXgtBFSEQDF0LQRYhEAxcC0EXIRAMWwtBGCEQDFoLQRkhEAxZC0EaIRAMWAtBGyEQDFcLQRwhEAxWC0EdIRAMVQtBHyEQDFQLQSEhEAxTC0EjIRAMUgtBxgAhEAxRC0EuIRAMUAtBLyEQDE8LQTshEAxOC0E9IRAMTQtByAAhEAxMC0HJACEQDEsLQcsAIRAMSgtBzAAhEAxJC0HOACEQDEgLQdEAIRAMRwtB1QAhEAxGC0HYACEQDEULQdkAIRAMRAtB2wAhEAxDC0HkACEQDEILQeUAIRAMQQtB8QAhEAxAC0H0ACEQDD8LQY0BIRAMPgtBlwEhEAw9C0GpASEQDDwLQawBIRAMOwtBwAEhEAw6C0G5ASEQDDkLQa8BIRAMOAtBsQEhEAw3C0GyASEQDDYLQbQBIRAMNQtBtQEhEAw0C0G6ASEQDDMLQb0BIRAMMgtBvwEhEAwxC0HBASEQDDALIABBADYCHCAAIAQ2AhQgAEHpi4CAADYCECAAQR82AgxBACEQDEgLIABB2wE2AhwgACAENgIUIABB+paAgAA2AhAgAEEVNgIMQQAhEAxHCyAAQfgANgIcIAAgDDYCFCAAQcqYgIAANgIQIABBFTYCDEEAIRAMRgsgAEHRADYCHCAAIAU2AhQgAEGwl4CAADYCECAAQRU2AgxBACEQDEULIABB+QA2AhwgACABNgIUIAAgEDYCDEEAIRAMRAsgAEH4ADYCHCAAIAE2AhQgAEHKmICAADYCECAAQRU2AgxBACEQDEMLIABB5AA2AhwgACABNgIUIABB45eAgAA2AhAgAEEVNgIMQQAhEAxCCyAAQdcANgIcIAAgATYCFCAAQcmXgIAANgIQIABBFTYCDEEAIRAMQQsgAEEANgIcIAAgATYCFCAAQbmNgIAANgIQIABBGjYCDEEAIRAMQAsgAEHCADYCHCAAIAE2AhQgAEHjmICAADYCECAAQRU2AgxBACEQDD8LIABBADYCBCAAIA8gDxCxgICAACIERQ0BIABBOjYCHCAAIAQ2AgwgACAPQQFqNgIUQQAhEAw+CyAAKAIEIQQgAEEANgIEAkAgACAEIAEQsYCAgAAiBEUNACAAQTs2AhwgACAENgIMIAAgAUEBajYCFEEAIRAMPgsgAUEBaiEBDC0LIA9BAWohAQwtCyAAQQA2AhwgACAPNgIUIABB5JKAgAA2AhAgAEEENgIMQQAhEAw7CyAAQTY2AhwgACAENgIUIAAgAjYCDEEAIRAMOgsgAEEuNgIcIAAgDjYCFCAAIAQ2AgxBACEQDDkLIABB0AA2AhwgACABNgIUIABBkZiAgAA2AhAgAEEVNgIMQQAhEAw4CyANQQFqIQEMLAsgAEEVNgIcIAAgATYCFCAAQYKZgIAANgIQIABBFTYCDEEAIRAMNgsgAEEbNgIcIAAgATYCFCAAQZGXgIAANgIQIABBFTYCDEEAIRAMNQsgAEEPNgIcIAAgATYCFCAAQZGXgIAANgIQIABBFTYCDEEAIRAMNAsgAEELNgIcIAAgATYCFCAAQZGXgIAANgIQIABBFTYCDEEAIRAMMwsgAEEaNgIcIAAgATYCFCAAQYKZgIAANgIQIABBFTYCDEEAIRAMMgsgAEELNgIcIAAgATYCFCAAQYKZgIAANgIQIABBFTYCDEEAIRAMMQsgAEEKNgIcIAAgATYCFCAAQeSWgIAANgIQIABBFTYCDEEAIRAMMAsgAEEeNgIcIAAgATYCFCAAQfmXgIAANgIQIABBFTYCDEEAIRAMLwsgAEEANgIcIAAgEDYCFCAAQdqNgIAANgIQIABBFDYCDEEAIRAMLgsgAEEENgIcIAAgATYCFCAAQbCYgIAANgIQIABBFTYCDEEAIRAMLQsgAEEANgIAIAtBAWohCwtBuAEhEAwSCyAAQQA2AgAgEEEBaiEBQfUAIRAMEQsgASEBAkAgAC0AKUEFRw0AQeMAIRAMEQtB4gAhEAwQC0EAIRAgAEEANgIcIABB5JGAgAA2AhAgAEEHNgIMIAAgFEEBajYCFAwoCyAAQQA2AgAgF0EBaiEBQcAAIRAMDgtBASEBCyAAIAE6ACwgAEEANgIAIBdBAWohAQtBKCEQDAsLIAEhAQtBOCEQDAkLAkAgASIPIAJGDQADQAJAIA8tAABBgL6AgABqLQAAIgFBAUYNACABQQJHDQMgD0EBaiEBDAQLIA9BAWoiDyACRw0AC0E+IRAMIgtBPiEQDCELIABBADoALCAPIQEMAQtBCyEQDAYLQTohEAwFCyABQQFqIQFBLSEQDAQLIAAgAToALCAAQQA2AgAgFkEBaiEBQQwhEAwDCyAAQQA2AgAgF0EBaiEBQQohEAwCCyAAQQA2AgALIABBADoALCANIQFBCSEQDAALC0EAIRAgAEEANgIcIAAgCzYCFCAAQc2QgIAANgIQIABBCTYCDAwXC0EAIRAgAEEANgIcIAAgCjYCFCAAQemKgIAANgIQIABBCTYCDAwWC0EAIRAgAEEANgIcIAAgCTYCFCAAQbeQgIAANgIQIABBCTYCDAwVC0EAIRAgAEEANgIcIAAgCDYCFCAAQZyRgIAANgIQIABBCTYCDAwUC0EAIRAgAEEANgIcIAAgATYCFCAAQc2QgIAANgIQIABBCTYCDAwTC0EAIRAgAEEANgIcIAAgATYCFCAAQemKgIAANgIQIABBCTYCDAwSC0EAIRAgAEEANgIcIAAgATYCFCAAQbeQgIAANgIQIABBCTYCDAwRC0EAIRAgAEEANgIcIAAgATYCFCAAQZyRgIAANgIQIABBCTYCDAwQC0EAIRAgAEEANgIcIAAgATYCFCAAQZeVgIAANgIQIABBDzYCDAwPC0EAIRAgAEEANgIcIAAgATYCFCAAQZeVgIAANgIQIABBDzYCDAwOC0EAIRAgAEEANgIcIAAgATYCFCAAQcCSgIAANgIQIABBCzYCDAwNC0EAIRAgAEEANgIcIAAgATYCFCAAQZWJgIAANgIQIABBCzYCDAwMC0EAIRAgAEEANgIcIAAgATYCFCAAQeGPgIAANgIQIABBCjYCDAwLC0EAIRAgAEEANgIcIAAgATYCFCAAQfuPgIAANgIQIABBCjYCDAwKC0EAIRAgAEEANgIcIAAgATYCFCAAQfGZgIAANgIQIABBAjYCDAwJC0EAIRAgAEEANgIcIAAgATYCFCAAQcSUgIAANgIQIABBAjYCDAwIC0EAIRAgAEEANgIcIAAgATYCFCAAQfKVgIAANgIQIABBAjYCDAwHCyAAQQI2AhwgACABNgIUIABBnJqAgAA2AhAgAEEWNgIMQQAhEAwGC0EBIRAMBQtB1AAhECABIgQgAkYNBCADQQhqIAAgBCACQdjCgIAAQQoQxYCAgAAgAygCDCEEIAMoAggOAwEEAgALEMqAgIAAAAsgAEEANgIcIABBtZqAgAA2AhAgAEEXNgIMIAAgBEEBajYCFEEAIRAMAgsgAEEANgIcIAAgBDYCFCAAQcqagIAANgIQIABBCTYCDEEAIRAMAQsCQCABIgQgAkcNAEEiIRAMAQsgAEGJgICAADYCCCAAIAQ2AgRBISEQCyADQRBqJICAgIAAIBALrwEBAn8gASgCACEGAkACQCACIANGDQAgBCAGaiEEIAYgA2ogAmshByACIAZBf3MgBWoiBmohBQNAAkAgAi0AACAELQAARg0AQQIhBAwDCwJAIAYNAEEAIQQgBSECDAMLIAZBf2ohBiAEQQFqIQQgAkEBaiICIANHDQALIAchBiADIQILIABBATYCACABIAY2AgAgACACNgIEDwsgAUEANgIAIAAgBDYCACAAIAI2AgQLCgAgABDHgICAAAvyNgELfyOAgICAAEEQayIBJICAgIAAAkBBACgCoNCAgAANAEEAEMuAgIAAQYDUhIAAayICQdkASQ0AQQAhAwJAQQAoAuDTgIAAIgQNAEEAQn83AuzTgIAAQQBCgICEgICAwAA3AuTTgIAAQQAgAUEIakFwcUHYqtWqBXMiBDYC4NOAgABBAEEANgL004CAAEEAQQA2AsTTgIAAC0EAIAI2AszTgIAAQQBBgNSEgAA2AsjTgIAAQQBBgNSEgAA2ApjQgIAAQQAgBDYCrNCAgABBAEF/NgKo0ICAAANAIANBxNCAgABqIANBuNCAgABqIgQ2AgAgBCADQbDQgIAAaiIFNgIAIANBvNCAgABqIAU2AgAgA0HM0ICAAGogA0HA0ICAAGoiBTYCACAFIAQ2AgAgA0HU0ICAAGogA0HI0ICAAGoiBDYCACAEIAU2AgAgA0HQ0ICAAGogBDYCACADQSBqIgNBgAJHDQALQYDUhIAAQXhBgNSEgABrQQ9xQQBBgNSEgABBCGpBD3EbIgNqIgRBBGogAkFIaiIFIANrIgNBAXI2AgBBAEEAKALw04CAADYCpNCAgABBACADNgKU0ICAAEEAIAQ2AqDQgIAAQYDUhIAAIAVqQTg2AgQLAkACQAJAAkACQAJAAkACQAJAAkACQAJAIABB7AFLDQACQEEAKAKI0ICAACIGQRAgAEETakFwcSAAQQtJGyICQQN2IgR2IgNBA3FFDQACQAJAIANBAXEgBHJBAXMiBUEDdCIEQbDQgIAAaiIDIARBuNCAgABqKAIAIgQoAggiAkcNAEEAIAZBfiAFd3E2AojQgIAADAELIAMgAjYCCCACIAM2AgwLIARBCGohAyAEIAVBA3QiBUEDcjYCBCAEIAVqIgQgBCgCBEEBcjYCBAwMCyACQQAoApDQgIAAIgdNDQECQCADRQ0AAkACQCADIAR0QQIgBHQiA0EAIANrcnEiA0EAIANrcUF/aiIDIANBDHZBEHEiA3YiBEEFdkEIcSIFIANyIAQgBXYiA0ECdkEEcSIEciADIAR2IgNBAXZBAnEiBHIgAyAEdiIDQQF2QQFxIgRyIAMgBHZqIgRBA3QiA0Gw0ICAAGoiBSADQbjQgIAAaigCACIDKAIIIgBHDQBBACAGQX4gBHdxIgY2AojQgIAADAELIAUgADYCCCAAIAU2AgwLIAMgAkEDcjYCBCADIARBA3QiBGogBCACayIFNgIAIAMgAmoiACAFQQFyNgIEAkAgB0UNACAHQXhxQbDQgIAAaiECQQAoApzQgIAAIQQCQAJAIAZBASAHQQN2dCIIcQ0AQQAgBiAIcjYCiNCAgAAgAiEIDAELIAIoAgghCAsgCCAENgIMIAIgBDYCCCAEIAI2AgwgBCAINgIICyADQQhqIQNBACAANgKc0ICAAEEAIAU2ApDQgIAADAwLQQAoAozQgIAAIglFDQEgCUEAIAlrcUF/aiIDIANBDHZBEHEiA3YiBEEFdkEIcSIFIANyIAQgBXYiA0ECdkEEcSIEciADIAR2IgNBAXZBAnEiBHIgAyAEdiIDQQF2QQFxIgRyIAMgBHZqQQJ0QbjSgIAAaigCACIAKAIEQXhxIAJrIQQgACEFAkADQAJAIAUoAhAiAw0AIAVBFGooAgAiA0UNAgsgAygCBEF4cSACayIFIAQgBSAESSIFGyEEIAMgACAFGyEAIAMhBQwACwsgACgCGCEKAkAgACgCDCIIIABGDQAgACgCCCIDQQAoApjQgIAASRogCCADNgIIIAMgCDYCDAwLCwJAIABBFGoiBSgCACIDDQAgACgCECIDRQ0DIABBEGohBQsDQCAFIQsgAyIIQRRqIgUoAgAiAw0AIAhBEGohBSAIKAIQIgMNAAsgC0EANgIADAoLQX8hAiAAQb9/Sw0AIABBE2oiA0FwcSECQQAoAozQgIAAIgdFDQBBACELAkAgAkGAAkkNAEEfIQsgAkH///8HSw0AIANBCHYiAyADQYD+P2pBEHZBCHEiA3QiBCAEQYDgH2pBEHZBBHEiBHQiBSAFQYCAD2pBEHZBAnEiBXRBD3YgAyAEciAFcmsiA0EBdCACIANBFWp2QQFxckEcaiELC0EAIAJrIQQCQAJAAkACQCALQQJ0QbjSgIAAaigCACIFDQBBACEDQQAhCAwBC0EAIQMgAkEAQRkgC0EBdmsgC0EfRht0IQBBACEIA0ACQCAFKAIEQXhxIAJrIgYgBE8NACAGIQQgBSEIIAYNAEEAIQQgBSEIIAUhAwwDCyADIAVBFGooAgAiBiAGIAUgAEEddkEEcWpBEGooAgAiBUYbIAMgBhshAyAAQQF0IQAgBQ0ACwsCQCADIAhyDQBBACEIQQIgC3QiA0EAIANrciAHcSIDRQ0DIANBACADa3FBf2oiAyADQQx2QRBxIgN2IgVBBXZBCHEiACADciAFIAB2IgNBAnZBBHEiBXIgAyAFdiIDQQF2QQJxIgVyIAMgBXYiA0EBdkEBcSIFciADIAV2akECdEG40oCAAGooAgAhAwsgA0UNAQsDQCADKAIEQXhxIAJrIgYgBEkhAAJAIAMoAhAiBQ0AIANBFGooAgAhBQsgBiAEIAAbIQQgAyAIIAAbIQggBSEDIAUNAAsLIAhFDQAgBEEAKAKQ0ICAACACa08NACAIKAIYIQsCQCAIKAIMIgAgCEYNACAIKAIIIgNBACgCmNCAgABJGiAAIAM2AgggAyAANgIMDAkLAkAgCEEUaiIFKAIAIgMNACAIKAIQIgNFDQMgCEEQaiEFCwNAIAUhBiADIgBBFGoiBSgCACIDDQAgAEEQaiEFIAAoAhAiAw0ACyAGQQA2AgAMCAsCQEEAKAKQ0ICAACIDIAJJDQBBACgCnNCAgAAhBAJAAkAgAyACayIFQRBJDQAgBCACaiIAIAVBAXI2AgRBACAFNgKQ0ICAAEEAIAA2ApzQgIAAIAQgA2ogBTYCACAEIAJBA3I2AgQMAQsgBCADQQNyNgIEIAQgA2oiAyADKAIEQQFyNgIEQQBBADYCnNCAgABBAEEANgKQ0ICAAAsgBEEIaiEDDAoLAkBBACgClNCAgAAiACACTQ0AQQAoAqDQgIAAIgMgAmoiBCAAIAJrIgVBAXI2AgRBACAFNgKU0ICAAEEAIAQ2AqDQgIAAIAMgAkEDcjYCBCADQQhqIQMMCgsCQAJAQQAoAuDTgIAARQ0AQQAoAujTgIAAIQQMAQtBAEJ/NwLs04CAAEEAQoCAhICAgMAANwLk04CAAEEAIAFBDGpBcHFB2KrVqgVzNgLg04CAAEEAQQA2AvTTgIAAQQBBADYCxNOAgABBgIAEIQQLQQAhAwJAIAQgAkHHAGoiB2oiBkEAIARrIgtxIgggAksNAEEAQTA2AvjTgIAADAoLAkBBACgCwNOAgAAiA0UNAAJAQQAoArjTgIAAIgQgCGoiBSAETQ0AIAUgA00NAQtBACEDQQBBMDYC+NOAgAAMCgtBAC0AxNOAgABBBHENBAJAAkACQEEAKAKg0ICAACIERQ0AQcjTgIAAIQMDQAJAIAMoAgAiBSAESw0AIAUgAygCBGogBEsNAwsgAygCCCIDDQALC0EAEMuAgIAAIgBBf0YNBSAIIQYCQEEAKALk04CAACIDQX9qIgQgAHFFDQAgCCAAayAEIABqQQAgA2txaiEGCyAGIAJNDQUgBkH+////B0sNBQJAQQAoAsDTgIAAIgNFDQBBACgCuNOAgAAiBCAGaiIFIARNDQYgBSADSw0GCyAGEMuAgIAAIgMgAEcNAQwHCyAGIABrIAtxIgZB/v///wdLDQQgBhDLgICAACIAIAMoAgAgAygCBGpGDQMgACEDCwJAIANBf0YNACACQcgAaiAGTQ0AAkAgByAGa0EAKALo04CAACIEakEAIARrcSIEQf7///8HTQ0AIAMhAAwHCwJAIAQQy4CAgABBf0YNACAEIAZqIQYgAyEADAcLQQAgBmsQy4CAgAAaDAQLIAMhACADQX9HDQUMAwtBACEIDAcLQQAhAAwFCyAAQX9HDQILQQBBACgCxNOAgABBBHI2AsTTgIAACyAIQf7///8HSw0BIAgQy4CAgAAhAEEAEMuAgIAAIQMgAEF/Rg0BIANBf0YNASAAIANPDQEgAyAAayIGIAJBOGpNDQELQQBBACgCuNOAgAAgBmoiAzYCuNOAgAACQCADQQAoArzTgIAATQ0AQQAgAzYCvNOAgAALAkACQAJAAkBBACgCoNCAgAAiBEUNAEHI04CAACEDA0AgACADKAIAIgUgAygCBCIIakYNAiADKAIIIgMNAAwDCwsCQAJAQQAoApjQgIAAIgNFDQAgACADTw0BC0EAIAA2ApjQgIAAC0EAIQNBACAGNgLM04CAAEEAIAA2AsjTgIAAQQBBfzYCqNCAgABBAEEAKALg04CAADYCrNCAgABBAEEANgLU04CAAANAIANBxNCAgABqIANBuNCAgABqIgQ2AgAgBCADQbDQgIAAaiIFNgIAIANBvNCAgABqIAU2AgAgA0HM0ICAAGogA0HA0ICAAGoiBTYCACAFIAQ2AgAgA0HU0ICAAGogA0HI0ICAAGoiBDYCACAEIAU2AgAgA0HQ0ICAAGogBDYCACADQSBqIgNBgAJHDQALIABBeCAAa0EPcUEAIABBCGpBD3EbIgNqIgQgBkFIaiIFIANrIgNBAXI2AgRBAEEAKALw04CAADYCpNCAgABBACADNgKU0ICAAEEAIAQ2AqDQgIAAIAAgBWpBODYCBAwCCyADLQAMQQhxDQAgBCAFSQ0AIAQgAE8NACAEQXggBGtBD3FBACAEQQhqQQ9xGyIFaiIAQQAoApTQgIAAIAZqIgsgBWsiBUEBcjYCBCADIAggBmo2AgRBAEEAKALw04CAADYCpNCAgABBACAFNgKU0ICAAEEAIAA2AqDQgIAAIAQgC2pBODYCBAwBCwJAIABBACgCmNCAgAAiCE8NAEEAIAA2ApjQgIAAIAAhCAsgACAGaiEFQcjTgIAAIQMCQAJAAkACQAJAAkACQANAIAMoAgAgBUYNASADKAIIIgMNAAwCCwsgAy0ADEEIcUUNAQtByNOAgAAhAwNAAkAgAygCACIFIARLDQAgBSADKAIEaiIFIARLDQMLIAMoAgghAwwACwsgAyAANgIAIAMgAygCBCAGajYCBCAAQXggAGtBD3FBACAAQQhqQQ9xG2oiCyACQQNyNgIEIAVBeCAFa0EPcUEAIAVBCGpBD3EbaiIGIAsgAmoiAmshAwJAIAYgBEcNAEEAIAI2AqDQgIAAQQBBACgClNCAgAAgA2oiAzYClNCAgAAgAiADQQFyNgIEDAMLAkAgBkEAKAKc0ICAAEcNAEEAIAI2ApzQgIAAQQBBACgCkNCAgAAgA2oiAzYCkNCAgAAgAiADQQFyNgIEIAIgA2ogAzYCAAwDCwJAIAYoAgQiBEEDcUEBRw0AIARBeHEhBwJAAkAgBEH/AUsNACAGKAIIIgUgBEEDdiIIQQN0QbDQgIAAaiIARhoCQCAGKAIMIgQgBUcNAEEAQQAoAojQgIAAQX4gCHdxNgKI0ICAAAwCCyAEIABGGiAEIAU2AgggBSAENgIMDAELIAYoAhghCQJAAkAgBigCDCIAIAZGDQAgBigCCCIEIAhJGiAAIAQ2AgggBCAANgIMDAELAkAgBkEUaiIEKAIAIgUNACAGQRBqIgQoAgAiBQ0AQQAhAAwBCwNAIAQhCCAFIgBBFGoiBCgCACIFDQAgAEEQaiEEIAAoAhAiBQ0ACyAIQQA2AgALIAlFDQACQAJAIAYgBigCHCIFQQJ0QbjSgIAAaiIEKAIARw0AIAQgADYCACAADQFBAEEAKAKM0ICAAEF+IAV3cTYCjNCAgAAMAgsgCUEQQRQgCSgCECAGRhtqIAA2AgAgAEUNAQsgACAJNgIYAkAgBigCECIERQ0AIAAgBDYCECAEIAA2AhgLIAYoAhQiBEUNACAAQRRqIAQ2AgAgBCAANgIYCyAHIANqIQMgBiAHaiIGKAIEIQQLIAYgBEF+cTYCBCACIANqIAM2AgAgAiADQQFyNgIEAkAgA0H/AUsNACADQXhxQbDQgIAAaiEEAkACQEEAKAKI0ICAACIFQQEgA0EDdnQiA3ENAEEAIAUgA3I2AojQgIAAIAQhAwwBCyAEKAIIIQMLIAMgAjYCDCAEIAI2AgggAiAENgIMIAIgAzYCCAwDC0EfIQQCQCADQf///wdLDQAgA0EIdiIEIARBgP4/akEQdkEIcSIEdCIFIAVBgOAfakEQdkEEcSIFdCIAIABBgIAPakEQdkECcSIAdEEPdiAEIAVyIAByayIEQQF0IAMgBEEVanZBAXFyQRxqIQQLIAIgBDYCHCACQgA3AhAgBEECdEG40oCAAGohBQJAQQAoAozQgIAAIgBBASAEdCIIcQ0AIAUgAjYCAEEAIAAgCHI2AozQgIAAIAIgBTYCGCACIAI2AgggAiACNgIMDAMLIANBAEEZIARBAXZrIARBH0YbdCEEIAUoAgAhAANAIAAiBSgCBEF4cSADRg0CIARBHXYhACAEQQF0IQQgBSAAQQRxakEQaiIIKAIAIgANAAsgCCACNgIAIAIgBTYCGCACIAI2AgwgAiACNgIIDAILIABBeCAAa0EPcUEAIABBCGpBD3EbIgNqIgsgBkFIaiIIIANrIgNBAXI2AgQgACAIakE4NgIEIAQgBUE3IAVrQQ9xQQAgBUFJakEPcRtqQUFqIgggCCAEQRBqSRsiCEEjNgIEQQBBACgC8NOAgAA2AqTQgIAAQQAgAzYClNCAgABBACALNgKg0ICAACAIQRBqQQApAtDTgIAANwIAIAhBACkCyNOAgAA3AghBACAIQQhqNgLQ04CAAEEAIAY2AszTgIAAQQAgADYCyNOAgABBAEEANgLU04CAACAIQSRqIQMDQCADQQc2AgAgA0EEaiIDIAVJDQALIAggBEYNAyAIIAgoAgRBfnE2AgQgCCAIIARrIgA2AgAgBCAAQQFyNgIEAkAgAEH/AUsNACAAQXhxQbDQgIAAaiEDAkACQEEAKAKI0ICAACIFQQEgAEEDdnQiAHENAEEAIAUgAHI2AojQgIAAIAMhBQwBCyADKAIIIQULIAUgBDYCDCADIAQ2AgggBCADNgIMIAQgBTYCCAwEC0EfIQMCQCAAQf///wdLDQAgAEEIdiIDIANBgP4/akEQdkEIcSIDdCIFIAVBgOAfakEQdkEEcSIFdCIIIAhBgIAPakEQdkECcSIIdEEPdiADIAVyIAhyayIDQQF0IAAgA0EVanZBAXFyQRxqIQMLIAQgAzYCHCAEQgA3AhAgA0ECdEG40oCAAGohBQJAQQAoAozQgIAAIghBASADdCIGcQ0AIAUgBDYCAEEAIAggBnI2AozQgIAAIAQgBTYCGCAEIAQ2AgggBCAENgIMDAQLIABBAEEZIANBAXZrIANBH0YbdCEDIAUoAgAhCANAIAgiBSgCBEF4cSAARg0DIANBHXYhCCADQQF0IQMgBSAIQQRxakEQaiIGKAIAIggNAAsgBiAENgIAIAQgBTYCGCAEIAQ2AgwgBCAENgIIDAMLIAUoAggiAyACNgIMIAUgAjYCCCACQQA2AhggAiAFNgIMIAIgAzYCCAsgC0EIaiEDDAULIAUoAggiAyAENgIMIAUgBDYCCCAEQQA2AhggBCAFNgIMIAQgAzYCCAtBACgClNCAgAAiAyACTQ0AQQAoAqDQgIAAIgQgAmoiBSADIAJrIgNBAXI2AgRBACADNgKU0ICAAEEAIAU2AqDQgIAAIAQgAkEDcjYCBCAEQQhqIQMMAwtBACEDQQBBMDYC+NOAgAAMAgsCQCALRQ0AAkACQCAIIAgoAhwiBUECdEG40oCAAGoiAygCAEcNACADIAA2AgAgAA0BQQAgB0F+IAV3cSIHNgKM0ICAAAwCCyALQRBBFCALKAIQIAhGG2ogADYCACAARQ0BCyAAIAs2AhgCQCAIKAIQIgNFDQAgACADNgIQIAMgADYCGAsgCEEUaigCACIDRQ0AIABBFGogAzYCACADIAA2AhgLAkACQCAEQQ9LDQAgCCAEIAJqIgNBA3I2AgQgCCADaiIDIAMoAgRBAXI2AgQMAQsgCCACaiIAIARBAXI2AgQgCCACQQNyNgIEIAAgBGogBDYCAAJAIARB/wFLDQAgBEF4cUGw0ICAAGohAwJAAkBBACgCiNCAgAAiBUEBIARBA3Z0IgRxDQBBACAFIARyNgKI0ICAACADIQQMAQsgAygCCCEECyAEIAA2AgwgAyAANgIIIAAgAzYCDCAAIAQ2AggMAQtBHyEDAkAgBEH///8HSw0AIARBCHYiAyADQYD+P2pBEHZBCHEiA3QiBSAFQYDgH2pBEHZBBHEiBXQiAiACQYCAD2pBEHZBAnEiAnRBD3YgAyAFciACcmsiA0EBdCAEIANBFWp2QQFxckEcaiEDCyAAIAM2AhwgAEIANwIQIANBAnRBuNKAgABqIQUCQCAHQQEgA3QiAnENACAFIAA2AgBBACAHIAJyNgKM0ICAACAAIAU2AhggACAANgIIIAAgADYCDAwBCyAEQQBBGSADQQF2ayADQR9GG3QhAyAFKAIAIQICQANAIAIiBSgCBEF4cSAERg0BIANBHXYhAiADQQF0IQMgBSACQQRxakEQaiIGKAIAIgINAAsgBiAANgIAIAAgBTYCGCAAIAA2AgwgACAANgIIDAELIAUoAggiAyAANgIMIAUgADYCCCAAQQA2AhggACAFNgIMIAAgAzYCCAsgCEEIaiEDDAELAkAgCkUNAAJAAkAgACAAKAIcIgVBAnRBuNKAgABqIgMoAgBHDQAgAyAINgIAIAgNAUEAIAlBfiAFd3E2AozQgIAADAILIApBEEEUIAooAhAgAEYbaiAINgIAIAhFDQELIAggCjYCGAJAIAAoAhAiA0UNACAIIAM2AhAgAyAINgIYCyAAQRRqKAIAIgNFDQAgCEEUaiADNgIAIAMgCDYCGAsCQAJAIARBD0sNACAAIAQgAmoiA0EDcjYCBCAAIANqIgMgAygCBEEBcjYCBAwBCyAAIAJqIgUgBEEBcjYCBCAAIAJBA3I2AgQgBSAEaiAENgIAAkAgB0UNACAHQXhxQbDQgIAAaiECQQAoApzQgIAAIQMCQAJAQQEgB0EDdnQiCCAGcQ0AQQAgCCAGcjYCiNCAgAAgAiEIDAELIAIoAgghCAsgCCADNgIMIAIgAzYCCCADIAI2AgwgAyAINgIIC0EAIAU2ApzQgIAAQQAgBDYCkNCAgAALIABBCGohAwsgAUEQaiSAgICAACADCwoAIAAQyYCAgAAL4g0BB38CQCAARQ0AIABBeGoiASAAQXxqKAIAIgJBeHEiAGohAwJAIAJBAXENACACQQNxRQ0BIAEgASgCACICayIBQQAoApjQgIAAIgRJDQEgAiAAaiEAAkAgAUEAKAKc0ICAAEYNAAJAIAJB/wFLDQAgASgCCCIEIAJBA3YiBUEDdEGw0ICAAGoiBkYaAkAgASgCDCICIARHDQBBAEEAKAKI0ICAAEF+IAV3cTYCiNCAgAAMAwsgAiAGRhogAiAENgIIIAQgAjYCDAwCCyABKAIYIQcCQAJAIAEoAgwiBiABRg0AIAEoAggiAiAESRogBiACNgIIIAIgBjYCDAwBCwJAIAFBFGoiAigCACIEDQAgAUEQaiICKAIAIgQNAEEAIQYMAQsDQCACIQUgBCIGQRRqIgIoAgAiBA0AIAZBEGohAiAGKAIQIgQNAAsgBUEANgIACyAHRQ0BAkACQCABIAEoAhwiBEECdEG40oCAAGoiAigCAEcNACACIAY2AgAgBg0BQQBBACgCjNCAgABBfiAEd3E2AozQgIAADAMLIAdBEEEUIAcoAhAgAUYbaiAGNgIAIAZFDQILIAYgBzYCGAJAIAEoAhAiAkUNACAGIAI2AhAgAiAGNgIYCyABKAIUIgJFDQEgBkEUaiACNgIAIAIgBjYCGAwBCyADKAIEIgJBA3FBA0cNACADIAJBfnE2AgRBACAANgKQ0ICAACABIABqIAA2AgAgASAAQQFyNgIEDwsgASADTw0AIAMoAgQiAkEBcUUNAAJAAkAgAkECcQ0AAkAgA0EAKAKg0ICAAEcNAEEAIAE2AqDQgIAAQQBBACgClNCAgAAgAGoiADYClNCAgAAgASAAQQFyNgIEIAFBACgCnNCAgABHDQNBAEEANgKQ0ICAAEEAQQA2ApzQgIAADwsCQCADQQAoApzQgIAARw0AQQAgATYCnNCAgABBAEEAKAKQ0ICAACAAaiIANgKQ0ICAACABIABBAXI2AgQgASAAaiAANgIADwsgAkF4cSAAaiEAAkACQCACQf8BSw0AIAMoAggiBCACQQN2IgVBA3RBsNCAgABqIgZGGgJAIAMoAgwiAiAERw0AQQBBACgCiNCAgABBfiAFd3E2AojQgIAADAILIAIgBkYaIAIgBDYCCCAEIAI2AgwMAQsgAygCGCEHAkACQCADKAIMIgYgA0YNACADKAIIIgJBACgCmNCAgABJGiAGIAI2AgggAiAGNgIMDAELAkAgA0EUaiICKAIAIgQNACADQRBqIgIoAgAiBA0AQQAhBgwBCwNAIAIhBSAEIgZBFGoiAigCACIEDQAgBkEQaiECIAYoAhAiBA0ACyAFQQA2AgALIAdFDQACQAJAIAMgAygCHCIEQQJ0QbjSgIAAaiICKAIARw0AIAIgBjYCACAGDQFBAEEAKAKM0ICAAEF+IAR3cTYCjNCAgAAMAgsgB0EQQRQgBygCECADRhtqIAY2AgAgBkUNAQsgBiAHNgIYAkAgAygCECICRQ0AIAYgAjYCECACIAY2AhgLIAMoAhQiAkUNACAGQRRqIAI2AgAgAiAGNgIYCyABIABqIAA2AgAgASAAQQFyNgIEIAFBACgCnNCAgABHDQFBACAANgKQ0ICAAA8LIAMgAkF+cTYCBCABIABqIAA2AgAgASAAQQFyNgIECwJAIABB/wFLDQAgAEF4cUGw0ICAAGohAgJAAkBBACgCiNCAgAAiBEEBIABBA3Z0IgBxDQBBACAEIAByNgKI0ICAACACIQAMAQsgAigCCCEACyAAIAE2AgwgAiABNgIIIAEgAjYCDCABIAA2AggPC0EfIQICQCAAQf///wdLDQAgAEEIdiICIAJBgP4/akEQdkEIcSICdCIEIARBgOAfakEQdkEEcSIEdCIGIAZBgIAPakEQdkECcSIGdEEPdiACIARyIAZyayICQQF0IAAgAkEVanZBAXFyQRxqIQILIAEgAjYCHCABQgA3AhAgAkECdEG40oCAAGohBAJAAkBBACgCjNCAgAAiBkEBIAJ0IgNxDQAgBCABNgIAQQAgBiADcjYCjNCAgAAgASAENgIYIAEgATYCCCABIAE2AgwMAQsgAEEAQRkgAkEBdmsgAkEfRht0IQIgBCgCACEGAkADQCAGIgQoAgRBeHEgAEYNASACQR12IQYgAkEBdCECIAQgBkEEcWpBEGoiAygCACIGDQALIAMgATYCACABIAQ2AhggASABNgIMIAEgATYCCAwBCyAEKAIIIgAgATYCDCAEIAE2AgggAUEANgIYIAEgBDYCDCABIAA2AggLQQBBACgCqNCAgABBf2oiAUF/IAEbNgKo0ICAAAsLBAAAAAtOAAJAIAANAD8AQRB0DwsCQCAAQf//A3ENACAAQX9MDQACQCAAQRB2QAAiAEF/Rw0AQQBBMDYC+NOAgABBfw8LIABBEHQPCxDKgICAAAAL8gICA38BfgJAIAJFDQAgACABOgAAIAIgAGoiA0F/aiABOgAAIAJBA0kNACAAIAE6AAIgACABOgABIANBfWogAToAACADQX5qIAE6AAAgAkEHSQ0AIAAgAToAAyADQXxqIAE6AAAgAkEJSQ0AIABBACAAa0EDcSIEaiIDIAFB/wFxQYGChAhsIgE2AgAgAyACIARrQXxxIgRqIgJBfGogATYCACAEQQlJDQAgAyABNgIIIAMgATYCBCACQXhqIAE2AgAgAkF0aiABNgIAIARBGUkNACADIAE2AhggAyABNgIUIAMgATYCECADIAE2AgwgAkFwaiABNgIAIAJBbGogATYCACACQWhqIAE2AgAgAkFkaiABNgIAIAQgA0EEcUEYciIFayICQSBJDQAgAa1CgYCAgBB+IQYgAyAFaiEBA0AgASAGNwMYIAEgBjcDECABIAY3AwggASAGNwMAIAFBIGohASACQWBqIgJBH0sNAAsLIAALC45IAQBBgAgLhkgBAAAAAgAAAAMAAAAAAAAAAAAAAAQAAAAFAAAAAAAAAAAAAAAGAAAABwAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEludmFsaWQgY2hhciBpbiB1cmwgcXVlcnkAU3BhbiBjYWxsYmFjayBlcnJvciBpbiBvbl9ib2R5AENvbnRlbnQtTGVuZ3RoIG92ZXJmbG93AENodW5rIHNpemUgb3ZlcmZsb3cAUmVzcG9uc2Ugb3ZlcmZsb3cASW52YWxpZCBtZXRob2QgZm9yIEhUVFAveC54IHJlcXVlc3QASW52YWxpZCBtZXRob2QgZm9yIFJUU1AveC54IHJlcXVlc3QARXhwZWN0ZWQgU09VUkNFIG1ldGhvZCBmb3IgSUNFL3gueCByZXF1ZXN0AEludmFsaWQgY2hhciBpbiB1cmwgZnJhZ21lbnQgc3RhcnQARXhwZWN0ZWQgZG90AFNwYW4gY2FsbGJhY2sgZXJyb3IgaW4gb25fc3RhdHVzAEludmFsaWQgcmVzcG9uc2Ugc3RhdHVzAEludmFsaWQgY2hhcmFjdGVyIGluIGNodW5rIGV4dGVuc2lvbnMAVXNlciBjYWxsYmFjayBlcnJvcgBgb25fcmVzZXRgIGNhbGxiYWNrIGVycm9yAGBvbl9jaHVua19oZWFkZXJgIGNhbGxiYWNrIGVycm9yAGBvbl9tZXNzYWdlX2JlZ2luYCBjYWxsYmFjayBlcnJvcgBgb25fY2h1bmtfZXh0ZW5zaW9uX3ZhbHVlYCBjYWxsYmFjayBlcnJvcgBgb25fc3RhdHVzX2NvbXBsZXRlYCBjYWxsYmFjayBlcnJvcgBgb25fdmVyc2lvbl9jb21wbGV0ZWAgY2FsbGJhY2sgZXJyb3IAYG9uX3VybF9jb21wbGV0ZWAgY2FsbGJhY2sgZXJyb3IAYG9uX2NodW5rX2NvbXBsZXRlYCBjYWxsYmFjayBlcnJvcgBgb25faGVhZGVyX3ZhbHVlX2NvbXBsZXRlYCBjYWxsYmFjayBlcnJvcgBgb25fbWVzc2FnZV9jb21wbGV0ZWAgY2FsbGJhY2sgZXJyb3IAYG9uX21ldGhvZF9jb21wbGV0ZWAgY2FsbGJhY2sgZXJyb3IAYG9uX2hlYWRlcl9maWVsZF9jb21wbGV0ZWAgY2FsbGJhY2sgZXJyb3IAYG9uX2NodW5rX2V4dGVuc2lvbl9uYW1lYCBjYWxsYmFjayBlcnJvcgBVbmV4cGVjdGVkIGNoYXIgaW4gdXJsIHNlcnZlcgBJbnZhbGlkIGhlYWRlciB2YWx1ZSBjaGFyAEludmFsaWQgaGVhZGVyIGZpZWxkIGNoYXIAU3BhbiBjYWxsYmFjayBlcnJvciBpbiBvbl92ZXJzaW9uAEludmFsaWQgbWlub3IgdmVyc2lvbgBJbnZhbGlkIG1ham9yIHZlcnNpb24ARXhwZWN0ZWQgc3BhY2UgYWZ0ZXIgdmVyc2lvbgBFeHBlY3RlZCBDUkxGIGFmdGVyIHZlcnNpb24ASW52YWxpZCBIVFRQIHZlcnNpb24ASW52YWxpZCBoZWFkZXIgdG9rZW4AU3BhbiBjYWxsYmFjayBlcnJvciBpbiBvbl91cmwASW52YWxpZCBjaGFyYWN0ZXJzIGluIHVybABVbmV4cGVjdGVkIHN0YXJ0IGNoYXIgaW4gdXJsAERvdWJsZSBAIGluIHVybABFbXB0eSBDb250ZW50LUxlbmd0aABJbnZhbGlkIGNoYXJhY3RlciBpbiBDb250ZW50LUxlbmd0aABEdXBsaWNhdGUgQ29udGVudC1MZW5ndGgASW52YWxpZCBjaGFyIGluIHVybCBwYXRoAENvbnRlbnQtTGVuZ3RoIGNhbid0IGJlIHByZXNlbnQgd2l0aCBUcmFuc2Zlci1FbmNvZGluZwBJbnZhbGlkIGNoYXJhY3RlciBpbiBjaHVuayBzaXplAFNwYW4gY2FsbGJhY2sgZXJyb3IgaW4gb25faGVhZGVyX3ZhbHVlAFNwYW4gY2FsbGJhY2sgZXJyb3IgaW4gb25fY2h1bmtfZXh0ZW5zaW9uX3ZhbHVlAEludmFsaWQgY2hhcmFjdGVyIGluIGNodW5rIGV4dGVuc2lvbnMgdmFsdWUATWlzc2luZyBleHBlY3RlZCBMRiBhZnRlciBoZWFkZXIgdmFsdWUASW52YWxpZCBgVHJhbnNmZXItRW5jb2RpbmdgIGhlYWRlciB2YWx1ZQBJbnZhbGlkIGNoYXJhY3RlciBpbiBjaHVuayBleHRlbnNpb25zIHF1b3RlIHZhbHVlAEludmFsaWQgY2hhcmFjdGVyIGluIGNodW5rIGV4dGVuc2lvbnMgcXVvdGVkIHZhbHVlAFBhdXNlZCBieSBvbl9oZWFkZXJzX2NvbXBsZXRlAEludmFsaWQgRU9GIHN0YXRlAG9uX3Jlc2V0IHBhdXNlAG9uX2NodW5rX2hlYWRlciBwYXVzZQBvbl9tZXNzYWdlX2JlZ2luIHBhdXNlAG9uX2NodW5rX2V4dGVuc2lvbl92YWx1ZSBwYXVzZQBvbl9zdGF0dXNfY29tcGxldGUgcGF1c2UAb25fdmVyc2lvbl9jb21wbGV0ZSBwYXVzZQBvbl91cmxfY29tcGxldGUgcGF1c2UAb25fY2h1bmtfY29tcGxldGUgcGF1c2UAb25faGVhZGVyX3ZhbHVlX2NvbXBsZXRlIHBhdXNlAG9uX21lc3NhZ2VfY29tcGxldGUgcGF1c2UAb25fbWV0aG9kX2NvbXBsZXRlIHBhdXNlAG9uX2hlYWRlcl9maWVsZF9jb21wbGV0ZSBwYXVzZQBvbl9jaHVua19leHRlbnNpb25fbmFtZSBwYXVzZQBVbmV4cGVjdGVkIHNwYWNlIGFmdGVyIHN0YXJ0IGxpbmUAU3BhbiBjYWxsYmFjayBlcnJvciBpbiBvbl9jaHVua19leHRlbnNpb25fbmFtZQBJbnZhbGlkIGNoYXJhY3RlciBpbiBjaHVuayBleHRlbnNpb25zIG5hbWUAUGF1c2Ugb24gQ09OTkVDVC9VcGdyYWRlAFBhdXNlIG9uIFBSSS9VcGdyYWRlAEV4cGVjdGVkIEhUVFAvMiBDb25uZWN0aW9uIFByZWZhY2UAU3BhbiBjYWxsYmFjayBlcnJvciBpbiBvbl9tZXRob2QARXhwZWN0ZWQgc3BhY2UgYWZ0ZXIgbWV0aG9kAFNwYW4gY2FsbGJhY2sgZXJyb3IgaW4gb25faGVhZGVyX2ZpZWxkAFBhdXNlZABJbnZhbGlkIHdvcmQgZW5jb3VudGVyZWQASW52YWxpZCBtZXRob2QgZW5jb3VudGVyZWQAVW5leHBlY3RlZCBjaGFyIGluIHVybCBzY2hlbWEAUmVxdWVzdCBoYXMgaW52YWxpZCBgVHJhbnNmZXItRW5jb2RpbmdgAFNXSVRDSF9QUk9YWQBVU0VfUFJPWFkATUtBQ1RJVklUWQBVTlBST0NFU1NBQkxFX0VOVElUWQBDT1BZAE1PVkVEX1BFUk1BTkVOVExZAFRPT19FQVJMWQBOT1RJRlkARkFJTEVEX0RFUEVOREVOQ1kAQkFEX0dBVEVXQVkAUExBWQBQVVQAQ0hFQ0tPVVQAR0FURVdBWV9USU1FT1VUAFJFUVVFU1RfVElNRU9VVABORVRXT1JLX0NPTk5FQ1RfVElNRU9VVABDT05ORUNUSU9OX1RJTUVPVVQATE9HSU5fVElNRU9VVABORVRXT1JLX1JFQURfVElNRU9VVABQT1NUAE1JU0RJUkVDVEVEX1JFUVVFU1QAQ0xJRU5UX0NMT1NFRF9SRVFVRVNUAENMSUVOVF9DTE9TRURfTE9BRF9CQUxBTkNFRF9SRVFVRVNUAEJBRF9SRVFVRVNUAEhUVFBfUkVRVUVTVF9TRU5UX1RPX0hUVFBTX1BPUlQAUkVQT1JUAElNX0FfVEVBUE9UAFJFU0VUX0NPTlRFTlQATk9fQ09OVEVOVABQQVJUSUFMX0NPTlRFTlQASFBFX0lOVkFMSURfQ09OU1RBTlQASFBFX0NCX1JFU0VUAEdFVABIUEVfU1RSSUNUAENPTkZMSUNUAFRFTVBPUkFSWV9SRURJUkVDVABQRVJNQU5FTlRfUkVESVJFQ1QAQ09OTkVDVABNVUxUSV9TVEFUVVMASFBFX0lOVkFMSURfU1RBVFVTAFRPT19NQU5ZX1JFUVVFU1RTAEVBUkxZX0hJTlRTAFVOQVZBSUxBQkxFX0ZPUl9MRUdBTF9SRUFTT05TAE9QVElPTlMAU1dJVENISU5HX1BST1RPQ09MUwBWQVJJQU5UX0FMU09fTkVHT1RJQVRFUwBNVUxUSVBMRV9DSE9JQ0VTAElOVEVSTkFMX1NFUlZFUl9FUlJPUgBXRUJfU0VSVkVSX1VOS05PV05fRVJST1IAUkFJTEdVTl9FUlJPUgBJREVOVElUWV9QUk9WSURFUl9BVVRIRU5USUNBVElPTl9FUlJPUgBTU0xfQ0VSVElGSUNBVEVfRVJST1IASU5WQUxJRF9YX0ZPUldBUkRFRF9GT1IAU0VUX1BBUkFNRVRFUgBHRVRfUEFSQU1FVEVSAEhQRV9VU0VSAFNFRV9PVEhFUgBIUEVfQ0JfQ0hVTktfSEVBREVSAE1LQ0FMRU5EQVIAU0VUVVAAV0VCX1NFUlZFUl9JU19ET1dOAFRFQVJET1dOAEhQRV9DTE9TRURfQ09OTkVDVElPTgBIRVVSSVNUSUNfRVhQSVJBVElPTgBESVNDT05ORUNURURfT1BFUkFUSU9OAE5PTl9BVVRIT1JJVEFUSVZFX0lORk9STUFUSU9OAEhQRV9JTlZBTElEX1ZFUlNJT04ASFBFX0NCX01FU1NBR0VfQkVHSU4AU0lURV9JU19GUk9aRU4ASFBFX0lOVkFMSURfSEVBREVSX1RPS0VOAElOVkFMSURfVE9LRU4ARk9SQklEREVOAEVOSEFOQ0VfWU9VUl9DQUxNAEhQRV9JTlZBTElEX1VSTABCTE9DS0VEX0JZX1BBUkVOVEFMX0NPTlRST0wATUtDT0wAQUNMAEhQRV9JTlRFUk5BTABSRVFVRVNUX0hFQURFUl9GSUVMRFNfVE9PX0xBUkdFX1VOT0ZGSUNJQUwASFBFX09LAFVOTElOSwBVTkxPQ0sAUFJJAFJFVFJZX1dJVEgASFBFX0lOVkFMSURfQ09OVEVOVF9MRU5HVEgASFBFX1VORVhQRUNURURfQ09OVEVOVF9MRU5HVEgARkxVU0gAUFJPUFBBVENIAE0tU0VBUkNIAFVSSV9UT09fTE9ORwBQUk9DRVNTSU5HAE1JU0NFTExBTkVPVVNfUEVSU0lTVEVOVF9XQVJOSU5HAE1JU0NFTExBTkVPVVNfV0FSTklORwBIUEVfSU5WQUxJRF9UUkFOU0ZFUl9FTkNPRElORwBFeHBlY3RlZCBDUkxGAEhQRV9JTlZBTElEX0NIVU5LX1NJWkUATU9WRQBDT05USU5VRQBIUEVfQ0JfU1RBVFVTX0NPTVBMRVRFAEhQRV9DQl9IRUFERVJTX0NPTVBMRVRFAEhQRV9DQl9WRVJTSU9OX0NPTVBMRVRFAEhQRV9DQl9VUkxfQ09NUExFVEUASFBFX0NCX0NIVU5LX0NPTVBMRVRFAEhQRV9DQl9IRUFERVJfVkFMVUVfQ09NUExFVEUASFBFX0NCX0NIVU5LX0VYVEVOU0lPTl9WQUxVRV9DT01QTEVURQBIUEVfQ0JfQ0hVTktfRVhURU5TSU9OX05BTUVfQ09NUExFVEUASFBFX0NCX01FU1NBR0VfQ09NUExFVEUASFBFX0NCX01FVEhPRF9DT01QTEVURQBIUEVfQ0JfSEVBREVSX0ZJRUxEX0NPTVBMRVRFAERFTEVURQBIUEVfSU5WQUxJRF9FT0ZfU1RBVEUASU5WQUxJRF9TU0xfQ0VSVElGSUNBVEUAUEFVU0UATk9fUkVTUE9OU0UAVU5TVVBQT1JURURfTUVESUFfVFlQRQBHT05FAE5PVF9BQ0NFUFRBQkxFAFNFUlZJQ0VfVU5BVkFJTEFCTEUAUkFOR0VfTk9UX1NBVElTRklBQkxFAE9SSUdJTl9JU19VTlJFQUNIQUJMRQBSRVNQT05TRV9JU19TVEFMRQBQVVJHRQBNRVJHRQBSRVFVRVNUX0hFQURFUl9GSUVMRFNfVE9PX0xBUkdFAFJFUVVFU1RfSEVBREVSX1RPT19MQVJHRQBQQVlMT0FEX1RPT19MQVJHRQBJTlNVRkZJQ0lFTlRfU1RPUkFHRQBIUEVfUEFVU0VEX1VQR1JBREUASFBFX1BBVVNFRF9IMl9VUEdSQURFAFNPVVJDRQBBTk5PVU5DRQBUUkFDRQBIUEVfVU5FWFBFQ1RFRF9TUEFDRQBERVNDUklCRQBVTlNVQlNDUklCRQBSRUNPUkQASFBFX0lOVkFMSURfTUVUSE9EAE5PVF9GT1VORABQUk9QRklORABVTkJJTkQAUkVCSU5EAFVOQVVUSE9SSVpFRABNRVRIT0RfTk9UX0FMTE9XRUQASFRUUF9WRVJTSU9OX05PVF9TVVBQT1JURUQAQUxSRUFEWV9SRVBPUlRFRABBQ0NFUFRFRABOT1RfSU1QTEVNRU5URUQATE9PUF9ERVRFQ1RFRABIUEVfQ1JfRVhQRUNURUQASFBFX0xGX0VYUEVDVEVEAENSRUFURUQASU1fVVNFRABIUEVfUEFVU0VEAFRJTUVPVVRfT0NDVVJFRABQQVlNRU5UX1JFUVVJUkVEAFBSRUNPTkRJVElPTl9SRVFVSVJFRABQUk9YWV9BVVRIRU5USUNBVElPTl9SRVFVSVJFRABORVRXT1JLX0FVVEhFTlRJQ0FUSU9OX1JFUVVJUkVEAExFTkdUSF9SRVFVSVJFRABTU0xfQ0VSVElGSUNBVEVfUkVRVUlSRUQAVVBHUkFERV9SRVFVSVJFRABQQUdFX0VYUElSRUQAUFJFQ09ORElUSU9OX0ZBSUxFRABFWFBFQ1RBVElPTl9GQUlMRUQAUkVWQUxJREFUSU9OX0ZBSUxFRABTU0xfSEFORFNIQUtFX0ZBSUxFRABMT0NLRUQAVFJBTlNGT1JNQVRJT05fQVBQTElFRABOT1RfTU9ESUZJRUQATk9UX0VYVEVOREVEAEJBTkRXSURUSF9MSU1JVF9FWENFRURFRABTSVRFX0lTX09WRVJMT0FERUQASEVBRABFeHBlY3RlZCBIVFRQLwAAXhMAACYTAAAwEAAA8BcAAJ0TAAAVEgAAORcAAPASAAAKEAAAdRIAAK0SAACCEwAATxQAAH8QAACgFQAAIxQAAIkSAACLFAAATRUAANQRAADPFAAAEBgAAMkWAADcFgAAwREAAOAXAAC7FAAAdBQAAHwVAADlFAAACBcAAB8QAABlFQAAoxQAACgVAAACFQAAmRUAACwQAACLGQAATw8AANQOAABqEAAAzhAAAAIXAACJDgAAbhMAABwTAABmFAAAVhcAAMETAADNEwAAbBMAAGgXAABmFwAAXxcAACITAADODwAAaQ4AANgOAABjFgAAyxMAAKoOAAAoFwAAJhcAAMUTAABdFgAA6BEAAGcTAABlEwAA8hYAAHMTAAAdFwAA+RYAAPMRAADPDgAAzhUAAAwSAACzEQAApREAAGEQAAAyFwAAuxMAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQIBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIDAgICAgIAAAICAAICAAICAgICAgICAgIABAAAAAAAAgICAgICAgICAgICAgICAgICAgICAgICAgIAAAACAgICAgICAgICAgICAgICAgICAgICAgICAgICAgACAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAICAgICAAACAgACAgACAgICAgICAgICAAMABAAAAAICAgICAgICAgICAgICAgICAgICAgICAgICAAAAAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAAgACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbG9zZWVlcC1hbGl2ZQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQIBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBY2h1bmtlZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEAAQEBAQEAAAEBAAEBAAEBAQEBAQEBAQEAAAAAAAAAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAAABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQABAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlY3Rpb25lbnQtbGVuZ3Rob25yb3h5LWNvbm5lY3Rpb24AAAAAAAAAAAAAAAAAAAByYW5zZmVyLWVuY29kaW5ncGdyYWRlDQoNCg0KU00NCg0KVFRQL0NFL1RTUC8AAAAAAAAAAAAAAAABAgABAwAAAAAAAAAAAAAAAAAAAAAAAAQBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAAAAAAAAAAAAQIAAQMAAAAAAAAAAAAAAAAAAAAAAAAEAQEFAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAAAAAAEAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAAAAAAAAAAAAAQAAAgAAAAAAAAAAAAAAAAAAAAAAAAMEAAAEBAQEBAQEBAQEBAUEBAQEBAQEBAQEBAQABAAGBwQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAEAAQABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAADAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAAAAAAAAMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAIAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMAAAAAAAADAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABOT1VOQ0VFQ0tPVVRORUNURVRFQ1JJQkVMVVNIRVRFQURTRUFSQ0hSR0VDVElWSVRZTEVOREFSVkVPVElGWVBUSU9OU0NIU0VBWVNUQVRDSEdFT1JESVJFQ1RPUlRSQ0hQQVJBTUVURVJVUkNFQlNDUklCRUFSRE9XTkFDRUlORE5LQ0tVQlNDUklCRUhUVFAvQURUUC8='
@@ -18453,7 +16669,7 @@ module.exports = 'AGFzbQEAAAABMAhgAX8Bf2ADf39/AX9gBH9/f38Bf2AAAGADf39/AGABfwBgAn
 
 /***/ }),
 
-/***/ 83:
+/***/ 80:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18463,10 +16679,10 @@ module.exports = 'AGFzbQEAAAABMAhgAX8Bf2ADf39/AX9gBH9/f38Bf2AAAGADf39/AGABfwBgAn
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageSharedKeyCredentialPolicyName = void 0;
 exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
-const node_crypto_1 = __nccwpck_require__(282);
-const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(490);
-const SharedKeyComparator_js_1 = __nccwpck_require__(181);
+const node_crypto_1 = __nccwpck_require__(281);
+const constants_js_1 = __nccwpck_require__(38);
+const utils_common_js_1 = __nccwpck_require__(491);
+const SharedKeyComparator_js_1 = __nccwpck_require__(178);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
  */
@@ -18596,15 +16812,15 @@ function storageSharedKeyCredentialPolicy(options) {
 
 /***/ }),
 
-/***/ 84:
+/***/ 81:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const assert = __nccwpck_require__(542)
-const { URLSerializer } = __nccwpck_require__(28)
-const { isValidHeaderName } = __nccwpck_require__(532)
+const assert = __nccwpck_require__(543)
+const { URLSerializer } = __nccwpck_require__(27)
+const { isValidHeaderName } = __nccwpck_require__(533)
 
 /**
  * @see https://url.spec.whatwg.org/#concept-url-equals
@@ -18653,7 +16869,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 85:
+/***/ 82:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18663,12 +16879,12 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageRetryPolicy = void 0;
 exports.NewRetryPolicyFactory = NewRetryPolicyFactory;
-const abort_controller_1 = __nccwpck_require__(510);
-const RequestPolicy_js_1 = __nccwpck_require__(50);
-const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(490);
-const log_js_1 = __nccwpck_require__(19);
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(428);
+const abort_controller_1 = __nccwpck_require__(511);
+const RequestPolicy_js_1 = __nccwpck_require__(48);
+const constants_js_1 = __nccwpck_require__(38);
+const utils_common_js_1 = __nccwpck_require__(491);
+const log_js_1 = __nccwpck_require__(18);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(429);
 /**
  * A factory method used to generated a RetryPolicy factory.
  *
@@ -18884,7 +17100,7 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 
 /***/ }),
 
-/***/ 86:
+/***/ 83:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18893,15 +17109,15 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = exports.useInstrumenter = void 0;
-var instrumenter_js_1 = __nccwpck_require__(418);
+var instrumenter_js_1 = __nccwpck_require__(419);
 Object.defineProperty(exports, "useInstrumenter", ({ enumerable: true, get: function () { return instrumenter_js_1.useInstrumenter; } }));
-var tracingClient_js_1 = __nccwpck_require__(357);
+var tracingClient_js_1 = __nccwpck_require__(355);
 Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: function () { return tracingClient_js_1.createTracingClient; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 87:
+/***/ 84:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -18913,7 +17129,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 88:
+/***/ 85:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18921,17 +17137,17 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 
 
-const { extractBody, mixinBody, cloneBody } = __nccwpck_require__(27)
-const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(530)
-const { FinalizationRegistry } = __nccwpck_require__(425)()
-const util = __nccwpck_require__(75)
+const { extractBody, mixinBody, cloneBody } = __nccwpck_require__(26)
+const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(531)
+const { FinalizationRegistry } = __nccwpck_require__(426)()
+const util = __nccwpck_require__(72)
 const {
   isValidHTTPToken,
   sameOrigin,
   normalizeMethod,
   makePolicyContainer,
   normalizeMethodRecord
-} = __nccwpck_require__(532)
+} = __nccwpck_require__(533)
 const {
   forbiddenMethodsSet,
   corsSafeListedMethodsSet,
@@ -18941,15 +17157,15 @@ const {
   requestCredentials,
   requestCache,
   requestDuplex
-} = __nccwpck_require__(33)
+} = __nccwpck_require__(32)
 const { kEnumerableProperty } = util
-const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(17)
-const { webidl } = __nccwpck_require__(470)
-const { getGlobalOrigin } = __nccwpck_require__(145)
-const { URLSerializer } = __nccwpck_require__(28)
-const { kHeadersList, kConstruct } = __nccwpck_require__(200)
-const assert = __nccwpck_require__(542)
-const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(486)
+const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(16)
+const { webidl } = __nccwpck_require__(471)
+const { getGlobalOrigin } = __nccwpck_require__(142)
+const { URLSerializer } = __nccwpck_require__(27)
+const { kHeadersList, kConstruct } = __nccwpck_require__(197)
+const assert = __nccwpck_require__(543)
+const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(487)
 
 let TransformStream = globalThis.TransformStream
 
@@ -19436,7 +17652,7 @@ class Request {
 
       // 2. Set finalBody to the result of creating a proxy for inputBody.
       if (!TransformStream) {
-        TransformStream = (__nccwpck_require__(265).TransformStream)
+        TransformStream = (__nccwpck_require__(263).TransformStream)
       }
 
       // https://streams.spec.whatwg.org/#readablestream-create-a-proxy
@@ -19867,7 +18083,7 @@ module.exports = { Request, makeRequest }
 
 /***/ }),
 
-/***/ 89:
+/***/ 86:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -19979,7 +18195,7 @@ function normalizeCompileCacheStats(raw) {
 
 /***/ }),
 
-/***/ 90:
+/***/ 87:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -20026,12 +18242,12 @@ exports.findBundledZccacheDir = findBundledZccacheDir;
 exports.managedReleaseUrl = managedReleaseUrl;
 exports.downloadManagedRelease = downloadManagedRelease;
 exports.seedZccache = seedZccache;
-const fs = __importStar(__nccwpck_require__(257));
-const os = __importStar(__nccwpck_require__(393));
-const path = __importStar(__nccwpck_require__(522));
-const core = __importStar(__nccwpck_require__(474));
-const exec = __importStar(__nccwpck_require__(20));
-const tc = __importStar(__nccwpck_require__(537));
+const fs = __importStar(__nccwpck_require__(255));
+const os = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(523));
+const core = __importStar(__nccwpck_require__(475));
+const exec = __importStar(__nccwpck_require__(19));
+const tc = __importStar(__nccwpck_require__(538));
 const LOCAL_DIR_ENV = "SOLDR_ZCCACHE_LOCAL_DIR";
 const VENDOR_DIR_ENV = "SETUP_SOLDR_ZCCACHE_VENDOR_DIR";
 const SEED_ENV = "SETUP_SOLDR_ZCCACHE_SEEDED";
@@ -20336,7 +18552,7 @@ exports._internal = {
 
 /***/ }),
 
-/***/ 91:
+/***/ 88:
 /***/ ((module) => {
 
 "use strict";
@@ -20344,7 +18560,7 @@ module.exports = require("url");
 
 /***/ }),
 
-/***/ 92:
+/***/ 89:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20354,10 +18570,10 @@ module.exports = require("url");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.deserializationPolicyName = void 0;
 exports.deserializationPolicy = deserializationPolicy;
-const interfaces_js_1 = __nccwpck_require__(105);
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const serializer_js_1 = __nccwpck_require__(496);
-const operationHelpers_js_1 = __nccwpck_require__(444);
+const interfaces_js_1 = __nccwpck_require__(102);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const serializer_js_1 = __nccwpck_require__(497);
+const operationHelpers_js_1 = __nccwpck_require__(445);
 const defaultJsonContentTypes = ["application/json", "text/json"];
 const defaultXmlContentTypes = ["application/xml", "application/atom+xml"];
 /**
@@ -20585,7 +18801,7 @@ async function parse(jsonContentTypes, xmlContentTypes, operationResponse, opts,
 
 /***/ }),
 
-/***/ 93:
+/***/ 90:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -20611,7 +18827,7 @@ __export(apiKeyAuthenticationPolicy_exports, {
   apiKeyAuthenticationPolicyName: () => apiKeyAuthenticationPolicyName
 });
 module.exports = __toCommonJS(apiKeyAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(447);
+var import_checkInsecureConnection = __nccwpck_require__(448);
 const apiKeyAuthenticationPolicyName = "apiKeyAuthenticationPolicy";
 function apiKeyAuthenticationPolicy(options) {
   return {
@@ -20637,7 +18853,7 @@ function apiKeyAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 94:
+/***/ 91:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20647,14 +18863,14 @@ function apiKeyAuthenticationPolicy(options) {
 
 /* global WebAssembly */
 
-const assert = __nccwpck_require__(542)
-const net = __nccwpck_require__(523)
-const http = __nccwpck_require__(338)
-const { pipeline } = __nccwpck_require__(135)
-const util = __nccwpck_require__(75)
-const timers = __nccwpck_require__(337)
-const Request = __nccwpck_require__(307)
-const DispatcherBase = __nccwpck_require__(68)
+const assert = __nccwpck_require__(543)
+const net = __nccwpck_require__(524)
+const http = __nccwpck_require__(336)
+const { pipeline } = __nccwpck_require__(132)
+const util = __nccwpck_require__(72)
+const timers = __nccwpck_require__(335)
+const Request = __nccwpck_require__(305)
+const DispatcherBase = __nccwpck_require__(65)
 const {
   RequestContentLengthMismatchError,
   ResponseContentLengthMismatchError,
@@ -20668,8 +18884,8 @@ const {
   HTTPParserError,
   ResponseExceededMaxSizeError,
   ClientDestroyedError
-} = __nccwpck_require__(504)
-const buildConnector = __nccwpck_require__(274)
+} = __nccwpck_require__(505)
+const buildConnector = __nccwpck_require__(273)
 const {
   kUrl,
   kReset,
@@ -20721,12 +18937,12 @@ const {
   kHTTP2BuildRequest,
   kHTTP2CopyHeaders,
   kHTTP1BuildRequest
-} = __nccwpck_require__(200)
+} = __nccwpck_require__(197)
 
 /** @type {import('http2')} */
 let http2
 try {
-  http2 = __nccwpck_require__(65)
+  http2 = __nccwpck_require__(62)
 } catch {
   // @ts-ignore
   http2 = { constants: {} }
@@ -20754,7 +18970,7 @@ const kClosedResolve = Symbol('kClosedResolve')
 const channels = {}
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(147)
+  const diagnosticsChannel = __nccwpck_require__(144)
   channels.sendHeaders = diagnosticsChannel.channel('undici:client:sendHeaders')
   channels.beforeConnect = diagnosticsChannel.channel('undici:client:beforeConnect')
   channels.connectError = diagnosticsChannel.channel('undici:client:connectError')
@@ -21127,16 +19343,16 @@ function onHTTP2GoAway (code) {
   resume(client)
 }
 
-const constants = __nccwpck_require__(461)
-const createRedirectInterceptor = __nccwpck_require__(263)
+const constants = __nccwpck_require__(462)
+const createRedirectInterceptor = __nccwpck_require__(261)
 const EMPTY_BUF = Buffer.alloc(0)
 
 async function lazyllhttp () {
-  const llhttpWasmData = process.env.JEST_WORKER_ID ? __nccwpck_require__(82) : undefined
+  const llhttpWasmData = process.env.JEST_WORKER_ID ? __nccwpck_require__(79) : undefined
 
   let mod
   try {
-    mod = await WebAssembly.compile(Buffer.from(__nccwpck_require__(73), 'base64'))
+    mod = await WebAssembly.compile(Buffer.from(__nccwpck_require__(70), 'base64'))
   } catch (e) {
     /* istanbul ignore next */
 
@@ -21144,7 +19360,7 @@ async function lazyllhttp () {
     // being enabled, but the occurring of this other error
     // * https://github.com/emscripten-core/emscripten/issues/11495
     // got me to remove that check to avoid breaking Node 12.
-    mod = await WebAssembly.compile(Buffer.from(llhttpWasmData || __nccwpck_require__(82), 'base64'))
+    mod = await WebAssembly.compile(Buffer.from(llhttpWasmData || __nccwpck_require__(79), 'base64'))
   }
 
   return await WebAssembly.instantiate(mod, {
@@ -22928,7 +21144,7 @@ module.exports = Client
 
 /***/ }),
 
-/***/ 95:
+/***/ 92:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -22969,15 +21185,15 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 var import_AbortError = __nccwpck_require__(11);
-var import_logger = __nccwpck_require__(253);
-var import_httpHeaders = __nccwpck_require__(501);
-var import_pipelineRequest = __nccwpck_require__(120);
-var import_pipeline = __nccwpck_require__(539);
-var import_restError = __nccwpck_require__(457);
-var import_bytesEncoding = __nccwpck_require__(295);
-var import_defaultHttpClient = __nccwpck_require__(382);
-var import_getClient = __nccwpck_require__(214);
-var import_operationOptionHelpers = __nccwpck_require__(394);
+var import_logger = __nccwpck_require__(251);
+var import_httpHeaders = __nccwpck_require__(502);
+var import_pipelineRequest = __nccwpck_require__(117);
+var import_pipeline = __nccwpck_require__(540);
+var import_restError = __nccwpck_require__(458);
+var import_bytesEncoding = __nccwpck_require__(293);
+var import_defaultHttpClient = __nccwpck_require__(381);
+var import_getClient = __nccwpck_require__(212);
+var import_operationOptionHelpers = __nccwpck_require__(393);
 var import_restError2 = __nccwpck_require__(377);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -22986,17 +21202,17 @@ var import_restError2 = __nccwpck_require__(377);
 
 /***/ }),
 
-/***/ 96:
+/***/ 93:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
-const base64_1 = __nccwpck_require__(312);
-const pb_long_1 = __nccwpck_require__(122);
-const reflection_info_1 = __nccwpck_require__(466);
-const assert_1 = __nccwpck_require__(500);
+const base64_1 = __nccwpck_require__(310);
+const pb_long_1 = __nccwpck_require__(119);
+const reflection_info_1 = __nccwpck_require__(467);
+const assert_1 = __nccwpck_require__(501);
 /**
  * Writes proto3 messages in canonical JSON format using reflection
  * information.
@@ -23224,7 +21440,7 @@ exports.ReflectionJsonWriter = ReflectionJsonWriter;
 
 /***/ }),
 
-/***/ 97:
+/***/ 94:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -23235,7 +21451,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Batch = void 0;
 // In browser, during webpack or browserify bundling, this module will be replaced by 'events'
 // https://github.com/Gozala/events
-const events_1 = __nccwpck_require__(486);
+const events_1 = __nccwpck_require__(487);
 /**
  * States for Batch.
  */
@@ -23365,7 +21581,7 @@ exports.Batch = Batch;
 
 /***/ }),
 
-/***/ 98:
+/***/ 95:
 /***/ ((module) => {
 
 "use strict";
@@ -23373,7 +21589,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 99:
+/***/ 96:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -23382,7 +21598,7 @@ module.exports = require("os");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredentialPolicy = void 0;
-const CredentialPolicy_js_1 = __nccwpck_require__(318);
+const CredentialPolicy_js_1 = __nccwpck_require__(316);
 /**
  * AnonymousCredentialPolicy is used with HTTP(S) requests that read public resources
  * or for use with Shared Access Signatures (SAS).
@@ -23404,7 +21620,7 @@ exports.AnonymousCredentialPolicy = AnonymousCredentialPolicy;
 
 /***/ }),
 
-/***/ 100:
+/***/ 97:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -23414,16 +21630,16 @@ const {
   staticPropertyDescriptors,
   readOperation,
   fireAProgressEvent
-} = __nccwpck_require__(58)
+} = __nccwpck_require__(55)
 const {
   kState,
   kError,
   kResult,
   kEvents,
   kAborted
-} = __nccwpck_require__(475)
-const { webidl } = __nccwpck_require__(470)
-const { kEnumerableProperty } = __nccwpck_require__(75)
+} = __nccwpck_require__(476)
+const { webidl } = __nccwpck_require__(471)
+const { kEnumerableProperty } = __nccwpck_require__(72)
 
 class FileReader extends EventTarget {
   constructor () {
@@ -23756,7 +21972,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 101:
+/***/ 98:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -23785,7 +22001,7 @@ exports.Credential = Credential;
 
 /***/ }),
 
-/***/ 102:
+/***/ 99:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -23806,7 +22022,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 103:
+/***/ 100:
 /***/ ((module) => {
 
 "use strict";
@@ -24104,7 +22320,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 104:
+/***/ 101:
 /***/ ((module) => {
 
 "use strict";
@@ -24124,7 +22340,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 105:
+/***/ 102:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -24145,7 +22361,7 @@ exports.XML_CHARKEY = "_";
 
 /***/ }),
 
-/***/ 106:
+/***/ 103:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -24175,7 +22391,7 @@ async function cancelablePromiseRace(abortablePromiseBuilders, options) {
 
 /***/ }),
 
-/***/ 107:
+/***/ 104:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -24245,39 +22461,39 @@ __export(src_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(src_exports);
-var import_pipeline = __nccwpck_require__(251);
-var import_createPipelineFromOptions = __nccwpck_require__(289);
-var import_defaultHttpClient = __nccwpck_require__(240);
-var import_httpHeaders = __nccwpck_require__(248);
-var import_pipelineRequest = __nccwpck_require__(22);
-var import_restError = __nccwpck_require__(363);
-var import_decompressResponsePolicy = __nccwpck_require__(244);
+var import_pipeline = __nccwpck_require__(249);
+var import_createPipelineFromOptions = __nccwpck_require__(287);
+var import_defaultHttpClient = __nccwpck_require__(238);
+var import_httpHeaders = __nccwpck_require__(246);
+var import_pipelineRequest = __nccwpck_require__(21);
+var import_restError = __nccwpck_require__(362);
+var import_decompressResponsePolicy = __nccwpck_require__(242);
 var import_exponentialRetryPolicy = __nccwpck_require__(404);
-var import_setClientRequestIdPolicy = __nccwpck_require__(157);
-var import_logPolicy = __nccwpck_require__(77);
-var import_multipartPolicy = __nccwpck_require__(279);
-var import_proxyPolicy = __nccwpck_require__(489);
-var import_redirectPolicy = __nccwpck_require__(350);
-var import_systemErrorRetryPolicy = __nccwpck_require__(222);
-var import_throttlingRetryPolicy = __nccwpck_require__(26);
-var import_retryPolicy = __nccwpck_require__(216);
-var import_tracingPolicy = __nccwpck_require__(345);
-var import_defaultRetryPolicy = __nccwpck_require__(61);
-var import_userAgentPolicy = __nccwpck_require__(400);
-var import_tlsPolicy = __nccwpck_require__(389);
-var import_formDataPolicy = __nccwpck_require__(276);
-var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(221);
-var import_ndJsonPolicy = __nccwpck_require__(245);
-var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(198);
-var import_agentPolicy = __nccwpck_require__(236);
-var import_file = __nccwpck_require__(336);
+var import_setClientRequestIdPolicy = __nccwpck_require__(154);
+var import_logPolicy = __nccwpck_require__(74);
+var import_multipartPolicy = __nccwpck_require__(278);
+var import_proxyPolicy = __nccwpck_require__(490);
+var import_redirectPolicy = __nccwpck_require__(348);
+var import_systemErrorRetryPolicy = __nccwpck_require__(221);
+var import_throttlingRetryPolicy = __nccwpck_require__(25);
+var import_retryPolicy = __nccwpck_require__(214);
+var import_tracingPolicy = __nccwpck_require__(343);
+var import_defaultRetryPolicy = __nccwpck_require__(58);
+var import_userAgentPolicy = __nccwpck_require__(399);
+var import_tlsPolicy = __nccwpck_require__(388);
+var import_formDataPolicy = __nccwpck_require__(275);
+var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(220);
+var import_ndJsonPolicy = __nccwpck_require__(243);
+var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(195);
+var import_agentPolicy = __nccwpck_require__(234);
+var import_file = __nccwpck_require__(334);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 
 
 /***/ }),
 
-/***/ 108:
+/***/ 105:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -24303,8 +22519,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(158);
-var import_sanitizer = __nccwpck_require__(126);
+var import_log = __nccwpck_require__(155);
+var import_sanitizer = __nccwpck_require__(123);
 const logPolicyName = "logPolicy";
 function logPolicy(options = {}) {
   const logger = options.logger ?? import_log.logger.info;
@@ -24333,11 +22549,11 @@ function logPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 109:
+/***/ 106:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { addAbortListener } = __nccwpck_require__(75)
-const { RequestAbortedError } = __nccwpck_require__(504)
+const { addAbortListener } = __nccwpck_require__(72)
+const { RequestAbortedError } = __nccwpck_require__(505)
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')
@@ -24394,7 +22610,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 110:
+/***/ 107:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -24425,7 +22641,7 @@ function rangeToString(iRange) {
 
 /***/ }),
 
-/***/ 111:
+/***/ 108:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24435,16 +22651,16 @@ const {
   Readable,
   Duplex,
   PassThrough
-} = __nccwpck_require__(135)
+} = __nccwpck_require__(132)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(504)
-const util = __nccwpck_require__(75)
-const { AsyncResource } = __nccwpck_require__(441)
-const { addSignal, removeSignal } = __nccwpck_require__(109)
-const assert = __nccwpck_require__(542)
+} = __nccwpck_require__(505)
+const util = __nccwpck_require__(72)
+const { AsyncResource } = __nccwpck_require__(442)
+const { addSignal, removeSignal } = __nccwpck_require__(106)
+const assert = __nccwpck_require__(543)
 
 const kResume = Symbol('resume')
 
@@ -24682,7 +22898,7 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 112:
+/***/ 109:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24691,7 +22907,7 @@ module.exports = pipeline
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = void 0;
-const logger_1 = __nccwpck_require__(48);
+const logger_1 = __nccwpck_require__(46);
 /**
  * The `@azure/logger` configuration for this package.
  */
@@ -24700,17 +22916,17 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 
 /***/ }),
 
-/***/ 113:
+/***/ 110:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = (__nccwpck_require__(150).EventEmitter)
-const inherits = (__nccwpck_require__(385).inherits)
-const getLimit = __nccwpck_require__(499)
+const EventEmitter = (__nccwpck_require__(147).EventEmitter)
+const inherits = (__nccwpck_require__(384).inherits)
+const getLimit = __nccwpck_require__(500)
 
-const StreamSearch = __nccwpck_require__(119)
+const StreamSearch = __nccwpck_require__(116)
 
 const B_DCRLF = Buffer.from('\r\n\r\n')
 const RE_CRLF = /\r\n/g
@@ -24808,7 +23024,7 @@ module.exports = HeaderParser
 
 /***/ }),
 
-/***/ 114:
+/***/ 111:
 /***/ ((module) => {
 
 "use strict";
@@ -24816,7 +23032,7 @@ module.exports = require("node:fs/promises");
 
 /***/ }),
 
-/***/ 115:
+/***/ 112:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -24844,7 +23060,7 @@ __export(util_exports, {
   toWebResourceLike: () => toWebResourceLike
 });
 module.exports = __toCommonJS(util_exports);
-var import_core_rest_pipeline = __nccwpck_require__(107);
+var import_core_rest_pipeline = __nccwpck_require__(104);
 const originalRequestSymbol = /* @__PURE__ */ Symbol("Original PipelineRequest");
 const originalClientRequestSymbol = /* @__PURE__ */ Symbol.for("@azure/core-client original request");
 function toPipelineRequest(webResource, options = {}) {
@@ -25086,7 +23302,7 @@ class HttpHeaders {
 
 /***/ }),
 
-/***/ 116:
+/***/ 113:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -25132,7 +23348,7 @@ function objectHasProperty(thing, property) {
 
 /***/ }),
 
-/***/ 117:
+/***/ 114:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25142,8 +23358,8 @@ function objectHasProperty(thing, property) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseCAEChallenge = parseCAEChallenge;
 exports.authorizeRequestOnClaimChallenge = authorizeRequestOnClaimChallenge;
-const log_js_1 = __nccwpck_require__(497);
-const base64_js_1 = __nccwpck_require__(450);
+const log_js_1 = __nccwpck_require__(498);
+const base64_js_1 = __nccwpck_require__(451);
 /**
  * Converts: `Bearer a="b", c="d", Bearer d="e", f="g"`.
  * Into: `[ { a: 'b', c: 'd' }, { d: 'e', f: 'g' } ]`.
@@ -25215,7 +23431,7 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 
 /***/ }),
 
-/***/ 118:
+/***/ 115:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25225,8 +23441,8 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.delay = delay;
 exports.calculateRetryDelay = calculateRetryDelay;
-const createAbortablePromise_js_1 = __nccwpck_require__(268);
-const util_1 = __nccwpck_require__(153);
+const createAbortablePromise_js_1 = __nccwpck_require__(266);
+const util_1 = __nccwpck_require__(150);
 const StandardAbortMessage = "The delay was aborted.";
 /**
  * A wrapper for setTimeout that resolves a promise after timeInMs milliseconds.
@@ -25265,7 +23481,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 119:
+/***/ 116:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25297,8 +23513,8 @@ function calculateRetryDelay(retryAttempt, config) {
  * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
-const EventEmitter = (__nccwpck_require__(150).EventEmitter)
-const inherits = (__nccwpck_require__(385).inherits)
+const EventEmitter = (__nccwpck_require__(147).EventEmitter)
+const inherits = (__nccwpck_require__(384).inherits)
 
 function SBMH (needle) {
   if (typeof needle === 'string') {
@@ -25501,7 +23717,7 @@ module.exports = SBMH
 
 /***/ }),
 
-/***/ 120:
+/***/ 117:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -25526,7 +23742,7 @@ __export(pipelineRequest_exports, {
   createPipelineRequest: () => createPipelineRequest
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
-var import_httpHeaders = __nccwpck_require__(501);
+var import_httpHeaders = __nccwpck_require__(502);
 var import_uuidUtils = __nccwpck_require__(405);
 class PipelineRequestImpl {
   url;
@@ -25580,7 +23796,7 @@ function createPipelineRequest(options) {
 
 /***/ }),
 
-/***/ 121:
+/***/ 118:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -25616,8 +23832,8 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(393));
-var import_node_process = __toESM(__nccwpck_require__(242));
+var import_node_os = __toESM(__nccwpck_require__(392));
+var import_node_process = __toESM(__nccwpck_require__(240));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -25640,14 +23856,14 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 122:
+/***/ 119:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PbLong = exports.PbULong = exports.detectBi = void 0;
-const goog_varint_1 = __nccwpck_require__(208);
+const goog_varint_1 = __nccwpck_require__(205);
 let BI;
 function detectBi() {
     const dv = new DataView(new ArrayBuffer(8));
@@ -25886,7 +24102,7 @@ PbLong.ZERO = new PbLong(0, 0);
 
 /***/ }),
 
-/***/ 123:
+/***/ 120:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -25903,7 +24119,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 124:
+/***/ 121:
 /***/ ((module) => {
 
 "use strict";
@@ -25911,7 +24127,7 @@ module.exports = require("buffer");
 
 /***/ }),
 
-/***/ 125:
+/***/ 122:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -25940,9 +24156,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
-const path = __importStar(__nccwpck_require__(256));
-const pathHelper = __importStar(__nccwpck_require__(226));
-const assert_1 = __importDefault(__nccwpck_require__(542));
+const path = __importStar(__nccwpck_require__(254));
+const pathHelper = __importStar(__nccwpck_require__(224));
+const assert_1 = __importDefault(__nccwpck_require__(543));
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Helper class for parsing paths into segments
@@ -26031,7 +24247,7 @@ exports.Path = Path;
 
 /***/ }),
 
-/***/ 126:
+/***/ 123:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -26056,7 +24272,7 @@ __export(sanitizer_exports, {
   Sanitizer: () => Sanitizer
 });
 module.exports = __toCommonJS(sanitizer_exports);
-var import_object = __nccwpck_require__(151);
+var import_object = __nccwpck_require__(148);
 const RedactedString = "REDACTED";
 const defaultAllowedHeaderNames = [
   "x-ms-client-request-id",
@@ -26205,7 +24421,7 @@ class Sanitizer {
 
 /***/ }),
 
-/***/ 127:
+/***/ 124:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -26222,7 +24438,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 128:
+/***/ 125:
 /***/ ((module) => {
 
 "use strict";
@@ -26230,19 +24446,19 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 129:
+/***/ 126:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
-var path = (function () { try { return __nccwpck_require__(256) } catch (e) {}}()) || {
+var path = (function () { try { return __nccwpck_require__(254) } catch (e) {}}()) || {
   sep: '/'
 }
 minimatch.sep = path.sep
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __nccwpck_require__(502)
+var expand = __nccwpck_require__(503)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -27242,7 +25458,7 @@ function regExpEscape (s) {
 
 /***/ }),
 
-/***/ 130:
+/***/ 127:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -27277,13 +25493,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
-const os = __importStar(__nccwpck_require__(98));
-const events = __importStar(__nccwpck_require__(486));
-const child = __importStar(__nccwpck_require__(170));
-const path = __importStar(__nccwpck_require__(256));
-const io = __importStar(__nccwpck_require__(302));
-const ioUtil = __importStar(__nccwpck_require__(230));
-const timers_1 = __nccwpck_require__(524);
+const os = __importStar(__nccwpck_require__(95));
+const events = __importStar(__nccwpck_require__(487));
+const child = __importStar(__nccwpck_require__(167));
+const path = __importStar(__nccwpck_require__(254));
+const io = __importStar(__nccwpck_require__(300));
+const ioUtil = __importStar(__nccwpck_require__(228));
+const timers_1 = __nccwpck_require__(525);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -27867,7 +26083,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 131:
+/***/ 128:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -27876,10 +26092,10 @@ class ExecState extends events.EventEmitter {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredentialPolicy = void 0;
-const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(490);
-const CredentialPolicy_js_1 = __nccwpck_require__(318);
-const SharedKeyComparator_js_1 = __nccwpck_require__(181);
+const constants_js_1 = __nccwpck_require__(38);
+const utils_common_js_1 = __nccwpck_require__(491);
+const CredentialPolicy_js_1 = __nccwpck_require__(316);
+const SharedKeyComparator_js_1 = __nccwpck_require__(178);
 /**
  * StorageSharedKeyCredentialPolicy is a policy used to sign HTTP request with a shared key.
  */
@@ -28023,7 +26239,7 @@ exports.StorageSharedKeyCredentialPolicy = StorageSharedKeyCredentialPolicy;
 
 /***/ }),
 
-/***/ 132:
+/***/ 129:
 /***/ ((module) => {
 
 "use strict";
@@ -28043,7 +26259,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 133:
+/***/ 130:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28051,11 +26267,11 @@ module.exports = {
 
 
 
-const assert = __nccwpck_require__(542)
-const { Readable } = __nccwpck_require__(135)
-const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(504)
-const util = __nccwpck_require__(75)
-const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(75)
+const assert = __nccwpck_require__(543)
+const { Readable } = __nccwpck_require__(132)
+const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(505)
+const util = __nccwpck_require__(72)
+const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(72)
 
 let Blob
 
@@ -28335,7 +26551,7 @@ function consumeEnd (consume) {
       resolve(dst.buffer)
     } else if (type === 'blob') {
       if (!Blob) {
-        Blob = (__nccwpck_require__(124).Blob)
+        Blob = (__nccwpck_require__(121).Blob)
       }
       resolve(new Blob(body, { type: stream[kContentType] }))
     }
@@ -28373,7 +26589,7 @@ function consumeFinish (consume, err) {
 
 /***/ }),
 
-/***/ 134:
+/***/ 131:
 /***/ ((module) => {
 
 "use strict";
@@ -28381,7 +26597,7 @@ module.exports = require("querystring");
 
 /***/ }),
 
-/***/ 135:
+/***/ 132:
 /***/ ((module) => {
 
 "use strict";
@@ -28389,7 +26605,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 136:
+/***/ 133:
 /***/ ((module) => {
 
 "use strict";
@@ -28459,7 +26675,7 @@ function range(a, b, str) {
 
 /***/ }),
 
-/***/ 137:
+/***/ 134:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28492,13 +26708,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpsProxyAgent = void 0;
-const net = __importStar(__nccwpck_require__(523));
-const tls = __importStar(__nccwpck_require__(520));
-const assert_1 = __importDefault(__nccwpck_require__(542));
-const debug_1 = __importDefault(__nccwpck_require__(529));
-const agent_base_1 = __nccwpck_require__(246);
-const url_1 = __nccwpck_require__(91);
-const parse_proxy_response_1 = __nccwpck_require__(430);
+const net = __importStar(__nccwpck_require__(524));
+const tls = __importStar(__nccwpck_require__(521));
+const assert_1 = __importDefault(__nccwpck_require__(543));
+const debug_1 = __importDefault(__nccwpck_require__(530));
+const agent_base_1 = __nccwpck_require__(244);
+const url_1 = __nccwpck_require__(88);
+const parse_proxy_response_1 = __nccwpck_require__(431);
 const debug = (0, debug_1.default)('https-proxy-agent');
 const setServernameFromNonIpHost = (options) => {
     if (options.servername === undefined &&
@@ -28646,7 +26862,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 138:
+/***/ 135:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28662,9 +26878,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(293);
-const auth_1 = __nccwpck_require__(30);
-const core_1 = __nccwpck_require__(474);
+const http_client_1 = __nccwpck_require__(291);
+const auth_1 = __nccwpck_require__(29);
+const core_1 = __nccwpck_require__(475);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -28730,7 +26946,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 139:
+/***/ 136:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28776,16 +26992,16 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._internal = void 0;
 exports.ensureSoldr = ensureSoldr;
-const fs = __importStar(__nccwpck_require__(257));
-const os = __importStar(__nccwpck_require__(393));
-const path = __importStar(__nccwpck_require__(522));
-const core = __importStar(__nccwpck_require__(474));
-const exec = __importStar(__nccwpck_require__(20));
-const tc = __importStar(__nccwpck_require__(537));
-const fzstd = __importStar(__nccwpck_require__(361));
-const log_utils_js_1 = __nccwpck_require__(196);
-const release_readiness_js_1 = __nccwpck_require__(388);
-const verify_soldr_js_1 = __nccwpck_require__(364);
+const fs = __importStar(__nccwpck_require__(255));
+const os = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(523));
+const core = __importStar(__nccwpck_require__(475));
+const exec = __importStar(__nccwpck_require__(19));
+const tc = __importStar(__nccwpck_require__(538));
+const fzstd = __importStar(__nccwpck_require__(360));
+const log_utils_js_1 = __nccwpck_require__(193);
+const release_readiness_js_1 = __nccwpck_require__(387);
+const verify_soldr_js_1 = __nccwpck_require__(363);
 function detectTarget() {
     const machine = process.arch;
     let arch;
@@ -29370,16 +27586,16 @@ exports._internal = {
 
 /***/ }),
 
-/***/ 140:
+/***/ 137:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
-const binary_format_contract_1 = __nccwpck_require__(342);
-const pb_long_1 = __nccwpck_require__(122);
-const goog_varint_1 = __nccwpck_require__(208);
+const binary_format_contract_1 = __nccwpck_require__(340);
+const pb_long_1 = __nccwpck_require__(119);
+const goog_varint_1 = __nccwpck_require__(205);
 const defaultsRead = {
     readUnknownField: true,
     readerFactory: bytes => new BinaryReader(bytes),
@@ -29561,7 +27777,7 @@ exports.BinaryReader = BinaryReader;
 
 /***/ }),
 
-/***/ 141:
+/***/ 138:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29575,9 +27791,9 @@ const {
   kDefaultTrailers,
   kContentLength,
   kMockDispatch
-} = __nccwpck_require__(487)
-const { InvalidArgumentError } = __nccwpck_require__(504)
-const { buildURL } = __nccwpck_require__(75)
+} = __nccwpck_require__(488)
+const { InvalidArgumentError } = __nccwpck_require__(505)
+const { buildURL } = __nccwpck_require__(72)
 
 /**
  * Defines the scope API for an interceptor reply
@@ -29775,7 +27991,7 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 142:
+/***/ 139:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -29873,7 +28089,7 @@ exports.reflectionMergePartial = reflectionMergePartial;
 
 /***/ }),
 
-/***/ 143:
+/***/ 140:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -29899,8 +28115,8 @@ __export(xml_exports, {
   stringifyXML: () => stringifyXML
 });
 module.exports = __toCommonJS(xml_exports);
-var import_fast_xml_parser = __nccwpck_require__(331);
-var import_xml_common = __nccwpck_require__(23);
+var import_fast_xml_parser = __nccwpck_require__(329);
+var import_xml_common = __nccwpck_require__(22);
 function getCommonOptions(options) {
   return {
     attributesGroupName: import_xml_common.XML_ATTRKEY,
@@ -29966,22 +28182,22 @@ async function parseXML(str, opts = {}) {
 
 /***/ }),
 
-/***/ 144:
+/***/ 141:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-module.exports.request = __nccwpck_require__(525)
-module.exports.stream = __nccwpck_require__(365)
-module.exports.pipeline = __nccwpck_require__(111)
-module.exports.upgrade = __nccwpck_require__(445)
-module.exports.connect = __nccwpck_require__(383)
+module.exports.request = __nccwpck_require__(526)
+module.exports.stream = __nccwpck_require__(364)
+module.exports.pipeline = __nccwpck_require__(108)
+module.exports.upgrade = __nccwpck_require__(446)
+module.exports.connect = __nccwpck_require__(382)
 
 
 /***/ }),
 
-/***/ 145:
+/***/ 142:
 /***/ ((module) => {
 
 "use strict";
@@ -30029,7 +28245,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 146:
+/***/ 143:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30038,8 +28254,8 @@ module.exports = {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollOperation = exports.initOperation = exports.deserializeState = void 0;
-const logger_js_1 = __nccwpck_require__(195);
-const constants_js_1 = __nccwpck_require__(66);
+const logger_js_1 = __nccwpck_require__(192);
+const constants_js_1 = __nccwpck_require__(63);
 /**
  * Deserializes the state
  */
@@ -30208,7 +28424,7 @@ exports.pollOperation = pollOperation;
 
 /***/ }),
 
-/***/ 147:
+/***/ 144:
 /***/ ((module) => {
 
 "use strict";
@@ -30216,7 +28432,7 @@ module.exports = require("diagnostics_channel");
 
 /***/ }),
 
-/***/ 148:
+/***/ 145:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -30257,11 +28473,11 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveReservedCache = saveReservedCache;
 exports.isReservationConflict = isReservationConflict;
-const fsp = __importStar(__nccwpck_require__(114));
-const config_js_1 = __nccwpck_require__(41);
-const cacheHttpClient = __importStar(__nccwpck_require__(38));
-const cacheUtils = __importStar(__nccwpck_require__(81));
-const twirp = __importStar(__nccwpck_require__(67));
+const fsp = __importStar(__nccwpck_require__(111));
+const config_js_1 = __nccwpck_require__(39);
+const cacheHttpClient = __importStar(__nccwpck_require__(36));
+const cacheUtils = __importStar(__nccwpck_require__(78));
+const twirp = __importStar(__nccwpck_require__(64));
 function log(options, message) {
     options.log?.(`two-phase-cache: ${message}`);
 }
@@ -30358,7 +28574,7 @@ function isReservationConflict(result) {
 
 /***/ }),
 
-/***/ 149:
+/***/ 146:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -30374,7 +28590,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(384);
+	createDebug.humanize = __nccwpck_require__(383);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -30657,7 +28873,7 @@ module.exports = setup;
 
 /***/ }),
 
-/***/ 150:
+/***/ 147:
 /***/ ((module) => {
 
 "use strict";
@@ -30665,7 +28881,7 @@ module.exports = require("node:events");
 
 /***/ }),
 
-/***/ 151:
+/***/ 148:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -30700,7 +28916,7 @@ function isObject(input) {
 
 /***/ }),
 
-/***/ 152:
+/***/ 149:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30768,7 +28984,7 @@ async function resolveSoldrReleaseVersion(repo, version, ref, env, deps) {
 
 /***/ }),
 
-/***/ 153:
+/***/ 150:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30809,15 +29025,15 @@ __export(internal_exports, {
   uint8ArrayToString: () => import_bytesEncoding.uint8ArrayToString
 });
 module.exports = __toCommonJS(internal_exports);
-var import_delay = __nccwpck_require__(491);
-var import_random = __nccwpck_require__(521);
-var import_object = __nccwpck_require__(151);
-var import_error = __nccwpck_require__(160);
-var import_sha256 = __nccwpck_require__(205);
+var import_delay = __nccwpck_require__(492);
+var import_random = __nccwpck_require__(522);
+var import_object = __nccwpck_require__(148);
+var import_error = __nccwpck_require__(157);
+var import_sha256 = __nccwpck_require__(202);
 var import_uuidUtils = __nccwpck_require__(405);
-var import_checkEnvironment = __nccwpck_require__(451);
-var import_bytesEncoding = __nccwpck_require__(295);
-var import_sanitizer = __nccwpck_require__(126);
+var import_checkEnvironment = __nccwpck_require__(452);
+var import_bytesEncoding = __nccwpck_require__(293);
+var import_sanitizer = __nccwpck_require__(123);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -30825,7 +29041,7 @@ var import_sanitizer = __nccwpck_require__(126);
 
 /***/ }),
 
-/***/ 154:
+/***/ 151:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30850,7 +29066,7 @@ __export(internal_exports, {
   createLoggerContext: () => import_logger.createLoggerContext
 });
 module.exports = __toCommonJS(internal_exports);
-var import_logger = __nccwpck_require__(253);
+var import_logger = __nccwpck_require__(251);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -30858,7 +29074,7 @@ var import_logger = __nccwpck_require__(253);
 
 /***/ }),
 
-/***/ 155:
+/***/ 152:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -31094,7 +29310,7 @@ exports.PathStylePorts = [
 
 /***/ }),
 
-/***/ 156:
+/***/ 153:
 /***/ ((module) => {
 
 "use strict";
@@ -31102,7 +29318,7 @@ module.exports = require("string_decoder");
 
 /***/ }),
 
-/***/ 157:
+/***/ 154:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -31146,7 +29362,7 @@ function setClientRequestIdPolicy(requestIdHeaderName = "x-ms-client-request-id"
 
 /***/ }),
 
-/***/ 158:
+/***/ 155:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -31171,7 +29387,7 @@ __export(log_exports, {
   logger: () => logger
 });
 module.exports = __toCommonJS(log_exports);
-var import_logger = __nccwpck_require__(253);
+var import_logger = __nccwpck_require__(251);
 const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -31180,7 +29396,7 @@ const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 
 /***/ }),
 
-/***/ 159:
+/***/ 156:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -31206,8 +29422,8 @@ __export(basicAuthenticationPolicy_exports, {
   basicAuthenticationPolicyName: () => basicAuthenticationPolicyName
 });
 module.exports = __toCommonJS(basicAuthenticationPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(295);
-var import_checkInsecureConnection = __nccwpck_require__(447);
+var import_bytesEncoding = __nccwpck_require__(293);
+var import_checkInsecureConnection = __nccwpck_require__(448);
 const basicAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function basicAuthenticationPolicy(options) {
   return {
@@ -31237,7 +29453,7 @@ function basicAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 160:
+/***/ 157:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -31262,7 +29478,7 @@ __export(error_exports, {
   isError: () => isError
 });
 module.exports = __toCommonJS(error_exports);
-var import_object = __nccwpck_require__(151);
+var import_object = __nccwpck_require__(148);
 function isError(e) {
   if ((0, import_object.isObject)(e)) {
     const hasName = typeof e.name === "string";
@@ -31278,7 +29494,7 @@ function isError(e) {
 
 /***/ }),
 
-/***/ 161:
+/***/ 158:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31322,9 +29538,9 @@ exports.ConvertInternalResponseOfListBlobHierarchy = ConvertInternalResponseOfLi
 exports.ExtractPageRangeInfoItems = ExtractPageRangeInfoItems;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const core_util_1 = __nccwpck_require__(16);
-const constants_js_1 = __nccwpck_require__(155);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const core_util_1 = __nccwpck_require__(15);
+const constants_js_1 = __nccwpck_require__(152);
 /**
  * Reserved URL characters must be properly escaped for Storage services like Blob or File.
  *
@@ -32092,7 +30308,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 162:
+/***/ 159:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -32101,7 +30317,7 @@ function assertResponse(response) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = void 0;
-const StorageBrowserPolicy_js_1 = __nccwpck_require__(54);
+const StorageBrowserPolicy_js_1 = __nccwpck_require__(51);
 Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get: function () { return StorageBrowserPolicy_js_1.StorageBrowserPolicy; } }));
 /**
  * StorageBrowserPolicyFactory is a factory class helping generating StorageBrowserPolicy objects.
@@ -32122,27 +30338,27 @@ exports.StorageBrowserPolicyFactory = StorageBrowserPolicyFactory;
 
 /***/ }),
 
-/***/ 163:
+/***/ 160:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(200).kConstruct)
+  kConstruct: (__nccwpck_require__(197).kConstruct)
 }
 
 
 /***/ }),
 
-/***/ 164:
+/***/ 161:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionLongConvert = void 0;
-const reflection_info_1 = __nccwpck_require__(466);
+const reflection_info_1 = __nccwpck_require__(467);
 /**
  * Utility method to convert a PbLong or PbUlong to a JavaScript
  * representation during runtime.
@@ -32167,7 +30383,7 @@ exports.reflectionLongConvert = reflectionLongConvert;
 
 /***/ }),
 
-/***/ 165:
+/***/ 162:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -32201,7 +30417,7 @@ const DEFAULT_RETRY_POLICY_COUNT = 3;
 
 /***/ }),
 
-/***/ 166:
+/***/ 163:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -32240,9 +30456,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.uploadCacheArchiveSDK = exports.UploadProgress = void 0;
-const core = __importStar(__nccwpck_require__(474));
-const storage_blob_1 = __nccwpck_require__(460);
-const errors_1 = __nccwpck_require__(314);
+const core = __importStar(__nccwpck_require__(475));
+const storage_blob_1 = __nccwpck_require__(461);
+const errors_1 = __nccwpck_require__(312);
 /**
  * Class for tracking the upload state and displaying stats.
  */
@@ -32375,7 +30591,7 @@ exports.uploadCacheArchiveSDK = uploadCacheArchiveSDK;
 
 /***/ }),
 
-/***/ 167:
+/***/ 164:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -32405,8 +30621,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.req = exports.json = exports.toBuffer = void 0;
-const http = __importStar(__nccwpck_require__(338));
-const https = __importStar(__nccwpck_require__(76));
+const http = __importStar(__nccwpck_require__(336));
+const https = __importStar(__nccwpck_require__(73));
 async function toBuffer(stream) {
     let length = 0;
     const chunks = [];
@@ -32448,7 +30664,7 @@ exports.req = req;
 
 /***/ }),
 
-/***/ 168:
+/***/ 165:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -32474,7 +30690,7 @@ __export(tokenCycler_exports, {
   createTokenCycler: () => createTokenCycler
 });
 module.exports = __toCommonJS(tokenCycler_exports);
-var import_core_util = __nccwpck_require__(16);
+var import_core_util = __nccwpck_require__(15);
 const DEFAULT_CYCLER_OPTIONS = {
   forcedRefreshWindowInMs: 1e3,
   // Force waiting for a refresh 1s before the token expires
@@ -32586,36 +30802,36 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 
 /***/ }),
 
-/***/ 169:
+/***/ 166:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Client = __nccwpck_require__(94)
-const Dispatcher = __nccwpck_require__(494)
-const errors = __nccwpck_require__(504)
-const Pool = __nccwpck_require__(346)
-const BalancedPool = __nccwpck_require__(392)
+const Client = __nccwpck_require__(91)
+const Dispatcher = __nccwpck_require__(495)
+const errors = __nccwpck_require__(505)
+const Pool = __nccwpck_require__(344)
+const BalancedPool = __nccwpck_require__(391)
 const Agent = __nccwpck_require__(5)
-const util = __nccwpck_require__(75)
+const util = __nccwpck_require__(72)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(144)
-const buildConnector = __nccwpck_require__(274)
-const MockClient = __nccwpck_require__(204)
-const MockAgent = __nccwpck_require__(387)
-const MockPool = __nccwpck_require__(359)
-const mockErrors = __nccwpck_require__(237)
-const ProxyAgent = __nccwpck_require__(351)
-const RetryHandler = __nccwpck_require__(281)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(386)
-const DecoratorHandler = __nccwpck_require__(492)
+const api = __nccwpck_require__(141)
+const buildConnector = __nccwpck_require__(273)
+const MockClient = __nccwpck_require__(201)
+const MockAgent = __nccwpck_require__(386)
+const MockPool = __nccwpck_require__(358)
+const mockErrors = __nccwpck_require__(235)
+const ProxyAgent = __nccwpck_require__(349)
+const RetryHandler = __nccwpck_require__(280)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(385)
+const DecoratorHandler = __nccwpck_require__(493)
 const RedirectHandler = __nccwpck_require__(401)
-const createRedirectInterceptor = __nccwpck_require__(263)
+const createRedirectInterceptor = __nccwpck_require__(261)
 
 let hasCrypto
 try {
-  __nccwpck_require__(299)
+  __nccwpck_require__(297)
   hasCrypto = true
 } catch {
   hasCrypto = false
@@ -32694,7 +30910,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   let fetchImpl = null
   module.exports.fetch = async function fetch (resource) {
     if (!fetchImpl) {
-      fetchImpl = (__nccwpck_require__(463).fetch)
+      fetchImpl = (__nccwpck_require__(464).fetch)
     }
 
     try {
@@ -32707,20 +30923,20 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
       throw err
     }
   }
-  module.exports.Headers = __nccwpck_require__(530).Headers
-  module.exports.Response = __nccwpck_require__(45).Response
-  module.exports.Request = __nccwpck_require__(88).Request
-  module.exports.FormData = __nccwpck_require__(212).FormData
+  module.exports.Headers = __nccwpck_require__(531).Headers
+  module.exports.Response = __nccwpck_require__(43).Response
+  module.exports.Request = __nccwpck_require__(85).Request
+  module.exports.FormData = __nccwpck_require__(209).FormData
   module.exports.File = __nccwpck_require__(373).File
-  module.exports.FileReader = __nccwpck_require__(100).FileReader
+  module.exports.FileReader = __nccwpck_require__(97).FileReader
 
-  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(145)
+  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(142)
 
   module.exports.setGlobalOrigin = setGlobalOrigin
   module.exports.getGlobalOrigin = getGlobalOrigin
 
-  const { CacheStorage } = __nccwpck_require__(291)
-  const { kConstruct } = __nccwpck_require__(163)
+  const { CacheStorage } = __nccwpck_require__(289)
+  const { kConstruct } = __nccwpck_require__(160)
 
   // Cache & CacheStorage are tightly coupled with fetch. Even if it may run
   // in an older version of Node, it doesn't have any use without fetch.
@@ -32728,21 +30944,21 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
 }
 
 if (util.nodeMajor >= 16) {
-  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(397)
+  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(396)
 
   module.exports.deleteCookie = deleteCookie
   module.exports.getCookies = getCookies
   module.exports.getSetCookies = getSetCookies
   module.exports.setCookie = setCookie
 
-  const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(28)
+  const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(27)
 
   module.exports.parseMIMEType = parseMIMEType
   module.exports.serializeAMimeType = serializeAMimeType
 }
 
 if (util.nodeMajor >= 18 && hasCrypto) {
-  const { WebSocket } = __nccwpck_require__(309)
+  const { WebSocket } = __nccwpck_require__(307)
 
   module.exports.WebSocket = WebSocket
 }
@@ -32761,7 +30977,7 @@ module.exports.mockErrors = mockErrors
 
 /***/ }),
 
-/***/ 170:
+/***/ 167:
 /***/ ((module) => {
 
 "use strict";
@@ -32769,7 +30985,7 @@ module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 171:
+/***/ 168:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -32782,18 +30998,18 @@ module.exports = require("child_process");
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(220);
-tslib_1.__exportStar(__nccwpck_require__(123), exports);
-tslib_1.__exportStar(__nccwpck_require__(185), exports);
-tslib_1.__exportStar(__nccwpck_require__(127), exports);
-tslib_1.__exportStar(__nccwpck_require__(326), exports);
-tslib_1.__exportStar(__nccwpck_require__(213), exports);
-tslib_1.__exportStar(__nccwpck_require__(278), exports);
+const tslib_1 = __nccwpck_require__(219);
+tslib_1.__exportStar(__nccwpck_require__(120), exports);
+tslib_1.__exportStar(__nccwpck_require__(182), exports);
+tslib_1.__exportStar(__nccwpck_require__(124), exports);
+tslib_1.__exportStar(__nccwpck_require__(324), exports);
+tslib_1.__exportStar(__nccwpck_require__(211), exports);
+tslib_1.__exportStar(__nccwpck_require__(277), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 172:
+/***/ 169:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -32803,13 +31019,13 @@ tslib_1.__exportStar(__nccwpck_require__(278), exports);
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageRetryPolicyName = void 0;
 exports.storageRetryPolicy = storageRetryPolicy;
-const abort_controller_1 = __nccwpck_require__(510);
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const core_util_1 = __nccwpck_require__(16);
-const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(335);
-const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(490);
-const log_js_1 = __nccwpck_require__(19);
+const abort_controller_1 = __nccwpck_require__(511);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const core_util_1 = __nccwpck_require__(15);
+const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(333);
+const constants_js_1 = __nccwpck_require__(38);
+const utils_common_js_1 = __nccwpck_require__(491);
+const log_js_1 = __nccwpck_require__(18);
 /**
  * Name of the {@link storageRetryPolicy}
  */
@@ -32968,7 +31184,7 @@ function storageRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 173:
+/***/ 170:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -32984,7 +31200,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.create = void 0;
-const internal_globber_1 = __nccwpck_require__(443);
+const internal_globber_1 = __nccwpck_require__(444);
 /**
  * Constructs a globber
  *
@@ -33001,7 +31217,7 @@ exports.create = create;
 
 /***/ }),
 
-/***/ 174:
+/***/ 171:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -33010,7 +31226,7 @@ exports.create = create;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.UserDelegationKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(282);
+const node_crypto_1 = __nccwpck_require__(281);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -33055,7 +31271,7 @@ exports.UserDelegationKeyCredential = UserDelegationKeyCredential;
 
 /***/ }),
 
-/***/ 175:
+/***/ 172:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -33081,10 +31297,10 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(295);
-var import_typeGuards = __nccwpck_require__(512);
+var import_bytesEncoding = __nccwpck_require__(293);
+var import_typeGuards = __nccwpck_require__(513);
 var import_uuidUtils = __nccwpck_require__(405);
-var import_concat = __nccwpck_require__(313);
+var import_concat = __nccwpck_require__(311);
 function generateBoundary() {
   return `----AzSDKFormBoundary${(0, import_uuidUtils.randomUUID)()}`;
 }
@@ -33193,12 +31409,12 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 176:
+/***/ 173:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(415)
+const f = __nccwpck_require__(416)
 
 class FloatingDateTime extends Date {
   constructor (value) {
@@ -33225,7 +31441,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 177:
+/***/ 174:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -33352,7 +31568,7 @@ function requestToOptions(request) {
 
 /***/ }),
 
-/***/ 178:
+/***/ 175:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -33364,7 +31580,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 179:
+/***/ 176:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -33373,44 +31589,44 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Note: we do not use `export * from ...` to help tree shakers,
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-var service_type_1 = __nccwpck_require__(495);
+var service_type_1 = __nccwpck_require__(496);
 Object.defineProperty(exports, "ServiceType", ({ enumerable: true, get: function () { return service_type_1.ServiceType; } }));
-var reflection_info_1 = __nccwpck_require__(543);
+var reflection_info_1 = __nccwpck_require__(544);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
 Object.defineProperty(exports, "readMethodOption", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOption; } }));
 Object.defineProperty(exports, "readServiceOption", ({ enumerable: true, get: function () { return reflection_info_1.readServiceOption; } }));
-var rpc_error_1 = __nccwpck_require__(180);
+var rpc_error_1 = __nccwpck_require__(177);
 Object.defineProperty(exports, "RpcError", ({ enumerable: true, get: function () { return rpc_error_1.RpcError; } }));
-var rpc_options_1 = __nccwpck_require__(301);
+var rpc_options_1 = __nccwpck_require__(299);
 Object.defineProperty(exports, "mergeRpcOptions", ({ enumerable: true, get: function () { return rpc_options_1.mergeRpcOptions; } }));
-var rpc_output_stream_1 = __nccwpck_require__(316);
+var rpc_output_stream_1 = __nccwpck_require__(314);
 Object.defineProperty(exports, "RpcOutputStreamController", ({ enumerable: true, get: function () { return rpc_output_stream_1.RpcOutputStreamController; } }));
-var test_transport_1 = __nccwpck_require__(526);
+var test_transport_1 = __nccwpck_require__(527);
 Object.defineProperty(exports, "TestTransport", ({ enumerable: true, get: function () { return test_transport_1.TestTransport; } }));
-var deferred_1 = __nccwpck_require__(57);
+var deferred_1 = __nccwpck_require__(54);
 Object.defineProperty(exports, "Deferred", ({ enumerable: true, get: function () { return deferred_1.Deferred; } }));
 Object.defineProperty(exports, "DeferredState", ({ enumerable: true, get: function () { return deferred_1.DeferredState; } }));
-var duplex_streaming_call_1 = __nccwpck_require__(315);
+var duplex_streaming_call_1 = __nccwpck_require__(313);
 Object.defineProperty(exports, "DuplexStreamingCall", ({ enumerable: true, get: function () { return duplex_streaming_call_1.DuplexStreamingCall; } }));
-var client_streaming_call_1 = __nccwpck_require__(360);
+var client_streaming_call_1 = __nccwpck_require__(359);
 Object.defineProperty(exports, "ClientStreamingCall", ({ enumerable: true, get: function () { return client_streaming_call_1.ClientStreamingCall; } }));
-var server_streaming_call_1 = __nccwpck_require__(464);
+var server_streaming_call_1 = __nccwpck_require__(465);
 Object.defineProperty(exports, "ServerStreamingCall", ({ enumerable: true, get: function () { return server_streaming_call_1.ServerStreamingCall; } }));
-var unary_call_1 = __nccwpck_require__(62);
+var unary_call_1 = __nccwpck_require__(59);
 Object.defineProperty(exports, "UnaryCall", ({ enumerable: true, get: function () { return unary_call_1.UnaryCall; } }));
-var rpc_interceptor_1 = __nccwpck_require__(547);
+var rpc_interceptor_1 = __nccwpck_require__(548);
 Object.defineProperty(exports, "stackIntercept", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackIntercept; } }));
 Object.defineProperty(exports, "stackDuplexStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackDuplexStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackClientStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackClientStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackServerStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackServerStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackUnaryInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackUnaryInterceptors; } }));
-var server_call_context_1 = __nccwpck_require__(436);
+var server_call_context_1 = __nccwpck_require__(437);
 Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: true, get: function () { return server_call_context_1.ServerCallContextController; } }));
 
 
 /***/ }),
 
-/***/ 180:
+/***/ 177:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -33454,7 +31670,7 @@ exports.RpcError = RpcError;
 
 /***/ }),
 
-/***/ 181:
+/***/ 178:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -33537,7 +31753,7 @@ function isLessThan(lhs, rhs) {
 
 /***/ }),
 
-/***/ 182:
+/***/ 179:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -33546,10 +31762,10 @@ function isLessThan(lhs, rhs) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-const operation_js_1 = __nccwpck_require__(368);
-const constants_js_1 = __nccwpck_require__(66);
-const poller_js_1 = __nccwpck_require__(80);
-const operation_js_2 = __nccwpck_require__(146);
+const operation_js_1 = __nccwpck_require__(367);
+const constants_js_1 = __nccwpck_require__(63);
+const poller_js_1 = __nccwpck_require__(77);
+const operation_js_2 = __nccwpck_require__(143);
 /**
  * The LRO Engine, a class that performs polling.
  */
@@ -33577,7 +31793,7 @@ exports.LroEngine = LroEngine;
 
 /***/ }),
 
-/***/ 183:
+/***/ 180:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -35227,7 +33443,7 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 184:
+/***/ 181:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -43570,7 +41786,7 @@ exports.BlockBlobGetBlockListExceptionHeaders = {
 
 /***/ }),
 
-/***/ 185:
+/***/ 182:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -43587,7 +41803,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 186:
+/***/ 183:
 /***/ ((module) => {
 
 "use strict";
@@ -43595,7 +41811,7 @@ module.exports = require("tty");
 
 /***/ }),
 
-/***/ 187:
+/***/ 184:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -43608,14 +41824,14 @@ exports.isPipelineLike = isPipelineLike;
 exports.newPipeline = newPipeline;
 exports.getCoreClientOptions = getCoreClientOptions;
 exports.getCredentialFromPipeline = getCredentialFromPipeline;
-const core_http_compat_1 = __nccwpck_require__(78);
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const core_client_1 = __nccwpck_require__(452);
-const core_xml_1 = __nccwpck_require__(199);
-const core_auth_1 = __nccwpck_require__(528);
-const log_js_1 = __nccwpck_require__(112);
-const storage_common_1 = __nccwpck_require__(285);
-const constants_js_1 = __nccwpck_require__(155);
+const core_http_compat_1 = __nccwpck_require__(75);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const core_client_1 = __nccwpck_require__(453);
+const core_xml_1 = __nccwpck_require__(196);
+const core_auth_1 = __nccwpck_require__(529);
+const log_js_1 = __nccwpck_require__(109);
+const storage_common_1 = __nccwpck_require__(283);
+const constants_js_1 = __nccwpck_require__(152);
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return constants_js_1.StorageOAuthScopes; } }));
 /**
  * A helper to decide if a given argument satisfies the Pipeline contract
@@ -43879,7 +42095,7 @@ function isCoreHttpPolicyFactory(factory) {
 
 /***/ }),
 
-/***/ 188:
+/***/ 185:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -43904,7 +42120,7 @@ __export(log_exports, {
   logger: () => logger
 });
 module.exports = __toCommonJS(log_exports);
-var import_logger = __nccwpck_require__(48);
+var import_logger = __nccwpck_require__(46);
 const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -43912,7 +42128,7 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 
 /***/ }),
 
-/***/ 189:
+/***/ 186:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -43921,27 +42137,27 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobClient = exports.BlockBlobClient = exports.AppendBlobClient = exports.BlobClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const core_auth_1 = __nccwpck_require__(528);
-const core_util_1 = __nccwpck_require__(16);
-const core_util_2 = __nccwpck_require__(16);
-const BlobDownloadResponse_js_1 = __nccwpck_require__(438);
-const BlobQueryResponse_js_1 = __nccwpck_require__(206);
-const storage_common_1 = __nccwpck_require__(285);
-const models_js_1 = __nccwpck_require__(426);
-const PageBlobRangeResponse_js_1 = __nccwpck_require__(32);
-const Pipeline_js_1 = __nccwpck_require__(187);
-const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(549);
-const Range_js_1 = __nccwpck_require__(110);
-const StorageClient_js_1 = __nccwpck_require__(468);
-const Batch_js_1 = __nccwpck_require__(97);
-const storage_common_2 = __nccwpck_require__(285);
-const constants_js_1 = __nccwpck_require__(155);
-const tracing_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(161);
-const utils_js_1 = __nccwpck_require__(207);
-const BlobSASSignatureValues_js_1 = __nccwpck_require__(74);
-const BlobLeaseClient_js_1 = __nccwpck_require__(209);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const core_auth_1 = __nccwpck_require__(529);
+const core_util_1 = __nccwpck_require__(15);
+const core_util_2 = __nccwpck_require__(15);
+const BlobDownloadResponse_js_1 = __nccwpck_require__(439);
+const BlobQueryResponse_js_1 = __nccwpck_require__(203);
+const storage_common_1 = __nccwpck_require__(283);
+const models_js_1 = __nccwpck_require__(427);
+const PageBlobRangeResponse_js_1 = __nccwpck_require__(31);
+const Pipeline_js_1 = __nccwpck_require__(184);
+const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(550);
+const Range_js_1 = __nccwpck_require__(107);
+const StorageClient_js_1 = __nccwpck_require__(469);
+const Batch_js_1 = __nccwpck_require__(94);
+const storage_common_2 = __nccwpck_require__(283);
+const constants_js_1 = __nccwpck_require__(152);
+const tracing_js_1 = __nccwpck_require__(33);
+const utils_common_js_1 = __nccwpck_require__(158);
+const utils_js_1 = __nccwpck_require__(204);
+const BlobSASSignatureValues_js_1 = __nccwpck_require__(71);
+const BlobLeaseClient_js_1 = __nccwpck_require__(206);
 /**
  * A BlobClient represents a URL to an Azure Storage blob; the blob may be a block blob,
  * append blob, or page blob.
@@ -46771,17 +44987,17 @@ exports.PageBlobClient = PageBlobClient;
 
 /***/ }),
 
-/***/ 190:
+/***/ 187:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryWriter = void 0;
-const binary_format_contract_1 = __nccwpck_require__(342);
-const reflection_info_1 = __nccwpck_require__(466);
-const assert_1 = __nccwpck_require__(500);
-const pb_long_1 = __nccwpck_require__(122);
+const binary_format_contract_1 = __nccwpck_require__(340);
+const reflection_info_1 = __nccwpck_require__(467);
+const assert_1 = __nccwpck_require__(501);
+const pb_long_1 = __nccwpck_require__(119);
 /**
  * Writes proto3 messages in binary format using reflection information.
  *
@@ -47012,18 +45228,18 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 
 /***/ }),
 
-/***/ 191:
+/***/ 188:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxUnsigned16Bit } = __nccwpck_require__(482)
+const { maxUnsigned16Bit } = __nccwpck_require__(483)
 
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(299)
+  crypto = __nccwpck_require__(297)
 } catch {
 
 }
@@ -47093,7 +45309,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 192:
+/***/ 189:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -47140,14 +45356,14 @@ function isApiKeyCredential(credential) {
 
 /***/ }),
 
-/***/ 193:
+/***/ 190:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const assert = __nccwpck_require__(542)
+const assert = __nccwpck_require__(543)
 const {
   ResponseStatusCodeError
-} = __nccwpck_require__(504)
-const { toUSVString } = __nccwpck_require__(75)
+} = __nccwpck_require__(505)
+const { toUSVString } = __nccwpck_require__(72)
 
 async function getResolveErrorBodyCallback ({ callback, body, contentType, statusCode, statusMessage, headers }) {
   assert(body)
@@ -47193,7 +45409,7 @@ module.exports = { getResolveErrorBodyCallback }
 
 /***/ }),
 
-/***/ 194:
+/***/ 191:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -47315,7 +45531,7 @@ exports.getSelectedOneofValue = getSelectedOneofValue;
 
 /***/ }),
 
-/***/ 195:
+/***/ 192:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47324,7 +45540,7 @@ exports.getSelectedOneofValue = getSelectedOneofValue;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = void 0;
-const logger_1 = __nccwpck_require__(48);
+const logger_1 = __nccwpck_require__(46);
 /**
  * The `@azure/logger` configuration for this package.
  * @internal
@@ -47334,7 +45550,7 @@ exports.logger = (0, logger_1.createClientLogger)("core-lro");
 
 /***/ }),
 
-/***/ 196:
+/***/ 193:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -47387,8 +45603,8 @@ exports.formatLogLine = formatLogLine;
 exports.isTimestampsEnabled = isTimestampsEnabled;
 exports.getTimestampFormat = getTimestampFormat;
 exports.streamExec = streamExec;
-const core = __importStar(__nccwpck_require__(474));
-const fs = __importStar(__nccwpck_require__(257));
+const core = __importStar(__nccwpck_require__(475));
+const fs = __importStar(__nccwpck_require__(255));
 function makeFileLogger(env) {
     const logPath = (env["SETUP_SOLDR_LOG"] ?? "").trim();
     if (!logPath)
@@ -47559,7 +45775,7 @@ function getTimestampFormat(env) {
  * modules that don't need @actions/exec).
  */
 async function streamExec(command, args, opts = {}) {
-    const exec = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 20, 23));
+    const exec = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 19, 23));
     const env = process.env;
     const colorEnv = colorForceEnvironment(env);
     const userEnv = opts.env ?? undefined;
@@ -47599,14 +45815,14 @@ async function streamExec(command, args, opts = {}) {
 
 /***/ }),
 
-/***/ 197:
+/***/ 194:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 /* eslint-disable object-property-newline */
 
 
-const decodeText = __nccwpck_require__(283)
+const decodeText = __nccwpck_require__(282)
 
 const RE_ENCODED = /%[a-fA-F0-9][a-fA-F0-9]/g
 
@@ -47803,7 +46019,7 @@ module.exports = parseParams
 
 /***/ }),
 
-/***/ 198:
+/***/ 195:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47829,8 +46045,8 @@ __export(auxiliaryAuthenticationHeaderPolicy_exports, {
   auxiliaryAuthenticationHeaderPolicyName: () => auxiliaryAuthenticationHeaderPolicyName
 });
 module.exports = __toCommonJS(auxiliaryAuthenticationHeaderPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(168);
-var import_log = __nccwpck_require__(188);
+var import_tokenCycler = __nccwpck_require__(165);
+var import_log = __nccwpck_require__(185);
 const auxiliaryAuthenticationHeaderPolicyName = "auxiliaryAuthenticationHeaderPolicy";
 const AUTHORIZATION_AUXILIARY_HEADER = "x-ms-authorization-auxiliary";
 async function sendAuthorizeRequest(options) {
@@ -47896,7 +46112,7 @@ function auxiliaryAuthenticationHeaderPolicy(options) {
 
 /***/ }),
 
-/***/ 199:
+/***/ 196:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47924,8 +46140,8 @@ __export(src_exports, {
   stringifyXML: () => import_xml.stringifyXML
 });
 module.exports = __toCommonJS(src_exports);
-var import_xml = __nccwpck_require__(143);
-var import_xml_common = __nccwpck_require__(23);
+var import_xml = __nccwpck_require__(140);
+var import_xml_common = __nccwpck_require__(22);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -47933,7 +46149,7 @@ var import_xml_common = __nccwpck_require__(23);
 
 /***/ }),
 
-/***/ 200:
+/***/ 197:
 /***/ ((module) => {
 
 module.exports = {
@@ -48003,7 +46219,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 201:
+/***/ 198:
 /***/ ((module) => {
 
 "use strict";
@@ -48128,7 +46344,7 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 202:
+/***/ 199:
 /***/ ((module) => {
 
 "use strict";
@@ -48136,7 +46352,7 @@ module.exports = require("node:child_process");
 
 /***/ }),
 
-/***/ 203:
+/***/ 200:
 /***/ ((module) => {
 
 "use strict";
@@ -48144,14 +46360,14 @@ module.exports = require("util/types");
 
 /***/ }),
 
-/***/ 204:
+/***/ 201:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(128)
-const Client = __nccwpck_require__(94)
+const { promisify } = __nccwpck_require__(125)
+const Client = __nccwpck_require__(91)
 const { buildMockDispatch } = __nccwpck_require__(8)
 const {
   kDispatches,
@@ -48161,10 +46377,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(487)
-const { MockInterceptor } = __nccwpck_require__(141)
-const Symbols = __nccwpck_require__(200)
-const { InvalidArgumentError } = __nccwpck_require__(504)
+} = __nccwpck_require__(488)
+const { MockInterceptor } = __nccwpck_require__(138)
+const Symbols = __nccwpck_require__(197)
+const { InvalidArgumentError } = __nccwpck_require__(505)
 
 /**
  * MockClient provides an API that extends the Client to influence the mockDispatches.
@@ -48211,7 +46427,7 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 205:
+/***/ 202:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48237,7 +46453,7 @@ __export(sha256_exports, {
   computeSha256Hmac: () => computeSha256Hmac
 });
 module.exports = __toCommonJS(sha256_exports);
-var import_node_crypto = __nccwpck_require__(282);
+var import_node_crypto = __nccwpck_require__(281);
 async function computeSha256Hmac(key, stringToSign, encoding) {
   const decodedKey = Buffer.from(key, "base64");
   return (0, import_node_crypto.createHmac)("sha256", decodedKey).update(stringToSign).digest(encoding);
@@ -48252,7 +46468,7 @@ async function computeSha256Hash(content, encoding) {
 
 /***/ }),
 
-/***/ 206:
+/***/ 203:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -48261,8 +46477,8 @@ async function computeSha256Hash(content, encoding) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQueryResponse = void 0;
-const core_util_1 = __nccwpck_require__(16);
-const BlobQuickQueryStream_js_1 = __nccwpck_require__(516);
+const core_util_1 = __nccwpck_require__(15);
+const BlobQuickQueryStream_js_1 = __nccwpck_require__(517);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -48632,7 +46848,7 @@ exports.BlobQueryResponse = BlobQueryResponse;
 
 /***/ }),
 
-/***/ 207:
+/***/ 204:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -48645,10 +46861,10 @@ exports.streamToBuffer = streamToBuffer;
 exports.streamToBuffer2 = streamToBuffer2;
 exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
-const tslib_1 = __nccwpck_require__(220);
-const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(257));
-const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(385));
-const constants_js_1 = __nccwpck_require__(155);
+const tslib_1 = __nccwpck_require__(219);
+const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(255));
+const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(384));
+const constants_js_1 = __nccwpck_require__(152);
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
  *
@@ -48779,7 +46995,7 @@ exports.fsCreateReadStream = node_fs_1.default.createReadStream;
 
 /***/ }),
 
-/***/ 208:
+/***/ 205:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -49061,7 +47277,7 @@ exports.varint32read = varint32read;
 
 /***/ }),
 
-/***/ 209:
+/***/ 206:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49070,10 +47286,10 @@ exports.varint32read = varint32read;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobLeaseClient = void 0;
-const core_util_1 = __nccwpck_require__(16);
-const constants_js_1 = __nccwpck_require__(155);
-const tracing_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(161);
+const core_util_1 = __nccwpck_require__(15);
+const constants_js_1 = __nccwpck_require__(152);
+const tracing_js_1 = __nccwpck_require__(33);
+const utils_common_js_1 = __nccwpck_require__(158);
 /**
  * A client that manages leases for a {@link ContainerClient} or a {@link BlobClient}.
  */
@@ -49273,15 +47489,15 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 /***/ }),
 
-/***/ 210:
+/***/ 207:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionCreate = void 0;
-const reflection_scalar_default_1 = __nccwpck_require__(478);
-const message_type_contract_1 = __nccwpck_require__(417);
+const reflection_scalar_default_1 = __nccwpck_require__(479);
+const message_type_contract_1 = __nccwpck_require__(418);
 /**
  * Creates an instance of the generic message, using the field
  * information.
@@ -49329,7 +47545,7 @@ exports.reflectionCreate = reflectionCreate;
 
 /***/ }),
 
-/***/ 211:
+/***/ 208:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49339,9 +47555,9 @@ exports.reflectionCreate = reflectionCreate;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageBrowserPolicyName = void 0;
 exports.storageBrowserPolicy = storageBrowserPolicy;
-const core_util_1 = __nccwpck_require__(16);
-const constants_js_1 = __nccwpck_require__(40);
-const utils_common_js_1 = __nccwpck_require__(490);
+const core_util_1 = __nccwpck_require__(15);
+const constants_js_1 = __nccwpck_require__(38);
+const utils_common_js_1 = __nccwpck_require__(491);
 /**
  * The programmatic identifier of the StorageBrowserPolicy.
  */
@@ -49371,17 +47587,17 @@ function storageBrowserPolicy() {
 
 /***/ }),
 
-/***/ 212:
+/***/ 209:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(532)
-const { kState } = __nccwpck_require__(17)
+const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(533)
+const { kState } = __nccwpck_require__(16)
 const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(373)
-const { webidl } = __nccwpck_require__(470)
-const { Blob, File: NativeFile } = __nccwpck_require__(124)
+const { webidl } = __nccwpck_require__(471)
+const { Blob, File: NativeFile } = __nccwpck_require__(121)
 
 /** @type {globalThis['File']} */
 const File = NativeFile ?? UndiciFile
@@ -49644,7 +47860,408 @@ module.exports = { FormData }
 
 /***/ }),
 
-/***/ 213:
+/***/ 210:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.cargoRegistryArchiveFormat = cargoRegistryArchiveFormat;
+exports.planCargoRegistryArchive = planCargoRegistryArchive;
+exports.cargoRegistryPayloadPaths = cargoRegistryPayloadPaths;
+exports.cargoRegistryZstdAsset = cargoRegistryZstdAsset;
+exports.resolveCargoRegistryZstd = resolveCargoRegistryZstd;
+exports.writeCargoRegistryExtrasArchive = writeCargoRegistryExtrasArchive;
+exports.extractCargoRegistryExtrasArchive = extractCargoRegistryExtrasArchive;
+exports.cargoRegistryPayloadCensus = cargoRegistryPayloadCensus;
+exports.saveCargoRegistryArchive = saveCargoRegistryArchive;
+exports.restoreCargoRegistryArchive = restoreCargoRegistryArchive;
+const fs = __importStar(__nccwpck_require__(111));
+const os = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(523));
+const node_crypto_1 = __nccwpck_require__(281);
+const node_child_process_1 = __nccwpck_require__(199);
+const io = __importStar(__nccwpck_require__(300));
+const tc = __importStar(__nccwpck_require__(538));
+const cache_compress_js_1 = __nccwpck_require__(481);
+const soldr_load_shim_js_1 = __nccwpck_require__(371);
+const OPTIONAL_EXTRA_BASENAMES = [".global-cache", "git"];
+function cargoRegistryArchiveFormat(input) {
+    return input.viaSoldr && !input.encrypted && !input.sourceRef && input.runtimeCompatible !== false
+        ? "soldr-v2"
+        : "legacy-v1";
+}
+function planCargoRegistryArchive(input) {
+    if (input.format === "legacy-v1") {
+        const registryArchivePath = `${path.join(input.cargoHome, "registry")}.tar.zst`;
+        return {
+            format: input.format,
+            registryArchivePath,
+            extrasArchivePath: "",
+            restorePaths: [registryArchivePath],
+        };
+    }
+    const root = path.join(input.runnerTemp, "setup-soldr-cargo-registry", "v2");
+    const registryArchivePath = path.join(root, "registry.soldr.tar.zst");
+    const extrasArchivePath = path.join(root, "extras.tar.zst");
+    return {
+        format: input.format,
+        registryArchivePath,
+        extrasArchivePath,
+        restorePaths: [registryArchivePath, extrasArchivePath],
+    };
+}
+async function exists(target) {
+    try {
+        await fs.stat(target);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+async function cargoRegistryPayloadPaths(cargoHome) {
+    const registry = path.join(cargoHome, "registry");
+    const extras = [];
+    for (const basename of OPTIONAL_EXTRA_BASENAMES) {
+        const candidate = path.join(cargoHome, basename);
+        if (await exists(candidate))
+            extras.push(candidate);
+    }
+    return { registry, extras };
+}
+function runPipe(producer, consumer) {
+    return new Promise((resolve, reject) => {
+        const prod = (0, node_child_process_1.spawn)(producer[0], producer[1], { stdio: ["ignore", "pipe", "inherit"] });
+        const cons = (0, node_child_process_1.spawn)(consumer[0], consumer[1], { stdio: ["pipe", "inherit", "inherit"] });
+        prod.once("error", reject);
+        cons.once("error", reject);
+        prod.stdout?.pipe(cons.stdin);
+        let producerExit = null;
+        let consumerExit = null;
+        const done = () => {
+            if (producerExit === null || consumerExit === null)
+                return;
+            if (producerExit !== 0)
+                reject(new Error(`${producer[0]} exited with code ${producerExit}`));
+            else if (consumerExit !== 0)
+                reject(new Error(`${consumer[0]} exited with code ${consumerExit}`));
+            else
+                resolve();
+        };
+        prod.once("close", (code) => { producerExit = code ?? 0; done(); });
+        cons.once("close", (code) => { consumerExit = code ?? 0; done(); });
+    });
+}
+const CARGO_REGISTRY_ZSTD_VERSION = "1.5.7";
+const CARGO_REGISTRY_ZSTD_WIN64_SHA256 = "acb4e8111511749dc7a3ebedca9b04190e37a17afeb73f55d4425dbf0b90fad9";
+function cargoRegistryZstdAsset(arch = process.arch) {
+    if (arch === "ia32") {
+        throw new Error("cargo-registry Soldr v2 does not support 32-bit Windows runners");
+    }
+    return `https://github.com/facebook/zstd/releases/download/v${CARGO_REGISTRY_ZSTD_VERSION}/zstd-v${CARGO_REGISTRY_ZSTD_VERSION}-win64.zip`;
+}
+async function findNamedFile(root, basename) {
+    let entries;
+    try {
+        entries = await fs.readdir(root, { withFileTypes: true });
+    }
+    catch {
+        return null;
+    }
+    for (const entry of entries) {
+        const full = path.join(root, entry.name);
+        if (entry.isFile() && entry.name.toLowerCase() === basename.toLowerCase())
+            return full;
+        if (entry.isDirectory()) {
+            const nested = await findNamedFile(full, basename);
+            if (nested)
+                return nested;
+        }
+    }
+    return null;
+}
+async function resolveCargoRegistryZstd() {
+    const existing = await io.which("zstd", false);
+    if (existing)
+        return existing;
+    if (process.platform !== "win32") {
+        throw new Error("cargo-registry Soldr v2 requires zstd on PATH outside Windows");
+    }
+    const root = path.join(process.env["RUNNER_TEMP"] || os.tmpdir(), "setup-soldr-tools", `zstd-${CARGO_REGISTRY_ZSTD_VERSION}-${process.arch}`);
+    const cached = await findNamedFile(root, "zstd.exe");
+    if (cached)
+        return cached;
+    await fs.mkdir(root, { recursive: true });
+    const zipPath = path.join(root, "zstd.zip");
+    await tc.downloadTool(cargoRegistryZstdAsset(), zipPath);
+    const digest = (0, node_crypto_1.createHash)("sha256").update(await fs.readFile(zipPath)).digest("hex");
+    if (digest !== CARGO_REGISTRY_ZSTD_WIN64_SHA256) {
+        throw new Error(`downloaded zstd archive failed SHA-256 verification (got ${digest})`);
+    }
+    const extracted = await tc.extractZip(zipPath, path.join(root, "extracted"));
+    const downloaded = await findNamedFile(extracted, "zstd.exe");
+    if (!downloaded)
+        throw new Error("downloaded zstd archive did not contain zstd.exe");
+    return downloaded;
+}
+async function writeCargoRegistryExtrasArchive(cargoHome, extras, archivePath) {
+    await fs.mkdir(path.dirname(archivePath), { recursive: true });
+    const manifestRoot = await fs.mkdtemp(path.join(os.tmpdir(), "setup-soldr-cargo-extras-"));
+    const manifestPath = path.join(manifestRoot, "manifest.txt");
+    try {
+        const basenames = extras.map((entry) => path.basename(entry));
+        await fs.writeFile(manifestPath, basenames.map((entry) => `${entry}\n`).join(""), "utf8");
+        const zstd = await resolveCargoRegistryZstd();
+        await runPipe(["tar", ["-cf", "-", "-C", cargoHome, "-T", manifestPath]], [zstd, ["-T0", "-3", "-f", "-o", archivePath]]);
+    }
+    finally {
+        await fs.rm(manifestRoot, { recursive: true, force: true }).catch(() => undefined);
+    }
+}
+async function extractCargoRegistryExtrasArchive(cargoHome, archivePath) {
+    const zstd = await resolveCargoRegistryZstd();
+    await fs.mkdir(cargoHome, { recursive: true });
+    await runPipe([zstd, ["-d", "-T0", "-c", archivePath]], ["tar", ["-xf", "-", "-C", cargoHome]]);
+}
+async function cargoRegistryPayloadCensus(cargoHome, topN) {
+    const payload = await cargoRegistryPayloadPaths(cargoHome);
+    const roots = [payload.registry, ...payload.extras];
+    const topFiles = [];
+    const topDirectories = [];
+    const topSubtrees = [];
+    let bytes = 0;
+    let files = 0;
+    let symlinks = 0;
+    let directories = 0;
+    const walk = async (entry, relative) => {
+        let stat;
+        try {
+            stat = await fs.lstat(entry);
+        }
+        catch {
+            return { bytes: 0, files: 0 };
+        }
+        if (stat.isSymbolicLink()) {
+            symlinks += 1;
+            return { bytes: 0, files: 0 };
+        }
+        if (stat.isFile()) {
+            bytes += stat.size;
+            files += 1;
+            topFiles.push({ path: relative, bytes: stat.size });
+            return { bytes: stat.size, files: 1 };
+        }
+        if (!stat.isDirectory())
+            return { bytes: 0, files: 0 };
+        directories += 1;
+        let directoryBytes = 0;
+        let directoryFiles = 0;
+        for (const child of await fs.readdir(entry)) {
+            const childStats = await walk(path.join(entry, child), path.join(relative, child));
+            directoryBytes += childStats.bytes;
+            directoryFiles += childStats.files;
+        }
+        topDirectories.push({ path: relative, bytes: directoryBytes });
+        return { bytes: directoryBytes, files: directoryFiles };
+    };
+    for (const root of roots) {
+        const basename = path.basename(root);
+        const subtree = await walk(root, basename);
+        topSubtrees.push({ path: basename, bytes: subtree.bytes, files: subtree.files });
+    }
+    const limit = Math.max(0, Math.min(50, Math.floor(topN)));
+    topFiles.sort((a, b) => b.bytes - a.bytes || a.path.localeCompare(b.path));
+    topDirectories.sort((a, b) => b.bytes - a.bytes || a.path.localeCompare(b.path));
+    topSubtrees.sort((a, b) => b.bytes - a.bytes || a.path.localeCompare(b.path));
+    return {
+        bytes,
+        files,
+        symlinks,
+        directories,
+        inputs: roots.map((entry) => path.basename(entry)),
+        topFiles: topFiles.slice(0, limit),
+        topDirectories: topDirectories.slice(0, limit),
+        topSubtrees: topSubtrees.slice(0, limit),
+        skipped: [],
+    };
+}
+async function treeStats(target) {
+    let bytes = 0;
+    let files = 0;
+    const walk = async (entry) => {
+        let stat;
+        try {
+            stat = await fs.lstat(entry);
+        }
+        catch {
+            return;
+        }
+        if (stat.isDirectory()) {
+            for (const child of await fs.readdir(entry))
+                await walk(path.join(entry, child));
+        }
+        else if (stat.isFile()) {
+            bytes += stat.size;
+            files += 1;
+        }
+    };
+    await walk(target);
+    return { bytes, files };
+}
+async function payloadStats(cargoHome) {
+    const payload = await cargoRegistryPayloadPaths(cargoHome);
+    const roots = [payload.registry, ...payload.extras];
+    let bytes = 0;
+    let files = 0;
+    for (const root of roots) {
+        const stats = await treeStats(root);
+        bytes += stats.bytes;
+        files += stats.files;
+    }
+    return { bytes, files };
+}
+async function saveCargoRegistryArchive(input) {
+    const started = Date.now();
+    const payload = await cargoRegistryPayloadPaths(input.cargoHome);
+    if (input.plan.format !== "soldr-v2") {
+        return { used: false, codecPath: "legacy-v1", archiveBytes: 0, restoredBytes: 0, restoredFiles: 0, durationMs: 0 };
+    }
+    if (!(0, soldr_load_shim_js_1.semverGte)(input.soldrVersion, soldr_load_shim_js_1.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP)) {
+        return { used: false, codecPath: "unsupported", archiveBytes: 0, restoredBytes: 0, restoredFiles: 0, durationMs: 0 };
+    }
+    await fs.mkdir(path.dirname(input.plan.registryArchivePath), { recursive: true });
+    await Promise.all([
+        fs.rm(input.plan.registryArchivePath, { force: true }),
+        fs.rm(input.plan.extrasArchivePath, { force: true }),
+    ]);
+    const registrySaved = input.operations?.saveRegistry
+        ? await input.operations.saveRegistry(payload.registry, input.plan.registryArchivePath)
+        : (await (0, soldr_load_shim_js_1.saveViaSoldr)({
+            cacheDir: payload.registry,
+            archivePath: input.plan.registryArchivePath,
+            soldrPath: input.soldrPath,
+            soldrVersion: input.soldrVersion,
+            debug: input.debug,
+            log: input.log,
+        })).used;
+    if (!registrySaved) {
+        throw new Error("Soldr v2 cargo-registry save did not produce a registry archive");
+    }
+    if (input.operations?.saveExtras) {
+        await input.operations.saveExtras(input.cargoHome, payload.extras, input.plan.extrasArchivePath);
+    }
+    else {
+        await writeCargoRegistryExtrasArchive(input.cargoHome, payload.extras, input.plan.extrasArchivePath);
+    }
+    const registryBytes = (await fs.stat(input.plan.registryArchivePath)).size;
+    const extrasBytes = (await fs.stat(input.plan.extrasArchivePath)).size;
+    const stats = await payloadStats(input.cargoHome);
+    return {
+        used: true,
+        codecPath: "soldr-v2",
+        archiveBytes: registryBytes + extrasBytes,
+        restoredBytes: stats.bytes,
+        restoredFiles: stats.files,
+        durationMs: Date.now() - started,
+    };
+}
+async function restoreCargoRegistryArchive(input) {
+    const started = Date.now();
+    if (input.plan.format === "legacy-v1") {
+        const result = await (0, cache_compress_js_1.decompressCache)({
+            archivePath: input.plan.registryArchivePath,
+            targetDir: path.join(input.cargoHome, "registry"),
+            cacheKey: input.cacheKey,
+            debug: input.debug,
+            log: input.log,
+        });
+        return {
+            used: true,
+            codecPath: "legacy-v1",
+            archiveBytes: result.archiveBytes,
+            restoredBytes: result.inflatedBytes,
+            restoredFiles: result.fileCount,
+            durationMs: Date.now() - started,
+        };
+    }
+    if (!(0, soldr_load_shim_js_1.semverGte)(input.soldrVersion, soldr_load_shim_js_1.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP)) {
+        return { used: false, codecPath: "unsupported", archiveBytes: 0, restoredBytes: 0, restoredFiles: 0, durationMs: 0 };
+    }
+    const registryLoaded = input.operations?.restoreRegistry
+        ? await input.operations.restoreRegistry(input.plan.registryArchivePath, path.join(input.cargoHome, "registry"))
+        : (await (0, soldr_load_shim_js_1.tryLoadViaSoldr)({
+            archivePath: input.plan.registryArchivePath,
+            targetDir: path.join(input.cargoHome, "registry"),
+            soldrPath: input.soldrPath,
+            soldrVersion: input.soldrVersion,
+            autoDefenderExclude: input.autoDefenderExclude,
+            debug: input.debug,
+            log: input.log,
+        })).used;
+    if (!registryLoaded) {
+        throw new Error("Soldr v2 cargo-registry archive is corrupt or incompatible");
+    }
+    if (await exists(input.plan.extrasArchivePath)) {
+        if (input.operations?.restoreExtras) {
+            await input.operations.restoreExtras(input.cargoHome, input.plan.extrasArchivePath);
+        }
+        else {
+            await extractCargoRegistryExtrasArchive(input.cargoHome, input.plan.extrasArchivePath);
+        }
+    }
+    const registryBytes = (await fs.stat(input.plan.registryArchivePath)).size;
+    const extrasBytes = await exists(input.plan.extrasArchivePath)
+        ? (await fs.stat(input.plan.extrasArchivePath)).size
+        : 0;
+    const stats = await payloadStats(input.cargoHome);
+    return {
+        used: true,
+        codecPath: "soldr-v2",
+        archiveBytes: registryBytes + extrasBytes,
+        restoredBytes: stats.bytes,
+        restoredFiles: stats.files,
+        durationMs: Date.now() - started,
+    };
+}
+
+
+/***/ }),
+
+/***/ 211:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -49661,7 +48278,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 214:
+/***/ 212:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49686,10 +48303,10 @@ __export(getClient_exports, {
   getClient: () => getClient
 });
 module.exports = __toCommonJS(getClient_exports);
-var import_clientHelpers = __nccwpck_require__(507);
-var import_sendRequest = __nccwpck_require__(462);
-var import_urlHelpers = __nccwpck_require__(333);
-var import_checkEnvironment = __nccwpck_require__(451);
+var import_clientHelpers = __nccwpck_require__(508);
+var import_sendRequest = __nccwpck_require__(463);
+var import_urlHelpers = __nccwpck_require__(331);
+var import_checkEnvironment = __nccwpck_require__(452);
 function getClient(endpoint, clientOptions = {}) {
   const pipeline = clientOptions.pipeline ?? (0, import_clientHelpers.createDefaultPipeline)(clientOptions);
   if (clientOptions.additionalPolicies?.length) {
@@ -49844,7 +48461,7 @@ function buildOperation(method, url, pipeline, options, allowInsecureConnection,
 
 /***/ }),
 
-/***/ 215:
+/***/ 213:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49869,8 +48486,8 @@ __export(httpClientAdapter_exports, {
   convertHttpClient: () => convertHttpClient
 });
 module.exports = __toCommonJS(httpClientAdapter_exports);
-var import_response = __nccwpck_require__(423);
-var import_util = __nccwpck_require__(115);
+var import_response = __nccwpck_require__(424);
+var import_util = __nccwpck_require__(112);
 function convertHttpClient(requestPolicyClient) {
   return {
     sendRequest: async (request) => {
@@ -49888,7 +48505,7 @@ function convertHttpClient(requestPolicyClient) {
 
 /***/ }),
 
-/***/ 216:
+/***/ 214:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49913,9 +48530,9 @@ __export(retryPolicy_exports, {
   retryPolicy: () => retryPolicy
 });
 module.exports = __toCommonJS(retryPolicy_exports);
-var import_logger = __nccwpck_require__(48);
-var import_constants = __nccwpck_require__(165);
-var import_policies = __nccwpck_require__(294);
+var import_logger = __nccwpck_require__(46);
+var import_constants = __nccwpck_require__(162);
+var import_policies = __nccwpck_require__(292);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("core-rest-pipeline retryPolicy");
 function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAULT_RETRY_POLICY_COUNT }) {
   return (0, import_policies.retryPolicy)(strategies, {
@@ -49929,7 +48546,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 
 /***/ }),
 
-/***/ 217:
+/***/ 215:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49938,7 +48555,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getErrorMessage = getErrorMessage;
-const util_1 = __nccwpck_require__(153);
+const util_1 = __nccwpck_require__(150);
 /**
  * Given what is thought to be an error object, return the message if possible.
  * If the message is missing, returns a stringified version of the input.
@@ -49969,7 +48586,1469 @@ function getErrorMessage(e) {
 
 /***/ }),
 
-/***/ 218:
+/***/ 216:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr entry point. Owned by Agent 2.
+//
+// Replaces the composite action's main-phase steps with a single JS
+// orchestrator. Calls the helpers in src/lib/* in the same order the
+// composite's steps fire.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.shouldSkipCargoRegistryExtractionError = shouldSkipCargoRegistryExtractionError;
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(255));
+const os = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(523));
+const core = __importStar(__nccwpck_require__(475));
+const cache = __importStar(__nccwpck_require__(217));
+const exec = __importStar(__nccwpck_require__(19));
+const log_utils_js_1 = __nccwpck_require__(193);
+const resolve_setup_js_1 = __nccwpck_require__(356);
+const phase_timing_js_1 = __nccwpck_require__(532);
+const ensure_rust_toolchain_js_1 = __nccwpck_require__(252);
+const ensure_soldr_js_1 = __nccwpck_require__(136);
+const verify_soldr_js_1 = __nccwpck_require__(363);
+const install_passthrough_js_1 = __nccwpck_require__(528);
+const normalize_source_mtime_js_1 = __nccwpck_require__(250);
+const detect_shared_target_warning_js_1 = __nccwpck_require__(226);
+const ensure_shims_js_1 = __nccwpck_require__(541);
+const zccache_seed_js_1 = __nccwpck_require__(87);
+const cache_compress_js_1 = __nccwpck_require__(481);
+const cargo_registry_archive_js_1 = __nccwpck_require__(210);
+const seed_isolated_cache_js_1 = __nccwpck_require__(302);
+const stats_collector_js_1 = __nccwpck_require__(450);
+const toolchain_snapshot_js_1 = __nccwpck_require__(474);
+const solo_toolchain_cache_js_1 = __nccwpck_require__(353);
+const cook_cache_js_1 = __nccwpck_require__(56);
+const soldr_mini_cache_js_1 = __nccwpck_require__(6);
+const diagnostics_js_1 = __nccwpck_require__(406);
+const shim_bypass_check_js_1 = __nccwpck_require__(319);
+const blessed_cross_prepare_js_1 = __nccwpck_require__(436);
+const target_lifecycle_js_1 = __nccwpck_require__(247);
+const source_mtime_snapshot_js_1 = __nccwpck_require__(473);
+/**
+ * Map (hit, matchedKey) → workflow-visible restore-status string.
+ * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
+ * for the `<layer>-cache-restore-status` outputs declared in action.yml.
+ */
+function deriveRestoreStatus(hit, matchedKey) {
+    if (hit)
+        return "exact-hit";
+    if (matchedKey.trim())
+        return "restore-key-hit";
+    return "miss";
+}
+function shouldSkipCargoRegistryExtractionError(err, format, onFailure) {
+    if (format !== "legacy-v1" || onFailure?.trim().toLowerCase() !== "skip")
+        return false;
+    const code = err?.code;
+    return code === "EAUTHFAIL" || code === "EENCNOKEY";
+}
+function writeCacheKeysManifest(result, runnerTemp, log) {
+    if (!runnerTemp)
+        return;
+    const keys = [
+        result.setupCache.key,
+        result.buildCache.key,
+        result.targetCache.key,
+        result.cargoRegistryCache.key,
+    ].filter((k) => Boolean(k));
+    if (keys.length === 0)
+        return;
+    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
+    try {
+        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
+        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
+    }
+    catch (err) {
+        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+function isTruthy(value) {
+    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
+}
+function isFalsy(value) {
+    return FALSY.has(((value ?? "").trim().toLowerCase()));
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+async function queryTargetPlan(soldrPath, target, log) {
+    const output = await exec.getExecOutput(soldrPath, ["env", "--target", target, "--json"], {
+        silent: true,
+        ignoreReturnCode: true,
+    });
+    if (output.exitCode !== 0) {
+        log(`target-plan: soldr env failed with exit ${output.exitCode}`);
+        return null;
+    }
+    const line = output.stdout.split(/\r?\n/).map((value) => value.trim()).filter(Boolean).at(-1);
+    if (!line)
+        return null;
+    try {
+        return JSON.parse(line);
+    }
+    catch {
+        log("target-plan: soldr env returned non-JSON output");
+        return null;
+    }
+}
+function publishTargetContract(result, contract, logger) {
+    const target = result.blessedPrepareCache.target;
+    if (!target)
+        return;
+    if (!contract.cacheIdentity)
+        throw new Error(`Soldr target plan for ${target} has no cache identity`);
+    (0, target_lifecycle_js_1.assertTargetOperationSupported)(contract, "prepare");
+    result.targetContract = contract;
+    const mergedEnvironment = (0, target_lifecycle_js_1.mergeTargetEnvironment)(process.env, contract.environment);
+    for (const key of Object.keys(contract.environment)) {
+        core.exportVariable(key, mergedEnvironment[key] ?? contract.environment[key]);
+    }
+    const outputs = (0, target_lifecycle_js_1.buildTargetOperationOutputs)(result.workspace, contract);
+    core.setOutput("target-plan-json", JSON.stringify(contract));
+    core.setOutput("target-capabilities-json", JSON.stringify({
+        schemaVersion: contract.schemaVersion,
+        canonicalTarget: contract.canonicalTarget,
+        cacheIdentity: contract.cacheIdentity,
+        supportedOperations: contract.supportedOperations,
+        toolchain: contract.toolchain,
+        platform: contract.platform,
+    }));
+    core.setOutput("target-env-json", JSON.stringify(contract.environment));
+    core.setOutput("target-cache-identity", contract.cacheIdentity);
+    core.setOutput("target-artifact-dir", outputs.artifactDirectory);
+    core.setOutput("target-build-hook", outputs.build);
+    core.setOutput("target-clippy-hook", outputs.clippy);
+    core.setOutput("target-test-hook", outputs.testNoRun);
+    core.setOutput("target-wheel-hook", outputs.pep517Wheel);
+    core.setOutput("target-sdist-hook", outputs.pep517Sdist);
+    core.saveState("targetPlanJson", JSON.stringify(contract));
+    logger.log(`target-plan: canonical=${contract.canonicalTarget} cache=${contract.cacheIdentity} operations=${contract.supportedOperations.join(",")}`);
+}
+function dirHasContent(p) {
+    try {
+        return fs.readdirSync(p).length > 0;
+    }
+    catch {
+        return false;
+    }
+}
+async function runGitCapture(workspace, args) {
+    let stdout = "";
+    let stderr = "";
+    const code = await exec.exec("git", ["-C", workspace, ...args], {
+        silent: true,
+        ignoreReturnCode: true,
+        listeners: {
+            stdout: (data) => { stdout += data.toString("utf8"); },
+            stderr: (data) => { stderr += data.toString("utf8"); },
+        },
+    });
+    return { code, stdout, stderr };
+}
+async function deriveParentSha(workspace, githubSha, logger) {
+    // #365: derive parent SHA so cook-cache-delta + target-cache +
+    // cargo-registry can fall back to the prior commit's saved
+    // entry. Returns "" on any error (no regression from prior
+    // behavior — caller treats "" as "no fallback").
+    //
+    // Strategy: try `git log -1 --format=%P HEAD` first. On a
+    // shallow clone (actions/checkout default fetch-depth=1) this
+    // returns empty for grafted root commits — fall back to
+    // `git cat-file -p HEAD` and parse the `parent` header lines
+    // from the raw commit object, which are preserved even when
+    // the parent commit object isn't present in the local repo.
+    // Pass 1: git log %P (works on full-depth checkouts).
+    try {
+        const { code, stdout, stderr } = await runGitCapture(workspace, [
+            "log", "-1", "--format=%P", "HEAD",
+        ]);
+        if (code === 0) {
+            const first = stdout.trim().split(/\s+/)[0] ?? "";
+            if (/^[0-9a-f]{7,40}$/i.test(first)) {
+                if (first === githubSha)
+                    return "";
+                logger.log(`parent-sha: derived ${first.slice(0, 12)} from git log (#365)`);
+                return first;
+            }
+            // empty / unparseable → fall through to cat-file
+        }
+        else {
+            logger.log(`parent-sha: git log exit=${code} stderr=${stderr.trim().slice(0, 120)}; trying cat-file`);
+        }
+    }
+    catch (err) {
+        logger.log(`parent-sha: git log threw (${err instanceof Error ? err.message : String(err)}); trying cat-file`);
+    }
+    // Pass 2: git cat-file -p HEAD (works on shallow clones — the
+    // commit object's `parent` header is preserved even when the
+    // parent commit isn't fetched).
+    try {
+        const { code, stdout, stderr } = await runGitCapture(workspace, [
+            "cat-file", "-p", "HEAD",
+        ]);
+        if (code !== 0) {
+            logger.log(`parent-sha: cat-file exit=${code} stderr=${stderr.trim().slice(0, 120)}; leaving empty`);
+            return "";
+        }
+        // Raw commit object format:
+        //   tree <sha>
+        //   parent <sha>      ← first parent (mainline)
+        //   parent <sha>      ← second parent (only for merges)
+        //   author ...
+        //   committer ...
+        //
+        //   <message>
+        for (const line of stdout.split("\n")) {
+            if (line.startsWith("parent ")) {
+                const sha = line.slice("parent ".length).trim();
+                if (/^[0-9a-f]{7,40}$/i.test(sha) && sha !== githubSha) {
+                    logger.log(`parent-sha: derived ${sha.slice(0, 12)} from cat-file (#365, shallow-safe)`);
+                    return sha;
+                }
+            }
+            if (line === "")
+                break; // header section ended
+        }
+        logger.log(`parent-sha: cat-file produced no usable parent (root commit?); leaving empty`);
+        return "";
+    }
+    catch (err) {
+        logger.log(`parent-sha: cat-file threw (${err instanceof Error ? err.message : String(err)}); leaving empty`);
+        return "";
+    }
+}
+async function buildActionContext() {
+    const env = process.env;
+    const logger = (0, log_utils_js_1.createLogger)(env);
+    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
+    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
+    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
+    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
+    const githubSha = env["GITHUB_SHA"]?.trim() || "";
+    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
+    // #365: parentSha enables cook-cache-delta + target-cache + cargo-
+    // registry to share entries across consecutive commits. The env
+    // override (ACTION_PARENT_SHA) lets a workflow set it explicitly;
+    // otherwise we derive it from `git log -1 --format=%P HEAD` so the
+    // fallback works out of the box for any repo with non-shallow
+    // checkout. Without this, every push-event run had the delta key
+    // mismatch the prior save (0% hit rate observed on zccache).
+    let parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
+    if (!parentSha && githubSha) {
+        parentSha = await deriveParentSha(workspace, githubSha, logger);
+    }
+    return {
+        env: { ...env },
+        workspace,
+        runnerTemp,
+        runnerOs,
+        runnerArch,
+        githubSha,
+        githubToken,
+        parentSha,
+        logger,
+    };
+}
+function actionRoot() {
+    const explicit = process.env["GITHUB_ACTION_PATH"]?.trim() || process.env["SETUP_SOLDR_ACTION_ROOT"]?.trim();
+    if (explicit)
+        return path.resolve(explicit);
+    const moduleDir = typeof __dirname === "string" ? __dirname : process.cwd();
+    return path.resolve(moduleDir, "..");
+}
+async function restoreCacheSafe(paths, key, restoreKeys, logger) {
+    if (paths.length === 0 || !key) {
+        return { hit: false, matchedKey: "" };
+    }
+    try {
+        const matched = await cache.restoreCache(paths, key, restoreKeys);
+        return { hit: matched === key, matchedKey: matched ?? "" };
+    }
+    catch (err) {
+        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "" };
+    }
+}
+async function run() {
+    const ctx = await buildActionContext();
+    const logger = ctx.logger;
+    await (0, phase_timing_js_1.markPhase)("action");
+    // ---- resolve ----
+    await (0, phase_timing_js_1.markPhase)("resolve");
+    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
+    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
+    await (0, resolve_setup_js_1.applyResolveResult)(result);
+    await (0, phase_timing_js_1.finishPhase)("resolve");
+    // Always emit the cache-keys manifest right after resolve so workflow
+    // steps that run between main and post (e.g. actions/upload-artifact)
+    // can read it. The four keys are fully determined by resolveSetup and
+    // never change later in the run.
+    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
+    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            logger,
+            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
+        });
+    }
+    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
+    if (dryRun) {
+        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
+        await (0, phase_timing_js_1.finishPhase)("action");
+        return;
+    }
+    // Persist resolve state for the post-job step.
+    core.saveState("resolveResult", JSON.stringify(result));
+    core.saveState("buildCacheMode", result.buildCache.mode);
+    core.saveState("logging", logging ? "true" : "false");
+    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
+    const statsMode = result.stats;
+    const debugMode = result.debugMode;
+    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
+    const statsCollector = new stats_collector_js_1.StatsCollector();
+    // ---- source-mtime-normalize ----
+    if (isTruthy(inputs.sourceMtimeNormalize)) {
+        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
+    }
+    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
+    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
+    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
+    core.saveState("setupCacheExactHit", "false");
+    core.saveState("setupCacheMatchedKey", "");
+    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
+    core.saveState("targetCacheExactHit", "false");
+    core.saveState("targetCacheMatchedKey", "");
+    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
+    core.saveState("buildCacheExactHit", "false");
+    core.saveState("buildCacheMatchedKey", "");
+    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
+    core.saveState("cargoRegistryCacheExactHit", "false");
+    core.saveState("cargoRegistryCacheMatchedKey", "");
+    core.saveState("dylintCacheEnabled", result.dylintCache.enabled ? "true" : "false");
+    core.saveState("dylintCacheExactHit", "false");
+    core.saveState("dylintCacheMatchedKey", "");
+    core.saveState("dylintOutputCacheEnabled", result.dylintCache.outputCacheEnabled ? "true" : "false");
+    core.saveState("dylintOutputCacheExactHit", "false");
+    core.saveState("dylintOutputCacheMatchedKey", "");
+    core.saveState("blessedPrepareCacheEnabled", result.blessedPrepareCache.enabled ? "true" : "false");
+    core.saveState("blessedPrepareCacheExactHit", "false");
+    core.saveState("blessedPrepareCacheMatchedKey", "");
+    core.saveState("blessedPrepareComplete", "false");
+    // ---- parallel restores ----
+    // setup-cache, target-cache, build-cache, and cargo-registry write to
+    // disjoint paths and have no inter-dependencies, so they run concurrently.
+    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
+    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
+    //
+    // Layers that must stay sequential (wired below): solo-toolchain (writes
+    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
+    // install dir, must precede ensureSoldr), cook (writes target/ and needs
+    // the soldr binary). Cargo-registry was previously after-cook — it's been
+    // moved into this parallel block because nothing the soldr install path
+    // touches depends on its hydrated cargo registry state.
+    await (0, phase_timing_js_1.markPhase)("parallel-restore");
+    let setupCacheExactHit = false;
+    // Capture target-cache match status so we can skip the redundant cook restore.
+    // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
+    // (~2.5 GB inflated) also contains compiled deps. When target-cache matched
+    // at the lockfile/shape/toolchain level (exact OR parent-SHA OR lock-prefix
+    // fallback), we have target/deps/ already populated with identical content —
+    // cook restore would just overwrite. Skipping saves ~5–10 s per warm run.
+    // A looser restoreKeyLockfile-only match (different shape) is NOT enough to
+    // skip cook, since cook output may differ across shapes.
+    let targetCacheMatchedKey = "";
+    const setupRestorePromise = (async () => {
+        if (!(cacheEnabled && result.setupCache.paths.length > 0))
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
+        setupCacheExactHit = restore.hit;
+        core.setOutput("cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("setup_cache_matched_key", restore.matchedKey);
+        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("setupCacheMatchedKey", restore.matchedKey);
+        // Expose for ensure_rust_toolchain to read via env. Must be visible by
+        // the time toolchain phase runs — guaranteed by the Promise.all below.
+        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
+        statsCollector.record({
+            label: "setup-cache", operation: "restore", hit: restore.hit,
+            key: result.setupCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.setupCache.restorePrefix],
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const targetRestorePromise = (async () => {
+        if (!result.targetCache.enabled)
+            return;
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (targetPaths.length === 0)
+            return;
+        const restoreKeys = [];
+        if (result.targetCache.restoreKeyParent)
+            restoreKeys.push(result.targetCache.restoreKeyParent);
+        if (result.targetCache.restoreKeyLock)
+            restoreKeys.push(result.targetCache.restoreKeyLock);
+        if (result.targetCache.restoreKeyLockfile)
+            restoreKeys.push(result.targetCache.restoreKeyLockfile);
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
+        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("target_cache_matched_key", restore.matchedKey);
+        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("targetCacheMatchedKey", restore.matchedKey);
+        targetCacheMatchedKey = restore.matchedKey;
+        statsCollector.record({
+            label: "target-cache", operation: "restore", hit: restore.hit,
+            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const buildRestorePromise = (async () => {
+        if (!buildCacheEnabled)
+            return;
+        const buildCachePath = result.buildCache.path;
+        const archivePath = `${buildCachePath}.tar.zst`;
+        const restoreKeys = [];
+        if (result.buildCache.restoreKeyParent)
+            restoreKeys.push(result.buildCache.restoreKeyParent);
+        if (result.buildCache.restoreKeyToolchain)
+            restoreKeys.push(result.buildCache.restoreKeyToolchain);
+        if (result.buildCache.restoreKeyOsArch)
+            restoreKeys.push(result.buildCache.restoreKeyOsArch);
+        const t0 = Date.now();
+        // @actions/cache hashes the `paths` array into a "version" key — save and
+        // restore MUST pass the same array or the lookup misses even when the
+        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
+        // restore must use the same single-path array. The decompression below
+        // unpacks archivePath → buildCachePath afterwards.
+        const restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
+        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("build_cache_matched_key", restore.matchedKey);
+        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("buildCacheMatchedKey", restore.matchedKey);
+        let buildArchiveBytes = null;
+        let buildInflatedBytes = null;
+        let buildFileCount = null;
+        if (fileExists(archivePath)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+            const haveEncryptKey = (process.env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] ?? "").trim().length > 0;
+            if (magic === "zstd" || magic === "gzip" || haveEncryptKey) {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({
+                        archivePath,
+                        targetDir: buildCachePath,
+                        debug: debugMode,
+                        log: debugLog,
+                        cacheKey: restore.matchedKey || result.buildCache.key,
+                    });
+                    buildArchiveBytes = dr.archiveBytes;
+                    buildInflatedBytes = dr.inflatedBytes;
+                    buildFileCount = dr.fileCount;
+                }
+                catch (err) {
+                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
+        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
+        // dir on the cold side; if it's present after decompress, walk it and
+        // set each matching source file's mtime to what cold saw. The replay
+        // is gated by (size, content-hash) match so we never overwrite a
+        // genuinely modified file's mtime — that would underbuild.
+        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
+            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
+            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
+            if (snapshot) {
+                const rt0 = Date.now();
+                try {
+                    // Match the project-root selection that post.ts uses when
+                    // writing the snapshot — the parent of the resolved target-dir,
+                    // not the (outer) GITHUB_WORKSPACE.
+                    const projectRoot = path.dirname(result.targetCache.targetPath);
+                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
+                        workspace: projectRoot,
+                        snapshot,
+                        log: (msg) => logger.log(msg),
+                    });
+                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
+                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
+                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
+                }
+                catch (err) {
+                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+            else {
+                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
+            }
+        }
+        statsCollector.record({
+            label: "build-cache", operation: "restore", hit: restore.hit,
+            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        // Seed an isolated SOLDR_CACHE_DIR from the just-restored build-cache
+        // artifact store (issue #240). Opt-in: only fires when the consumer
+        // declares the isolated root(s) it switches its self-test phase to, so a
+        // daemon-isolated coverage/integration phase starts warm instead of cold.
+        const seedTargets = (0, seed_isolated_cache_js_1.parseIsolatedSeedTargets)(inputs.seedIsolatedBuildCache);
+        if (seedTargets.length > 0) {
+            try {
+                (0, seed_isolated_cache_js_1.seedIsolatedBuildCache)({
+                    sourceZccacheDir: buildCachePath,
+                    targetSoldrRoots: seedTargets,
+                    log: (msg) => logger.log(msg),
+                });
+            }
+            catch (err) {
+                logger.log(`seed-isolated-build-cache: failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    })();
+    let cargoRegistryDownload = null;
+    // Download only. Archive extraction is deliberately deferred until after
+    // ensureSoldr() + runtime verification because soldr-v2 needs the installed
+    // binary and must never race its setup-cache/mini-cache restore.
+    const cargoRegistryRestorePromise = (async () => {
+        if (!result.cargoRegistryCache.enabled)
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.cargoRegistryCache.archive.restorePaths, result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
+        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
+        cargoRegistryDownload = { hit: restore.hit, matchedKey: restore.matchedKey, startedMs: t0 };
+    })();
+    const blessedPrepareRestorePromise = (async () => {
+        const plan = result.blessedPrepareCache;
+        if (!plan.enabled)
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(plan.archivePaths, plan.key, [], logger);
+        core.saveState("blessedPrepareCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("blessedPrepareCacheMatchedKey", restore.matchedKey);
+        core.setOutput("blessed-prepare-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("blessed-prepare-cache-key", plan.key);
+        statsCollector.record({
+            label: "blessed-prepare-cache", operation: "restore", hit: restore.hit,
+            key: plan.key, matchedKey: restore.matchedKey, restoreKeys: [],
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    })();
+    const dylintRestorePromise = (async () => {
+        if (!result.dylintCache.enabled)
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.dylintCache.paths, result.dylintCache.key, [], logger);
+        core.setOutput("dylint-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("dylint-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("dylint_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("dylint_cache_matched_key", restore.matchedKey);
+        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_HIT", restore.hit ? "true" : "false");
+        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_MATCHED_KEY", restore.matchedKey);
+        core.saveState("dylintCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("dylintCacheMatchedKey", restore.matchedKey);
+        statsCollector.record({
+            label: "dylint-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: result.dylintCache.key,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - t0,
+            timestamp: new Date().toISOString(),
+        });
+        logger.log(`dylint-cache: key=${result.dylintCache.key} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const dylintOutputRestorePromise = (async () => {
+        if (!result.dylintCache.outputCacheEnabled || result.dylintCache.outputPaths.length === 0) {
+            return;
+        }
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.dylintCache.outputPaths, result.dylintCache.outputKey, [], logger);
+        core.setOutput("dylint-output-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("dylint-output-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.saveState("dylintOutputCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("dylintOutputCacheMatchedKey", restore.matchedKey);
+        statsCollector.record({
+            label: "dylint-output-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: result.dylintCache.outputKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - t0,
+            timestamp: new Date().toISOString(),
+        });
+        logger.log(`dylint-output-cache: key=${result.dylintCache.outputKey} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
+    // try/catches, so this should only see rejections for genuine programming
+    // bugs.
+    await Promise.all([
+        setupRestorePromise,
+        targetRestorePromise,
+        buildRestorePromise,
+        cargoRegistryRestorePromise,
+        blessedPrepareRestorePromise,
+        dylintRestorePromise,
+        dylintOutputRestorePromise,
+    ]);
+    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
+    // ---- target-tree-cache (full mode) ----
+    // The bundle path is included in target-cache restore paths above when full
+    // mode is requested, so there's no separate restore here. We keep the phase
+    // marker for parity with the composite step ordering.
+    await (0, phase_timing_js_1.markPhase)("target-tree");
+    await (0, phase_timing_js_1.finishPhase)("target-tree");
+    // Plan soldr-mini-cache restore now, but perform the extract inside the
+    // install phase. Restoring this layer in the background can rewrite the
+    // install dir while later phases spawn PATH tools, which surfaced as Linux
+    // ETXTBSY on the warm demo after soldr-cook started invoking soldr earlier.
+    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
+    const miniInstallDir = path.dirname(result.soldrPath);
+    const miniArchive = `${miniInstallDir}.tar.zst`;
+    let miniHit = false;
+    let miniKey = "";
+    let miniSkipReason = "";
+    let miniRestoreEligible = false;
+    if (miniEnabled) {
+        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
+            hasRef: Boolean(result.soldrRef.trim()),
+            enable: result.enabled,
+            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
+        });
+        if (eligibility.eligible) {
+            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
+            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
+                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+                soldrVersion: version,
+            });
+            miniRestoreEligible = true;
+            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir}`);
+        }
+        else {
+            miniSkipReason = eligibility.reason;
+        }
+    }
+    // Kick off cook restore in the background. It overlaps with the
+    // sequential toolchain + soldr install + shims + verify steps that
+    // follow. By the time the cook phase runs, the restore is done — we
+    // just await the promise. Saves ~5–7 s of warm-build wall clock.
+    //
+    // Why this is safe (vs the disastrous PR #145 which added cook to the
+    // BIG parallel block): cook now races with SMALL ops (rust install
+    // ~1–2 s, soldr install ~2–3 s, shims/verify ~1–2 s). Those don't
+    // contend on disk write bandwidth the way target/build/cargo-registry
+    // restores did. Cook's 2.5 GB tar write becomes the long pole and
+    // hides behind the small ops.
+    //
+    // SAFETY: when target-cache writes to target/ (build-cache-mode: full),
+    // cook restore would race with target-cache restore on the same dir.
+    // The parallel-restore block above already finished target-cache, but
+    // we still want a runtime gate just in case the mode changes.
+    const cookGate = (0, cook_cache_js_1.decideCookGate)({
+        prebuildDeps: inputs.prebuildDeps,
+        cacheUmbrella: cacheEnabled,
+        lockfilePath: result.targetCache.lockfilePath,
+    });
+    const cookActive = cookGate.enabled && result.enabled;
+    let cookFlags = [];
+    let cookKey = "";
+    let cookBaseKey = "";
+    let cookDeltaKey = "";
+    let cookDeltaParentKey = "";
+    let cookDeltaRestoreKeys = [];
+    let cookProjectRoot = "";
+    let cookTargetDir = "";
+    let cookArchive = "";
+    let cookBaseArchive = "";
+    let cookDeltaArchive = "";
+    let cookBaseManifest = "";
+    let cookLayered = false;
+    let cookRestoreT0 = Date.now();
+    let cookRestorePromise = null;
+    let cookLayeredRestorePromise = null;
+    // Skip cook restore when target-cache matched at the lockfile/shape level.
+    // restoreKeyLock = `${prefix}-${targetInputsHash}-${suffix}-` where
+    // targetInputsHash = sha256(toolchain, lockfile, manifest, shape). A
+    // matchedKey starting with restoreKeyLock means the cached entry was built
+    // with the same toolchain + lockfile + shape — its target/deps/ matches
+    // what cook would restore. Covers:
+    //   - exact hit  (matchedKey === current key, also startsWith restoreKeyLock)
+    //   - parent-SHA hit (matchedKey === restoreKeyParent, also startsWith)
+    //   - lock-prefix fallback (any saved entry with same lockfile+shape)
+    // Does NOT cover restoreKeyLockfile fallback (shorter prefix that drops
+    // shape) — different shape may mean different cook output, so cook still
+    // runs there as the safety net.
+    const targetCacheLockMatch = !!targetCacheMatchedKey &&
+        !!result.targetCache.restoreKeyLock &&
+        targetCacheMatchedKey.startsWith(result.targetCache.restoreKeyLock);
+    const cookSkippedDueToTargetHit = cookActive && targetCacheLockMatch;
+    if (cookActive && !cookSkippedDueToTargetHit) {
+        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
+        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
+        const lockHash = result.targetCache.lockfileHash || "no-lock";
+        const cookKeyParts = {
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            flagsHash,
+            lockHash,
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        };
+        cookProjectRoot = path.dirname(result.targetCache.targetPath);
+        cookTargetDir = result.targetCache.targetPath;
+        cookRestoreT0 = Date.now();
+        const deltaInput = inputs.prebuildDepsDeltaCache.trim() || "true";
+        const deltaRequested = !isFalsy(deltaInput);
+        const soldrVersionForCook = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
+        cookLayered = deltaRequested && (0, cook_cache_js_1.supportsLayeredCookCache)(soldrVersionForCook);
+        if (cookLayered) {
+            const shapeHash = (0, cook_cache_js_1.hashCookBuildShape)(result.targetCache.restoreKeyLock || result.targetCache.key);
+            cookBaseKey = (0, cook_cache_js_1.buildCookBaseCacheKey)(cookKeyParts);
+            cookDeltaKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
+                ...cookKeyParts,
+                buildShapeHash: shapeHash,
+                githubSha: ctx.githubSha || "nosha",
+            });
+            if (ctx.parentSha && ctx.parentSha !== ctx.githubSha) {
+                cookDeltaParentKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
+                    ...cookKeyParts,
+                    buildShapeHash: shapeHash,
+                    githubSha: ctx.parentSha,
+                });
+            }
+            cookDeltaRestoreKeys = cookDeltaParentKey ? [cookDeltaParentKey] : [];
+            cookDeltaRestoreKeys.push((0, cook_cache_js_1.buildCookDeltaCacheRestorePrefix)({
+                ...cookKeyParts,
+                buildShapeHash: shapeHash,
+            }));
+            cookBaseArchive = `${cookTargetDir}.soldr-base.tar.zst`;
+            cookDeltaArchive = `${cookTargetDir}.soldr-delta.tar.zst`;
+            cookBaseManifest = `${cookTargetDir}.soldr-base-manifest.pb`;
+            logger.log(`cook: layered keys base=${cookBaseKey} delta=${cookDeltaKey}` +
+                (cookDeltaParentKey ? ` delta-fallback=${cookDeltaParentKey}` : ` (no parent-fallback — parentSha unavailable, #365)`) +
+                ` delta-prefix=${cookDeltaRestoreKeys.at(-1)}` +
+                ` starting archive restore concurrent with install`);
+            cookLayeredRestorePromise = (0, cook_cache_js_1.restoreLayeredCookCacheArchives)({
+                baseKey: cookBaseKey,
+                deltaKey: cookDeltaKey,
+                deltaRestoreKeys: cookDeltaRestoreKeys,
+                baseArchivePath: cookBaseArchive,
+                deltaArchivePath: cookDeltaArchive,
+                log: (msg) => logger.log(msg),
+            });
+        }
+        else {
+            if (deltaRequested) {
+                logger.log(`cook: layered cache requires soldr >=0.7.38; ` +
+                    `version=${soldrVersionForCook || "unknown"} falling back to legacy cook cache`);
+            }
+            else {
+                logger.log("cook: layered cache disabled via prebuild-deps-delta-cache=false");
+            }
+            cookKey = (0, cook_cache_js_1.buildCookCacheKey)(cookKeyParts);
+            cookArchive = `${cookTargetDir}.tar.zst`;
+            logger.log(`cook: key=${cookKey} starting background restore concurrent with install`);
+            cookRestorePromise = (0, cook_cache_js_1.restoreCookCache)({
+                exactKey: cookKey,
+                archivePath: cookArchive,
+                targetDir: cookTargetDir,
+                longWindow: 27,
+                debug: debugMode,
+                log: (msg) => logger.log(msg),
+            });
+        }
+    }
+    // ---- toolchain ----
+    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
+    // toolchain install so we can see which inodes setup-soldr added on
+    // top of the runner image. When solo-toolchain-cache is opted in, a
+    // third snapshot is taken *before* the cache restore so the saved
+    // tarball captures the full above-runner state — not just the
+    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
+    // lifetime axis".
+    await (0, phase_timing_js_1.markPhase)("toolchain");
+    const snapshotRoots = [
+        path.join(result.rustupHome, "toolchains"),
+        path.join(result.cargoHome, "bin"),
+    ];
+    const soloRootMap = {
+        "rustup-toolchains": snapshotRoots[0],
+        "cargo-bin": snapshotRoots[1],
+    };
+    const soloEnabled = isTruthy(inputs.soloToolchainCache);
+    // #310: default-changed from "19" → "9". Measured first-save cost
+    // dropped from ~104s → ~12s on 140 MB toolchain delta; restore stays
+    // bandwidth-bound either way.
+    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "9");
+    let soloKeys = null;
+    let soloMatchedKey = "";
+    let soloExactHit = false;
+    let forceToolchainRepair = false;
+    // Pre-restore snapshot — only needed when solo cache is enabled, so
+    // we can compute the full save-diff (post-install vs runner-image,
+    // not vs post-restore baseline). (#302: timed as sub-phase.)
+    const preRestoreSnapshot = soloEnabled
+        ? await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-pre", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots))
+        : null;
+    if (soloEnabled) {
+        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
+            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        });
+        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
+        const restoreT0 = Date.now();
+        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
+        const restored = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "solo-restore", () => (0, solo_toolchain_cache_js_1.restoreSoloCache)({
+            keys: soloKeys,
+            rootMap: soloRootMap,
+            stagingDir,
+            log: (msg) => logger.log(msg),
+            // #316 follow-up: pass canonical archive path explicitly so
+            // save and restore agree regardless of stagingDir layout.
+            cacheArchivePath: (0, solo_toolchain_cache_js_1.soloCacheArchivePath)(ctx.runnerTemp),
+        }));
+        soloMatchedKey = restored.matchedKey;
+        let verifiedMatch = true;
+        if (restored.verified && restored.matchedKey) {
+            const expected = result.toolchain.cacheChannel.trim();
+            // The rustup home is set up so `rustc` will resolve through the
+            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
+            // the cargo bin one.
+            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
+            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
+                expectedRelease: expected,
+                expectedTargets: result.toolchain.targets,
+                rustcCommand: rustcCmd,
+                log: (msg) => logger.log(msg),
+            });
+            verifiedMatch = verify.match;
+            forceToolchainRepair = restored.verified && !verify.match;
+        }
+        soloExactHit = restored.hit && verifiedMatch;
+        core.saveState("soloToolchainEnabled", "true");
+        core.saveState("soloToolchainExactKey", soloKeys.exact);
+        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
+        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
+        core.saveState("soloToolchainLevel", soloLevel);
+        statsCollector.record({
+            label: "solo-toolchain-cache",
+            operation: "restore",
+            hit: soloExactHit,
+            key: soloKeys.exact,
+            matchedKey: soloMatchedKey,
+            restoreKeys: soloKeys.fallbacks,
+            archiveBytes: restored.restoredBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - restoreT0,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    else {
+        core.saveState("soloToolchainEnabled", "false");
+    }
+    const baselineSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-base", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
+    // #323: when solo-cache exact-hit AND verifyRestoredToolchain
+    // passed, the requested toolchain is already on disk from the
+    // restore. `rustup toolchain install` would be a no-op but still
+    // costs ~8s on hosted runners (self-update check, metadata fetch,
+    // profile diff). Skip the install entirely on the verified
+    // exact-hit path. The snapshot still runs so cache-save logic
+    // downstream sees an unchanged tree (install-delta empty).
+    if (soloExactHit) {
+        logger.log("toolchain: solo-cache exact-hit + verified — skipping rustup install (#323)");
+        // The restored tree is already valid, but the skipped installer is also
+        // where ensureRustToolchain normally exports the selected channel. Keep
+        // cache-hit jobs explicit so rustup proxies used by later probes never
+        // depend on a runner-global default toolchain.
+        core.exportVariable("RUSTUP_TOOLCHAIN", result.toolchain.channel);
+        process.env["RUSTUP_TOOLCHAIN"] = result.toolchain.channel;
+    }
+    else {
+        await (0, phase_timing_js_1.timeSubPhase)("toolchain", "rustup-install", () => (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({
+            resolveResult: result,
+            setupCacheExactHit,
+            forceRepair: forceToolchainRepair,
+        }));
+    }
+    const postInstallSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-post", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
+    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
+    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
+    // When solo cache is enabled, also compute the save-diff (post-install
+    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
+    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
+        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
+        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
+        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
+        try {
+            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
+            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
+            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
+            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
+                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
+                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
+                `incremental-empty=${toolchainDiff.added.length === 0}`);
+        }
+        catch (err) {
+            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
+        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
+    if (ctx.runnerTemp) {
+        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
+        try {
+            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
+            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
+        }
+        catch (err) {
+            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    await (0, phase_timing_js_1.finishPhase)("toolchain");
+    // ---- install soldr ----
+    // Restore soldr-mini-cache synchronously so the install dir is quiescent
+    // before ensureSoldr's installedVersion() check or any later soldr spawn.
+    await (0, phase_timing_js_1.markPhase)("install");
+    if (miniRestoreEligible) {
+        const miniT0 = Date.now();
+        const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
+            exactKey: miniKey,
+            installDir: miniInstallDir,
+            archivePath: miniArchive,
+            longWindow: 27,
+            debug: debugMode,
+            log: (msg) => logger.log(msg),
+        });
+        miniHit = restore.hit;
+        statsCollector.record({
+            label: "soldr-mini-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: miniKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - miniT0,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    else if (miniSkipReason) {
+        logger.log(`soldr-mini-cache: skipped — ${miniSkipReason}`);
+    }
+    else if (!miniEnabled) {
+        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
+    }
+    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
+    core.saveState("soldrMiniExactKey", miniKey);
+    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
+    core.saveState("soldrMiniInstallDir", miniInstallDir);
+    core.saveState("soldrMiniArchive", miniArchive);
+    if (result.enabled) {
+        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
+        // restored binary at the expected path with the expected version and
+        // short-circuits — no GH fetch.
+        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
+    }
+    else {
+        (0, install_passthrough_js_1.installPassthrough)({
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
+            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
+            "verbatim, and soldr-aware caching/observability is disabled.");
+    }
+    await (0, phase_timing_js_1.finishPhase)("install");
+    // ---- zccache-seed ----
+    // Pin setup-soldr's zccache before user workflow steps. The pinned
+    // install is home-anchored inside soldr, so later self-tests can isolate
+    // SOLDR_CACHE_DIR without repeating release lookup or cargo-install fallback.
+    await (0, phase_timing_js_1.markPhase)("zccache-seed");
+    await (0, zccache_seed_js_1.seedZccache)({
+        soldrPath: result.soldrPath,
+        actionRoot: actionRoot(),
+        enabled: result.enabled,
+        strict: isTruthy(inputs.zccacheSeedStrict),
+        log: (msg) => logger.log(msg),
+        warn: (msg) => logger.warning(msg),
+    });
+    await (0, phase_timing_js_1.finishPhase)("zccache-seed");
+    // Export SOLDR_BINARY so shims can exec it directly
+    core.exportVariable("SOLDR_BINARY", result.soldrPath);
+    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
+    // ---- shims ----
+    if (result.shimsEnabled) {
+        await (0, ensure_shims_js_1.ensureShims)({
+            shimsDir: result.shimsDir,
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+    }
+    // ---- verify ----
+    await (0, phase_timing_js_1.markPhase)("verify");
+    let soldrRuntimeVersion = "passthrough";
+    if (result.enabled) {
+        const verify = await (0, verify_soldr_js_1.verifySoldr)({
+            soldrPath: result.soldrPath,
+            buildCacheMode: result.buildCache.mode,
+            requireRustPlan: result.targetCache.enabled,
+            minimumVersion: result.blessedPrepareCache.target ? "0.8.39" : undefined,
+        });
+        core.setOutput("soldr-version", verify.soldrVersion);
+        core.setOutput("soldr_version", verify.soldrVersion);
+        soldrRuntimeVersion = verify.soldrVersion;
+        core.saveState("soldrRuntimeVersion", verify.soldrVersion);
+    }
+    else {
+        core.setOutput("soldr-version", "passthrough");
+        core.setOutput("soldr_version", "passthrough");
+    }
+    await (0, phase_timing_js_1.finishPhase)("verify");
+    // ---- cargo-registry extraction ----
+    // Network download overlapped other layers in parallel-restore. Extraction
+    // starts only after the Soldr binary has been installed and runtime-verified.
+    await (0, phase_timing_js_1.markPhase)("cargo-registry-extract");
+    const registryDownload = cargoRegistryDownload;
+    if (registryDownload) {
+        let archiveBytes = null;
+        let restoredBytes = null;
+        let restoredFiles = null;
+        let restoredHit = registryDownload.hit;
+        let matched = registryDownload.matchedKey;
+        const markRegistryMiss = () => {
+            restoredHit = false;
+            matched = "";
+            core.setOutput("cargo-registry-cache-hit", "false");
+            core.setOutput("cargo_registry_cache_hit", "false");
+            core.saveState("cargoRegistryCacheExactHit", "false");
+            core.saveState("cargoRegistryCacheMatchedKey", "");
+        };
+        if (matched) {
+            try {
+                const archiveResult = await (0, cargo_registry_archive_js_1.restoreCargoRegistryArchive)({
+                    plan: result.cargoRegistryCache.archive,
+                    cargoHome: result.cargoHome,
+                    soldrPath: result.soldrPath,
+                    soldrVersion: soldrRuntimeVersion,
+                    cacheKey: matched,
+                    autoDefenderExclude: process.platform === "win32",
+                    debug: debugMode,
+                    log: debugLog,
+                });
+                if (!archiveResult.used) {
+                    logger.log(`cargo-registry: ${archiveResult.codecPath} unavailable for runtime Soldr ${soldrRuntimeVersion}; treating restored entry as a miss`);
+                    markRegistryMiss();
+                }
+                else {
+                    archiveBytes = archiveResult.archiveBytes;
+                    restoredBytes = archiveResult.restoredBytes;
+                    restoredFiles = archiveResult.restoredFiles;
+                    logger.log(`cargo-registry: extracted format=${archiveResult.codecPath} archive_bytes=${archiveBytes} restored_bytes=${restoredBytes} files=${restoredFiles} duration_ms=${archiveResult.durationMs}`);
+                }
+            }
+            catch (err) {
+                if (shouldSkipCargoRegistryExtractionError(err, result.cargoRegistryCache.archive.format, process.env["SETUP_SOLDR_CACHE_ENCRYPT_ON_FAILURE"])) {
+                    core.warning(`cargo-registry encrypted archive could not be restored; cache-encrypt-on-failure=skip treats it as a cold miss: ${err instanceof Error ? err.message : String(err)}`);
+                    markRegistryMiss();
+                }
+                else {
+                    throw new Error(`cargo-registry archive extraction failed for ${registryDownload.hit ? "exact-hit" : "fallback-hit"} ${matched}: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+        statsCollector.record({
+            label: `cargo-registry-${result.cargoRegistryCache.archive.format}`,
+            operation: "restore",
+            hit: restoredHit,
+            key: result.cargoRegistryCache.key,
+            matchedKey: matched,
+            restoreKeys: [result.cargoRegistryCache.restorePrefix],
+            archiveBytes,
+            inflatedBytes: restoredBytes,
+            fileCount: restoredFiles,
+            durationMs: Date.now() - registryDownload.startedMs,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    await (0, phase_timing_js_1.finishPhase)("cargo-registry-extract");
+    // ---- cross-prepare ----
+    await (0, phase_timing_js_1.markPhase)("cross-prepare");
+    const preparePlan = result.blessedPrepareCache;
+    if (preparePlan.target) {
+        if (!result.enabled)
+            throw new Error("cross-targets requires enable: true");
+        const installedVersion = result.soldrVersionResolved || result.soldrVersionRequested;
+        (0, blessed_cross_prepare_js_1.assertMinimumSoldrVersion)(installedVersion);
+        const exactHit = core.getState("blessedPrepareCacheExactHit") === "true";
+        const prepareTargets = (0, blessed_cross_prepare_js_1.prepareTargetsFor)(preparePlan.target);
+        const archivesExist = preparePlan.archivePaths.length === prepareTargets.length
+            && preparePlan.archivePaths.every((archivePath) => fs.existsSync(archivePath));
+        const effectiveExactHit = exactHit && archivesExist;
+        if (exactHit && !archivesExist) {
+            logger.log("cross-prepare: exact cache key restored without every prepared archive; reseeding");
+            core.saveState("blessedPrepareCacheExactHit", "false");
+            core.setOutput("blessed-prepare-cache-hit", "false");
+        }
+        logger.log(`cross-prepare: target=${preparePlan.target} cache=${preparePlan.enabled ? (effectiveExactHit ? "hit" : "miss") : "disabled"}`);
+        const contracts = [];
+        for (const [index, target] of prepareTargets.entries()) {
+            await (0, blessed_cross_prepare_js_1.executeBlessedPrepare)({
+                soldrPath: result.soldrPath,
+                target,
+                githubEnv: process.env["GITHUB_ENV"],
+                archivePath: preparePlan.archivePaths[index],
+                restore: preparePlan.enabled && effectiveExactHit,
+                save: preparePlan.enabled && !effectiveExactHit,
+            });
+            const targetPlan = await queryTargetPlan(result.soldrPath, target, (message) => logger.log(message));
+            if (!targetPlan) {
+                throw new Error(`Soldr did not report a machine-readable target plan for ${target}; target capability is unavailable`);
+            }
+            contracts.push((0, target_lifecycle_js_1.normalizeTargetPlan)(target, targetPlan));
+        }
+        const contract = preparePlan.target === "universal2-apple-darwin"
+            ? (0, target_lifecycle_js_1.buildUniversal2TargetContract)(contracts)
+            : contracts[0];
+        publishTargetContract(result, contract, logger);
+        core.saveState("blessedPrepareComplete", "true");
+    }
+    await (0, phase_timing_js_1.finishPhase)("cross-prepare");
+    // ---- cook (prebuild-deps via soldr-cook) ----
+    // The RESTORE was kicked off as a background promise right after the
+    // parallel-restore block above — we just await its result here. The
+    // RUN (`soldr cook`) still happens in this phase if
+    // the restore missed.
+    // Failures here are logged but never fail the action — the user's
+    // own cargo build will still work without the cooked deps.
+    await (0, phase_timing_js_1.markPhase)("cook");
+    if (cookActive && cookLayeredRestorePromise) {
+        const restore = await cookLayeredRestorePromise;
+        const loaded = await (0, cook_cache_js_1.loadLayeredCookCache)({
+            soldrBinary: result.soldrPath,
+            projectRoot: cookProjectRoot,
+            targetDir: cookTargetDir,
+            baseArchivePath: cookBaseArchive,
+            deltaArchivePath: cookDeltaArchive,
+            baseManifestPath: cookBaseManifest,
+            restore,
+            log: (msg) => logger.log(msg),
+        });
+        const baseReady = (0, cook_cache_js_1.layeredCookBaseReady)(restore, loaded);
+        const deltaReady = (0, cook_cache_js_1.layeredCookDeltaReady)(restore, loaded);
+        statsCollector.record({
+            label: "cook-cache-base",
+            operation: "restore",
+            hit: baseReady,
+            key: cookBaseKey,
+            matchedKey: restore.base.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.base.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: loaded.baseReport?.cacheFilesRestored ?? null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        statsCollector.record({
+            label: "cook-cache-delta",
+            operation: "restore",
+            hit: deltaReady,
+            key: cookDeltaKey,
+            matchedKey: restore.delta.matchedKey,
+            restoreKeys: cookDeltaRestoreKeys,
+            archiveBytes: restore.delta.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: loaded.deltaReport?.cacheFilesRestored ?? null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        let cookRan = false;
+        if (!deltaReady) {
+            const runRes = await (0, cook_cache_js_1.runCook)({
+                soldrBinary: result.soldrPath,
+                projectRoot: cookProjectRoot,
+                flags: cookFlags,
+                log: (msg) => logger.log(msg),
+            });
+            cookRan = runRes.exitCode === 0;
+        }
+        else {
+            logger.log("cook: base+delta cache hit - skipping cook run, target/deps already warm");
+        }
+        const cookSaveLayer = cookRan ? (baseReady ? "delta" : "base") : "none";
+        core.saveState("cookEnabled", "true");
+        core.saveState("cookLayered", "true");
+        core.saveState("cookBaseExactKey", cookBaseKey);
+        core.saveState("cookDeltaExactKey", cookDeltaKey);
+        core.saveState("cookBaseMatchedKey", restore.base.matchedKey);
+        core.saveState("cookDeltaMatchedKey", restore.delta.matchedKey);
+        core.saveState("cookBaseHit", baseReady ? "true" : "false");
+        core.saveState("cookDeltaHit", deltaReady ? "true" : "false");
+        core.saveState("cookHit", deltaReady ? "true" : "false");
+        core.saveState("cookRan", cookRan ? "true" : "false");
+        core.saveState("cookSaveLayer", cookSaveLayer);
+        core.saveState("cookProjectRoot", cookProjectRoot);
+        core.saveState("cookTargetDir", cookTargetDir);
+        core.saveState("cookBaseArchive", cookBaseArchive);
+        core.saveState("cookDeltaArchive", cookDeltaArchive);
+        core.saveState("cookBaseManifest", cookBaseManifest);
+        core.saveState("cookSoldrBinary", result.soldrPath);
+        // #268/#358: cook-cache-base previously used zstd-level 19, but
+        // production observation showed 165s of compress wall-clock per
+        // matrix job for ~224 MB output. In a 5-way matrix where 1 job
+        // wins the cache reservation and 4 lose the race, that's 660s
+        // of post-step CPU wasted per CI cycle. Lowering to -9 cuts the
+        // compress wall-clock ~4× (target ~40s) at the cost of ~25%
+        // larger archive (~280 MB) and ~1s extra upload wall-clock per
+        // save. zstd decompression speed is level-independent, so warm
+        // restores are unaffected. Net: ~125s win per save-attempt, big
+        // multiplier on race-loss scenarios.
+        core.saveState("cookCompressLevel", "9");
+        core.saveState("cookDeltaCompressLevel", "3");
+    }
+    else if (cookActive && cookRestorePromise) {
+        const restore = await cookRestorePromise;
+        statsCollector.record({
+            label: "cook-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: cookKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        let cookRan = false;
+        if (!restore.hit) {
+            const runRes = await (0, cook_cache_js_1.runCook)({
+                soldrBinary: result.soldrPath,
+                projectRoot: cookProjectRoot,
+                flags: cookFlags,
+                log: (msg) => logger.log(msg),
+            });
+            cookRan = runRes.exitCode === 0;
+        }
+        else {
+            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
+        }
+        core.saveState("cookEnabled", "true");
+        core.saveState("cookLayered", "false");
+        core.saveState("cookExactKey", cookKey);
+        core.saveState("cookMatchedKey", restore.matchedKey);
+        core.saveState("cookHit", restore.hit ? "true" : "false");
+        core.saveState("cookRan", cookRan ? "true" : "false");
+        core.saveState("cookTargetDir", cookTargetDir);
+        core.saveState("cookLongWindow", "27");
+        // #268/#358: see saveState("cookCompressLevel", "9") above for
+        // rationale on lowering from -19. Same logic applies to the
+        // non-layered path.
+        core.saveState("cookCompressLevel", "9");
+    }
+    else if (cookSkippedDueToTargetHit) {
+        logger.log(`cook: skipped - target-cache matched at lockfile/shape level (matched=${targetCacheMatchedKey}); cook output would be redundant`);
+        core.saveState("cookEnabled", "false");
+        core.saveState("cookLayered", "false");
+    }
+    else {
+        logger.log(`cook: skipped - ${cookGate.reason}`);
+        core.saveState("cookEnabled", "false");
+        core.saveState("cookLayered", "false");
+    }
+    await (0, phase_timing_js_1.finishPhase)("cook");
+    // ---- shared-target warning ----
+    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
+        buildCacheEnabled,
+        effectiveTargetCacheEnabled: result.targetCache.enabled,
+        buildCacheMode: result.buildCache.mode,
+        targetDir: result.targetCache.targetPath,
+        soldrPath: result.soldrPath,
+    });
+    // ---- shim-bypass diagnostic ----
+    // Issue #160: when shims: true is requested but the effective environment
+    // (PATH ordering, CARGO/RUSTC/RUSTC_WRAPPER overrides) would bypass them,
+    // caching looks configured but compile work runs through plain cargo.
+    // Emit advisory warnings naming each offender. Runs at the very end so it
+    // sees the final state of process.env after every prior phase.
+    if (result.shimsEnabled) {
+        const bypassWarnings = (0, shim_bypass_check_js_1.diagnoseShimBypass)({
+            shimsEnabled: true,
+            shimDir: result.shimsDir,
+            path: process.env["PATH"] ?? "",
+            cargoEnv: process.env["CARGO"],
+            rustcEnv: process.env["RUSTC"],
+            rustcWrapperEnv: process.env["RUSTC_WRAPPER"],
+            soldrBinary: result.soldrPath,
+        });
+        for (const msg of bypassWarnings) {
+            core.warning(msg);
+        }
+        if (bypassWarnings.length === 0) {
+            logger.log(`shim-bypass check clean: shim dir ${result.shimsDir} at PATH front, no competing CARGO/RUSTC/RUSTC_WRAPPER overrides`);
+        }
+    }
+    // ---- stats report ----
+    statsCollector.report(statsMode, (msg) => logger.log(msg));
+    if (statsMode === "detailed") {
+        try {
+            await statsCollector.writeFiles(ctx.runnerTemp);
+            statsCollector.setGithubOutputs();
+        }
+        catch (err) {
+            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    core.saveState("statsCollector", statsCollector.serialize());
+    core.saveState("statsMode", statsMode);
+    core.saveState("compileCacheStats", result.compileCacheStats);
+    core.saveState("runnerTemp", ctx.runnerTemp);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            cacheOutcomes: statsCollector.snapshot(),
+            logger,
+        });
+    }
+    // #269-companion (setup side): one-line aggregate of where each
+    // setup phase's wall-clock went, before we finish the `action`
+    // phase. Mirrors the post-step `cache save totals:` line that
+    // ships from `StatsCollector.saveSummaryOneLine()`. Operators see
+    // the pre-build budget at a glance without scrolling raw
+    // SETUP_SOLDR_PHASE_*_START_MS env vars or hunting through the
+    // timeline. Phases in declared serial order:
+    const setupPhaseSummary = (0, phase_timing_js_1.setupPhaseSummaryOneLine)([
+        "resolve",
+        "parallel-restore",
+        "target-tree",
+        "toolchain",
+        "install",
+        "zccache-seed",
+        "verify",
+        "cargo-registry-extract",
+        "cross-prepare",
+        "cook",
+    ]);
+    if (setupPhaseSummary)
+        core.info(setupPhaseSummary);
+    await (0, phase_timing_js_1.finishPhase)("action");
+    // dirHasContent is exported for tests; suppress unused warning here.
+    void dirHasContent;
+}
+// Auto-invoke only when this module is run as the main entry point. This lets
+// tests import `run` (and helpers) without triggering the side-effectful
+// orchestration. The dist/main.js produced by ncc is invoked directly by the
+// Actions runtime so the check trips and the action executes normally.
+if (typeof process !== "undefined" &&
+    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
+    // import.meta.url is the file URL of this module; argv[1] is the runner
+    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
+    // the dev path — we rely on the env-var opt-out for tests instead.
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    run().catch((err) => {
+        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        core.setFailed(`setup-soldr failed: ${message}`);
+    });
+}
+
+
+/***/ }),
+
+/***/ 217:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -50008,14 +50087,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.restoreCache = exports.isFeatureAvailable = exports.FinalizeCacheError = exports.ReserveCacheError = exports.ValidationError = void 0;
-const core = __importStar(__nccwpck_require__(474));
-const path = __importStar(__nccwpck_require__(256));
-const utils = __importStar(__nccwpck_require__(81));
-const cacheHttpClient = __importStar(__nccwpck_require__(38));
-const cacheTwirpClient = __importStar(__nccwpck_require__(67));
-const config_1 = __nccwpck_require__(41);
-const tar_1 = __nccwpck_require__(453);
-const http_client_1 = __nccwpck_require__(293);
+const core = __importStar(__nccwpck_require__(475));
+const path = __importStar(__nccwpck_require__(254));
+const utils = __importStar(__nccwpck_require__(78));
+const cacheHttpClient = __importStar(__nccwpck_require__(36));
+const cacheTwirpClient = __importStar(__nccwpck_require__(64));
+const config_1 = __nccwpck_require__(39);
+const tar_1 = __nccwpck_require__(454);
+const http_client_1 = __nccwpck_require__(291);
 class ValidationError extends Error {
     constructor(message) {
         super(message);
@@ -50495,7 +50574,7 @@ function saveCacheV2(paths, key, options, enableCrossOsArchive = false) {
 
 /***/ }),
 
-/***/ 219:
+/***/ 218:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -50521,9 +50600,9 @@ __export(extendedClient_exports, {
 });
 module.exports = __toCommonJS(extendedClient_exports);
 var import_disableKeepAlivePolicy = __nccwpck_require__(9);
-var import_core_rest_pipeline = __nccwpck_require__(107);
-var import_core_client = __nccwpck_require__(452);
-var import_response = __nccwpck_require__(423);
+var import_core_rest_pipeline = __nccwpck_require__(104);
+var import_core_client = __nccwpck_require__(453);
+var import_response = __nccwpck_require__(424);
 class ExtendedServiceClient extends import_core_client.ServiceClient {
   constructor(options) {
     super(options);
@@ -50572,7 +50651,7 @@ class ExtendedServiceClient extends import_core_client.ServiceClient {
 
 /***/ }),
 
-/***/ 220:
+/***/ 219:
 /***/ ((module) => {
 
 /******************************************************************************
@@ -51030,7 +51109,7 @@ var __rewriteRelativeImportExtension;
 
 /***/ }),
 
-/***/ 221:
+/***/ 220:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51057,9 +51136,9 @@ __export(bearerTokenAuthenticationPolicy_exports, {
   parseChallenges: () => parseChallenges
 });
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(168);
-var import_log = __nccwpck_require__(188);
-var import_restError = __nccwpck_require__(363);
+var import_tokenCycler = __nccwpck_require__(165);
+var import_log = __nccwpck_require__(185);
+var import_restError = __nccwpck_require__(362);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
   try {
@@ -51249,7 +51328,7 @@ function getCaeChallengeClaims(challenges) {
 
 /***/ }),
 
-/***/ 222:
+/***/ 221:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51275,7 +51354,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(292);
 const systemErrorRetryPolicyName = import_policies.systemErrorRetryPolicyName;
 function systemErrorRetryPolicy(options = {}) {
   return (0, import_policies.systemErrorRetryPolicy)(options);
@@ -51286,164 +51365,7 @@ function systemErrorRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 223:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-// $GITHUB_OUTPUT key/value mapping for setup-soldr. Pure function of
-// the resolved state — split out of resolve-setup.ts to keep the
-// orchestration module focused on input parsing / cache-key derivation.
-// Mirrors resolve_setup.py's `_write_outputs()` call so tests can
-// assert byte-for-byte.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.buildOutputs = buildOutputs;
-const target_lifecycle_js_1 = __nccwpck_require__(249);
-/**
- * Build the $GITHUB_OUTPUT key/value map. Exposed for tests so they
- * can assert byte-for-byte parity with the legacy Python action's
- * `_write_outputs()` call.
- *
- * Naming: emits the kebab-case names declared in action.yml so that
- * `${{ steps.<id>.outputs.<name> }}` references in downstream workflow
- * steps resolve to non-empty values. zackees/setup-soldr#125 was a
- * regression where this map used underscored Python-port keys that
- * never matched the hyphenated action.yml declarations, leaving every
- * scalar output empty in consuming workflows.
- *
- * A handful of underscored aliases are emitted in parallel for
- * backwards compatibility with internal callers that hard-coded the
- * old names (none known externally; action.yml only declared the
- * hyphenated forms). Treat the underscored aliases as legacy — remove
- * them after a deprecation window once we've confirmed nothing
- * downstream relies on them.
- */
-function buildOutputs(result) {
-    // Canonical kebab-case outputs (these are the ones declared in action.yml
-    // and the names users should reference). Adding a new output? Put it here.
-    const canonical = {
-        "enabled": result.enabled ? "true" : "false",
-        "soldr-path": result.soldrPath,
-        "cache-dir": result.cacheRoot,
-        "cache-key": result.setupCache.key,
-        "build-cache-key": result.buildCache.key,
-        "build-cache-path": result.buildCache.path,
-        "build-cache-mode": result.buildCache.mode,
-        "target-cache-key": result.targetCache.key,
-        "target-cache-path": result.targetCache.targetPath,
-        "target-cache-paths": result.targetCache.paths,
-        "target-cache-mode": result.targetCache.effectiveMode,
-        "target-cache-profile": result.targetCache.profile,
-        "target-cache-compress": result.targetCacheCompress,
-        "target-cache-compress-level": result.targetCacheCompressLevel,
-        "target-cache-budget-bytes": result.targetCache.budgetBytes,
-        "target-cache-budget-files": result.targetCache.budgetFiles,
-        "target-lockfile": result.targetCache.lockfilePath,
-        "target-lockfile-hash": result.targetCache.lockfileHash,
-        "dylint-cache-key": result.dylintCache.key,
-        "dylint-driver-path": result.dylintCache.driverPath,
-        "dylint-toolchain": result.dylintCache.toolchain,
-        "dylint-rustc-release": result.dylintCache.rustcRelease,
-        "dylint-rustc-commit-hash": result.dylintCache.rustcCommitHash,
-        "dylint-cache-identity": result.dylintCache.cacheIdentity,
-        "dylint-output-cache-key": result.dylintCache.outputKey,
-        "dylint-output-cache-paths": result.dylintCache.outputPaths.join("\n"),
-        "shims-dir": result.shimsDir,
-        "toolchain": result.toolchain.channel,
-        "cache-preset-effective": result.cachePresetEffective,
-        "prepared-target": result.blessedPrepareCache.target,
-        "blessed-prepare-cache-key": result.blessedPrepareCache.key,
-        "target-plan-json": result.targetContract ? JSON.stringify(result.targetContract) : "",
-        "target-capabilities-json": result.targetContract
-            ? JSON.stringify({
-                schemaVersion: result.targetContract.schemaVersion,
-                canonicalTarget: result.targetContract.canonicalTarget,
-                cacheIdentity: result.targetContract.cacheIdentity,
-                supportedOperations: result.targetContract.supportedOperations,
-                toolchain: result.targetContract.toolchain,
-                platform: result.targetContract.platform,
-            })
-            : "",
-        "target-env-json": result.targetContract ? JSON.stringify(result.targetContract.environment) : "",
-        "target-cache-identity": result.targetContract?.cacheIdentity ?? "",
-        "target-artifact-dir": result.targetContract
-            ? (0, target_lifecycle_js_1.targetArtifactDirectory)(result.workspace, result.targetContract.canonicalTarget)
-            : "",
-        "target-build-hook": result.targetContract ? (0, target_lifecycle_js_1.buildTargetHooks)(result.targetContract.canonicalTarget).build : "",
-        "target-clippy-hook": result.targetContract ? (0, target_lifecycle_js_1.buildTargetHooks)(result.targetContract.canonicalTarget).clippy : "",
-        "target-test-hook": result.targetContract ? (0, target_lifecycle_js_1.buildTargetHooks)(result.targetContract.canonicalTarget).testNoRun : "",
-        "target-wheel-hook": result.targetContract ? (0, target_lifecycle_js_1.buildTargetHooks)(result.targetContract.canonicalTarget).pep517Wheel : "",
-        "target-sdist-hook": result.targetContract ? (0, target_lifecycle_js_1.buildTargetHooks)(result.targetContract.canonicalTarget).pep517Sdist : "",
-    };
-    // Legacy underscored aliases retained for backwards compatibility with
-    // any consumer that latched onto the old Python-port output names from
-    // before #125 (most of these were never declared in action.yml so
-    // technically undocumented, but free to keep around).
-    const legacy = {
-        cache_root: result.cacheRoot,
-        setup_cache_path: result.setupCache.setupCachePath,
-        setup_cache_paths: result.setupCache.paths.join("\n"),
-        cache_key: result.setupCache.key,
-        cache_restore_prefix: result.setupCache.restorePrefix,
-        build_cache_key: result.buildCache.key,
-        build_cache_restore_key_parent: result.buildCache.restoreKeyParent,
-        build_cache_restore_key_toolchain: result.buildCache.restoreKeyToolchain,
-        build_cache_restore_key_os_arch: result.buildCache.restoreKeyOsArch,
-        build_cache_path: result.buildCache.path,
-        build_cache_mode: result.buildCache.mode,
-        target_cache_path: result.targetCache.targetPath,
-        target_cache_bundle_path: result.targetCache.bundlePath,
-        target_cache_paths: result.targetCache.paths,
-        target_cache_enabled: result.targetCache.enabled ? "true" : "false",
-        target_cache_mode: result.targetCache.effectiveMode,
-        target_cache_profile: result.targetCache.profile,
-        target_cache_compress: result.targetCacheCompress,
-        target_cache_compress_level: result.targetCacheCompressLevel,
-        target_cache_key: result.targetCache.key,
-        target_cache_restore_key_parent: result.targetCache.restoreKeyParent,
-        target_cache_restore_key_lock: result.targetCache.restoreKeyLock,
-        target_cache_restore_key_lockfile: result.targetCache.restoreKeyLockfile,
-        target_cache_budget_bytes: result.targetCache.budgetBytes,
-        target_cache_budget_files: result.targetCache.budgetFiles,
-        target_lockfile_path: result.targetCache.lockfilePath,
-        target_lockfile_hash: result.targetCache.lockfileHash,
-        cargo_registry_cache_enabled: result.cargoRegistryCache.enabled ? "true" : "false",
-        cargo_registry_cache_path: result.cargoRegistryCache.path,
-        cargo_registry_cache_key: result.cargoRegistryCache.key,
-        cargo_registry_cache_restore_prefix: result.cargoRegistryCache.restorePrefix,
-        dylint_cache_enabled: result.dylintCache.enabled ? "true" : "false",
-        dylint_cache_key: result.dylintCache.key,
-        dylint_driver_path: result.dylintCache.driverPath,
-        dylint_host_triple: result.dylintCache.hostTriple,
-        dylint_toolchain: result.dylintCache.toolchain,
-        dylint_rustc_release: result.dylintCache.rustcRelease,
-        dylint_rustc_commit_hash: result.dylintCache.rustcCommitHash,
-        dylint_cache_identity: result.dylintCache.cacheIdentity,
-        dylint_driver_rev: result.dylintCache.driverRev,
-        soldr_root: result.soldrRoot,
-        soldr_bin_cache_path: result.soldrBinCachePath,
-        cargo_home: result.cargoHome,
-        rustup_home: result.rustupHome,
-        setup_cache_layout: result.setupCache.layout,
-        bin_dir: result.binDir,
-        shims_dir: result.shimsDir,
-        soldr_path: result.soldrPath,
-        soldr_repo: result.soldrRepo,
-        soldr_ref: result.soldrRef,
-        soldr_version_requested: result.soldrVersionRequested,
-        soldr_version_resolved: result.soldrVersionResolved,
-        toolchain_channel: result.toolchain.channel,
-        toolchain_cache_channel: result.toolchain.cacheChannel,
-        toolchain_profile: result.toolchain.profile,
-        toolchain_source: result.toolchain.source,
-    };
-    return { ...legacy, ...canonical };
-}
-
-
-/***/ }),
-
-/***/ 224:
+/***/ 222:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51457,10 +51379,10 @@ function buildOutputs(result) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
-const tslib_1 = __nccwpck_require__(220);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(184));
-const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
+const tslib_1 = __nccwpck_require__(219);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const Parameters = tslib_1.__importStar(__nccwpck_require__(68));
 /** Class containing Container operations. */
 class ContainerImpl {
     client;
@@ -52171,7 +52093,7 @@ const getAccountInfoOperationSpec = {
 
 /***/ }),
 
-/***/ 225:
+/***/ 223:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -52216,7 +52138,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 226:
+/***/ 224:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52245,8 +52167,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.safeTrimTrailingSeparator = exports.normalizeSeparators = exports.hasRoot = exports.hasAbsoluteRoot = exports.ensureAbsoluteRoot = exports.dirname = void 0;
-const path = __importStar(__nccwpck_require__(256));
-const assert_1 = __importDefault(__nccwpck_require__(542));
+const path = __importStar(__nccwpck_require__(254));
+const assert_1 = __importDefault(__nccwpck_require__(543));
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Similar to path.dirname except normalizes the path separators and slightly better handling for Windows UNC paths.
@@ -52421,20 +52343,20 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 
 /***/ }),
 
-/***/ 227:
+/***/ 225:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-module.exports = __nccwpck_require__(296)
-module.exports.async = __nccwpck_require__(422)
-module.exports.stream = __nccwpck_require__(431)
-module.exports.prettyError = __nccwpck_require__(287)
+module.exports = __nccwpck_require__(294)
+module.exports.async = __nccwpck_require__(423)
+module.exports.stream = __nccwpck_require__(432)
+module.exports.prettyError = __nccwpck_require__(285)
 
 
 /***/ }),
 
-/***/ 228:
+/***/ 226:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52485,11 +52407,11 @@ exports.targetDirHasCompiledArtifacts = targetDirHasCompiledArtifacts;
 exports.shouldEmitSharedTargetWarning = shouldEmitSharedTargetWarning;
 exports.tryDelegateToSoldrDoctorSharedTargetWarning = tryDelegateToSoldrDoctorSharedTargetWarning;
 exports.detectSharedTargetWarning = detectSharedTargetWarning;
-const fs = __importStar(__nccwpck_require__(257));
-const path = __importStar(__nccwpck_require__(522));
-const core = __importStar(__nccwpck_require__(474));
-const log_utils_js_1 = __nccwpck_require__(196);
-const soldr_toolchain_client_js_1 = __nccwpck_require__(349);
+const fs = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(523));
+const core = __importStar(__nccwpck_require__(475));
+const log_utils_js_1 = __nccwpck_require__(193);
+const soldr_toolchain_client_js_1 = __nccwpck_require__(347);
 const WARNING_MESSAGE = "setup-soldr detected a pre-populated shared target directory; a " +
     "subsequent `soldr cargo build` using the same `--target-dir` may fail " +
     "with a missing .rmeta error - see README 'Known limitations'.";
@@ -52678,7 +52600,7 @@ async function detectSharedTargetWarning(opts) {
 
 /***/ }),
 
-/***/ 229:
+/***/ 227:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52711,12 +52633,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpProxyAgent = void 0;
-const net = __importStar(__nccwpck_require__(523));
-const tls = __importStar(__nccwpck_require__(520));
-const debug_1 = __importDefault(__nccwpck_require__(529));
-const events_1 = __nccwpck_require__(486);
-const agent_base_1 = __nccwpck_require__(246);
-const url_1 = __nccwpck_require__(91);
+const net = __importStar(__nccwpck_require__(524));
+const tls = __importStar(__nccwpck_require__(521));
+const debug_1 = __importDefault(__nccwpck_require__(530));
+const events_1 = __nccwpck_require__(487);
+const agent_base_1 = __nccwpck_require__(244);
+const url_1 = __nccwpck_require__(88);
 const debug = (0, debug_1.default)('http-proxy-agent');
 /**
  * The `HttpProxyAgent` implements an HTTP Agent subclass that connects
@@ -52833,7 +52755,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 230:
+/***/ 228:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52869,8 +52791,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
-const fs = __importStar(__nccwpck_require__(546));
-const path = __importStar(__nccwpck_require__(256));
+const fs = __importStar(__nccwpck_require__(547));
+const path = __importStar(__nccwpck_require__(254));
 _a = fs.promises
 // export const {open} = 'fs'
 , exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
@@ -53023,7 +52945,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 231:
+/***/ 229:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53032,8 +52954,8 @@ exports.getCmdPath = getCmdPath;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
-const tslib_1 = __nccwpck_require__(220);
-var poller_js_1 = __nccwpck_require__(329);
+const tslib_1 = __nccwpck_require__(219);
+var poller_js_1 = __nccwpck_require__(327);
 Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: function () { return poller_js_1.createHttpPoller; } }));
 /**
  * This can be uncommented to expose the protocol-agnostic poller
@@ -53047,14 +52969,14 @@ Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: fun
 // } from "./poller/models";
 // export { buildCreatePoller } from "./poller/poller";
 /** legacy */
-tslib_1.__exportStar(__nccwpck_require__(250), exports);
-tslib_1.__exportStar(__nccwpck_require__(80), exports);
-tslib_1.__exportStar(__nccwpck_require__(44), exports);
+tslib_1.__exportStar(__nccwpck_require__(248), exports);
+tslib_1.__exportStar(__nccwpck_require__(77), exports);
+tslib_1.__exportStar(__nccwpck_require__(42), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 232:
+/***/ 230:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -53100,7 +53022,7 @@ function apiVersionPolicy(options) {
 
 /***/ }),
 
-/***/ 233:
+/***/ 231:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -53347,7 +53269,7 @@ exports.AbortSignal = AbortSignal;
 
 /***/ }),
 
-/***/ 234:
+/***/ 232:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -53364,7 +53286,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 
 /***/ }),
 
-/***/ 235:
+/***/ 233:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53378,10 +53300,10 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
-const tslib_1 = __nccwpck_require__(220);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(184));
-const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
+const tslib_1 = __nccwpck_require__(219);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const Parameters = tslib_1.__importStar(__nccwpck_require__(68));
 /** Class containing Service operations. */
 class ServiceImpl {
     client;
@@ -53700,7 +53622,7 @@ const filterBlobsOperationSpec = {
 
 /***/ }),
 
-/***/ 236:
+/***/ 234:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53726,7 +53648,7 @@ __export(agentPolicy_exports, {
   agentPolicyName: () => agentPolicyName
 });
 module.exports = __toCommonJS(agentPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(292);
 const agentPolicyName = import_policies.agentPolicyName;
 function agentPolicy(agent) {
   return (0, import_policies.agentPolicy)(agent);
@@ -53737,13 +53659,13 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 237:
+/***/ 235:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { UndiciError } = __nccwpck_require__(504)
+const { UndiciError } = __nccwpck_require__(505)
 
 class MockNotMatchedError extends UndiciError {
   constructor (message) {
@@ -53762,14 +53684,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 238:
+/***/ 236:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Transform } = __nccwpck_require__(135)
-const { Console } = __nccwpck_require__(36)
+const { Transform } = __nccwpck_require__(132)
+const { Console } = __nccwpck_require__(34)
 
 /**
  * Gets the output of `console.table(…)` as a string.
@@ -53810,19 +53732,19 @@ module.exports = class PendingInterceptorsFormatter {
 
 /***/ }),
 
-/***/ 239:
+/***/ 237:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CacheMetadata = void 0;
-const runtime_1 = __nccwpck_require__(21);
-const runtime_2 = __nccwpck_require__(21);
-const runtime_3 = __nccwpck_require__(21);
-const runtime_4 = __nccwpck_require__(21);
-const runtime_5 = __nccwpck_require__(21);
-const cachescope_1 = __nccwpck_require__(408);
+const runtime_1 = __nccwpck_require__(20);
+const runtime_2 = __nccwpck_require__(20);
+const runtime_3 = __nccwpck_require__(20);
+const runtime_4 = __nccwpck_require__(20);
+const runtime_5 = __nccwpck_require__(20);
+const cachescope_1 = __nccwpck_require__(409);
 // @generated message type with reflection information, may provide speed optimized methods
 class CacheMetadata$Type extends runtime_5.MessageType {
     constructor() {
@@ -53881,7 +53803,7 @@ exports.CacheMetadata = new CacheMetadata$Type();
 
 /***/ }),
 
-/***/ 240:
+/***/ 238:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53906,8 +53828,8 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_ts_http_runtime = __nccwpck_require__(95);
-var import_wrapAbortSignal = __nccwpck_require__(458);
+var import_ts_http_runtime = __nccwpck_require__(92);
+var import_wrapAbortSignal = __nccwpck_require__(459);
 function createDefaultHttpClient() {
   const client = (0, import_ts_http_runtime.createDefaultHttpClient)();
   return {
@@ -53928,7 +53850,7 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 241:
+/***/ 239:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -54003,11 +53925,11 @@ exports.isEncryptedArchive = isEncryptedArchive;
 exports.getEncryptionConfig = getEncryptionConfig;
 exports.decryptedTempPathFor = decryptedTempPathFor;
 exports._testInMemoryRoundTrip = _testInMemoryRoundTrip;
-const crypto = __importStar(__nccwpck_require__(282));
-const fs = __importStar(__nccwpck_require__(257));
-const fsp = __importStar(__nccwpck_require__(114));
-const path = __importStar(__nccwpck_require__(522));
-const os = __importStar(__nccwpck_require__(393));
+const crypto = __importStar(__nccwpck_require__(281));
+const fs = __importStar(__nccwpck_require__(255));
+const fsp = __importStar(__nccwpck_require__(111));
+const path = __importStar(__nccwpck_require__(523));
+const os = __importStar(__nccwpck_require__(392));
 const promises_1 = __nccwpck_require__(402);
 exports.ENCRYPT_MAGIC = Buffer.from("SOLDRENC", "ascii");
 exports.ENCRYPT_VERSION = 0x01;
@@ -54232,7 +54154,7 @@ exports.tmpdir = os.tmpdir;
 
 /***/ }),
 
-/***/ 242:
+/***/ 240:
 /***/ ((module) => {
 
 "use strict";
@@ -54240,7 +54162,7 @@ module.exports = require("node:process");
 
 /***/ }),
 
-/***/ 243:
+/***/ 241:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -54250,8 +54172,8 @@ module.exports = require("node:process");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRequestUrl = getRequestUrl;
 exports.appendQueryParams = appendQueryParams;
-const operationHelpers_js_1 = __nccwpck_require__(444);
-const interfaceHelpers_js_1 = __nccwpck_require__(411);
+const operationHelpers_js_1 = __nccwpck_require__(445);
+const interfaceHelpers_js_1 = __nccwpck_require__(412);
 const CollectionFormatToDelimiterMap = {
     CSV: ",",
     SSV: " ",
@@ -54484,7 +54406,7 @@ function appendQueryParams(url, queryParams, sequenceParams, noOverwrite = false
 
 /***/ }),
 
-/***/ 244:
+/***/ 242:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -54510,7 +54432,7 @@ __export(decompressResponsePolicy_exports, {
   decompressResponsePolicyName: () => decompressResponsePolicyName
 });
 module.exports = __toCommonJS(decompressResponsePolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(292);
 const decompressResponsePolicyName = import_policies.decompressResponsePolicyName;
 function decompressResponsePolicy() {
   return (0, import_policies.decompressResponsePolicy)();
@@ -54521,7 +54443,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 245:
+/***/ 243:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -54568,7 +54490,7 @@ function ndJsonPolicy() {
 
 /***/ }),
 
-/***/ 246:
+/***/ 244:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -54601,10 +54523,10 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Agent = void 0;
-const net = __importStar(__nccwpck_require__(523));
-const http = __importStar(__nccwpck_require__(338));
-const https_1 = __nccwpck_require__(76);
-__exportStar(__nccwpck_require__(167), exports);
+const net = __importStar(__nccwpck_require__(524));
+const http = __importStar(__nccwpck_require__(336));
+const https_1 = __nccwpck_require__(73);
+__exportStar(__nccwpck_require__(164), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
 class Agent extends http.Agent {
     constructor(opts) {
@@ -54753,7 +54675,7 @@ exports.Agent = Agent;
 
 /***/ }),
 
-/***/ 247:
+/***/ 245:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -54796,7 +54718,7 @@ exports.mergeJsonOptions = mergeJsonOptions;
 
 /***/ }),
 
-/***/ 248:
+/***/ 246:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -54821,7 +54743,7 @@ __export(httpHeaders_exports, {
   createHttpHeaders: () => createHttpHeaders
 });
 module.exports = __toCommonJS(httpHeaders_exports);
-var import_ts_http_runtime = __nccwpck_require__(95);
+var import_ts_http_runtime = __nccwpck_require__(92);
 function createHttpHeaders(rawHeaders) {
   return (0, import_ts_http_runtime.createHttpHeaders)(rawHeaders);
 }
@@ -54831,7 +54753,7 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 249:
+/***/ 247:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -54877,7 +54799,7 @@ exports.mergeTargetEnvironment = mergeTargetEnvironment;
 exports.buildTargetHooks = buildTargetHooks;
 exports.buildTargetOperationOutputs = buildTargetOperationOutputs;
 exports.targetArtifactDirectory = targetArtifactDirectory;
-const path = __importStar(__nccwpck_require__(522));
+const path = __importStar(__nccwpck_require__(523));
 /** Fail before invoking an operation that Soldr did not advertise. */
 function assertTargetOperationSupported(contract, operation) {
     const requested = operation.trim();
@@ -55006,7 +54928,7 @@ function targetArtifactDirectory(workspace, target) {
 
 /***/ }),
 
-/***/ 250:
+/***/ 248:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55015,13 +54937,13 @@ function targetArtifactDirectory(workspace, target) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-var lroEngine_js_1 = __nccwpck_require__(182);
+var lroEngine_js_1 = __nccwpck_require__(179);
 Object.defineProperty(exports, "LroEngine", ({ enumerable: true, get: function () { return lroEngine_js_1.LroEngine; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 251:
+/***/ 249:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -55046,7 +54968,7 @@ __export(pipeline_exports, {
   createEmptyPipeline: () => createEmptyPipeline
 });
 module.exports = __toCommonJS(pipeline_exports);
-var import_ts_http_runtime = __nccwpck_require__(95);
+var import_ts_http_runtime = __nccwpck_require__(92);
 function createEmptyPipeline() {
   return (0, import_ts_http_runtime.createEmptyPipeline)();
 }
@@ -55056,7 +54978,7 @@ function createEmptyPipeline() {
 
 /***/ }),
 
-/***/ 252:
+/***/ 250:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -55107,10 +55029,10 @@ exports.isGitRepo = isGitRepo;
 exports.listTrackedFiles = listTrackedFiles;
 exports.normalizeWorkspace = normalizeWorkspace;
 exports.normalizeSourceMtime = normalizeSourceMtime;
-const fs = __importStar(__nccwpck_require__(257));
-const path = __importStar(__nccwpck_require__(522));
-const exec = __importStar(__nccwpck_require__(20));
-const log_utils_js_1 = __nccwpck_require__(196);
+const fs = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(523));
+const exec = __importStar(__nccwpck_require__(19));
+const log_utils_js_1 = __nccwpck_require__(193);
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 // Globs evaluated against the repo-relative POSIX path of each tracked file.
 const INCLUDE_GLOBS = [
@@ -55342,7 +55264,7 @@ exports._internal = {
 
 /***/ }),
 
-/***/ 253:
+/***/ 251:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -55381,7 +55303,7 @@ __export(logger_exports, {
   setLogLevel: () => setLogLevel
 });
 module.exports = __toCommonJS(logger_exports);
-var import_debug = __toESM(__nccwpck_require__(483));
+var import_debug = __toESM(__nccwpck_require__(484));
 const TYPESPEC_RUNTIME_LOG_LEVELS = ["verbose", "info", "warning", "error"];
 const levelMap = {
   verbose: 400,
@@ -55487,7 +55409,7 @@ function createClientLogger(namespace) {
 
 /***/ }),
 
-/***/ 254:
+/***/ 252:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -55535,15 +55457,15 @@ exports.shouldRefreshToolchain = shouldRefreshToolchain;
 exports.shouldSkipRefreshForExactHit = shouldSkipRefreshForExactHit;
 exports.tryDelegateToSoldrToolchainEnsure = tryDelegateToSoldrToolchainEnsure;
 exports.ensureRustToolchain = ensureRustToolchain;
-const fs = __importStar(__nccwpck_require__(257));
-const os = __importStar(__nccwpck_require__(393));
-const path = __importStar(__nccwpck_require__(522));
-const core = __importStar(__nccwpck_require__(474));
-const exec = __importStar(__nccwpck_require__(20));
-const io = __importStar(__nccwpck_require__(302));
-const tc = __importStar(__nccwpck_require__(537));
-const log_utils_js_1 = __nccwpck_require__(196);
-const soldr_toolchain_client_js_1 = __nccwpck_require__(349);
+const fs = __importStar(__nccwpck_require__(255));
+const os = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(523));
+const core = __importStar(__nccwpck_require__(475));
+const exec = __importStar(__nccwpck_require__(19));
+const io = __importStar(__nccwpck_require__(300));
+const tc = __importStar(__nccwpck_require__(538));
+const log_utils_js_1 = __nccwpck_require__(193);
+const soldr_toolchain_client_js_1 = __nccwpck_require__(347);
 function rustupInitTargetTriple() {
     const system = process.platform;
     const arch = process.arch;
@@ -55893,7 +55815,7 @@ async function ensureRustToolchain(opts) {
 
 /***/ }),
 
-/***/ 255:
+/***/ 253:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -55940,7 +55862,7 @@ function isTokenCredential(credential) {
 
 /***/ }),
 
-/***/ 256:
+/***/ 254:
 /***/ ((module) => {
 
 "use strict";
@@ -55948,7 +55870,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 257:
+/***/ 255:
 /***/ ((module) => {
 
 "use strict";
@@ -55956,15 +55878,15 @@ module.exports = require("node:fs");
 
 /***/ }),
 
-/***/ 258:
+/***/ 256:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(470)
-const { kEnumerableProperty } = __nccwpck_require__(75)
-const { MessagePort } = __nccwpck_require__(328)
+const { webidl } = __nccwpck_require__(471)
+const { kEnumerableProperty } = __nccwpck_require__(72)
+const { MessagePort } = __nccwpck_require__(326)
 
 /**
  * @see https://html.spec.whatwg.org/multipage/comms.html#messageevent
@@ -56267,16 +56189,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 259:
+/***/ 257:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryWriter = exports.binaryWriteOptions = void 0;
-const pb_long_1 = __nccwpck_require__(122);
-const goog_varint_1 = __nccwpck_require__(208);
-const assert_1 = __nccwpck_require__(500);
+const pb_long_1 = __nccwpck_require__(119);
+const goog_varint_1 = __nccwpck_require__(205);
+const assert_1 = __nccwpck_require__(501);
 const defaultsWrite = {
     writeUnknownFields: true,
     writerFactory: () => new BinaryWriter(),
@@ -56507,7 +56429,7 @@ exports.BinaryWriter = BinaryWriter;
 
 /***/ }),
 
-/***/ 260:
+/***/ 258:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56516,9 +56438,9 @@ exports.BinaryWriter = BinaryWriter;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
-const AvroReadable_js_1 = __nccwpck_require__(398);
-const abort_controller_1 = __nccwpck_require__(511);
-const buffer_1 = __nccwpck_require__(124);
+const AvroReadable_js_1 = __nccwpck_require__(397);
+const abort_controller_1 = __nccwpck_require__(512);
+const buffer_1 = __nccwpck_require__(121);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
 class AvroReadableFromStream extends AvroReadable_js_1.AvroReadable {
     _position;
@@ -56604,7 +56526,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 
 /***/ }),
 
-/***/ 261:
+/***/ 259:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56613,7 +56535,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(107);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
 let _defaultHttpClient;
 function getCachedDefaultHttpClient() {
     if (!_defaultHttpClient) {
@@ -56625,7 +56547,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 262:
+/***/ 260:
 /***/ ((module) => {
 
 "use strict";
@@ -56662,7 +56584,7 @@ module.exports = class Pluralizer {
 
 /***/ }),
 
-/***/ 263:
+/***/ 261:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56691,7 +56613,7 @@ module.exports = createRedirectInterceptor
 
 /***/ }),
 
-/***/ 264:
+/***/ 262:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -56717,8 +56639,8 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(440);
-var import_constants = __nccwpck_require__(52);
+var import_userAgentPlatform = __nccwpck_require__(441);
+var import_constants = __nccwpck_require__(50);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
   for (const [key, value] of telemetryInfo) {
@@ -56745,7 +56667,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 265:
+/***/ 263:
 /***/ ((module) => {
 
 "use strict";
@@ -56753,7 +56675,7 @@ module.exports = require("stream/web");
 
 /***/ }),
 
-/***/ 266:
+/***/ 264:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56763,8 +56685,8 @@ module.exports = require("stream/web");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getBodyAsText = getBodyAsText;
 exports.utf8ByteLength = utf8ByteLength;
-const utils_js_1 = __nccwpck_require__(207);
-const constants_js_1 = __nccwpck_require__(155);
+const utils_js_1 = __nccwpck_require__(204);
+const constants_js_1 = __nccwpck_require__(152);
 async function getBodyAsText(batchResponse) {
     let buffer = Buffer.alloc(constants_js_1.BATCH_MAX_PAYLOAD_IN_BYTES);
     const responseLength = await (0, utils_js_1.streamToBuffer2)(batchResponse.readableStreamBody, buffer);
@@ -56779,7 +56701,7 @@ function utf8ByteLength(str) {
 
 /***/ }),
 
-/***/ 267:
+/***/ 265:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -56805,7 +56727,7 @@ __export(wrapAbortSignalLikePolicy_exports, {
   wrapAbortSignalLikePolicyName: () => wrapAbortSignalLikePolicyName
 });
 module.exports = __toCommonJS(wrapAbortSignalLikePolicy_exports);
-var import_wrapAbortSignal = __nccwpck_require__(458);
+var import_wrapAbortSignal = __nccwpck_require__(459);
 const wrapAbortSignalLikePolicyName = "wrapAbortSignalLikePolicy";
 function wrapAbortSignalLikePolicy() {
   return {
@@ -56830,7 +56752,7 @@ function wrapAbortSignalLikePolicy() {
 
 /***/ }),
 
-/***/ 268:
+/***/ 266:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56839,7 +56761,7 @@ function wrapAbortSignalLikePolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createAbortablePromise = createAbortablePromise;
-const abort_controller_1 = __nccwpck_require__(509);
+const abort_controller_1 = __nccwpck_require__(510);
 /**
  * Creates an abortable promise.
  * @param buildPromise - A function that takes the resolve and reject functions as parameters.
@@ -56882,7 +56804,7 @@ function createAbortablePromise(buildPromise, options) {
 
 /***/ }),
 
-/***/ 269:
+/***/ 267:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -56921,9 +56843,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.retryHttpClientResponse = exports.retryTypedResponse = exports.retry = exports.isRetryableStatusCode = exports.isServerErrorStatusCode = exports.isSuccessStatusCode = void 0;
-const core = __importStar(__nccwpck_require__(474));
-const http_client_1 = __nccwpck_require__(293);
-const constants_1 = __nccwpck_require__(49);
+const core = __importStar(__nccwpck_require__(475));
+const http_client_1 = __nccwpck_require__(291);
+const constants_1 = __nccwpck_require__(47);
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
         return false;
@@ -57026,7 +56948,7 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 
 /***/ }),
 
-/***/ 270:
+/***/ 268:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57035,9 +56957,9 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(282);
-const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(131);
-const Credential_js_1 = __nccwpck_require__(101);
+const node_crypto_1 = __nccwpck_require__(281);
+const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(128);
+const Credential_js_1 = __nccwpck_require__(98);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -57085,7 +57007,7 @@ exports.StorageSharedKeyCredential = StorageSharedKeyCredential;
 
 /***/ }),
 
-/***/ 271:
+/***/ 269:
 /***/ ((module) => {
 
 "use strict";
@@ -57093,7 +57015,7 @@ module.exports = require("node:http");
 
 /***/ }),
 
-/***/ 272:
+/***/ 270:
 /***/ ((module) => {
 
 "use strict";
@@ -57101,7 +57023,7 @@ module.exports = require("node:buffer");
 
 /***/ }),
 
-/***/ 273:
+/***/ 271:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -57131,7 +57053,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDownloadOptions = exports.getUploadOptions = void 0;
-const core = __importStar(__nccwpck_require__(474));
+const core = __importStar(__nccwpck_require__(475));
 /**
  * Returns a copy of the upload options with defaults filled in.
  *
@@ -57225,16 +57147,367 @@ exports.getDownloadOptions = getDownloadOptions;
 
 /***/ }),
 
-/***/ 274:
+/***/ 272:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Read + summarize zccache's per-rustc-invocation JSONL journal so
+// `dumpDiagnostics` can emit a `[compile_journal]` section telling
+// the reader (or future-me) *what* was cached and *why* every miss
+// missed. Without this, "warm reports hits=0 misses=206" is true but
+// useless — we can't tell whether the cache lookups all returned
+// "no cache file with this key" (genuinely-new fingerprint) or "the
+// cached entry's recorded inputs don't match my current inputs"
+// (content/path/env drift between cold and warm). The journal records
+// the per-invocation `outcome` and `miss_reason`; soldr's
+// `cache report --json` already returns `zccache analyze --json`'s
+// rollups under `report.rollups`. We just have to parse them.
+//
+// Pure-functional: no `core.*` here, no side effects beyond reading
+// the journal file. Easier to unit-test that way.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.readJournal = readJournal;
+exports.summarize = summarize;
+exports.formatJournalSection = formatJournalSection;
+exports.formatRollupsSection = formatRollupsSection;
+const fs = __importStar(__nccwpck_require__(255));
+const diagnostics_js_1 = __nccwpck_require__(406);
+const SLOWEST_TOP_N = 20;
+/**
+ * Read a `last-session.jsonl` file. Returns `null` if it doesn't exist
+ * (the common "no build happened" case); throws nothing for malformed
+ * lines — they're silently skipped so a single garbled record doesn't
+ * blank the whole dump.
+ */
+function readJournal(path) {
+    let raw;
+    try {
+        raw = fs.readFileSync(path, "utf8");
+    }
+    catch (err) {
+        if (err.code === "ENOENT")
+            return null;
+        throw err;
+    }
+    const out = [];
+    for (const line of raw.split(/\r?\n/)) {
+        if (line.trim() === "")
+            continue;
+        try {
+            const obj = JSON.parse(line);
+            if (obj && typeof obj === "object")
+                out.push(obj);
+        }
+        catch {
+            // Skip malformed lines.
+        }
+    }
+    return out;
+}
+/**
+ * Pure summary. Stable across runs given the same input order so the
+ * dump diffs cleanly across CI runs.
+ */
+function summarize(records) {
+    const outcomes = {};
+    const miss_reasons = {};
+    const per_extension = {};
+    const misses = [];
+    for (const r of records) {
+        const outcome = r.outcome ?? "unknown";
+        outcomes[outcome] = (outcomes[outcome] ?? 0) + 1;
+        if (outcome === "miss") {
+            const reason = r.miss_reason ?? "unknown";
+            miss_reasons[reason] = (miss_reasons[reason] ?? 0) + 1;
+            misses.push(r);
+        }
+        const ext = r.output_ext ?? "?";
+        if (!per_extension[ext])
+            per_extension[ext] = { hit: 0, miss: 0 };
+        if (outcome === "hit" || outcome === "link_hit")
+            per_extension[ext].hit += 1;
+        else if (outcome === "miss" || outcome === "link_miss")
+            per_extension[ext].miss += 1;
+    }
+    // Sort misses by latency descending and take top N.
+    const slowest_misses = [...misses]
+        .sort((a, b) => (b.latency_ns ?? 0) - (a.latency_ns ?? 0))
+        .slice(0, SLOWEST_TOP_N)
+        .map((r) => ({
+        crate: r.crate_name ?? "?",
+        reason: r.miss_reason ?? "?",
+        ext: r.output_ext ?? "?",
+        latency_ms: Math.round((r.latency_ns ?? 0) / 1_000_000),
+        diff: r.miss_diff ?? null,
+    }));
+    // One sample per distinct miss_reason (covers the long-tail rarer
+    // reasons even when ContentChanged dominates the histogram).
+    const seenReasons = new Set();
+    const sample_records = [];
+    for (const r of misses) {
+        const reason = r.miss_reason ?? "unknown";
+        if (seenReasons.has(reason))
+            continue;
+        seenReasons.add(reason);
+        sample_records.push(r);
+        if (sample_records.length >= 5)
+            break;
+    }
+    // Also include one hit sample if we have any, so cold/warm diffs are
+    // diffable in both directions.
+    const firstHit = records.find((r) => r.outcome === "hit" || r.outcome === "link_hit");
+    if (firstHit && sample_records.length < 6)
+        sample_records.push(firstHit);
+    return {
+        total: records.length,
+        outcomes,
+        miss_reasons,
+        per_extension,
+        slowest_misses,
+        sample_records,
+    };
+}
+// ---------- formatters ----------
+function pad(left, right, label, value) {
+    return `${label.padEnd(left)}${String(value).padStart(right)}`;
+}
+/**
+ * Normalise zccache's `env` field into a plain `{key: value}` map.
+ * The wire format is array-of-pairs (`Array<[string, string]>`) in
+ * current zccache builds; older / future builds may use a plain
+ * object. We tolerate both — and crucially, when given the array
+ * form we DO NOT use array indices as keys (the previous bug:
+ * indices like "0", "1" don't match the redaction regex so secrets
+ * leaked verbatim).
+ */
+function normaliseEnv(env) {
+    if (!env)
+        return {};
+    if (Array.isArray(env)) {
+        const out = {};
+        for (const pair of env) {
+            if (Array.isArray(pair) && pair.length >= 2 && typeof pair[0] === "string") {
+                out[pair[0]] = String(pair[1] ?? "");
+            }
+        }
+        return out;
+    }
+    // Plain object form. Defend against the legacy index-keyed shape that
+    // sneaks in if some intermediate code stringifies an array via
+    // `Object.fromEntries(arr.entries())` — detect that and recover.
+    const entries = Object.entries(env);
+    const looksLikeIndexedArray = entries.length > 0 &&
+        entries.every(([k, v]) => /^\d+$/.test(k) &&
+            Array.isArray(v) &&
+            v.length >= 2 &&
+            typeof v[0] === "string");
+    if (looksLikeIndexedArray) {
+        const out = {};
+        for (const [, v] of entries) {
+            const pair = v;
+            out[pair[0]] = String(pair[1] ?? "");
+        }
+        return out;
+    }
+    return env;
+}
+function redactEnv(env) {
+    const norm = normaliseEnv(env);
+    const out = {};
+    for (const [k, v] of Object.entries(norm))
+        out[k] = (0, diagnostics_js_1.redactValue)(k, v);
+    return out;
+}
+function envIsNonEmpty(env) {
+    if (!env)
+        return false;
+    if (Array.isArray(env))
+        return env.length > 0;
+    return Object.keys(env).length > 0;
+}
+function formatRecord(r) {
+    // Hand-shape JSON to keep one record-per-line readable: top-level keys
+    // on one line, then args/env/miss_diff (if present) on their own.
+    const summary = {
+        outcome: r.outcome,
+        miss_reason: r.miss_reason,
+        crate_name: r.crate_name,
+        crate_type: r.crate_type,
+        output_ext: r.output_ext,
+        latency_ms: r.latency_ns !== undefined ? Math.round(r.latency_ns / 1_000_000) : undefined,
+        cwd: r.cwd,
+    };
+    const parts = [];
+    parts.push(`    summary: ${JSON.stringify(summary)}`);
+    if (r.args && r.args.length > 0) {
+        parts.push(`    args: ${JSON.stringify(r.args)}`);
+    }
+    if (envIsNonEmpty(r.env)) {
+        parts.push(`    env (redacted): ${JSON.stringify(redactEnv(r.env))}`);
+    }
+    if (r.miss_diff && Object.keys(r.miss_diff).length > 0) {
+        parts.push(`    miss_diff: ${JSON.stringify(r.miss_diff)}`);
+    }
+    if (r.self_profile_ns) {
+        parts.push(`    self_profile_ns: ${JSON.stringify(r.self_profile_ns)}`);
+    }
+    return parts.join("\n");
+}
+/**
+ * Format a `[compile_journal]` section's body lines (without the
+ * surrounding header/footer — those are added by `dumpDiagnostics`).
+ */
+function formatJournalSection(summary) {
+    const lines = [];
+    lines.push(`[compile_journal]`);
+    lines.push(`  total_records=${summary.total}`);
+    lines.push(`  outcomes:`);
+    const outcomeEntries = Object.entries(summary.outcomes).sort((a, b) => b[1] - a[1]);
+    if (outcomeEntries.length === 0)
+        lines.push(`    (none)`);
+    for (const [k, v] of outcomeEntries)
+        lines.push(`    ${pad(16, 8, k, v)}`);
+    lines.push(`  miss_reasons (zccache fingerprint divergence; the answer to "why warm missed"):`);
+    const missEntries = Object.entries(summary.miss_reasons).sort((a, b) => b[1] - a[1]);
+    if (missEntries.length === 0)
+        lines.push(`    (none)`);
+    for (const [k, v] of missEntries)
+        lines.push(`    ${pad(28, 8, k, v)}`);
+    lines.push(`  per_output_ext (hit/miss split per artifact kind):`);
+    const extEntries = Object.entries(summary.per_extension).sort((a, b) => a[0] < b[0] ? -1 : 1);
+    if (extEntries.length === 0)
+        lines.push(`    (none)`);
+    for (const [ext, c] of extEntries) {
+        lines.push(`    ${ext.padEnd(10)}hit=${String(c.hit).padStart(5)}  miss=${String(c.miss).padStart(5)}`);
+    }
+    lines.push(`  slowest_misses (top ${summary.slowest_misses.length} by wall-clock):`);
+    if (summary.slowest_misses.length === 0)
+        lines.push(`    (none)`);
+    for (const m of summary.slowest_misses) {
+        lines.push(`    ${String(m.latency_ms + "ms").padStart(7)}  ${m.reason.padEnd(20)}  ${m.ext.padEnd(8)}  ${m.crate}`);
+        if (m.diff && typeof m.diff === "object" && Object.keys(m.diff).length > 0) {
+            lines.push(`        diff: ${JSON.stringify(m.diff)}`);
+        }
+    }
+    lines.push(`  sample_records (one verbatim per distinct outcome, env redacted):`);
+    if (summary.sample_records.length === 0)
+        lines.push(`    (none)`);
+    for (let i = 0; i < summary.sample_records.length; i += 1) {
+        lines.push(`  --- record ${i + 1} ---`);
+        lines.push(formatRecord(summary.sample_records[i]));
+    }
+    return lines;
+}
+/**
+ * Format the `rollups` field returned by `soldr cache report --json`
+ * (i.e. `zccache analyze --json` output). Tolerates missing /
+ * malformed fields — older soldr versions or error paths just yield
+ * an empty section.
+ */
+function formatRollupsSection(report) {
+    const lines = [];
+    lines.push(`[compile_rollups (zccache analyze --json)]`);
+    if (!report || typeof report !== "object") {
+        lines.push(`  (no report payload)`);
+        return lines;
+    }
+    const rollups = report.rollups;
+    if (!rollups || typeof rollups !== "object") {
+        lines.push(`  (no rollups field)`);
+        return lines;
+    }
+    const r = rollups;
+    // by_extension: { ext: { hits, misses, total_ns } }
+    const byExt = r.by_extension;
+    lines.push(`  by_extension:`);
+    if (!byExt || Object.keys(byExt).length === 0)
+        lines.push(`    (none)`);
+    else {
+        for (const [ext, v] of Object.entries(byExt)) {
+            const hits = v?.hits ?? 0;
+            const misses = v?.misses ?? 0;
+            const totalMs = Math.round((v?.total_ns ?? 0) / 1_000_000);
+            const denom = hits + misses;
+            const rate = denom > 0 ? ((hits / denom) * 100).toFixed(1) : "n/a";
+            lines.push(`    ${ext.padEnd(10)}hits=${String(hits).padStart(5)}  misses=${String(misses).padStart(5)}  rate=${rate.padStart(5)}%  total=${totalMs}ms`);
+        }
+    }
+    // slowest_entries: [{outcome, crate_name, latency_ns}, ...]
+    const slowest = r.slowest_entries;
+    lines.push(`  slowest_entries (analyze top-N):`);
+    if (!slowest || slowest.length === 0)
+        lines.push(`    (none)`);
+    else {
+        for (const e of slowest.slice(0, 20)) {
+            const latencyMs = Math.round(Number(e.latency_ns ?? 0) / 1_000_000);
+            const outcome = String(e.outcome ?? "?");
+            const crate = String(e.crate_name ?? "?");
+            lines.push(`    ${String(latencyMs + "ms").padStart(7)}  ${outcome.padEnd(10)}  ${crate}`);
+        }
+    }
+    // miss_crate_counts: { crate: N }
+    const missByCrate = r.miss_crate_counts;
+    lines.push(`  miss_crate_counts (top 20):`);
+    if (!missByCrate || Object.keys(missByCrate).length === 0)
+        lines.push(`    (none)`);
+    else {
+        const sorted = Object.entries(missByCrate)
+            .sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))
+            .slice(0, 20);
+        for (const [crate, count] of sorted) {
+            lines.push(`    ${String(count).padStart(5)}  ${crate}`);
+        }
+    }
+    return lines;
+}
+
+
+/***/ }),
+
+/***/ 273:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const net = __nccwpck_require__(523)
-const assert = __nccwpck_require__(542)
-const util = __nccwpck_require__(75)
-const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(504)
+const net = __nccwpck_require__(524)
+const assert = __nccwpck_require__(543)
+const util = __nccwpck_require__(72)
+const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(505)
 
 let tls // include tls conditionally since it is not always available
 
@@ -57317,7 +57590,7 @@ function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, ...o
     let socket
     if (protocol === 'https:') {
       if (!tls) {
-        tls = __nccwpck_require__(520)
+        tls = __nccwpck_require__(521)
       }
       servername = servername || options.servername || util.getServerName(host) || null
 
@@ -57422,7 +57695,7 @@ module.exports = buildConnector
 
 /***/ }),
 
-/***/ 275:
+/***/ 274:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57431,7 +57704,7 @@ module.exports = buildConnector
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageContextClient = void 0;
-const index_js_1 = __nccwpck_require__(305);
+const index_js_1 = __nccwpck_require__(303);
 /**
  * @internal
  */
@@ -57450,7 +57723,7 @@ exports.StorageContextClient = StorageContextClient;
 
 /***/ }),
 
-/***/ 276:
+/***/ 275:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -57476,7 +57749,7 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(292);
 const formDataPolicyName = import_policies.formDataPolicyName;
 function formDataPolicy() {
   return (0, import_policies.formDataPolicy)();
@@ -57487,7 +57760,7 @@ function formDataPolicy() {
 
 /***/ }),
 
-/***/ 277:
+/***/ 276:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -57513,10 +57786,10 @@ __export(multipart_exports, {
   buildMultipartBody: () => buildMultipartBody
 });
 module.exports = __toCommonJS(multipart_exports);
-var import_restError = __nccwpck_require__(457);
-var import_httpHeaders = __nccwpck_require__(501);
-var import_bytesEncoding = __nccwpck_require__(295);
-var import_typeGuards = __nccwpck_require__(512);
+var import_restError = __nccwpck_require__(458);
+var import_httpHeaders = __nccwpck_require__(502);
+var import_bytesEncoding = __nccwpck_require__(293);
+var import_typeGuards = __nccwpck_require__(513);
 function getHeaderValue(descriptor, headerName) {
   if (descriptor.headers) {
     const actualHeaderName = Object.keys(descriptor.headers).find(
@@ -57625,7 +57898,7 @@ function buildMultipartBody(parts) {
 
 /***/ }),
 
-/***/ 278:
+/***/ 277:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -57642,7 +57915,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 279:
+/***/ 278:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -57668,8 +57941,8 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_policies = __nccwpck_require__(294);
-var import_file = __nccwpck_require__(336);
+var import_policies = __nccwpck_require__(292);
+var import_file = __nccwpck_require__(334);
 const multipartPolicyName = import_policies.multipartPolicyName;
 function multipartPolicy() {
   const tspPolicy = (0, import_policies.multipartPolicy)();
@@ -57693,7 +57966,7 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 280:
+/***/ 279:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -57788,14 +58061,14 @@ exports.listEnumNumbers = listEnumNumbers;
 
 /***/ }),
 
-/***/ 281:
+/***/ 280:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const assert = __nccwpck_require__(542)
+const assert = __nccwpck_require__(543)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(200)
-const { RequestRetryError } = __nccwpck_require__(504)
-const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(75)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(197)
+const { RequestRetryError } = __nccwpck_require__(505)
+const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(72)
 
 function calculateRetryAfterHeader (retryAfter) {
   const current = Date.now()
@@ -58131,7 +58404,7 @@ module.exports = RetryHandler
 
 /***/ }),
 
-/***/ 282:
+/***/ 281:
 /***/ ((module) => {
 
 "use strict";
@@ -58139,7 +58412,7 @@ module.exports = require("node:crypto");
 
 /***/ }),
 
-/***/ 283:
+/***/ 282:
 /***/ (function(module) {
 
 "use strict";
@@ -58261,358 +58534,7 @@ module.exports = decodeText
 
 /***/ }),
 
-/***/ 284:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// Read + summarize zccache's per-rustc-invocation JSONL journal so
-// `dumpDiagnostics` can emit a `[compile_journal]` section telling
-// the reader (or future-me) *what* was cached and *why* every miss
-// missed. Without this, "warm reports hits=0 misses=206" is true but
-// useless — we can't tell whether the cache lookups all returned
-// "no cache file with this key" (genuinely-new fingerprint) or "the
-// cached entry's recorded inputs don't match my current inputs"
-// (content/path/env drift between cold and warm). The journal records
-// the per-invocation `outcome` and `miss_reason`; soldr's
-// `cache report --json` already returns `zccache analyze --json`'s
-// rollups under `report.rollups`. We just have to parse them.
-//
-// Pure-functional: no `core.*` here, no side effects beyond reading
-// the journal file. Easier to unit-test that way.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.readJournal = readJournal;
-exports.summarize = summarize;
-exports.formatJournalSection = formatJournalSection;
-exports.formatRollupsSection = formatRollupsSection;
-const fs = __importStar(__nccwpck_require__(257));
-const diagnostics_js_1 = __nccwpck_require__(53);
-const SLOWEST_TOP_N = 20;
-/**
- * Read a `last-session.jsonl` file. Returns `null` if it doesn't exist
- * (the common "no build happened" case); throws nothing for malformed
- * lines — they're silently skipped so a single garbled record doesn't
- * blank the whole dump.
- */
-function readJournal(path) {
-    let raw;
-    try {
-        raw = fs.readFileSync(path, "utf8");
-    }
-    catch (err) {
-        if (err.code === "ENOENT")
-            return null;
-        throw err;
-    }
-    const out = [];
-    for (const line of raw.split(/\r?\n/)) {
-        if (line.trim() === "")
-            continue;
-        try {
-            const obj = JSON.parse(line);
-            if (obj && typeof obj === "object")
-                out.push(obj);
-        }
-        catch {
-            // Skip malformed lines.
-        }
-    }
-    return out;
-}
-/**
- * Pure summary. Stable across runs given the same input order so the
- * dump diffs cleanly across CI runs.
- */
-function summarize(records) {
-    const outcomes = {};
-    const miss_reasons = {};
-    const per_extension = {};
-    const misses = [];
-    for (const r of records) {
-        const outcome = r.outcome ?? "unknown";
-        outcomes[outcome] = (outcomes[outcome] ?? 0) + 1;
-        if (outcome === "miss") {
-            const reason = r.miss_reason ?? "unknown";
-            miss_reasons[reason] = (miss_reasons[reason] ?? 0) + 1;
-            misses.push(r);
-        }
-        const ext = r.output_ext ?? "?";
-        if (!per_extension[ext])
-            per_extension[ext] = { hit: 0, miss: 0 };
-        if (outcome === "hit" || outcome === "link_hit")
-            per_extension[ext].hit += 1;
-        else if (outcome === "miss" || outcome === "link_miss")
-            per_extension[ext].miss += 1;
-    }
-    // Sort misses by latency descending and take top N.
-    const slowest_misses = [...misses]
-        .sort((a, b) => (b.latency_ns ?? 0) - (a.latency_ns ?? 0))
-        .slice(0, SLOWEST_TOP_N)
-        .map((r) => ({
-        crate: r.crate_name ?? "?",
-        reason: r.miss_reason ?? "?",
-        ext: r.output_ext ?? "?",
-        latency_ms: Math.round((r.latency_ns ?? 0) / 1_000_000),
-        diff: r.miss_diff ?? null,
-    }));
-    // One sample per distinct miss_reason (covers the long-tail rarer
-    // reasons even when ContentChanged dominates the histogram).
-    const seenReasons = new Set();
-    const sample_records = [];
-    for (const r of misses) {
-        const reason = r.miss_reason ?? "unknown";
-        if (seenReasons.has(reason))
-            continue;
-        seenReasons.add(reason);
-        sample_records.push(r);
-        if (sample_records.length >= 5)
-            break;
-    }
-    // Also include one hit sample if we have any, so cold/warm diffs are
-    // diffable in both directions.
-    const firstHit = records.find((r) => r.outcome === "hit" || r.outcome === "link_hit");
-    if (firstHit && sample_records.length < 6)
-        sample_records.push(firstHit);
-    return {
-        total: records.length,
-        outcomes,
-        miss_reasons,
-        per_extension,
-        slowest_misses,
-        sample_records,
-    };
-}
-// ---------- formatters ----------
-function pad(left, right, label, value) {
-    return `${label.padEnd(left)}${String(value).padStart(right)}`;
-}
-/**
- * Normalise zccache's `env` field into a plain `{key: value}` map.
- * The wire format is array-of-pairs (`Array<[string, string]>`) in
- * current zccache builds; older / future builds may use a plain
- * object. We tolerate both — and crucially, when given the array
- * form we DO NOT use array indices as keys (the previous bug:
- * indices like "0", "1" don't match the redaction regex so secrets
- * leaked verbatim).
- */
-function normaliseEnv(env) {
-    if (!env)
-        return {};
-    if (Array.isArray(env)) {
-        const out = {};
-        for (const pair of env) {
-            if (Array.isArray(pair) && pair.length >= 2 && typeof pair[0] === "string") {
-                out[pair[0]] = String(pair[1] ?? "");
-            }
-        }
-        return out;
-    }
-    // Plain object form. Defend against the legacy index-keyed shape that
-    // sneaks in if some intermediate code stringifies an array via
-    // `Object.fromEntries(arr.entries())` — detect that and recover.
-    const entries = Object.entries(env);
-    const looksLikeIndexedArray = entries.length > 0 &&
-        entries.every(([k, v]) => /^\d+$/.test(k) &&
-            Array.isArray(v) &&
-            v.length >= 2 &&
-            typeof v[0] === "string");
-    if (looksLikeIndexedArray) {
-        const out = {};
-        for (const [, v] of entries) {
-            const pair = v;
-            out[pair[0]] = String(pair[1] ?? "");
-        }
-        return out;
-    }
-    return env;
-}
-function redactEnv(env) {
-    const norm = normaliseEnv(env);
-    const out = {};
-    for (const [k, v] of Object.entries(norm))
-        out[k] = (0, diagnostics_js_1.redactValue)(k, v);
-    return out;
-}
-function envIsNonEmpty(env) {
-    if (!env)
-        return false;
-    if (Array.isArray(env))
-        return env.length > 0;
-    return Object.keys(env).length > 0;
-}
-function formatRecord(r) {
-    // Hand-shape JSON to keep one record-per-line readable: top-level keys
-    // on one line, then args/env/miss_diff (if present) on their own.
-    const summary = {
-        outcome: r.outcome,
-        miss_reason: r.miss_reason,
-        crate_name: r.crate_name,
-        crate_type: r.crate_type,
-        output_ext: r.output_ext,
-        latency_ms: r.latency_ns !== undefined ? Math.round(r.latency_ns / 1_000_000) : undefined,
-        cwd: r.cwd,
-    };
-    const parts = [];
-    parts.push(`    summary: ${JSON.stringify(summary)}`);
-    if (r.args && r.args.length > 0) {
-        parts.push(`    args: ${JSON.stringify(r.args)}`);
-    }
-    if (envIsNonEmpty(r.env)) {
-        parts.push(`    env (redacted): ${JSON.stringify(redactEnv(r.env))}`);
-    }
-    if (r.miss_diff && Object.keys(r.miss_diff).length > 0) {
-        parts.push(`    miss_diff: ${JSON.stringify(r.miss_diff)}`);
-    }
-    if (r.self_profile_ns) {
-        parts.push(`    self_profile_ns: ${JSON.stringify(r.self_profile_ns)}`);
-    }
-    return parts.join("\n");
-}
-/**
- * Format a `[compile_journal]` section's body lines (without the
- * surrounding header/footer — those are added by `dumpDiagnostics`).
- */
-function formatJournalSection(summary) {
-    const lines = [];
-    lines.push(`[compile_journal]`);
-    lines.push(`  total_records=${summary.total}`);
-    lines.push(`  outcomes:`);
-    const outcomeEntries = Object.entries(summary.outcomes).sort((a, b) => b[1] - a[1]);
-    if (outcomeEntries.length === 0)
-        lines.push(`    (none)`);
-    for (const [k, v] of outcomeEntries)
-        lines.push(`    ${pad(16, 8, k, v)}`);
-    lines.push(`  miss_reasons (zccache fingerprint divergence; the answer to "why warm missed"):`);
-    const missEntries = Object.entries(summary.miss_reasons).sort((a, b) => b[1] - a[1]);
-    if (missEntries.length === 0)
-        lines.push(`    (none)`);
-    for (const [k, v] of missEntries)
-        lines.push(`    ${pad(28, 8, k, v)}`);
-    lines.push(`  per_output_ext (hit/miss split per artifact kind):`);
-    const extEntries = Object.entries(summary.per_extension).sort((a, b) => a[0] < b[0] ? -1 : 1);
-    if (extEntries.length === 0)
-        lines.push(`    (none)`);
-    for (const [ext, c] of extEntries) {
-        lines.push(`    ${ext.padEnd(10)}hit=${String(c.hit).padStart(5)}  miss=${String(c.miss).padStart(5)}`);
-    }
-    lines.push(`  slowest_misses (top ${summary.slowest_misses.length} by wall-clock):`);
-    if (summary.slowest_misses.length === 0)
-        lines.push(`    (none)`);
-    for (const m of summary.slowest_misses) {
-        lines.push(`    ${String(m.latency_ms + "ms").padStart(7)}  ${m.reason.padEnd(20)}  ${m.ext.padEnd(8)}  ${m.crate}`);
-        if (m.diff && typeof m.diff === "object" && Object.keys(m.diff).length > 0) {
-            lines.push(`        diff: ${JSON.stringify(m.diff)}`);
-        }
-    }
-    lines.push(`  sample_records (one verbatim per distinct outcome, env redacted):`);
-    if (summary.sample_records.length === 0)
-        lines.push(`    (none)`);
-    for (let i = 0; i < summary.sample_records.length; i += 1) {
-        lines.push(`  --- record ${i + 1} ---`);
-        lines.push(formatRecord(summary.sample_records[i]));
-    }
-    return lines;
-}
-/**
- * Format the `rollups` field returned by `soldr cache report --json`
- * (i.e. `zccache analyze --json` output). Tolerates missing /
- * malformed fields — older soldr versions or error paths just yield
- * an empty section.
- */
-function formatRollupsSection(report) {
-    const lines = [];
-    lines.push(`[compile_rollups (zccache analyze --json)]`);
-    if (!report || typeof report !== "object") {
-        lines.push(`  (no report payload)`);
-        return lines;
-    }
-    const rollups = report.rollups;
-    if (!rollups || typeof rollups !== "object") {
-        lines.push(`  (no rollups field)`);
-        return lines;
-    }
-    const r = rollups;
-    // by_extension: { ext: { hits, misses, total_ns } }
-    const byExt = r.by_extension;
-    lines.push(`  by_extension:`);
-    if (!byExt || Object.keys(byExt).length === 0)
-        lines.push(`    (none)`);
-    else {
-        for (const [ext, v] of Object.entries(byExt)) {
-            const hits = v?.hits ?? 0;
-            const misses = v?.misses ?? 0;
-            const totalMs = Math.round((v?.total_ns ?? 0) / 1_000_000);
-            const denom = hits + misses;
-            const rate = denom > 0 ? ((hits / denom) * 100).toFixed(1) : "n/a";
-            lines.push(`    ${ext.padEnd(10)}hits=${String(hits).padStart(5)}  misses=${String(misses).padStart(5)}  rate=${rate.padStart(5)}%  total=${totalMs}ms`);
-        }
-    }
-    // slowest_entries: [{outcome, crate_name, latency_ns}, ...]
-    const slowest = r.slowest_entries;
-    lines.push(`  slowest_entries (analyze top-N):`);
-    if (!slowest || slowest.length === 0)
-        lines.push(`    (none)`);
-    else {
-        for (const e of slowest.slice(0, 20)) {
-            const latencyMs = Math.round(Number(e.latency_ns ?? 0) / 1_000_000);
-            const outcome = String(e.outcome ?? "?");
-            const crate = String(e.crate_name ?? "?");
-            lines.push(`    ${String(latencyMs + "ms").padStart(7)}  ${outcome.padEnd(10)}  ${crate}`);
-        }
-    }
-    // miss_crate_counts: { crate: N }
-    const missByCrate = r.miss_crate_counts;
-    lines.push(`  miss_crate_counts (top 20):`);
-    if (!missByCrate || Object.keys(missByCrate).length === 0)
-        lines.push(`    (none)`);
-    else {
-        const sorted = Object.entries(missByCrate)
-            .sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))
-            .slice(0, 20);
-        for (const [crate, count] of sorted) {
-            lines.push(`    ${String(count).padStart(5)}  ${crate}`);
-        }
-    }
-    return lines;
-}
-
-
-/***/ }),
-
-/***/ 285:
+/***/ 283:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -58621,32 +58543,32 @@ function formatRollupsSection(report) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
-const tslib_1 = __nccwpck_require__(220);
+const tslib_1 = __nccwpck_require__(219);
 tslib_1.__exportStar(__nccwpck_require__(372), exports);
-var cache_js_1 = __nccwpck_require__(261);
+var cache_js_1 = __nccwpck_require__(259);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(87), exports);
-tslib_1.__exportStar(__nccwpck_require__(162), exports);
-tslib_1.__exportStar(__nccwpck_require__(409), exports);
-tslib_1.__exportStar(__nccwpck_require__(101), exports);
-tslib_1.__exportStar(__nccwpck_require__(270), exports);
-tslib_1.__exportStar(__nccwpck_require__(335), exports);
-var RequestPolicy_js_1 = __nccwpck_require__(50);
+tslib_1.__exportStar(__nccwpck_require__(84), exports);
+tslib_1.__exportStar(__nccwpck_require__(159), exports);
+tslib_1.__exportStar(__nccwpck_require__(410), exports);
+tslib_1.__exportStar(__nccwpck_require__(98), exports);
+tslib_1.__exportStar(__nccwpck_require__(268), exports);
+tslib_1.__exportStar(__nccwpck_require__(333), exports);
+var RequestPolicy_js_1 = __nccwpck_require__(48);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
-tslib_1.__exportStar(__nccwpck_require__(99), exports);
-tslib_1.__exportStar(__nccwpck_require__(318), exports);
-tslib_1.__exportStar(__nccwpck_require__(211), exports);
-tslib_1.__exportStar(__nccwpck_require__(479), exports);
-tslib_1.__exportStar(__nccwpck_require__(172), exports);
-tslib_1.__exportStar(__nccwpck_require__(131), exports);
-tslib_1.__exportStar(__nccwpck_require__(83), exports);
-tslib_1.__exportStar(__nccwpck_require__(439), exports);
-tslib_1.__exportStar(__nccwpck_require__(174), exports);
+tslib_1.__exportStar(__nccwpck_require__(96), exports);
+tslib_1.__exportStar(__nccwpck_require__(316), exports);
+tslib_1.__exportStar(__nccwpck_require__(208), exports);
+tslib_1.__exportStar(__nccwpck_require__(480), exports);
+tslib_1.__exportStar(__nccwpck_require__(169), exports);
+tslib_1.__exportStar(__nccwpck_require__(128), exports);
+tslib_1.__exportStar(__nccwpck_require__(80), exports);
+tslib_1.__exportStar(__nccwpck_require__(440), exports);
+tslib_1.__exportStar(__nccwpck_require__(171), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 286:
+/***/ 284:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -58659,18 +58581,18 @@ tslib_1.__exportStar(__nccwpck_require__(174), exports);
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(220);
-tslib_1.__exportStar(__nccwpck_require__(235), exports);
-tslib_1.__exportStar(__nccwpck_require__(224), exports);
-tslib_1.__exportStar(__nccwpck_require__(51), exports);
-tslib_1.__exportStar(__nccwpck_require__(290), exports);
-tslib_1.__exportStar(__nccwpck_require__(29), exports);
-tslib_1.__exportStar(__nccwpck_require__(366), exports);
+const tslib_1 = __nccwpck_require__(219);
+tslib_1.__exportStar(__nccwpck_require__(233), exports);
+tslib_1.__exportStar(__nccwpck_require__(222), exports);
+tslib_1.__exportStar(__nccwpck_require__(49), exports);
+tslib_1.__exportStar(__nccwpck_require__(288), exports);
+tslib_1.__exportStar(__nccwpck_require__(28), exports);
+tslib_1.__exportStar(__nccwpck_require__(365), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 287:
+/***/ 285:
 /***/ ((module) => {
 
 "use strict";
@@ -58711,7 +58633,7 @@ function prettyError (err, buf) {
 
 /***/ }),
 
-/***/ 288:
+/***/ 286:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58941,7 +58863,7 @@ exports.ContainerSASPermissions = ContainerSASPermissions;
 
 /***/ }),
 
-/***/ 289:
+/***/ 287:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -58966,21 +58888,21 @@ __export(createPipelineFromOptions_exports, {
   createPipelineFromOptions: () => createPipelineFromOptions
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
-var import_logPolicy = __nccwpck_require__(77);
-var import_pipeline = __nccwpck_require__(251);
-var import_redirectPolicy = __nccwpck_require__(350);
-var import_userAgentPolicy = __nccwpck_require__(400);
-var import_multipartPolicy = __nccwpck_require__(279);
-var import_decompressResponsePolicy = __nccwpck_require__(244);
-var import_defaultRetryPolicy = __nccwpck_require__(61);
-var import_formDataPolicy = __nccwpck_require__(276);
-var import_core_util = __nccwpck_require__(16);
-var import_proxyPolicy = __nccwpck_require__(489);
-var import_setClientRequestIdPolicy = __nccwpck_require__(157);
-var import_agentPolicy = __nccwpck_require__(236);
-var import_tlsPolicy = __nccwpck_require__(389);
-var import_tracingPolicy = __nccwpck_require__(345);
-var import_wrapAbortSignalLikePolicy = __nccwpck_require__(267);
+var import_logPolicy = __nccwpck_require__(74);
+var import_pipeline = __nccwpck_require__(249);
+var import_redirectPolicy = __nccwpck_require__(348);
+var import_userAgentPolicy = __nccwpck_require__(399);
+var import_multipartPolicy = __nccwpck_require__(278);
+var import_decompressResponsePolicy = __nccwpck_require__(242);
+var import_defaultRetryPolicy = __nccwpck_require__(58);
+var import_formDataPolicy = __nccwpck_require__(275);
+var import_core_util = __nccwpck_require__(15);
+var import_proxyPolicy = __nccwpck_require__(490);
+var import_setClientRequestIdPolicy = __nccwpck_require__(154);
+var import_agentPolicy = __nccwpck_require__(234);
+var import_tlsPolicy = __nccwpck_require__(388);
+var import_tracingPolicy = __nccwpck_require__(343);
+var import_wrapAbortSignalLikePolicy = __nccwpck_require__(265);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_core_util.isNodeLike) {
@@ -59014,7 +58936,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 290:
+/***/ 288:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59028,10 +58950,10 @@ function createPipelineFromOptions(options) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(220);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(184));
-const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
+const tslib_1 = __nccwpck_require__(219);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const Parameters = tslib_1.__importStar(__nccwpck_require__(68));
 /** Class containing PageBlob operations. */
 class PageBlobImpl {
     client;
@@ -59484,16 +59406,16 @@ const copyIncrementalOperationSpec = {
 
 /***/ }),
 
-/***/ 291:
+/***/ 289:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(163)
-const { Cache } = __nccwpck_require__(14)
-const { webidl } = __nccwpck_require__(470)
-const { kEnumerableProperty } = __nccwpck_require__(75)
+const { kConstruct } = __nccwpck_require__(160)
+const { Cache } = __nccwpck_require__(13)
+const { webidl } = __nccwpck_require__(471)
+const { kEnumerableProperty } = __nccwpck_require__(72)
 
 class CacheStorage {
   /**
@@ -59636,7 +59558,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 292:
+/***/ 290:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59645,9 +59567,9 @@ module.exports = {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createClientPipeline = createClientPipeline;
-const deserializationPolicy_js_1 = __nccwpck_require__(92);
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const serializationPolicy_js_1 = __nccwpck_require__(505);
+const deserializationPolicy_js_1 = __nccwpck_require__(89);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const serializationPolicy_js_1 = __nccwpck_require__(506);
 /**
  * Creates a new Pipeline for use with a Service Client.
  * Adds in deserializationPolicy by default.
@@ -59672,7 +59594,7 @@ function createClientPipeline(options = {}) {
 
 /***/ }),
 
-/***/ 293:
+/***/ 291:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -59712,11 +59634,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
-const http = __importStar(__nccwpck_require__(338));
-const https = __importStar(__nccwpck_require__(76));
-const pm = __importStar(__nccwpck_require__(320));
-const tunnel = __importStar(__nccwpck_require__(535));
-const undici_1 = __nccwpck_require__(169);
+const http = __importStar(__nccwpck_require__(336));
+const https = __importStar(__nccwpck_require__(73));
+const pm = __importStar(__nccwpck_require__(318));
+const tunnel = __importStar(__nccwpck_require__(536));
+const undici_1 = __nccwpck_require__(166);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -60331,7 +60253,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 294:
+/***/ 292:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60383,20 +60305,20 @@ __export(internal_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(internal_exports);
-var import_agentPolicy = __nccwpck_require__(481);
-var import_decompressResponsePolicy = __nccwpck_require__(367);
-var import_defaultRetryPolicy = __nccwpck_require__(334);
-var import_exponentialRetryPolicy = __nccwpck_require__(538);
-var import_retryPolicy = __nccwpck_require__(18);
-var import_systemErrorRetryPolicy = __nccwpck_require__(31);
-var import_throttlingRetryPolicy = __nccwpck_require__(536);
-var import_formDataPolicy = __nccwpck_require__(348);
-var import_logPolicy = __nccwpck_require__(108);
-var import_multipartPolicy = __nccwpck_require__(175);
-var import_proxyPolicy = __nccwpck_require__(43);
-var import_redirectPolicy = __nccwpck_require__(327);
-var import_tlsPolicy = __nccwpck_require__(225);
-var import_userAgentPolicy = __nccwpck_require__(370);
+var import_agentPolicy = __nccwpck_require__(482);
+var import_decompressResponsePolicy = __nccwpck_require__(366);
+var import_defaultRetryPolicy = __nccwpck_require__(332);
+var import_exponentialRetryPolicy = __nccwpck_require__(539);
+var import_retryPolicy = __nccwpck_require__(17);
+var import_systemErrorRetryPolicy = __nccwpck_require__(30);
+var import_throttlingRetryPolicy = __nccwpck_require__(537);
+var import_formDataPolicy = __nccwpck_require__(346);
+var import_logPolicy = __nccwpck_require__(105);
+var import_multipartPolicy = __nccwpck_require__(172);
+var import_proxyPolicy = __nccwpck_require__(41);
+var import_redirectPolicy = __nccwpck_require__(325);
+var import_tlsPolicy = __nccwpck_require__(223);
+var import_userAgentPolicy = __nccwpck_require__(369);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -60404,7 +60326,7 @@ var import_userAgentPolicy = __nccwpck_require__(370);
 
 /***/ }),
 
-/***/ 295:
+/***/ 293:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -60443,15 +60365,15 @@ function stringToUint8Array(value, format) {
 
 /***/ }),
 
-/***/ 296:
+/***/ 294:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseString
 
-const TOMLParser = __nccwpck_require__(356)
-const prettyError = __nccwpck_require__(287)
+const TOMLParser = __nccwpck_require__(354)
+const prettyError = __nccwpck_require__(285)
 
 function parseString (str) {
   if (global.Buffer && global.Buffer.isBuffer(str)) {
@@ -60469,7 +60391,7 @@ function parseString (str) {
 
 /***/ }),
 
-/***/ 297:
+/***/ 295:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60479,13 +60401,13 @@ function parseString (str) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.generateAccountSASQueryParameters = generateAccountSASQueryParameters;
 exports.generateAccountSASQueryParametersInternal = generateAccountSASQueryParametersInternal;
-const AccountSASPermissions_js_1 = __nccwpck_require__(64);
+const AccountSASPermissions_js_1 = __nccwpck_require__(61);
 const AccountSASResourceTypes_js_1 = __nccwpck_require__(2);
-const AccountSASServices_js_1 = __nccwpck_require__(390);
-const SasIPRange_js_1 = __nccwpck_require__(369);
-const SASQueryParameters_js_1 = __nccwpck_require__(541);
-const constants_js_1 = __nccwpck_require__(155);
-const utils_common_js_1 = __nccwpck_require__(161);
+const AccountSASServices_js_1 = __nccwpck_require__(389);
+const SasIPRange_js_1 = __nccwpck_require__(368);
+const SASQueryParameters_js_1 = __nccwpck_require__(542);
+const constants_js_1 = __nccwpck_require__(152);
+const utils_common_js_1 = __nccwpck_require__(158);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -60580,15 +60502,15 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 
 /***/ }),
 
-/***/ 298:
+/***/ 296:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
-const reflection_info_1 = __nccwpck_require__(466);
-const oneof_1 = __nccwpck_require__(194);
+const reflection_info_1 = __nccwpck_require__(467);
+const oneof_1 = __nccwpck_require__(191);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
     constructor(info) {
@@ -60818,7 +60740,7 @@ exports.ReflectionTypeCheck = ReflectionTypeCheck;
 
 /***/ }),
 
-/***/ 299:
+/***/ 297:
 /***/ ((module) => {
 
 "use strict";
@@ -60826,7 +60748,7 @@ module.exports = require("crypto");
 
 /***/ }),
 
-/***/ 300:
+/***/ 298:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -60852,8 +60774,8 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(121);
-var import_constants = __nccwpck_require__(165);
+var import_userAgentPlatform = __nccwpck_require__(118);
+var import_constants = __nccwpck_require__(162);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
   for (const [key, value] of telemetryInfo) {
@@ -60879,14 +60801,14 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 301:
+/***/ 299:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.mergeRpcOptions = void 0;
-const runtime_1 = __nccwpck_require__(21);
+const runtime_1 = __nccwpck_require__(20);
 /**
  * Merges custom RPC options with defaults. Returns a new instance and keeps
  * the "defaults" and the "options" unmodified.
@@ -60953,7 +60875,7 @@ function copy(a, into) {
 
 /***/ }),
 
-/***/ 302:
+/***/ 300:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -60988,9 +60910,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
-const assert_1 = __nccwpck_require__(542);
-const path = __importStar(__nccwpck_require__(256));
-const ioUtil = __importStar(__nccwpck_require__(230));
+const assert_1 = __nccwpck_require__(543);
+const path = __importStar(__nccwpck_require__(254));
+const ioUtil = __importStar(__nccwpck_require__(228));
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -61259,14 +61181,14 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 303:
+/***/ 301:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.maskSecretUrls = exports.maskSigUrl = void 0;
-const core_1 = __nccwpck_require__(474);
+const core_1 = __nccwpck_require__(475);
 /**
  * Masks the `sig` parameter in a URL and sets it as a secret.
  *
@@ -61340,7 +61262,7 @@ exports.maskSecretUrls = maskSecretUrls;
 
 /***/ }),
 
-/***/ 304:
+/***/ 302:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61396,9 +61318,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseIsolatedSeedTargets = parseIsolatedSeedTargets;
 exports.shouldSeedBuildCacheEntry = shouldSeedBuildCacheEntry;
 exports.seedIsolatedBuildCache = seedIsolatedBuildCache;
-const fs = __importStar(__nccwpck_require__(257));
-const path = __importStar(__nccwpck_require__(522));
-const cache_compress_js_1 = __nccwpck_require__(480);
+const fs = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(523));
+const cache_compress_js_1 = __nccwpck_require__(481);
 const TRANSIENT_SEED_SUFFIXES = [".lock", ".lck", ".sock", ".pid", ".tmp", ".temp", ".part", ".partial"];
 /** Parse the `seed-isolated-build-cache` input into isolated SOLDR_CACHE_DIR roots. */
 function parseIsolatedSeedTargets(value) {
@@ -61545,7 +61467,7 @@ function seedIsolatedBuildCache(opts) {
 
 /***/ }),
 
-/***/ 305:
+/***/ 303:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61559,16 +61481,16 @@ function seedIsolatedBuildCache(opts) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(220);
-tslib_1.__exportStar(__nccwpck_require__(488), exports);
-var storageClient_js_1 = __nccwpck_require__(459);
+const tslib_1 = __nccwpck_require__(219);
+tslib_1.__exportStar(__nccwpck_require__(489), exports);
+var storageClient_js_1 = __nccwpck_require__(460);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(171), exports);
+tslib_1.__exportStar(__nccwpck_require__(168), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 306:
+/***/ 304:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -61618,7 +61540,7 @@ exports.AzureKeyCredential = AzureKeyCredential;
 
 /***/ }),
 
-/***/ 307:
+/***/ 305:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -61627,10 +61549,10 @@ exports.AzureKeyCredential = AzureKeyCredential;
 const {
   InvalidArgumentError,
   NotSupportedError
-} = __nccwpck_require__(504)
-const assert = __nccwpck_require__(542)
-const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(200)
-const util = __nccwpck_require__(75)
+} = __nccwpck_require__(505)
+const assert = __nccwpck_require__(543)
+const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(197)
+const util = __nccwpck_require__(72)
 
 // tokenRegExp and headerCharRegex have been lifted from
 // https://github.com/nodejs/node/blob/main/lib/_http_common.js
@@ -61660,7 +61582,7 @@ const channels = {}
 let extractBody
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(147)
+  const diagnosticsChannel = __nccwpck_require__(144)
   channels.create = diagnosticsChannel.channel('undici:request:create')
   channels.bodySent = diagnosticsChannel.channel('undici:request:bodySent')
   channels.headers = diagnosticsChannel.channel('undici:request:headers')
@@ -61825,7 +61747,7 @@ class Request {
       }
 
       if (!extractBody) {
-        extractBody = (__nccwpck_require__(27).extractBody)
+        extractBody = (__nccwpck_require__(26).extractBody)
       }
 
       const [bodyStream, contentType] = extractBody(body)
@@ -62125,7 +62047,7 @@ module.exports = Request
 
 /***/ }),
 
-/***/ 308:
+/***/ 306:
 /***/ ((module) => {
 
 "use strict";
@@ -62429,17 +62351,17 @@ function stringifyComplexTable (prefix, indent, key, value) {
 
 /***/ }),
 
-/***/ 309:
+/***/ 307:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(470)
-const { DOMException } = __nccwpck_require__(33)
-const { URLSerializer } = __nccwpck_require__(28)
-const { getGlobalOrigin } = __nccwpck_require__(145)
-const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(482)
+const { webidl } = __nccwpck_require__(471)
+const { DOMException } = __nccwpck_require__(32)
+const { URLSerializer } = __nccwpck_require__(27)
+const { getGlobalOrigin } = __nccwpck_require__(142)
+const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(483)
 const {
   kWebSocketURL,
   kReadyState,
@@ -62448,14 +62370,14 @@ const {
   kResponse,
   kSentClose,
   kByteParser
-} = __nccwpck_require__(104)
-const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(63)
+} = __nccwpck_require__(101)
+const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(60)
 const { establishWebSocketConnection } = __nccwpck_require__(374)
-const { WebsocketFrameSend } = __nccwpck_require__(191)
-const { ByteParser } = __nccwpck_require__(498)
-const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(75)
-const { getGlobalDispatcher } = __nccwpck_require__(386)
-const { types } = __nccwpck_require__(128)
+const { WebsocketFrameSend } = __nccwpck_require__(188)
+const { ByteParser } = __nccwpck_require__(499)
+const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(72)
+const { getGlobalDispatcher } = __nccwpck_require__(385)
+const { types } = __nccwpck_require__(125)
 
 let experimentalWarned = false
 
@@ -63078,7 +63000,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 310:
+/***/ 308:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -63130,12 +63052,12 @@ exports.rustChannelManifestRelease = rustChannelManifestRelease;
 exports.resolveToolchainCacheChannel = resolveToolchainCacheChannel;
 exports.loadToolchainSpec = loadToolchainSpec;
 exports.systemRustupSatisfiesRequest = systemRustupSatisfiesRequest;
-const node_crypto_1 = __nccwpck_require__(282);
-const fs = __importStar(__nccwpck_require__(257));
-const path = __importStar(__nccwpck_require__(522));
-const toml = __importStar(__nccwpck_require__(412));
-const io = __importStar(__nccwpck_require__(302));
-const exec = __importStar(__nccwpck_require__(20));
+const node_crypto_1 = __nccwpck_require__(281);
+const fs = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(523));
+const toml = __importStar(__nccwpck_require__(413));
+const io = __importStar(__nccwpck_require__(300));
+const exec = __importStar(__nccwpck_require__(19));
 const ROLLING_TOOLCHAIN_ALIASES = ["stable", "beta", "nightly"];
 /**
  * If the supplied channel is one of the rolling aliases (stable, beta,
@@ -63466,7 +63388,7 @@ async function defaultWhich(cmd) {
 
 /***/ }),
 
-/***/ 311:
+/***/ 309:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -63801,7 +63723,7 @@ class AvroRecordType extends AvroType {
 
 /***/ }),
 
-/***/ 312:
+/***/ 310:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -63927,7 +63849,7 @@ exports.base64encode = base64encode;
 
 /***/ }),
 
-/***/ 313:
+/***/ 311:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -63952,8 +63874,8 @@ __export(concat_exports, {
   concat: () => concat
 });
 module.exports = __toCommonJS(concat_exports);
-var import_stream = __nccwpck_require__(135);
-var import_typeGuards = __nccwpck_require__(512);
+var import_stream = __nccwpck_require__(132);
+var import_typeGuards = __nccwpck_require__(513);
 async function* streamAsyncIterator() {
   const reader = this.getReader();
   try {
@@ -64014,7 +63936,7 @@ async function concat(sources) {
 
 /***/ }),
 
-/***/ 314:
+/***/ 312:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -64091,7 +64013,7 @@ UsageError.isUsageErrorMessage = (msg) => {
 
 /***/ }),
 
-/***/ 315:
+/***/ 313:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -64148,15 +64070,15 @@ exports.DuplexStreamingCall = DuplexStreamingCall;
 
 /***/ }),
 
-/***/ 316:
+/***/ 314:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RpcOutputStreamController = void 0;
-const deferred_1 = __nccwpck_require__(57);
-const runtime_1 = __nccwpck_require__(21);
+const deferred_1 = __nccwpck_require__(54);
+const runtime_1 = __nccwpck_require__(20);
 /**
  * A `RpcOutputStream` that you control.
  */
@@ -64326,7 +64248,7 @@ exports.RpcOutputStreamController = RpcOutputStreamController;
 
 /***/ }),
 
-/***/ 317:
+/***/ 315:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -64348,7 +64270,7 @@ exports.enumToMap = enumToMap;
 
 /***/ }),
 
-/***/ 318:
+/***/ 316:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -64357,7 +64279,7 @@ exports.enumToMap = enumToMap;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CredentialPolicy = void 0;
-const RequestPolicy_js_1 = __nccwpck_require__(50);
+const RequestPolicy_js_1 = __nccwpck_require__(48);
 /**
  * Credential policy used to sign HTTP(S) requests before sending. This is an
  * abstract class.
@@ -64388,7 +64310,7 @@ exports.CredentialPolicy = CredentialPolicy;
 
 /***/ }),
 
-/***/ 319:
+/***/ 317:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -64397,11 +64319,11 @@ exports.CredentialPolicy = CredentialPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BatchResponseParser = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const core_http_compat_1 = __nccwpck_require__(78);
-const constants_js_1 = __nccwpck_require__(155);
-const BatchUtils_js_1 = __nccwpck_require__(266);
-const log_js_1 = __nccwpck_require__(112);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const core_http_compat_1 = __nccwpck_require__(75);
+const constants_js_1 = __nccwpck_require__(152);
+const BatchUtils_js_1 = __nccwpck_require__(264);
+const log_js_1 = __nccwpck_require__(109);
 const HTTP_HEADER_DELIMITER = ": ";
 const SPACE_DELIMITER = " ";
 const NOT_FOUND = -1;
@@ -64541,7 +64463,7 @@ exports.BatchResponseParser = BatchResponseParser;
 
 /***/ }),
 
-/***/ 320:
+/***/ 318:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -64643,7 +64565,7 @@ class DecodedURL extends URL {
 
 /***/ }),
 
-/***/ 321:
+/***/ 319:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -64709,7 +64631,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SHIMMED_TOOLS = void 0;
 exports.diagnoseShimBypass = diagnoseShimBypass;
-const path = __importStar(__nccwpck_require__(522));
+const path = __importStar(__nccwpck_require__(523));
 /** Tools we write shims for. Mirror of ROUTED_TOOLS in ensure-shims.ts. */
 const SHIMMED_TOOLS = ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"];
 exports.SHIMMED_TOOLS = SHIMMED_TOOLS;
@@ -64869,7 +64791,7 @@ function diagnoseShimBypass(input) {
 
 /***/ }),
 
-/***/ 322:
+/***/ 320:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65010,7 +64932,7 @@ function flattenResponse(fullResponse, responseSpec) {
 
 /***/ }),
 
-/***/ 323:
+/***/ 321:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65019,9 +64941,9 @@ function flattenResponse(fullResponse, responseSpec) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.buildCreatePoller = void 0;
-const operation_js_1 = __nccwpck_require__(146);
-const constants_js_1 = __nccwpck_require__(66);
-const core_util_1 = __nccwpck_require__(16);
+const operation_js_1 = __nccwpck_require__(143);
+const constants_js_1 = __nccwpck_require__(63);
+const core_util_1 = __nccwpck_require__(15);
 const createStateProxy = () => ({
     /**
      * The state at this point is created to be of type OperationState<TResult>.
@@ -65191,7 +65113,7 @@ exports.buildCreatePoller = buildCreatePoller;
 
 /***/ }),
 
-/***/ 324:
+/***/ 322:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65200,14 +65122,14 @@ exports.buildCreatePoller = buildCreatePoller;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const pipeline_js_1 = __nccwpck_require__(292);
-const utils_js_1 = __nccwpck_require__(322);
-const httpClientCache_js_1 = __nccwpck_require__(410);
-const operationHelpers_js_1 = __nccwpck_require__(444);
-const urlHelpers_js_1 = __nccwpck_require__(243);
-const interfaceHelpers_js_1 = __nccwpck_require__(411);
-const log_js_1 = __nccwpck_require__(497);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const pipeline_js_1 = __nccwpck_require__(290);
+const utils_js_1 = __nccwpck_require__(320);
+const httpClientCache_js_1 = __nccwpck_require__(411);
+const operationHelpers_js_1 = __nccwpck_require__(445);
+const urlHelpers_js_1 = __nccwpck_require__(241);
+const interfaceHelpers_js_1 = __nccwpck_require__(412);
+const log_js_1 = __nccwpck_require__(498);
 /**
  * Initializes a new instance of the ServiceClient.
  */
@@ -65374,7 +65296,7 @@ function getCredentialScopes(options) {
 
 /***/ }),
 
-/***/ 325:
+/***/ 323:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65399,18 +65321,18 @@ __export(createPipelineFromOptions_exports, {
   createPipelineFromOptions: () => createPipelineFromOptions
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
-var import_logPolicy = __nccwpck_require__(108);
-var import_pipeline = __nccwpck_require__(539);
-var import_redirectPolicy = __nccwpck_require__(327);
-var import_userAgentPolicy = __nccwpck_require__(370);
-var import_decompressResponsePolicy = __nccwpck_require__(367);
-var import_defaultRetryPolicy = __nccwpck_require__(334);
-var import_formDataPolicy = __nccwpck_require__(348);
-var import_checkEnvironment = __nccwpck_require__(451);
-var import_proxyPolicy = __nccwpck_require__(43);
-var import_agentPolicy = __nccwpck_require__(481);
-var import_tlsPolicy = __nccwpck_require__(225);
-var import_multipartPolicy = __nccwpck_require__(175);
+var import_logPolicy = __nccwpck_require__(105);
+var import_pipeline = __nccwpck_require__(540);
+var import_redirectPolicy = __nccwpck_require__(325);
+var import_userAgentPolicy = __nccwpck_require__(369);
+var import_decompressResponsePolicy = __nccwpck_require__(366);
+var import_defaultRetryPolicy = __nccwpck_require__(332);
+var import_formDataPolicy = __nccwpck_require__(346);
+var import_checkEnvironment = __nccwpck_require__(452);
+var import_proxyPolicy = __nccwpck_require__(41);
+var import_agentPolicy = __nccwpck_require__(482);
+var import_tlsPolicy = __nccwpck_require__(223);
+var import_multipartPolicy = __nccwpck_require__(172);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_checkEnvironment.isNodeLike) {
@@ -65440,7 +65362,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 326:
+/***/ 324:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65457,7 +65379,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 327:
+/***/ 325:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65483,7 +65405,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_log = __nccwpck_require__(158);
+var import_log = __nccwpck_require__(155);
 const redirectPolicyName = "redirectPolicy";
 const allowedRedirect = ["GET", "HEAD"];
 function redirectPolicy(options = {}) {
@@ -65529,7 +65451,7 @@ async function handleRedirect(next, response, maxRetries, allowCrossOriginRedire
 
 /***/ }),
 
-/***/ 328:
+/***/ 326:
 /***/ ((module) => {
 
 "use strict";
@@ -65537,7 +65459,7 @@ module.exports = require("worker_threads");
 
 /***/ }),
 
-/***/ 329:
+/***/ 327:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65546,8 +65468,8 @@ module.exports = require("worker_threads");
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
-const operation_js_1 = __nccwpck_require__(56);
-const poller_js_1 = __nccwpck_require__(323);
+const operation_js_1 = __nccwpck_require__(53);
+const poller_js_1 = __nccwpck_require__(321);
 /**
  * Creates a poller that can be used to poll a long-running operation.
  * @param lro - Description of the long-running operation
@@ -65592,7 +65514,7 @@ exports.createHttpPoller = createHttpPoller;
 
 /***/ }),
 
-/***/ 330:
+/***/ 328:
 /***/ ((module) => {
 
 "use strict";
@@ -65600,14 +65522,14 @@ module.exports = require("perf_hooks");
 
 /***/ }),
 
-/***/ 331:
+/***/ 329:
 /***/ ((module) => {
 
 (()=>{"use strict";var t={d:(e,n)=>{for(var i in n)t.o(n,i)&&!t.o(e,i)&&Object.defineProperty(e,i,{enumerable:!0,get:n[i]})},o:(t,e)=>Object.prototype.hasOwnProperty.call(t,e),r:t=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(t,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(t,"__esModule",{value:!0})}},e={};t.r(e),t.d(e,{XMLBuilder:()=>ie,XMLParser:()=>Lt,XMLValidator:()=>se});const n=":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD",i=new RegExp("^["+n+"]["+n+"\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$");function s(t,e){const n=[];let i=e.exec(t);for(;i;){const s=[];s.startIndex=e.lastIndex-i[0].length;const r=i.length;for(let t=0;t<r;t++)s.push(i[t]);n.push(s),i=e.exec(t)}return n}const r=function(t){return!(null==i.exec(t))},o=["hasOwnProperty","toString","valueOf","__defineGetter__","__defineSetter__","__lookupGetter__","__lookupSetter__"],a=["__proto__","constructor","prototype"],h={allowBooleanAttributes:!1,unpairedTags:[]};function l(t,e){e=Object.assign({},h,e);const n=[];let i=!1,s=!1;"\ufeff"===t[0]&&(t=t.substr(1));for(let r=0;r<t.length;r++)if("<"===t[r]&&"?"===t[r+1]){if(r+=2,r=p(t,r),r.err)return r}else{if("<"!==t[r]){if(u(t[r]))continue;return b("InvalidChar","char '"+t[r]+"' is not expected.",w(t,r))}{let o=r;if(r++,"!"===t[r]){r=c(t,r);continue}{let a=!1;"/"===t[r]&&(a=!0,r++);let h="";for(;r<t.length&&">"!==t[r]&&" "!==t[r]&&"\t"!==t[r]&&"\n"!==t[r]&&"\r"!==t[r];r++)h+=t[r];if(h=h.trim(),"/"===h[h.length-1]&&(h=h.substring(0,h.length-1),r--),!E(h)){let e;return e=0===h.trim().length?"Invalid space after '<'.":"Tag '"+h+"' is an invalid name.",b("InvalidTag",e,w(t,r))}const l=g(t,r);if(!1===l)return b("InvalidAttr","Attributes for '"+h+"' have open quote.",w(t,r));let d=l.value;if(r=l.index,"/"===d[d.length-1]){const n=r-d.length;d=d.substring(0,d.length-1);const s=x(d,e);if(!0!==s)return b(s.err.code,s.err.msg,w(t,n+s.err.line));i=!0}else if(a){if(!l.tagClosed)return b("InvalidTag","Closing tag '"+h+"' doesn't have proper closing.",w(t,r));if(d.trim().length>0)return b("InvalidTag","Closing tag '"+h+"' can't have attributes or invalid starting.",w(t,o));if(0===n.length)return b("InvalidTag","Closing tag '"+h+"' has not been opened.",w(t,o));{const e=n.pop();if(h!==e.tagName){let n=w(t,e.tagStartPos);return b("InvalidTag","Expected closing tag '"+e.tagName+"' (opened in line "+n.line+", col "+n.col+") instead of closing tag '"+h+"'.",w(t,o))}0==n.length&&(s=!0)}}else{const a=x(d,e);if(!0!==a)return b(a.err.code,a.err.msg,w(t,r-d.length+a.err.line));if(!0===s)return b("InvalidXml","Multiple possible root nodes found.",w(t,r));-1!==e.unpairedTags.indexOf(h)||n.push({tagName:h,tagStartPos:o}),i=!0}for(r++;r<t.length;r++)if("<"===t[r]){if("!"===t[r+1]){r++,r=c(t,r);continue}if("?"!==t[r+1])break;if(r=p(t,++r),r.err)return r}else if("&"===t[r]){const e=N(t,r);if(-1==e)return b("InvalidChar","char '&' is not expected.",w(t,r));r=e}else if(!0===s&&!u(t[r]))return b("InvalidXml","Extra text at the end",w(t,r));"<"===t[r]&&r--}}}return i?1==n.length?b("InvalidTag","Unclosed tag '"+n[0].tagName+"'.",w(t,n[0].tagStartPos)):!(n.length>0)||b("InvalidXml","Invalid '"+JSON.stringify(n.map(t=>t.tagName),null,4).replace(/\r?\n/g,"")+"' found.",{line:1,col:1}):b("InvalidXml","Start tag expected.",1)}function u(t){return" "===t||"\t"===t||"\n"===t||"\r"===t}function p(t,e){const n=e;for(;e<t.length;e++)if("?"==t[e]||" "==t[e]){const i=t.substr(n,e-n);if(e>5&&"xml"===i)return b("InvalidXml","XML declaration allowed only at the start of the document.",w(t,e));if("?"==t[e]&&">"==t[e+1]){e++;break}continue}return e}function c(t,e){if(t.length>e+5&&"-"===t[e+1]&&"-"===t[e+2]){for(e+=3;e<t.length;e++)if("-"===t[e]&&"-"===t[e+1]&&">"===t[e+2]){e+=2;break}}else if(t.length>e+8&&"D"===t[e+1]&&"O"===t[e+2]&&"C"===t[e+3]&&"T"===t[e+4]&&"Y"===t[e+5]&&"P"===t[e+6]&&"E"===t[e+7]){let n=1;for(e+=8;e<t.length;e++)if("<"===t[e])n++;else if(">"===t[e]&&(n--,0===n))break}else if(t.length>e+9&&"["===t[e+1]&&"C"===t[e+2]&&"D"===t[e+3]&&"A"===t[e+4]&&"T"===t[e+5]&&"A"===t[e+6]&&"["===t[e+7])for(e+=8;e<t.length;e++)if("]"===t[e]&&"]"===t[e+1]&&">"===t[e+2]){e+=2;break}return e}const d='"',f="'";function g(t,e){let n="",i="",s=!1;for(;e<t.length;e++){if(t[e]===d||t[e]===f)""===i?i=t[e]:i!==t[e]||(i="");else if(">"===t[e]&&""===i){s=!0;break}n+=t[e]}return""===i&&{value:n,index:e,tagClosed:s}}const m=new RegExp("(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['\"])(([\\s\\S])*?)\\5)?","g");function x(t,e){const n=s(t,m),i={};for(let t=0;t<n.length;t++){if(0===n[t][1].length)return b("InvalidAttr","Attribute '"+n[t][2]+"' has no space in starting.",v(n[t]));if(void 0!==n[t][3]&&void 0===n[t][4])return b("InvalidAttr","Attribute '"+n[t][2]+"' is without value.",v(n[t]));if(void 0===n[t][3]&&!e.allowBooleanAttributes)return b("InvalidAttr","boolean attribute '"+n[t][2]+"' is not allowed.",v(n[t]));const s=n[t][2];if(!y(s))return b("InvalidAttr","Attribute '"+s+"' is an invalid name.",v(n[t]));if(Object.prototype.hasOwnProperty.call(i,s))return b("InvalidAttr","Attribute '"+s+"' is repeated.",v(n[t]));i[s]=1}return!0}function N(t,e){if(";"===t[++e])return-1;if("#"===t[e])return function(t,e){let n=/\d/;for("x"===t[e]&&(e++,n=/[\da-fA-F]/);e<t.length;e++){if(";"===t[e])return e;if(!t[e].match(n))break}return-1}(t,++e);let n=0;for(;e<t.length;e++,n++)if(!(t[e].match(/\w/)&&n<20)){if(";"===t[e])break;return-1}return e}function b(t,e,n){return{err:{code:t,msg:e,line:n.line||n,col:n.col}}}function y(t){return r(t)}function E(t){return r(t)}function w(t,e){const n=t.substring(0,e).split(/\r?\n/);return{line:n.length,col:n[n.length-1].length+1}}function v(t){return t.startIndex+t[1].length}const S=t=>o.includes(t)?"__"+t:t,_={preserveOrder:!1,attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,removeNSPrefix:!1,allowBooleanAttributes:!1,parseTagValue:!0,parseAttributeValue:!1,trimValues:!0,cdataPropName:!1,numberParseOptions:{hex:!0,leadingZeros:!0,eNotation:!0},tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},stopNodes:[],alwaysCreateTextNode:!1,isArray:()=>!1,commentPropName:!1,unpairedTags:[],processEntities:!0,htmlEntities:!1,entityDecoder:null,ignoreDeclaration:!1,ignorePiTags:!1,transformTagName:!1,transformAttributeName:!1,updateTag:function(t,e,n){return t},captureMetaData:!1,maxNestedTags:100,strictReservedNames:!0,jPath:!0,onDangerousProperty:S};function A(t,e){if("string"!=typeof t)return;const n=t.toLowerCase();if(o.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);if(a.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`)}function T(t,e){return"boolean"==typeof t?{enabled:t,maxEntitySize:1e4,maxExpansionDepth:1e4,maxTotalExpansions:1/0,maxExpandedLength:1e5,maxEntityCount:1e3,allowedTags:null,tagFilter:null,appliesTo:"all"}:"object"==typeof t&&null!==t?{enabled:!1!==t.enabled,maxEntitySize:Math.max(1,t.maxEntitySize??1e4),maxExpansionDepth:Math.max(1,t.maxExpansionDepth??1e4),maxTotalExpansions:Math.max(1,t.maxTotalExpansions??1/0),maxExpandedLength:Math.max(1,t.maxExpandedLength??1e5),maxEntityCount:Math.max(1,t.maxEntityCount??1e3),allowedTags:t.allowedTags??null,tagFilter:t.tagFilter??null,appliesTo:t.appliesTo??"all"}:T(!0)}const C=function(t){const e=Object.assign({},_,t),n=[{value:e.attributeNamePrefix,name:"attributeNamePrefix"},{value:e.attributesGroupName,name:"attributesGroupName"},{value:e.textNodeName,name:"textNodeName"},{value:e.cdataPropName,name:"cdataPropName"},{value:e.commentPropName,name:"commentPropName"}];for(const{value:t,name:e}of n)t&&A(t,e);return null===e.onDangerousProperty&&(e.onDangerousProperty=S),e.processEntities=T(e.processEntities,e.htmlEntities),e.unpairedTagsSet=new Set(e.unpairedTags),e.stopNodes&&Array.isArray(e.stopNodes)&&(e.stopNodes=e.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),e};let P;P="function"!=typeof Symbol?"@@xmlMetadata":Symbol("XML Node Metadata");class ${constructor(t){this.tagname=t,this.child=[],this[":@"]=Object.create(null)}add(t,e){"__proto__"===t&&(t="#__proto__"),this.child.push({[t]:e})}addChild(t,e){"__proto__"===t.tagname&&(t.tagname="#__proto__"),t[":@"]&&Object.keys(t[":@"]).length>0?this.child.push({[t.tagname]:t.child,":@":t[":@"]}):this.child.push({[t.tagname]:t.child}),void 0!==e&&(this.child[this.child.length-1][P]={startIndex:e})}static getMetaDataSymbol(){return P}}const O=":A-Za-z_À-ÖØ-öø-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�",I=":A-Za-z_À-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�𐀀-󯿿",V=I+"\\-\\.\\d·̀-ͯ҇‿-⁀",D=(t,e,n="")=>{const i=`[${t.replace(":","")}][${e.replace(":","")}]*`;return{name:new RegExp(`^[${t}][${e}]*$`,n),ncName:new RegExp(`^${i}$`,n),qName:new RegExp(`^${i}(?::${i})?$`,n),nmToken:new RegExp(`^[${e}]+$`,n),nmTokens:new RegExp(`^[${e}]+(?:\\s+[${e}]+)*$`,n)}},M=D(O,O+"\\-\\.\\d·̀-ͯ‿-⁀"),j=D(I,V,"u"),L=(t,{xmlVersion:e="1.0"}={})=>((t="1.0")=>"1.1"===t?j:M)(e).qName.test(t);class k{constructor(t,e){this.suppressValidationErr=!t,this.options=t,this.xmlVersion=e||1}setXmlVersion(t=1){this.xmlVersion=t}readDocType(t,e){const n=Object.create(null);let i=0;if("O"!==t[e+3]||"C"!==t[e+4]||"T"!==t[e+5]||"Y"!==t[e+6]||"P"!==t[e+7]||"E"!==t[e+8])throw new Error("Invalid Tag instead of DOCTYPE");{e+=9;let s=1,r=!1,o=!1,a="";for(;e<t.length;e++)if("<"!==t[e]||o)if(">"===t[e]){if(o?"-"===t[e-1]&&"-"===t[e-2]&&(o=!1,s--):s--,0===s)break}else"["===t[e]?r=!0:a+=t[e];else{if(r&&F(t,"!ENTITY",e)){let s,r;if(e+=7,[s,r,e]=this.readEntityExp(t,e+1,this.suppressValidationErr),-1===r.indexOf("&")){if(!1!==this.options.enabled&&null!=this.options.maxEntityCount&&i>=this.options.maxEntityCount)throw new Error(`Entity count (${i+1}) exceeds maximum allowed (${this.options.maxEntityCount})`);n[s]=r,i++}}else if(r&&F(t,"!ELEMENT",e)){e+=8;const{index:n}=this.readElementExp(t,e+1);e=n}else if(r&&F(t,"!ATTLIST",e))e+=8;else if(r&&F(t,"!NOTATION",e)){e+=9;const{index:n}=this.readNotationExp(t,e+1,this.suppressValidationErr);e=n}else{if(!F(t,"!--",e))throw new Error("Invalid DOCTYPE");o=!0}s++,a=""}if(0!==s)throw new Error("Unclosed DOCTYPE")}return{entities:n,i:e}}readEntityExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e])&&'"'!==t[e]&&"'"!==t[e];)e++;let i=t.substring(n,e);if(G(i,{xmlVersion:this.xmlVersion}),e=R(t,e),!this.suppressValidationErr){if("SYSTEM"===t.substring(e,e+6).toUpperCase())throw new Error("External entities are not supported");if("%"===t[e])throw new Error("Parameter entities are not supported")}let s="";if([e,s]=this.readIdentifierVal(t,e,"entity"),!1!==this.options.enabled&&null!=this.options.maxEntitySize&&s.length>this.options.maxEntitySize)throw new Error(`Entity "${i}" size (${s.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`);return[i,s,--e]}readNotationExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);!this.suppressValidationErr&&G(i,{xmlVersion:this.xmlVersion}),e=R(t,e);const s=t.substring(e,e+6).toUpperCase();if(!this.suppressValidationErr&&"SYSTEM"!==s&&"PUBLIC"!==s)throw new Error(`Expected SYSTEM or PUBLIC, found "${s}"`);e+=s.length,e=R(t,e);let r=null,o=null;if("PUBLIC"===s)[e,r]=this.readIdentifierVal(t,e,"publicIdentifier"),'"'!==t[e=R(t,e)]&&"'"!==t[e]||([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"));else if("SYSTEM"===s&&([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"),!this.suppressValidationErr&&!o))throw new Error("Missing mandatory system identifier for SYSTEM notation");return{notationName:i,publicIdentifier:r,systemIdentifier:o,index:--e}}readIdentifierVal(t,e,n){let i="";const s=t[e];if('"'!==s&&"'"!==s)throw new Error(`Expected quoted string, found "${s}"`);const r=++e;for(;e<t.length&&t[e]!==s;)e++;if(i=t.substring(r,e),t[e]!==s)throw new Error(`Unterminated ${n} value`);return[++e,i]}readElementExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);if(!this.suppressValidationErr&&!L(i,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid element name: "${i}"`);let s="";if("E"===t[e=R(t,e)]&&F(t,"MPTY",e))e+=4;else if("A"===t[e]&&F(t,"NY",e))e+=2;else if("("===t[e]){const n=++e;for(;e<t.length&&")"!==t[e];)e++;if(s=t.substring(n,e),")"!==t[e])throw new Error("Unterminated content model")}else if(!this.suppressValidationErr)throw new Error(`Invalid Element Expression, found "${t[e]}"`);return{elementName:i,contentModel:s.trim(),index:e}}readAttlistExp(t,e){let n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);for(G(i,{xmlVersion:this.xmlVersion}),n=e=R(t,e);e<t.length&&!/\s/.test(t[e]);)e++;let s=t.substring(n,e);if(!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid attribute name: "${s}"`);e=R(t,e);let r="";if("NOTATION"===t.substring(e,e+8).toUpperCase()){if(r="NOTATION","("!==t[e=R(t,e+=8)])throw new Error(`Expected '(', found "${t[e]}"`);e++;let n=[];for(;e<t.length&&")"!==t[e];){const i=e;for(;e<t.length&&"|"!==t[e]&&")"!==t[e];)e++;let s=t.substring(i,e);if(s=s.trim(),!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid notation name: "${s}"`);n.push(s),"|"===t[e]&&(e++,e=R(t,e))}if(")"!==t[e])throw new Error("Unterminated list of notations");e++,r+=" ("+n.join("|")+")"}else{const n=e;for(;e<t.length&&!/\s/.test(t[e]);)e++;r+=t.substring(n,e);const i=["CDATA","ID","IDREF","IDREFS","ENTITY","ENTITIES","NMTOKEN","NMTOKENS"];if(!this.suppressValidationErr&&!i.includes(r.toUpperCase()))throw new Error(`Invalid attribute type: "${r}"`)}e=R(t,e);let o="";return"#REQUIRED"===t.substring(e,e+8).toUpperCase()?(o="#REQUIRED",e+=8):"#IMPLIED"===t.substring(e,e+7).toUpperCase()?(o="#IMPLIED",e+=7):[e,o]=this.readIdentifierVal(t,e,"ATTLIST"),{elementName:i,attributeName:s,attributeType:r,defaultValue:o,index:e}}}const R=(t,e)=>{for(;e<t.length&&/\s/.test(t[e]);)e++;return e};function F(t,e,n){for(let i=0;i<e.length;i++)if(e[i]!==t[n+i+1])return!1;return!0}function G(t,e){if(L(t,{xmlVersion:e}))return t;throw new Error(`Invalid entity name ${t}`)}const U=/^[-+]?0x[a-fA-F0-9]+$/,B=/^0b[01]+$/,W=/^0o[0-7]+$/,z=/^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/,X={hex:!0,binary:!1,octal:!1,leadingZeros:!0,decimalPoint:".",eNotation:!0,infinity:"original"};const Y=/^([-+])?(0*)(\d*(\.\d*)?[eE][-\+]?\d+)$/;function q(t,e){const n=t.trim();if(2!==e&&8!==e||(t=n.substring(2)),parseInt)return parseInt(t,e);if(Number.parseInt)return Number.parseInt(t,e);if(window&&window.parseInt)return window.parseInt(t,e);throw new Error("parseInt, Number.parseInt, window.parseInt are not supported")}class Z{constructor(t){this._matcher=t}get separator(){return this._matcher.separator}getCurrentTag(){const t=this._matcher.path;return t.length>0?t[t.length-1].tag:void 0}getCurrentNamespace(){const t=this._matcher.path;return t.length>0?t[t.length-1].namespace:void 0}getAttrValue(t){const e=this._matcher.path;if(0!==e.length)return e[e.length-1].values?.[t]}hasAttr(t){const e=this._matcher.path;if(0===e.length)return!1;const n=e[e.length-1];return void 0!==n.values&&t in n.values}getPosition(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].position??0}getCounter(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this._matcher.path.length}toString(t,e=!0){return this._matcher.toString(t,e)}toArray(){return this._matcher.path.map(t=>t.tag)}matches(t){return this._matcher.matches(t)}matchesAny(t){return t.matchesAny(this._matcher)}}class J{constructor(t={}){this.separator=t.separator||".",this.path=[],this.siblingStacks=[],this._pathStringCache=null,this._view=new Z(this)}push(t,e=null,n=null){this._pathStringCache=null,this.path.length>0&&(this.path[this.path.length-1].values=void 0);const i=this.path.length;this.siblingStacks[i]||(this.siblingStacks[i]=new Map);const s=this.siblingStacks[i],r=n?`${n}:${t}`:t,o=s.get(r)||0;let a=0;for(const t of s.values())a+=t;s.set(r,o+1);const h={tag:t,position:a,counter:o};null!=n&&(h.namespace=n),null!=e&&(h.values=e),this.path.push(h)}pop(){if(0===this.path.length)return;this._pathStringCache=null;const t=this.path.pop();return this.siblingStacks.length>this.path.length+1&&(this.siblingStacks.length=this.path.length+1),t}updateCurrent(t){if(this.path.length>0){const e=this.path[this.path.length-1];null!=t&&(e.values=t)}}getCurrentTag(){return this.path.length>0?this.path[this.path.length-1].tag:void 0}getCurrentNamespace(){return this.path.length>0?this.path[this.path.length-1].namespace:void 0}getAttrValue(t){if(0!==this.path.length)return this.path[this.path.length-1].values?.[t]}hasAttr(t){if(0===this.path.length)return!1;const e=this.path[this.path.length-1];return void 0!==e.values&&t in e.values}getPosition(){return 0===this.path.length?-1:this.path[this.path.length-1].position??0}getCounter(){return 0===this.path.length?-1:this.path[this.path.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this.path.length}toString(t,e=!0){const n=t||this.separator;if(n===this.separator&&!0===e){if(null!==this._pathStringCache)return this._pathStringCache;const t=this.path.map(t=>t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n);return this._pathStringCache=t,t}return this.path.map(t=>e&&t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n)}toArray(){return this.path.map(t=>t.tag)}reset(){this._pathStringCache=null,this.path=[],this.siblingStacks=[]}matches(t){const e=t.segments;return 0!==e.length&&(t.hasDeepWildcard()?this._matchWithDeepWildcard(e):this._matchSimple(e))}_matchSimple(t){if(this.path.length!==t.length)return!1;for(let e=0;e<t.length;e++)if(!this._matchSegment(t[e],this.path[e],e===this.path.length-1))return!1;return!0}_matchWithDeepWildcard(t){let e=this.path.length-1,n=t.length-1;for(;n>=0&&e>=0;){const i=t[n];if("deep-wildcard"===i.type){if(n--,n<0)return!0;const i=t[n];let s=!1;for(let t=e;t>=0;t--)if(this._matchSegment(i,this.path[t],t===this.path.length-1)){e=t-1,n--,s=!0;break}if(!s)return!1}else{if(!this._matchSegment(i,this.path[e],e===this.path.length-1))return!1;e--,n--}}return n<0}_matchSegment(t,e,n){if("*"!==t.tag&&t.tag!==e.tag)return!1;if(void 0!==t.namespace&&"*"!==t.namespace&&t.namespace!==e.namespace)return!1;if(void 0!==t.attrName){if(!n)return!1;if(!e.values||!(t.attrName in e.values))return!1;if(void 0!==t.attrValue&&String(e.values[t.attrName])!==String(t.attrValue))return!1}if(void 0!==t.position){if(!n)return!1;const i=e.counter??0;if("first"===t.position&&0!==i)return!1;if("odd"===t.position&&i%2!=1)return!1;if("even"===t.position&&i%2!=0)return!1;if("nth"===t.position&&i!==t.positionValue)return!1}return!0}matchesAny(t){return t.matchesAny(this)}snapshot(){return{path:this.path.map(t=>({...t})),siblingStacks:this.siblingStacks.map(t=>new Map(t))}}restore(t){this._pathStringCache=null,this.path=t.path.map(t=>({...t})),this.siblingStacks=t.siblingStacks.map(t=>new Map(t))}readOnly(){return this._view}}class K{constructor(t,e={},n){this.pattern=t,this.separator=e.separator||".",this.segments=this._parse(t),this.data=n,this._hasDeepWildcard=this.segments.some(t=>"deep-wildcard"===t.type),this._hasAttributeCondition=this.segments.some(t=>void 0!==t.attrName),this._hasPositionSelector=this.segments.some(t=>void 0!==t.position)}_parse(t){const e=[];let n=0,i="";for(;n<t.length;)t[n]===this.separator?n+1<t.length&&t[n+1]===this.separator?(i.trim()&&(e.push(this._parseSegment(i.trim())),i=""),e.push({type:"deep-wildcard"}),n+=2):(i.trim()&&e.push(this._parseSegment(i.trim())),i="",n++):(i+=t[n],n++);return i.trim()&&e.push(this._parseSegment(i.trim())),e}_parseSegment(t){const e={type:"tag"};let n=null,i=t;const s=t.match(/^([^\[]+)(\[[^\]]*\])(.*)$/);if(s&&(i=s[1]+s[3],s[2])){const t=s[2].slice(1,-1);t&&(n=t)}let r,o,a=i;if(i.includes("::")){const e=i.indexOf("::");if(r=i.substring(0,e).trim(),a=i.substring(e+2).trim(),!r)throw new Error(`Invalid namespace in pattern: ${t}`)}let h=null;if(a.includes(":")){const t=a.lastIndexOf(":"),e=a.substring(0,t).trim(),n=a.substring(t+1).trim();["first","last","odd","even"].includes(n)||/^nth\(\d+\)$/.test(n)?(o=e,h=n):o=a}else o=a;if(!o)throw new Error(`Invalid segment pattern: ${t}`);if(e.tag=o,r&&(e.namespace=r),n)if(n.includes("=")){const t=n.indexOf("=");e.attrName=n.substring(0,t).trim(),e.attrValue=n.substring(t+1).trim()}else e.attrName=n.trim();if(h){const t=h.match(/^nth\((\d+)\)$/);t?(e.position="nth",e.positionValue=parseInt(t[1],10)):e.position=h}return e}get length(){return this.segments.length}hasDeepWildcard(){return this._hasDeepWildcard}hasAttributeCondition(){return this._hasAttributeCondition}hasPositionSelector(){return this._hasPositionSelector}toString(){return this.pattern}}class Q{constructor(){this._byDepthAndTag=new Map,this._wildcardByDepth=new Map,this._deepWildcards=[],this._patterns=new Set,this._sealed=!1}add(t){if(this._sealed)throw new TypeError("ExpressionSet is sealed. Create a new ExpressionSet to add more expressions.");if(this._patterns.has(t.pattern))return this;if(this._patterns.add(t.pattern),t.hasDeepWildcard())return this._deepWildcards.push(t),this;const e=t.length,n=t.segments[t.segments.length-1],i=n?.tag;if(i&&"*"!==i){const n=`${e}:${i}`;this._byDepthAndTag.has(n)||this._byDepthAndTag.set(n,[]),this._byDepthAndTag.get(n).push(t)}else this._wildcardByDepth.has(e)||this._wildcardByDepth.set(e,[]),this._wildcardByDepth.get(e).push(t);return this}addAll(t){for(const e of t)this.add(e);return this}has(t){return this._patterns.has(t.pattern)}get size(){return this._patterns.size}seal(){return this._sealed=!0,this}get isSealed(){return this._sealed}matchesAny(t){return null!==this.findMatch(t)}findMatch(t){const e=t.getDepth(),n=`${e}:${t.getCurrentTag()}`,i=this._byDepthAndTag.get(n);if(i)for(let e=0;e<i.length;e++)if(t.matches(i[e]))return i[e];const s=this._wildcardByDepth.get(e);if(s)for(let e=0;e<s.length;e++)if(t.matches(s[e]))return s[e];for(let e=0;e<this._deepWildcards.length;e++)if(t.matches(this._deepWildcards[e]))return this._deepWildcards[e];return null}}const H={cent:"¢",pound:"£",curren:"¤",yen:"¥",euro:"€",dollar:"$",euro:"€",fnof:"ƒ",inr:"₹",af:"؋",birr:"ብር",peso:"₱",rub:"₽",won:"₩",yuan:"¥",cedil:"¸"},tt={amp:"&",apos:"'",gt:">",lt:"<",quot:'"'},et={nbsp:" ",copy:"©",reg:"®",trade:"™",mdash:"—",ndash:"–",hellip:"…",laquo:"«",raquo:"»",lsquo:"‘",rsquo:"’",ldquo:"“",rdquo:"”",bull:"•",para:"¶",sect:"§",deg:"°",frac12:"½",frac14:"¼",frac34:"¾"},nt=new Set("!?\\\\/[]$%{}^&*()<>|+");function it(t){if("#"===t[0])throw new Error(`[EntityReplacer] Invalid character '#' in entity name: "${t}"`);for(const e of t)if(nt.has(e))throw new Error(`[EntityReplacer] Invalid character '${e}' in entity name: "${t}"`);return t}function st(...t){const e=Object.create(null);for(const n of t)if(n)for(const t of Object.keys(n)){const i=n[t];if("string"==typeof i)e[t]=i;else if(i&&"object"==typeof i&&void 0!==i.val){const n=i.val;"string"==typeof n&&(e[t]=n)}}return e}const rt="external",ot="base",at="all",ht=Object.freeze({allow:0,leave:1,remove:2,throw:3}),lt=new Set([9,10,13]);class ut{constructor(t={}){var e;this._limit=t.limit||{},this._maxTotalExpansions=this._limit.maxTotalExpansions||0,this._maxExpandedLength=this._limit.maxExpandedLength||0,this._postCheck="function"==typeof t.postCheck?t.postCheck:t=>t,this._limitTiers=(e=this._limit.applyLimitsTo??rt)&&e!==rt?e===at?new Set([at]):e===ot?new Set([ot]):Array.isArray(e)?new Set(e):new Set([rt]):new Set([rt]),this._numericAllowed=t.numericAllowed??!0,this._baseMap=st(tt,t.namedEntities||null),this._externalMap=Object.create(null),this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this._removeSet=new Set(t.remove&&Array.isArray(t.remove)?t.remove:[]),this._leaveSet=new Set(t.leave&&Array.isArray(t.leave)?t.leave:[]);const n=function(t){if(!t)return{xmlVersion:1,onLevel:ht.allow,nullLevel:ht.remove};const e=1.1===t.xmlVersion?1.1:1,n=ht[t.onNCR]??ht.allow,i=ht[t.nullNCR]??ht.remove;return{xmlVersion:e,onLevel:n,nullLevel:Math.max(i,ht.remove)}}(t.ncr);this._ncrXmlVersion=n.xmlVersion,this._ncrOnLevel=n.onLevel,this._ncrNullLevel=n.nullLevel}setExternalEntities(t){if(t)for(const e of Object.keys(t))it(e);this._externalMap=st(t)}addExternalEntity(t,e){it(t),"string"==typeof e&&-1===e.indexOf("&")&&(this._externalMap[t]=e)}addInputEntities(t){this._totalExpansions=0,this._expandedLength=0,this._inputMap=st(t)}reset(){return this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this}setXmlVersion(t){this._ncrXmlVersion=1.1===t?1.1:1}decode(t){if("string"!=typeof t||0===t.length)return t;const e=t,n=[],i=t.length;let s=0,r=0;const o=this._maxTotalExpansions>0,a=this._maxExpandedLength>0,h=o||a;for(;r<i;){if(38!==t.charCodeAt(r)){r++;continue}let e=r+1;for(;e<i&&59!==t.charCodeAt(e)&&e-r<=32;)e++;if(e>=i||59!==t.charCodeAt(e)){r++;continue}const l=t.slice(r+1,e);if(0===l.length){r++;continue}let u,p;if(this._removeSet.has(l))u="",void 0===p&&(p=rt);else{if(this._leaveSet.has(l)){r++;continue}if(35===l.charCodeAt(0)){const t=this._resolveNCR(l);if(void 0===t){r++;continue}u=t,p=ot}else{const t=this._resolveName(l);u=t?.value,p=t?.tier}}if(void 0!==u){if(r>s&&n.push(t.slice(s,r)),n.push(u),s=e+1,r=s,h&&this._tierCounts(p)){if(o&&(this._totalExpansions++,this._totalExpansions>this._maxTotalExpansions))throw new Error(`[EntityReplacer] Entity expansion count limit exceeded: ${this._totalExpansions} > ${this._maxTotalExpansions}`);if(a){const t=u.length-(l.length+2);if(t>0&&(this._expandedLength+=t,this._expandedLength>this._maxExpandedLength))throw new Error(`[EntityReplacer] Expanded content length limit exceeded: ${this._expandedLength} > ${this._maxExpandedLength}`)}}}else r++}s<i&&n.push(t.slice(s));const l=0===n.length?t:n.join("");return this._postCheck(l,e)}_tierCounts(t){return!!this._limitTiers.has(at)||this._limitTiers.has(t)}_resolveName(t){return t in this._inputMap?{value:this._inputMap[t],tier:rt}:t in this._externalMap?{value:this._externalMap[t],tier:rt}:t in this._baseMap?{value:this._baseMap[t],tier:ot}:void 0}_classifyNCR(t){return 0===t?this._ncrNullLevel:t>=55296&&t<=57343||1===this._ncrXmlVersion&&t>=1&&t<=31&&!lt.has(t)?ht.remove:-1}_applyNCRAction(t,e,n){switch(t){case ht.allow:return String.fromCodePoint(n);case ht.remove:return"";case ht.leave:return;case ht.throw:throw new Error(`[EntityDecoder] Prohibited numeric character reference &${e}; (U+${n.toString(16).toUpperCase().padStart(4,"0")})`);default:return String.fromCodePoint(n)}}_resolveNCR(t){const e=t.charCodeAt(1);let n;if(n=120===e||88===e?parseInt(t.slice(2),16):parseInt(t.slice(1),10),Number.isNaN(n)||n<0||n>1114111)return;const i=this._classifyNCR(n);if(!this._numericAllowed&&i<ht.remove)return;const s=-1===i?this._ncrOnLevel:Math.max(this._ncrOnLevel,i);return this._applyNCRAction(s,t,n)}}function pt(t,e){if(!t)return{};const n=e.attributesGroupName?t[e.attributesGroupName]:t;if(!n)return{};const i={};for(const t in n)t.startsWith(e.attributeNamePrefix)?i[t.substring(e.attributeNamePrefix.length)]=n[t]:i[t]=n[t];return i}function ct(t){if(!t||"string"!=typeof t)return;const e=t.indexOf(":");if(-1!==e&&e>0){const n=t.substring(0,e);if("xmlns"!==n)return n}}class dt{constructor(t,e){var n;this.options=t,this.currentNode=null,this.tagsNodeStack=[],this.parseXml=Nt,this.parseTextData=ft,this.resolveNameSpace=gt,this.buildAttributesMap=xt,this.isItStopNode=wt,this.replaceEntitiesValue=yt,this.readStopNodeData=At,this.saveTextToParentTag=Et,this.addChild=bt,this.ignoreAttributesFn="function"==typeof(n=this.options.ignoreAttributes)?n:Array.isArray(n)?t=>{for(const e of n){if("string"==typeof e&&t===e)return!0;if(e instanceof RegExp&&e.test(t))return!0}}:()=>!1,this.entityExpansionCount=0,this.currentExpandedLength=0;let i={...tt};this.options.entityDecoder?this.entityDecoder=this.options.entityDecoder:("object"==typeof this.options.htmlEntities?i=this.options.htmlEntities:!0===this.options.htmlEntities&&(i={...et,...H}),this.entityDecoder=new ut({namedEntities:{...i,...e},numericAllowed:this.options.htmlEntities,limit:{maxTotalExpansions:this.options.processEntities.maxTotalExpansions,maxExpandedLength:this.options.processEntities.maxExpandedLength,applyLimitsTo:this.options.processEntities.appliesTo}})),this.matcher=new J,this.readonlyMatcher=this.matcher.readOnly(),this.isCurrentNodeStopNode=!1,this.stopNodeExpressionsSet=new Q;const s=this.options.stopNodes;if(s&&s.length>0){for(let t=0;t<s.length;t++){const e=s[t];"string"==typeof e?this.stopNodeExpressionsSet.add(new K(e)):e instanceof K&&this.stopNodeExpressionsSet.add(e)}this.stopNodeExpressionsSet.seal()}}}function ft(t,e,n,i,s,r,o){const a=this.options;if(void 0!==t&&(a.trimValues&&!i&&(t=t.trim()),t.length>0)){o||(t=this.replaceEntitiesValue(t,e,n));const i=a.jPath?n.toString():n,h=a.tagValueProcessor(e,t,i,s,r);return null==h?t:typeof h!=typeof t||h!==t?h:a.trimValues||t.trim()===t?Tt(t,a.parseTagValue,a.numberParseOptions):t}}function gt(t){if(this.options.removeNSPrefix){const e=t.split(":"),n="/"===t.charAt(0)?"/":"";if("xmlns"===e[0])return"";2===e.length&&(t=n+e[1])}return t}const mt=new RegExp("([^\\s=]+)\\s*(=\\s*(['\"])([\\s\\S]*?)\\3)?","gm");function xt(t,e,n,i=!1){const r=this.options;if(!0===i||!0!==r.ignoreAttributes&&"string"==typeof t){const i=s(t,mt),o=i.length,a={},h=new Array(o);let l=!1;const u={};for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]),s=i[t][4];if(e.length&&void 0!==s){let i=s;r.trimValues&&(i=i.trim()),i=this.replaceEntitiesValue(i,n,this.readonlyMatcher),h[t]=i,u[e]=i,l=!0}}l&&"object"==typeof e&&e.updateCurrent&&e.updateCurrent(u);const p=r.jPath?e.toString():this.readonlyMatcher;let c=!1;for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]);if(this.ignoreAttributesFn(e,p))continue;let n=r.attributeNamePrefix+e;if(e.length)if(r.transformAttributeName&&(n=r.transformAttributeName(n)),n=Pt(n,r),void 0!==i[t][4]){const i=h[t],s=r.attributeValueProcessor(e,i,p);a[n]=null==s?i:typeof s!=typeof i||s!==i?s:Tt(i,r.parseAttributeValue,r.numberParseOptions),c=!0}else r.allowBooleanAttributes&&(a[n]=!0,c=!0)}if(!c)return;if(r.attributesGroupName&&!r.preserveOrder){const t={};return t[r.attributesGroupName]=a,t}return a}}const Nt=function(t){t=t.replace(/\r\n?/g,"\n");const e=new $("!xml");let n=e,i="";this.matcher.reset(),this.entityDecoder.reset(),this.entityExpansionCount=0,this.currentExpandedLength=0;const s=this.options,r=new k(s.processEntities),o=t.length;for(let a=0;a<o;a++)if("<"===t[a]){const h=t.charCodeAt(a+1);if(47===h){const e=vt(t,">",a,"Closing Tag is not closed.");let r=t.substring(a+2,e).trim();if(s.removeNSPrefix){const t=r.indexOf(":");-1!==t&&(r=r.substr(t+1))}r=Ct(s.transformTagName,r,"",s).tagName,n&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher));const o=this.matcher.getCurrentTag();if(r&&s.unpairedTagsSet.has(r))throw new Error(`Unpaired tag can not be used as closing tag: </${r}>`);o&&s.unpairedTagsSet.has(o)&&(this.matcher.pop(),this.tagsNodeStack.pop()),this.matcher.pop(),this.isCurrentNodeStopNode=!1,n=this.tagsNodeStack.pop(),i="",a=e}else if(63===h){let e=_t(t,a,!1,"?>");if(!e)throw new Error("Pi Tag is not closed.");i=this.saveTextToParentTag(i,n,this.readonlyMatcher);const o=this.buildAttributesMap(e.tagExp,this.matcher,e.tagName,!0);if(o){const t=o[this.options.attributeNamePrefix+"version"];this.entityDecoder.setXmlVersion(Number(t)||1),r.setXmlVersion(Number(t)||1)}if(s.ignoreDeclaration&&"?xml"===e.tagName||s.ignorePiTags);else{const t=new $(e.tagName);t.add(s.textNodeName,""),e.tagName!==e.tagExp&&e.attrExpPresent&&!0!==s.ignoreAttributes&&(t[":@"]=o),this.addChild(n,t,this.readonlyMatcher,a)}a=e.closeIndex+1}else if(33===h&&45===t.charCodeAt(a+2)&&45===t.charCodeAt(a+3)){const e=vt(t,"--\x3e",a+4,"Comment is not closed.");if(s.commentPropName){const r=t.substring(a+4,e-2);i=this.saveTextToParentTag(i,n,this.readonlyMatcher),n.add(s.commentPropName,[{[s.textNodeName]:r}])}a=e}else if(33===h&&68===t.charCodeAt(a+2)){const e=r.readDocType(t,a);this.entityDecoder.addInputEntities(e.entities),a=e.i}else if(33===h&&91===t.charCodeAt(a+2)){const e=vt(t,"]]>",a,"CDATA is not closed.")-2,r=t.substring(a+9,e);i=this.saveTextToParentTag(i,n,this.readonlyMatcher);let o=this.parseTextData(r,n.tagname,this.readonlyMatcher,!0,!1,!0,!0);null==o&&(o=""),s.cdataPropName?n.add(s.cdataPropName,[{[s.textNodeName]:r}]):n.add(s.textNodeName,o),a=e+2}else{let r=_t(t,a,s.removeNSPrefix);if(!r){const e=t.substring(Math.max(0,a-50),Math.min(o,a+50));throw new Error(`readTagExp returned undefined at position ${a}. Context: "${e}"`)}let h=r.tagName;const l=r.rawTagName;let u=r.tagExp,p=r.attrExpPresent,c=r.closeIndex;if(({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s)),s.strictReservedNames&&(h===s.commentPropName||h===s.cdataPropName||h===s.textNodeName||h===s.attributesGroupName))throw new Error(`Invalid tag name: ${h}`);n&&i&&"!xml"!==n.tagname&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher,!1));const d=n;d&&s.unpairedTagsSet.has(d.tagname)&&(n=this.tagsNodeStack.pop(),this.matcher.pop());let f=!1;u.length>0&&u.lastIndexOf("/")===u.length-1&&(f=!0,"/"===h[h.length-1]?(h=h.substr(0,h.length-1),u=h):u=u.substr(0,u.length-1),p=h!==u);let g,m=null,x={};g=ct(l),h!==e.tagname&&this.matcher.push(h,{},g),h!==u&&p&&(m=this.buildAttributesMap(u,this.matcher,h),m&&(x=pt(m,s))),h!==e.tagname&&(this.isCurrentNodeStopNode=this.isItStopNode());const N=a;if(this.isCurrentNodeStopNode){let e="";if(f)a=r.closeIndex;else if(s.unpairedTagsSet.has(h))a=r.closeIndex;else{const n=this.readStopNodeData(t,l,c+1);if(!n)throw new Error(`Unexpected end of ${l}`);a=n.i,e=n.tagContent}const i=new $(h);m&&(i[":@"]=m),i.add(s.textNodeName,e),this.matcher.pop(),this.isCurrentNodeStopNode=!1,this.addChild(n,i,this.readonlyMatcher,N)}else{if(f){({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s));const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1}else{if(s.unpairedTagsSet.has(h)){const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1,a=r.closeIndex;continue}{const t=new $(h);if(this.tagsNodeStack.length>s.maxNestedTags)throw new Error("Maximum nested tags exceeded");this.tagsNodeStack.push(n),m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),n=t}}i="",a=c}}}else i+=t[a];return e.child};function bt(t,e,n,i){this.options.captureMetaData||(i=void 0);const s=this.options.jPath?n.toString():n,r=this.options.updateTag(e.tagname,s,e[":@"]);!1===r||("string"==typeof r?(e.tagname=r,t.addChild(e,i)):t.addChild(e,i))}function yt(t,e,n){const i=this.options.processEntities;if(!i||!i.enabled)return t;if(i.allowedTags){const s=this.options.jPath?n.toString():n;if(!(Array.isArray(i.allowedTags)?i.allowedTags.includes(e):i.allowedTags(e,s)))return t}if(i.tagFilter){const s=this.options.jPath?n.toString():n;if(!i.tagFilter(e,s))return t}return this.entityDecoder.decode(t)}function Et(t,e,n,i){return t&&(void 0===i&&(i=0===e.child.length),void 0!==(t=this.parseTextData(t,e.tagname,n,!1,!!e[":@"]&&0!==Object.keys(e[":@"]).length,i))&&""!==t&&e.add(this.options.textNodeName,t),t=""),t}function wt(){return 0!==this.stopNodeExpressionsSet.size&&this.matcher.matchesAny(this.stopNodeExpressionsSet)}function vt(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s+e.length-1}function St(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s}function _t(t,e,n,i=">"){const s=function(t,e,n=">"){let i=0;const s=t.length,r=n.charCodeAt(0),o=n.length>1?n.charCodeAt(1):-1;let a="",h=e;for(let n=e;n<s;n++){const e=t.charCodeAt(n);if(i)e===i&&(i=0);else if(34===e||39===e)i=e;else if(e===r){if(-1===o)return a+=t.substring(h,n),{data:a,index:n};if(t.charCodeAt(n+1)===o)return a+=t.substring(h,n),{data:a,index:n}}else 9!==e||i||(a+=t.substring(h,n)+" ",h=n+1)}}(t,e+1,i);if(!s)return;let r=s.data;const o=s.index,a=r.search(/\s/);let h=r,l=!0;-1!==a&&(h=r.substring(0,a),r=r.substring(a+1).trimStart());const u=h;if(n){const t=h.indexOf(":");-1!==t&&(h=h.substr(t+1),l=h!==s.data.substr(t+1))}return{tagName:h,tagExp:r,closeIndex:o,attrExpPresent:l,rawTagName:u}}function At(t,e,n){const i=n;let s=1;const r=t.length;for(;n<r;n++)if("<"===t[n]){const r=t.charCodeAt(n+1);if(47===r){const r=St(t,">",n,`${e} is not closed`);if(t.substring(n+2,r).trim()===e&&(s--,0===s))return{tagContent:t.substring(i,n),i:r};n=r}else if(63===r)n=vt(t,"?>",n+1,"StopNode is not closed.");else if(33===r&&45===t.charCodeAt(n+2)&&45===t.charCodeAt(n+3))n=vt(t,"--\x3e",n+3,"StopNode is not closed.");else if(33===r&&91===t.charCodeAt(n+2))n=vt(t,"]]>",n,"StopNode is not closed.")-2;else{const i=_t(t,n,!1);i&&((i&&i.tagName)===e&&"/"!==i.tagExp[i.tagExp.length-1]&&s++,n=i.closeIndex)}}}function Tt(t,e,n){if(e&&"string"==typeof t){const e=t.trim();return"true"===e||"false"!==e&&function(t,e={}){if(e=Object.assign({},X,e),!t||"string"!=typeof t)return t;let n=t.trim();if(0===n.length)return t;if(void 0!==e.skipLike&&e.skipLike.test(n))return t;if("0"===n)return 0;if(e.hex&&U.test(n))return q(n,16);if(e.binary&&B.test(n))return q(n,2);if(e.octal&&W.test(n))return q(n,8);if(isFinite(n)){if(n.includes("e")||n.includes("E"))return function(t,e,n){if(!n.eNotation)return t;const i=e.match(Y);if(i){let s=i[1]||"";const r=-1===i[3].indexOf("e")?"E":"e",o=i[2],a=s?t[o.length+1]===r:t[o.length]===r;return o.length>1&&a?t:(1!==o.length||!i[3].startsWith(`.${r}`)&&i[3][0]!==r)&&o.length>0?n.leadingZeros&&!a?(e=(i[1]||"")+i[3],Number(e)):t:Number(e)}return t}(t,n,e);{const s=z.exec(n);if(s){const r=s[1]||"",o=s[2];let a=(i=s[3])&&-1!==i.indexOf(".")?("."===(i=i.replace(/0+$/,""))?i="0":"."===i[0]?i="0"+i:"."===i[i.length-1]&&(i=i.substring(0,i.length-1)),i):i;const h=r?"."===t[o.length+1]:"."===t[o.length];if(!e.leadingZeros&&(o.length>1||1===o.length&&!h))return t;{const i=Number(n),s=String(i);if(0===i)return i;if(-1!==s.search(/[eE]/))return e.eNotation?i:t;if(-1!==n.indexOf("."))return"0"===s||s===a||s===`${r}${a}`?i:t;let h=o?a:n;return o?h===s||r+h===s?i:t:h===s||h===r+s?i:t}}return t}}var i;return function(t,e,n){const i=e===1/0;switch(n.infinity.toLowerCase()){case"null":return null;case"infinity":return e;case"string":return i?"Infinity":"-Infinity";default:return t}}(t,Number(n),e)}(t,n)}return void 0!==t?t:""}function Ct(t,e,n,i){if(t){const i=t(e);n===e&&(n=i),e=i}return{tagName:e=Pt(e,i),tagExp:n}}function Pt(t,e){if(a.includes(t))throw new Error(`[SECURITY] Invalid name: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);return o.includes(t)?e.onDangerousProperty(t):t}const $t=$.getMetaDataSymbol();function Ot(t,e){if(!t||"object"!=typeof t)return{};if(!e)return t;const n={};for(const i in t)i.startsWith(e)?n[i.substring(e.length)]=t[i]:n[i]=t[i];return n}function It(t,e,n,i){return Vt(t,e,n,i)}function Vt(t,e,n,i){let s;const r={};for(let o=0;o<t.length;o++){const a=t[o],h=Dt(a);if(void 0!==h&&h!==e.textNodeName){const t=Ot(a[":@"]||{},e.attributeNamePrefix);n.push(h,t)}if(h===e.textNodeName)void 0===s?s=a[h]:s+=""+a[h];else{if(void 0===h)continue;if(a[h]){let t=Vt(a[h],e,n,i);const s=jt(t,e);if(0===Object.keys(t).length&&e.alwaysCreateTextNode&&(t[e.textNodeName]=""),a[":@"]?Mt(t,a[":@"],i,e):1!==Object.keys(t).length||void 0===t[e.textNodeName]||e.alwaysCreateTextNode?0===Object.keys(t).length&&(e.alwaysCreateTextNode?t[e.textNodeName]="":t=""):t=t[e.textNodeName],void 0!==a[$t]&&"object"==typeof t&&null!==t&&(t[$t]=a[$t]),void 0!==r[h]&&Object.prototype.hasOwnProperty.call(r,h))Array.isArray(r[h])||(r[h]=[r[h]]),r[h].push(t);else{const n=e.jPath?i.toString():i;e.isArray(h,n,s)?r[h]=[t]:r[h]=t}void 0!==h&&h!==e.textNodeName&&n.pop()}}}return"string"==typeof s?s.length>0&&(r[e.textNodeName]=s):void 0!==s&&(r[e.textNodeName]=s),r}function Dt(t){const e=Object.keys(t);for(let t=0;t<e.length;t++){const n=e[t];if(":@"!==n)return n}}function Mt(t,e,n,i){if(e){const s=Object.keys(e),r=s.length;for(let o=0;o<r;o++){const r=s[o],a=r.startsWith(i.attributeNamePrefix)?r.substring(i.attributeNamePrefix.length):r,h=i.jPath?n.toString()+"."+a:n;i.isArray(r,h,!0,!0)?t[r]=[e[r]]:t[r]=e[r]}}}function jt(t,e){const{textNodeName:n}=e,i=Object.keys(t).length;return 0===i||!(1!==i||!t[n]&&"boolean"!=typeof t[n]&&0!==t[n])}class Lt{constructor(t){this.externalEntities={},this.options=C(t)}parse(t,e){if("string"!=typeof t&&t.toString)t=t.toString();else if("string"!=typeof t)throw new Error("XML data is accepted in String or Bytes[] form.");if(e){!0===e&&(e={});const n=l(t,e);if(!0!==n)throw Error(`${n.err.msg}:${n.err.line}:${n.err.col}`)}const n=new dt(this.options,this.externalEntities),i=n.parseXml(t);return this.options.preserveOrder||void 0===i?i:It(i,this.options,n.matcher,n.readonlyMatcher)}addEntity(t,e){if(-1!==e.indexOf("&"))throw new Error("Entity value can't have '&'");if(-1!==t.indexOf("&")||-1!==t.indexOf(";"))throw new Error("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");if("&"===e)throw new Error("An entity with value '&' is not permitted");this.externalEntities[t]=e}static getMetaDataSymbol(){return $.getMetaDataSymbol()}}function kt(t){return String(t).replace(/--/g,"- -").replace(/--/g,"- -").replace(/-$/,"- ")}function Rt(t){return String(t).replace(/\]\]>/g,"]]]]><![CDATA[>")}function Ft(t){return String(t).replace(/"/g,"&quot;").replace(/'/g,"&apos;")}function Gt(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function Ut(t,e){let n="";e.format&&(n="\n");const i=[];if(e.stopNodes&&Array.isArray(e.stopNodes))for(let t=0;t<e.stopNodes.length;t++){const n=e.stopNodes[t];"string"==typeof n?i.push(new K(n)):n instanceof K&&i.push(n)}const s=function(t,e){if(!Array.isArray(t)||0===t.length)return"1.0";const n=t[0];if("?xml"===Yt(n)){const t=n[":@"];if(t){const n=e.attributeNamePrefix+"version";if(t[n])return t[n]}}return"1.0"}(t,e);return Bt(t,e,n,new J,i,s)}function Bt(t,e,n,i,s,r){let o="",a=!1;if(e.maxNestedTags&&i.getDepth()>e.maxNestedTags)throw new Error("Maximum nested tags exceeded");if(!Array.isArray(t)){if(null!=t){let n=t.toString();return n=Jt(n,e),n}return""}for(let h=0;h<t.length;h++){const l=t[h],u=Yt(l);if(void 0===u)continue;const p=u===e.textNodeName||u===e.cdataPropName||u===e.commentPropName||"?"===u[0]?u:Gt(u,!1,e,i,r),c=Wt(l[":@"],e);i.push(p,c);const d=Zt(i,s);if(p===e.textNodeName){let t=l[u];d||(t=e.tagValueProcessor(p,t),t=Jt(t,e)),a&&(o+=n),o+=t,a=!1,i.pop();continue}if(p===e.cdataPropName){a&&(o+=n),o+=`<![CDATA[${Rt(l[u][0][e.textNodeName])}]]>`,a=!1,i.pop();continue}if(p===e.commentPropName){o+=n+`\x3c!--${kt(l[u][0][e.textNodeName])}--\x3e`,a=!0,i.pop();continue}if("?"===p[0]){o+=("?xml"===p?"":n)+`<${p}${qt(l[":@"],e,d,i,r)}?>`,a=!0,i.pop();continue}let f=n;""!==f&&(f+=e.indentBy);const g=n+`<${p}${qt(l[":@"],e,d,i,r)}`;let m;m=d?zt(l[u],e):Bt(l[u],e,f,i,s,r),-1!==e.unpairedTags.indexOf(p)?e.suppressUnpairedNode?o+=g+">":o+=g+"/>":m&&0!==m.length||!e.suppressEmptyNode?m&&m.endsWith(">")?o+=g+`>${m}${n}</${p}>`:(o+=g+">",m&&""!==n&&(m.includes("/>")||m.includes("</"))?o+=n+e.indentBy+m+n:o+=m,o+=`</${p}>`):o+=g+"/>",a=!0,i.pop()}return o}function Wt(t,e){if(!t||e.ignoreAttributes)return null;const n={};let i=!1;for(let s in t)Object.prototype.hasOwnProperty.call(t,s)&&(n[s.startsWith(e.attributeNamePrefix)?s.substr(e.attributeNamePrefix.length):s]=Ft(t[s]),i=!0);return i?n:null}function zt(t,e){if(!Array.isArray(t))return null!=t?t.toString():"";let n="";for(let i=0;i<t.length;i++){const s=t[i],r=Yt(s);if(r===e.textNodeName)n+=s[r];else if(r===e.cdataPropName)n+=s[r][0][e.textNodeName];else if(r===e.commentPropName)n+=s[r][0][e.textNodeName];else{if(r&&"?"===r[0])continue;if(r){const t=Xt(s[":@"],e),i=zt(s[r],e);i&&0!==i.length?n+=`<${r}${t}>${i}</${r}>`:n+=`<${r}${t}/>`}}}return n}function Xt(t,e){let n="";if(t&&!e.ignoreAttributes)for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;let s=t[i];!0===s&&e.suppressBooleanAttributes?n+=` ${i.substr(e.attributeNamePrefix.length)}`:n+=` ${i.substr(e.attributeNamePrefix.length)}="${Ft(s)}"`}return n}function Yt(t){const e=Object.keys(t);for(let n=0;n<e.length;n++){const i=e[n];if(Object.prototype.hasOwnProperty.call(t,i)&&":@"!==i)return i}}function qt(t,e,n,i,s){let r="";if(t&&!e.ignoreAttributes)for(let o in t){if(!Object.prototype.hasOwnProperty.call(t,o))continue;const a=o.substr(e.attributeNamePrefix.length),h=n?a:Gt(a,!0,e,i,s);let l;n?l=t[o]:(l=e.attributeValueProcessor(o,t[o]),l=Jt(l,e)),!0===l&&e.suppressBooleanAttributes?r+=` ${h}`:r+=` ${h}="${Ft(l)}"`}return r}function Zt(t,e){if(!e||0===e.length)return!1;for(let n=0;n<e.length;n++)if(t.matches(e[n]))return!0;return!1}function Jt(t,e){if(t&&t.length>0&&e.processEntities)for(let n=0;n<e.entities.length;n++){const i=e.entities[n];t=t.replace(i.regex,i.val)}return t}const Kt={attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,cdataPropName:!1,format:!1,indentBy:"  ",suppressEmptyNode:!1,suppressUnpairedNode:!0,suppressBooleanAttributes:!0,tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},preserveOrder:!1,commentPropName:!1,unpairedTags:[],entities:[{regex:new RegExp("&","g"),val:"&amp;"},{regex:new RegExp(">","g"),val:"&gt;"},{regex:new RegExp("<","g"),val:"&lt;"},{regex:new RegExp("'","g"),val:"&apos;"},{regex:new RegExp('"',"g"),val:"&quot;"}],processEntities:!0,stopNodes:[],oneListGroup:!1,maxNestedTags:100,jPath:!0,sanitizeName:!1};function Qt(t){if(this.options=Object.assign({},Kt,t),this.options.stopNodes&&Array.isArray(this.options.stopNodes)&&(this.options.stopNodes=this.options.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),this.stopNodeExpressions=[],this.options.stopNodes&&Array.isArray(this.options.stopNodes))for(let t=0;t<this.options.stopNodes.length;t++){const e=this.options.stopNodes[t];"string"==typeof e?this.stopNodeExpressions.push(new K(e)):e instanceof K&&this.stopNodeExpressions.push(e)}var e;!0===this.options.ignoreAttributes||this.options.attributesGroupName?this.isAttribute=function(){return!1}:(this.ignoreAttributesFn="function"==typeof(e=this.options.ignoreAttributes)?e:Array.isArray(e)?t=>{for(const n of e){if("string"==typeof n&&t===n)return!0;if(n instanceof RegExp&&n.test(t))return!0}}:()=>!1,this.attrPrefixLen=this.options.attributeNamePrefix.length,this.isAttribute=ne),this.processTextOrObjNode=te,this.options.format?(this.indentate=ee,this.tagEndChar=">\n",this.newLine="\n"):(this.indentate=function(){return""},this.tagEndChar=">",this.newLine="")}function Ht(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function te(t,e,n,i,s){const r=this.extractAttributes(t);if(i.push(e,r),this.checkStopNode(i)){const s=this.buildRawContent(t),r=this.buildAttributesForStopNode(t);return i.pop(),this.buildObjectNode(s,e,r,n)}const o=this.j2x(t,n+1,i,s);return i.pop(),"?"===e[0]?this.buildTextValNode("",e,o.attrStr,n,i):void 0!==t[this.options.textNodeName]&&1===Object.keys(t).length?this.buildTextValNode(t[this.options.textNodeName],e,o.attrStr,n,i):this.buildObjectNode(o.val,e,o.attrStr,n)}function ee(t){return this.options.indentBy.repeat(t)}function ne(t){return!(!t.startsWith(this.options.attributeNamePrefix)||t===this.options.textNodeName)&&t.substr(this.attrPrefixLen)}Qt.prototype.build=function(t){if(this.options.preserveOrder)return Ut(t,this.options);{Array.isArray(t)&&this.options.arrayNodeName&&this.options.arrayNodeName.length>1&&(t={[this.options.arrayNodeName]:t});const e=new J,n=function(t,e){const n=t["?xml"];if(n&&"object"==typeof n){if(e.attributesGroupName&&n[e.attributesGroupName]){const t=n[e.attributesGroupName][e.attributeNamePrefix+"version"];if(t)return t}const t=n[e.attributeNamePrefix+"version"];if(t)return t}return"1.0"}(t,this.options);return this.j2x(t,0,e,n).val}},Qt.prototype.j2x=function(t,e,n,i){let s="",r="";if(this.options.maxNestedTags&&n.getDepth()>=this.options.maxNestedTags)throw new Error("Maximum nested tags exceeded");const o=this.options.jPath?n.toString():n,a=this.checkStopNode(n);for(let h in t){if(!Object.prototype.hasOwnProperty.call(t,h))continue;const l=h===this.options.textNodeName||h===this.options.cdataPropName||h===this.options.commentPropName||this.options.attributesGroupName&&h===this.options.attributesGroupName||this.isAttribute(h)||"?"===h[0]?h:Ht(h,!1,this.options,n,i);if(void 0===t[h])this.isAttribute(h)&&(r+="");else if(null===t[h])this.isAttribute(h)||l===this.options.cdataPropName||l===this.options.commentPropName?r+="":"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if(t[h]instanceof Date)r+=this.buildTextValNode(t[h],l,"",e,n);else if("object"!=typeof t[h]){const u=this.isAttribute(h);if(u&&!this.ignoreAttributesFn(u,o)){const e=Ht(u,!0,this.options,n,i);s+=this.buildAttrPairStr(e,""+t[h],a)}else if(!u)if(h===this.options.textNodeName){let e=this.options.tagValueProcessor(h,""+t[h]);r+=this.replaceEntitiesValue(e)}else{n.push(l);const i=this.checkStopNode(n);if(n.pop(),i){const n=""+t[h];r+=""===n?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+n+"</"+l+this.tagEndChar}else r+=this.buildTextValNode(t[h],l,"",e,n)}}else if(Array.isArray(t[h])){const s=t[h].length;let o="",a="";for(let u=0;u<s;u++){const s=t[h][u];if(void 0===s);else if(null===s)"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if("object"==typeof s)if(this.options.oneListGroup){n.push(l);const t=this.j2x(s,e+1,n,i);n.pop(),o+=t.val,this.options.attributesGroupName&&s.hasOwnProperty(this.options.attributesGroupName)&&(a+=t.attrStr)}else o+=this.processTextOrObjNode(s,l,e,n,i);else if(this.options.oneListGroup){let t=this.options.tagValueProcessor(l,s);t=this.replaceEntitiesValue(t),o+=t}else{n.push(l);const t=this.checkStopNode(n);if(n.pop(),t){const t=""+s;o+=""===t?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+t+"</"+l+this.tagEndChar}else o+=this.buildTextValNode(s,l,"",e,n)}}this.options.oneListGroup&&(o=this.buildObjectNode(o,l,a,e)),r+=o}else if(this.options.attributesGroupName&&h===this.options.attributesGroupName){const e=Object.keys(t[h]),r=e.length;for(let o=0;o<r;o++){const r=Ht(e[o],!0,this.options,n,i);s+=this.buildAttrPairStr(r,""+t[h][e[o]],a)}}else r+=this.processTextOrObjNode(t[h],l,e,n,i)}return{attrStr:s,val:r}},Qt.prototype.buildAttrPairStr=function(t,e,n){return n||(e=this.options.attributeValueProcessor(t,""+e),e=this.replaceEntitiesValue(e)),this.options.suppressBooleanAttributes&&"true"===e?" "+t:" "+t+'="'+Ft(e)+'"'},Qt.prototype.extractAttributes=function(t){if(!t||"object"!=typeof t)return null;const e={};let n=!1;if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const i=t[this.options.attributesGroupName];for(let t in i)Object.prototype.hasOwnProperty.call(i,t)&&(e[t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t]=Ft(i[t]),n=!0)}else for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;const s=this.isAttribute(i);s&&(e[s]=Ft(t[i]),n=!0)}return n?e:null},Qt.prototype.buildRawContent=function(t){if("string"==typeof t)return t;if("object"!=typeof t||null===t)return String(t);if(void 0!==t[this.options.textNodeName])return t[this.options.textNodeName];let e="";for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;if(this.isAttribute(n))continue;if(this.options.attributesGroupName&&n===this.options.attributesGroupName)continue;const i=t[n];if(n===this.options.textNodeName)e+=i;else if(Array.isArray(i)){for(let t of i)if("string"==typeof t||"number"==typeof t)e+=`<${n}>${t}</${n}>`;else if("object"==typeof t&&null!==t){const i=this.buildRawContent(t),s=this.buildAttributesForStopNode(t);e+=""===i?`<${n}${s}/>`:`<${n}${s}>${i}</${n}>`}}else if("object"==typeof i&&null!==i){const t=this.buildRawContent(i),s=this.buildAttributesForStopNode(i);e+=""===t?`<${n}${s}/>`:`<${n}${s}>${t}</${n}>`}else e+=`<${n}>${i}</${n}>`}return e},Qt.prototype.buildAttributesForStopNode=function(t){if(!t||"object"!=typeof t)return"";let e="";if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const n=t[this.options.attributesGroupName];for(let t in n){if(!Object.prototype.hasOwnProperty.call(n,t))continue;const i=t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t,s=n[t];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}else for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;const i=this.isAttribute(n);if(i){const s=t[n];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}return e},Qt.prototype.buildObjectNode=function(t,e,n,i){if(""===t)return"?"===e[0]?this.indentate(i)+"<"+e+n+"?"+this.tagEndChar:this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar;if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s="</"+e+this.tagEndChar,r="";return"?"===e[0]&&(r="?",s=""),!n&&""!==n||-1!==t.indexOf("<")?!1!==this.options.commentPropName&&e===this.options.commentPropName&&0===r.length?this.indentate(i)+`\x3c!--${t}--\x3e`+this.newLine:this.indentate(i)+"<"+e+n+r+this.tagEndChar+t+this.indentate(i)+s:this.indentate(i)+"<"+e+n+r+">"+t+s}},Qt.prototype.closeTag=function(t){let e="";return-1!==this.options.unpairedTags.indexOf(t)?this.options.suppressUnpairedNode||(e="/"):e=this.options.suppressEmptyNode?"/":`></${t}`,e},Qt.prototype.checkStopNode=function(t){if(!this.stopNodeExpressions||0===this.stopNodeExpressions.length)return!1;for(let e=0;e<this.stopNodeExpressions.length;e++)if(t.matches(this.stopNodeExpressions[e]))return!0;return!1},Qt.prototype.buildTextValNode=function(t,e,n,i,s){if(!1!==this.options.cdataPropName&&e===this.options.cdataPropName){const e=Rt(t);return this.indentate(i)+`<![CDATA[${e}]]>`+this.newLine}if(!1!==this.options.commentPropName&&e===this.options.commentPropName){const e=kt(t);return this.indentate(i)+`\x3c!--${e}--\x3e`+this.newLine}if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s=this.options.tagValueProcessor(e,t);return s=this.replaceEntitiesValue(s),""===s?this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar:this.indentate(i)+"<"+e+n+">"+s+"</"+e+this.tagEndChar}},Qt.prototype.replaceEntitiesValue=function(t){if(t&&t.length>0&&this.options.processEntities)for(let e=0;e<this.options.entities.length;e++){const n=this.options.entities[e];t=t.replace(n.regex,n.val)}return t};const ie=Qt,se={validate:l};module.exports=e})();
 
 /***/ }),
 
-/***/ 332:
+/***/ 330:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65625,7 +65547,7 @@ var KnownEncryptionAlgorithmType;
 
 /***/ }),
 
-/***/ 333:
+/***/ 331:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -65854,7 +65776,7 @@ function replaceAll(value, searchValue, replaceValue) {
 
 /***/ }),
 
-/***/ 334:
+/***/ 332:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65880,10 +65802,10 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(407);
-var import_throttlingRetryStrategy = __nccwpck_require__(39);
-var import_retryPolicy = __nccwpck_require__(18);
-var import_constants = __nccwpck_require__(52);
+var import_exponentialRetryStrategy = __nccwpck_require__(408);
+var import_throttlingRetryStrategy = __nccwpck_require__(37);
+var import_retryPolicy = __nccwpck_require__(17);
+var import_constants = __nccwpck_require__(50);
 const defaultRetryPolicyName = "defaultRetryPolicy";
 function defaultRetryPolicy(options = {}) {
   return {
@@ -65900,7 +65822,7 @@ function defaultRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 335:
+/***/ 333:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65909,10 +65831,10 @@ function defaultRetryPolicy(options = {}) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageRetryPolicyFactory = exports.NewRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = void 0;
-const StorageRetryPolicy_js_1 = __nccwpck_require__(85);
+const StorageRetryPolicy_js_1 = __nccwpck_require__(82);
 Object.defineProperty(exports, "StorageRetryPolicy", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.StorageRetryPolicy; } }));
 Object.defineProperty(exports, "NewRetryPolicyFactory", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.NewRetryPolicyFactory; } }));
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(428);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(429);
 Object.defineProperty(exports, "StorageRetryPolicyType", ({ enumerable: true, get: function () { return StorageRetryPolicyType_js_1.StorageRetryPolicyType; } }));
 /**
  * StorageRetryPolicyFactory is a factory class helping generating {@link StorageRetryPolicy} objects.
@@ -65941,7 +65863,7 @@ exports.StorageRetryPolicyFactory = StorageRetryPolicyFactory;
 
 /***/ }),
 
-/***/ 336:
+/***/ 334:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65969,7 +65891,7 @@ __export(file_exports, {
   hasRawContent: () => hasRawContent
 });
 module.exports = __toCommonJS(file_exports);
-var import_core_util = __nccwpck_require__(16);
+var import_core_util = __nccwpck_require__(15);
 function isNodeReadableStream(x) {
   return Boolean(x && typeof x["pipe"] === "function");
 }
@@ -66047,7 +65969,7 @@ function toArrayBuffer(source) {
 
 /***/ }),
 
-/***/ 337:
+/***/ 335:
 /***/ ((module) => {
 
 "use strict";
@@ -66152,7 +66074,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 338:
+/***/ 336:
 /***/ ((module) => {
 
 "use strict";
@@ -66160,7 +66082,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 339:
+/***/ 337:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -66179,7 +66101,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 340:
+/***/ 338:
 /***/ (function(module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -66218,13 +66140,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._readLinuxVersionFile = exports._getOsVersion = exports._findMatch = void 0;
-const semver = __importStar(__nccwpck_require__(183));
-const core_1 = __nccwpck_require__(474);
+const semver = __importStar(__nccwpck_require__(180));
+const core_1 = __nccwpck_require__(475);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
-const os = __nccwpck_require__(98);
-const cp = __nccwpck_require__(170);
-const fs = __nccwpck_require__(546);
+const os = __nccwpck_require__(95);
+const cp = __nccwpck_require__(167);
+const fs = __nccwpck_require__(547);
 function _findMatch(versionSpec, stable, candidates, archFilter) {
     return __awaiter(this, void 0, void 0, function* () {
         const platFilter = os.platform();
@@ -66315,7 +66237,7 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
-/***/ 341:
+/***/ 339:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -66345,7 +66267,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-const path = __importStar(__nccwpck_require__(256));
+const path = __importStar(__nccwpck_require__(254));
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
  * replaced with /.
@@ -66384,7 +66306,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 342:
+/***/ 340:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -66492,7 +66414,7 @@ var WireType;
 
 /***/ }),
 
-/***/ 343:
+/***/ 341:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66501,19 +66423,19 @@ var WireType;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatch = void 0;
-const core_util_1 = __nccwpck_require__(16);
-const core_auth_1 = __nccwpck_require__(528);
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const core_util_2 = __nccwpck_require__(16);
-const storage_common_1 = __nccwpck_require__(285);
-const Clients_js_1 = __nccwpck_require__(189);
-const Mutex_js_1 = __nccwpck_require__(533);
-const Pipeline_js_1 = __nccwpck_require__(187);
-const utils_common_js_1 = __nccwpck_require__(161);
-const core_xml_1 = __nccwpck_require__(199);
-const constants_js_1 = __nccwpck_require__(155);
-const tracing_js_1 = __nccwpck_require__(35);
-const core_client_1 = __nccwpck_require__(452);
+const core_util_1 = __nccwpck_require__(15);
+const core_auth_1 = __nccwpck_require__(529);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const core_util_2 = __nccwpck_require__(15);
+const storage_common_1 = __nccwpck_require__(283);
+const Clients_js_1 = __nccwpck_require__(186);
+const Mutex_js_1 = __nccwpck_require__(534);
+const Pipeline_js_1 = __nccwpck_require__(184);
+const utils_common_js_1 = __nccwpck_require__(158);
+const core_xml_1 = __nccwpck_require__(196);
+const constants_js_1 = __nccwpck_require__(152);
+const tracing_js_1 = __nccwpck_require__(33);
+const core_client_1 = __nccwpck_require__(453);
 /**
  * A BlobBatch represents an aggregated set of operations on blobs.
  * Currently, only `delete` and `setAccessTier` are supported.
@@ -66777,7 +66699,7 @@ function batchHeaderFilterPolicy() {
 
 /***/ }),
 
-/***/ 344:
+/***/ 342:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66786,17 +66708,17 @@ function batchHeaderFilterPolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = exports.AvroReadable = exports.AvroReader = void 0;
-var AvroReader_js_1 = __nccwpck_require__(432);
+var AvroReader_js_1 = __nccwpck_require__(433);
 Object.defineProperty(exports, "AvroReader", ({ enumerable: true, get: function () { return AvroReader_js_1.AvroReader; } }));
-var AvroReadable_js_1 = __nccwpck_require__(398);
+var AvroReadable_js_1 = __nccwpck_require__(397);
 Object.defineProperty(exports, "AvroReadable", ({ enumerable: true, get: function () { return AvroReadable_js_1.AvroReadable; } }));
-var AvroReadableFromStream_js_1 = __nccwpck_require__(260);
+var AvroReadableFromStream_js_1 = __nccwpck_require__(258);
 Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, get: function () { return AvroReadableFromStream_js_1.AvroReadableFromStream; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 345:
+/***/ 343:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -66822,13 +66744,13 @@ __export(tracingPolicy_exports, {
   tracingPolicyName: () => tracingPolicyName
 });
 module.exports = __toCommonJS(tracingPolicy_exports);
-var import_core_tracing = __nccwpck_require__(86);
-var import_constants = __nccwpck_require__(165);
-var import_userAgent = __nccwpck_require__(300);
-var import_log = __nccwpck_require__(188);
-var import_core_util = __nccwpck_require__(16);
-var import_restError = __nccwpck_require__(363);
-var import_util = __nccwpck_require__(153);
+var import_core_tracing = __nccwpck_require__(83);
+var import_constants = __nccwpck_require__(162);
+var import_userAgent = __nccwpck_require__(298);
+var import_log = __nccwpck_require__(185);
+var import_core_util = __nccwpck_require__(15);
+var import_restError = __nccwpck_require__(362);
+var import_util = __nccwpck_require__(150);
 const tracingPolicyName = "tracingPolicy";
 function tracingPolicy(options = {}) {
   const userAgentPromise = (0, import_userAgent.getUserAgentValue)(options.userAgentPrefix);
@@ -66942,7 +66864,7 @@ function tryProcessResponse(span, response) {
 
 /***/ }),
 
-/***/ 346:
+/***/ 344:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -66955,13 +66877,13 @@ const {
   kAddClient,
   kGetDispatcher
 } = __nccwpck_require__(378)
-const Client = __nccwpck_require__(94)
+const Client = __nccwpck_require__(91)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(504)
-const util = __nccwpck_require__(75)
-const { kUrl, kInterceptors } = __nccwpck_require__(200)
-const buildConnector = __nccwpck_require__(274)
+} = __nccwpck_require__(505)
+const util = __nccwpck_require__(72)
+const { kUrl, kInterceptors } = __nccwpck_require__(197)
+const buildConnector = __nccwpck_require__(273)
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -67058,7 +66980,7 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 347:
+/***/ 345:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67084,7 +67006,7 @@ __export(oauth2AuthenticationPolicy_exports, {
   oauth2AuthenticationPolicyName: () => oauth2AuthenticationPolicyName
 });
 module.exports = __toCommonJS(oauth2AuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(447);
+var import_checkInsecureConnection = __nccwpck_require__(448);
 const oauth2AuthenticationPolicyName = "oauth2AuthenticationPolicy";
 function oauth2AuthenticationPolicy(options) {
   return {
@@ -67110,7 +67032,7 @@ function oauth2AuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 348:
+/***/ 346:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67136,9 +67058,9 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(295);
-var import_checkEnvironment = __nccwpck_require__(451);
-var import_httpHeaders = __nccwpck_require__(501);
+var import_bytesEncoding = __nccwpck_require__(293);
+var import_checkEnvironment = __nccwpck_require__(452);
+var import_httpHeaders = __nccwpck_require__(502);
 const formDataPolicyName = "formDataPolicy";
 function formDataToFormDataMap(formData) {
   const formDataMap = {};
@@ -67226,7 +67148,7 @@ async function prepareFormData(formData, request) {
 
 /***/ }),
 
-/***/ 349:
+/***/ 347:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -67284,8 +67206,8 @@ exports.detectSoldrSupportsToolchainSubcommands = detectSoldrSupportsToolchainSu
 exports.soldrToolchainEnsure = soldrToolchainEnsure;
 exports.soldrToolchainLink = soldrToolchainLink;
 exports.soldrToolchainDoctor = soldrToolchainDoctor;
-const exec = __importStar(__nccwpck_require__(20));
-const verify_soldr_js_1 = __nccwpck_require__(364);
+const exec = __importStar(__nccwpck_require__(19));
+const verify_soldr_js_1 = __nccwpck_require__(363);
 /**
  * Minimum soldr version that exposes the `toolchain ensure/link/doctor`
  * JSON subcommands. Set by Wave 3.4 of zackees/soldr#514.
@@ -67540,7 +67462,7 @@ async function soldrToolchainDoctor(soldrPath, deps) {
 
 /***/ }),
 
-/***/ 350:
+/***/ 348:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67566,7 +67488,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(292);
 const redirectPolicyName = import_policies.redirectPolicyName;
 function redirectPolicy(options = {}) {
   return (0, import_policies.redirectPolicy)(options);
@@ -67577,19 +67499,19 @@ function redirectPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 351:
+/***/ 349:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(200)
-const { URL } = __nccwpck_require__(91)
+const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(197)
+const { URL } = __nccwpck_require__(88)
 const Agent = __nccwpck_require__(5)
-const Pool = __nccwpck_require__(346)
-const DispatcherBase = __nccwpck_require__(68)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(504)
-const buildConnector = __nccwpck_require__(274)
+const Pool = __nccwpck_require__(344)
+const DispatcherBase = __nccwpck_require__(65)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(505)
+const buildConnector = __nccwpck_require__(273)
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -67774,19 +67696,19 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 352:
+/***/ 350:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonReader = void 0;
-const json_typings_1 = __nccwpck_require__(406);
-const base64_1 = __nccwpck_require__(312);
-const reflection_info_1 = __nccwpck_require__(466);
-const pb_long_1 = __nccwpck_require__(122);
-const assert_1 = __nccwpck_require__(500);
-const reflection_long_convert_1 = __nccwpck_require__(164);
+const json_typings_1 = __nccwpck_require__(407);
+const base64_1 = __nccwpck_require__(310);
+const reflection_info_1 = __nccwpck_require__(467);
+const pb_long_1 = __nccwpck_require__(119);
+const assert_1 = __nccwpck_require__(501);
+const reflection_long_convert_1 = __nccwpck_require__(161);
 /**
  * Reads proto3 messages in canonical JSON format using reflection information.
  *
@@ -68099,7 +68021,7 @@ exports.ReflectionJsonReader = ReflectionJsonReader;
 
 /***/ }),
 
-/***/ 353:
+/***/ 351:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -68115,8 +68037,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
-const os_1 = __nccwpck_require__(98);
-const fs_1 = __nccwpck_require__(546);
+const os_1 = __nccwpck_require__(95);
+const fs_1 = __nccwpck_require__(547);
 const { access, appendFile, writeFile } = fs_1.promises;
 exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
 exports.SUMMARY_DOCS_URL = 'https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary';
@@ -68389,7 +68311,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 354:
+/***/ 352:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -68472,7 +68394,7 @@ exports.utf8read = utf8read;
 
 /***/ }),
 
-/***/ 355:
+/***/ 353:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -68533,14 +68455,14 @@ exports.applyStagedToLiveRoots = applyStagedToLiveRoots;
 exports.saveSoloCache = saveSoloCache;
 exports.restoreSoloCache = restoreSoloCache;
 exports.verifyRestoredToolchain = verifyRestoredToolchain;
-const node_crypto_1 = __nccwpck_require__(282);
-const fs = __importStar(__nccwpck_require__(257));
-const fsp = __importStar(__nccwpck_require__(114));
-const os = __importStar(__nccwpck_require__(393));
-const path = __importStar(__nccwpck_require__(522));
-const cache = __importStar(__nccwpck_require__(218));
-const exec = __importStar(__nccwpck_require__(20));
-const cache_compress_js_1 = __nccwpck_require__(480);
+const node_crypto_1 = __nccwpck_require__(281);
+const fs = __importStar(__nccwpck_require__(255));
+const fsp = __importStar(__nccwpck_require__(111));
+const os = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(523));
+const cache = __importStar(__nccwpck_require__(217));
+const exec = __importStar(__nccwpck_require__(19));
+const cache_compress_js_1 = __nccwpck_require__(481);
 /**
  * The two live roots whose deltas this cache layer tracks. The string keys
  * are also the directory names used inside the tarball staging layout.
@@ -69033,13 +68955,13 @@ async function verifyRestoredToolchain(opts) {
 
 /***/ }),
 
-/***/ 356:
+/***/ 354:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 /* eslint-disable no-new-wrappers, no-eval, camelcase, operator-linebreak */
-module.exports = makeParserClass(__nccwpck_require__(437))
+module.exports = makeParserClass(__nccwpck_require__(438))
 module.exports.makeParserClass = makeParserClass
 
 class TomlError extends Error {
@@ -69060,10 +68982,10 @@ TomlError.wrap = err => {
 }
 module.exports.TomlError = TomlError
 
-const createDateTime = __nccwpck_require__(395)
-const createDateTimeFloat = __nccwpck_require__(176)
-const createDate = __nccwpck_require__(60)
-const createTime = __nccwpck_require__(358)
+const createDateTime = __nccwpck_require__(394)
+const createDateTimeFloat = __nccwpck_require__(173)
+const createDate = __nccwpck_require__(57)
+const createTime = __nccwpck_require__(357)
 
 const CTRL_I = 0x09
 const CTRL_J = 0x0A
@@ -70420,7 +70342,7 @@ function makeParserClass (Parser) {
 
 /***/ }),
 
-/***/ 357:
+/***/ 355:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70429,8 +70351,8 @@ function makeParserClass (Parser) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = createTracingClient;
-const instrumenter_js_1 = __nccwpck_require__(418);
-const tracingContext_js_1 = __nccwpck_require__(380);
+const instrumenter_js_1 = __nccwpck_require__(419);
+const tracingContext_js_1 = __nccwpck_require__(379);
 /**
  * Creates a new tracing client.
  *
@@ -70508,12 +70430,1171 @@ function createTracingClient(options) {
 
 /***/ }),
 
-/***/ 358:
+/***/ 356:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Top-level resolve-setup entry point. Owned by Agent 1.
+//
+// Full port of resolve_setup.py::main(). Reads INPUT_* / GITHUB_* env vars,
+// resolves the toolchain spec, derives all cache keys, computes the env
+// exports + outputs the orchestrator needs.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.pythonDefaultJson = exports.buildOutputs = exports.detectMuslCcEnv = exports.detectUserLinkerEnv = exports.parseRustBacktrace = exports.parseCacheShutdownOnIdleSeconds = exports.readRawInputs = void 0;
+exports.resolveRustupStrategy = resolveRustupStrategy;
+exports.detectZccachePrivateOverlap = detectZccachePrivateOverlap;
+exports.resolveSetup = resolveSetup;
+exports.applyResolveResult = applyResolveResult;
+const os = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(523));
+const fs = __importStar(__nccwpck_require__(255));
+const core = __importStar(__nccwpck_require__(475));
+const cache_keys_js_1 = __nccwpck_require__(23);
+const blessed_cross_prepare_js_1 = __nccwpck_require__(436);
+const log_utils_js_1 = __nccwpck_require__(193);
+const cache_encrypt_js_1 = __nccwpck_require__(239);
+const dylint_nightly_js_1 = __nccwpck_require__(376);
+const detect_musl_cc_js_1 = __nccwpck_require__(478);
+Object.defineProperty(exports, "detectMuslCcEnv", ({ enumerable: true, get: function () { return detect_musl_cc_js_1.detectMuslCcEnv; } }));
+const build_outputs_js_1 = __nccwpck_require__(400);
+Object.defineProperty(exports, "buildOutputs", ({ enumerable: true, get: function () { return build_outputs_js_1.buildOutputs; } }));
+const raw_inputs_js_1 = __nccwpck_require__(466);
+Object.defineProperty(exports, "readRawInputs", ({ enumerable: true, get: function () { return raw_inputs_js_1.readRawInputs; } }));
+const phase_timing_js_1 = __nccwpck_require__(532);
+const input_parsers_js_1 = __nccwpck_require__(86);
+Object.defineProperty(exports, "detectUserLinkerEnv", ({ enumerable: true, get: function () { return input_parsers_js_1.detectUserLinkerEnv; } }));
+Object.defineProperty(exports, "parseCacheShutdownOnIdleSeconds", ({ enumerable: true, get: function () { return input_parsers_js_1.parseCacheShutdownOnIdleSeconds; } }));
+Object.defineProperty(exports, "parseRustBacktrace", ({ enumerable: true, get: function () { return input_parsers_js_1.parseRustBacktrace; } }));
+const fetch_release_js_1 = __nccwpck_require__(149);
+const cargo_registry_archive_js_1 = __nccwpck_require__(210);
+const soldr_load_shim_js_1 = __nccwpck_require__(371);
+const python_json_js_1 = __nccwpck_require__(12);
+Object.defineProperty(exports, "pythonDefaultJson", ({ enumerable: true, get: function () { return python_json_js_1.pythonDefaultJson; } }));
+const toolchain_js_1 = __nccwpck_require__(308);
+const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
+const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
+const ALLOWED_LINKER_VALUES = [
+    "default",
+    "platform-default",
+    "ld",
+    "mold",
+    "rust-lld",
+    "fast",
+];
+// CARGO_MAKEFLAGS / MAKEFLAGS describe an in-process jobserver pipe whose
+// FDs are closed once the producing process exits. Forwarding via $GITHUB_ENV
+// causes "failed to connect to jobserver" warnings in every downstream step.
+// See setup-soldr#71.
+const GITHUB_ENV_DENY_LIST = new Set(["CARGO_MAKEFLAGS", "MAKEFLAGS"]);
+function expanduser(p, env) {
+    if (!p)
+        return p;
+    if (p.startsWith("~")) {
+        const home = env["HOME"] || env["USERPROFILE"] || "";
+        if (p === "~")
+            return home;
+        if (p.startsWith("~/") || p.startsWith("~\\")) {
+            return path.join(home, p.slice(2));
+        }
+    }
+    return p;
+}
+function resolveAbsolute(p, env) {
+    return path.resolve(expanduser(p, env));
+}
+function isFalsy(value) {
+    return FALSY_VALUES.has(value.trim().toLowerCase());
+}
+function isTruthy(value) {
+    return TRUTHY_VALUES.has(value.trim().toLowerCase());
+}
+function defaultHomeDir(env, name) {
+    const home = env["HOME"] || env["USERPROFILE"] || os.homedir();
+    return path.resolve(path.join(home, name));
+}
+function parseOptInBool(inputName, value, defaultValue = false) {
+    const raw = value.trim().toLowerCase();
+    if (!raw)
+        return defaultValue;
+    if (TRUTHY_VALUES.has(raw))
+        return true;
+    if (FALSY_VALUES.has(raw))
+        return false;
+    throw new Error(`invalid '${inputName}' input: '${value}'. Allowed: true | false`);
+}
+function semverAtLeast(value, minimum) {
+    const parse = (v) => {
+        const m = v.trim().replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)/);
+        if (!m)
+            return null;
+        return [Number(m[1]), Number(m[2]), Number(m[3])];
+    };
+    const got = parse(value);
+    const want = parse(minimum);
+    if (!got || !want)
+        return false;
+    for (let i = 0; i < 3; i += 1) {
+        if (got[i] > want[i])
+            return true;
+        if (got[i] < want[i])
+            return false;
+    }
+    return true;
+}
+function rustHostTriple(runnerOs, runnerArch) {
+    const osName = runnerOs.trim().toLowerCase();
+    const archName = runnerArch.trim().toLowerCase();
+    const arch = archName === "x64" || archName === "amd64"
+        ? "x86_64"
+        : archName === "arm64" || archName === "aarch64"
+            ? "aarch64"
+            : archName === "x86" || archName === "ia32"
+                ? "i686"
+                : (0, cache_keys_js_1.sanitizeFragment)(archName || "unknown");
+    if (osName === "windows" || osName === "win32")
+        return `${arch}-pc-windows-msvc`;
+    if (osName === "macos" || osName === "darwin")
+        return `${arch}-apple-darwin`;
+    if (osName === "linux")
+        return `${arch}-unknown-linux-gnu`;
+    return `${arch}-${(0, cache_keys_js_1.sanitizeFragment)(osName || "unknown")}`;
+}
+function splitPathInput(value) {
+    return value
+        .split(/[\r\n,]+/g)
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0);
+}
+function defaultDylintCachePaths(cargoHome, driverPath) {
+    return [
+        path.join(cargoHome, "bin", "cargo-dylint*"),
+        path.join(cargoHome, "bin", "dylint-link*"),
+        path.join(cargoHome, ".crates.toml"),
+        path.join(cargoHome, ".crates2.json"),
+        driverPath,
+    ];
+}
+function makeDirs(...paths) {
+    for (const p of paths) {
+        fs.mkdirSync(p, { recursive: true });
+    }
+}
+/**
+ * Pure helper: decide the final rustup strategy from the requested one and
+ * the host platform. On macOS we always override `system` to `managed` to
+ * avoid the pre-installed rustup toolchain conflicts (see setup-soldr#105).
+ *
+ * GitHub-hosted `macos-15` (ARM) runners ship with a stable rustup toolchain
+ * that already includes `clippy`. Downstream actions that try to install a
+ * different toolchain with clippy hit
+ *   detected conflict: 'bin/cargo-clippy'
+ * because rustup component add refuses to overwrite the existing binary in
+ * the shared rustup home. Forcing the managed strategy gives setup-soldr its
+ * own private rustup home so the pre-installed components cannot collide.
+ *
+ * `explicit` (user-provided RUSTUP_HOME) is left untouched on every platform
+ * — opting in to a specific home means accepting any conflicts that come
+ * with it.
+ */
+function resolveRustupStrategy(opts) {
+    const { requested, platform, warn } = opts;
+    if (platform === "darwin" && requested === "system") {
+        warn?.("setup-soldr: forcing rustup strategy to 'managed' on macOS to avoid " +
+            "pre-installed rustup toolchain component conflicts (e.g. " +
+            "\"detected conflict: 'bin/cargo-clippy'\" on macos-15 runners). " +
+            "See https://github.com/zackees/setup-soldr/issues/105 for context. " +
+            "This may change which setup-cache key is used compared to other " +
+            "platforms.");
+        return "managed";
+    }
+    return requested;
+}
+/**
+ * Detect the `SOLDR_ZCCACHE_PRIVATE` ↔ `ZCCACHE_CACHE_DIR` overlap.
+ *
+ * soldr#807 added `SOLDR_ZCCACHE_PRIVATE` as an opt-in that reroutes the
+ * managed zccache cache to `<cwd>/.zccache` — but only when
+ * `ZCCACHE_CACHE_DIR` is *not* explicitly set. setup-soldr always sets
+ * `ZCCACHE_CACHE_DIR` to `<soldr-root>/cache/zccache`, so when a workflow
+ * also sets `SOLDR_ZCCACHE_PRIVATE=1` (truthy: `1`/`true`/`yes`/`on`)
+ * the env var becomes a silent no-op. Return a warning string the caller
+ * should surface via `core.warning`; return `null` otherwise.
+ */
+function detectZccachePrivateOverlap(env) {
+    const raw = (env["SOLDR_ZCCACHE_PRIVATE"] ?? "").trim().toLowerCase();
+    if (!TRUTHY_VALUES.has(raw))
+        return null;
+    return ("setup-soldr: SOLDR_ZCCACHE_PRIVATE is set but will be ignored — " +
+        "setup-soldr pins ZCCACHE_CACHE_DIR=<soldr-root>/cache/zccache " +
+        "explicitly, and soldr#807 makes explicit ZCCACHE_CACHE_DIR take " +
+        "precedence over the private-session opt-in. The zccache cache " +
+        "will stay in setup-soldr's managed location, not <cwd>/.zccache. " +
+        "Unset ZCCACHE_CACHE_DIR (or run outside setup-soldr) to use the " +
+        "private cache path.");
+}
+// `fetchReleaseTagDefault` and `resolveSoldrReleaseVersion` live in
+// ./fetch-release.js — used directly from resolveSetup() below.
+/**
+ * Resolve setup state. The orchestrator calls this once at the start of the
+ * action and uses the returned ResolveResult to drive every subsequent step.
+ */
+async function resolveSetup(ctx, inputs, deps) {
+    const env = { ...ctx.env };
+    // ---- timing seed ----
+    const logStart = String(Math.floor(Date.now() / 1000));
+    const timestamps = (inputs.timestamps && inputs.timestamps.trim()) || "true";
+    const timestampFormatRaw = (inputs.timestampFormat || "").trim().toLowerCase();
+    const VALID_TIMESTAMP_FORMATS = ["mmss", "seconds"];
+    if (timestampFormatRaw && !VALID_TIMESTAMP_FORMATS.includes(timestampFormatRaw)) {
+        throw new Error(`invalid timestamp-format '${inputs.timestampFormat}'; expected one of ${VALID_TIMESTAMP_FORMATS.join(", ")}`);
+    }
+    const timestampFormat = timestampFormatRaw || "mmss";
+    env["SETUP_SOLDR_LOG_START_EPOCH"] = logStart;
+    env["SETUP_SOLDR_TIMESTAMPS"] = timestamps;
+    env["SETUP_SOLDR_TIMESTAMP_FORMAT"] = timestampFormat;
+    // ---- #387 Feature 1: cache encryption ----
+    // Validate the key shape NOW (fail fast on a malformed key) and mark the
+    // raw value as a GitHub Actions secret so any incidental log line that
+    // captures it is auto-redacted. We do NOT keep the parsed Buffer in
+    // ResolveResult — downstream cache layers re-read SETUP_SOLDR_CACHE_ENCRYPT_KEY
+    // at the time of use and re-parse, so the key only exists in memory inside
+    // the closure that needs it.
+    const cacheEncryptKeyRaw = (inputs.cacheEncryptKey || "").trim();
+    if (cacheEncryptKeyRaw) {
+        core.setSecret(cacheEncryptKeyRaw);
+        // Throw early with a clean diagnostic when the key shape is wrong. The
+        // raw value is never echoed back in the error message.
+        (0, cache_encrypt_js_1.parseEncryptionKey)(cacheEncryptKeyRaw);
+    }
+    const cacheEncryptOnFailureRaw = (inputs.cacheEncryptOnFailure || "error")
+        .trim()
+        .toLowerCase();
+    if (cacheEncryptOnFailureRaw && !["error", "skip"].includes(cacheEncryptOnFailureRaw)) {
+        throw new Error(`invalid cache-encrypt-on-failure '${inputs.cacheEncryptOnFailure}'; expected 'error' or 'skip'`);
+    }
+    const cacheEncryptOnFailure = cacheEncryptOnFailureRaw === "skip" ? "skip" : "error";
+    if (cacheEncryptKeyRaw) {
+        env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] = cacheEncryptKeyRaw;
+        env["SETUP_SOLDR_CACHE_ENCRYPT_ON_FAILURE"] = cacheEncryptOnFailure;
+    }
+    const logger = ctx.logger ?? (0, log_utils_js_1.createLogger)(env);
+    const log = (msg) => logger.log(msg);
+    if (!ctx.workspace) {
+        throw new Error("ACTION_WORKSPACE / ctx.workspace must be set");
+    }
+    const workspace = path.resolve(ctx.workspace);
+    const runnerTemp = ctx.runnerTemp
+        ? path.resolve(ctx.runnerTemp)
+        : path.resolve(path.join(workspace, ".tmp"));
+    const dylintModeEnabled = parseOptInBool("dylint", inputs.dylint, false);
+    const explicitCargoRegistryCache = inputs.cargoRegistryCache.trim();
+    // ---- cache-preset resolution (#251) ----
+    // The umbrella `cache-preset` fills any cache-affecting input the consumer
+    // left unset; explicit fine-grained inputs always win. Resolved BEFORE the
+    // per-layer reads below so downstream logic only sees the post-preset
+    // values. The historical default of each input is the fallback when
+    // neither an explicit value nor a preset is set, which keeps behavior
+    // identical for consumers who never set `cache-preset`.
+    const cachePresetRaw = inputs.cachePreset.trim().toLowerCase();
+    const validCachePresets = ["minimal", "foundation", "full"];
+    if (cachePresetRaw && !validCachePresets.includes(cachePresetRaw)) {
+        throw new Error(`invalid cache-preset '${inputs.cachePreset}'; expected one of ${validCachePresets.join(", ")}`);
+    }
+    const cachePresetEffective = (cachePresetRaw || "");
+    const cachePresetMap = {
+        minimal: {
+            buildCache: "false",
+            targetCache: "false",
+            cargoRegistryCache: "false",
+            prebuildDeps: "soldr-cook",
+            buildCacheMode: "",
+        },
+        foundation: {
+            buildCache: "true",
+            targetCache: "false",
+            cargoRegistryCache: "false",
+            prebuildDeps: "soldr-cook",
+            buildCacheMode: "",
+        },
+        full: {
+            buildCache: "true",
+            targetCache: "true",
+            cargoRegistryCache: "true",
+            prebuildDeps: "soldr-cook",
+            buildCacheMode: "thin",
+        },
+    };
+    const cachePresetCfg = cachePresetEffective ? cachePresetMap[cachePresetEffective] : null;
+    // Explicit non-empty user value wins; else preset value when a preset is
+    // set; else leave empty so the existing downstream fall-through
+    // (`inputs.X.trim() || "<historical default>"`) applies as before. This
+    // preserves behavior for consumers who never set `cache-preset` — only
+    // unset inputs *under a preset* are filled here. Mutating `inputs` folds
+    // the resolution into the single source of truth that downstream code
+    // (here + main.ts + cook-cache.ts) reads from.
+    if (cachePresetCfg) {
+        const fillFromPreset = (explicit, presetValue) => {
+            const e = explicit.trim();
+            return e ? e : presetValue;
+        };
+        inputs.buildCache = fillFromPreset(inputs.buildCache, cachePresetCfg.buildCache);
+        inputs.targetCache = fillFromPreset(inputs.targetCache, cachePresetCfg.targetCache);
+        inputs.cargoRegistryCache = fillFromPreset(inputs.cargoRegistryCache, cachePresetCfg.cargoRegistryCache);
+        inputs.prebuildDeps = fillFromPreset(inputs.prebuildDeps, cachePresetCfg.prebuildDeps);
+        inputs.buildCacheMode = fillFromPreset(inputs.buildCacheMode, cachePresetCfg.buildCacheMode);
+    }
+    if (dylintModeEnabled) {
+        if (!explicitCargoRegistryCache)
+            inputs.cargoRegistryCache = "true";
+        // Ordinary cook is stable/build-shaped and cannot warm Dylint's isolated
+        // nightly/check-shaped tree. Dylint mode therefore always disables it.
+        inputs.prebuildDeps = "none";
+    }
+    // ---- cache roots ----
+    const requestedCacheDir = inputs.cacheDir.trim();
+    const cacheRoot = requestedCacheDir
+        ? resolveAbsolute(requestedCacheDir, env)
+        : path.resolve(path.join(runnerTemp, "setup-soldr"));
+    const soldrRoot = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-soldr`);
+    const cargoHomeInput = (env["CARGO_HOME"] ?? "").trim();
+    const cargoHome = cargoHomeInput
+        ? resolveAbsolute(cargoHomeInput, env)
+        : defaultHomeDir(env, ".cargo");
+    const binDir = path.join(cacheRoot, "bin");
+    const setupCachePath = cacheRoot;
+    const soldrBinCachePath = path.join(soldrRoot, "bin");
+    const zccacheCacheDir = path.join(soldrRoot, "cache", "zccache");
+    const thinTargetCacheBundlePath = path.join(path.dirname(cacheRoot), `${path.basename(cacheRoot)}-target-thin`);
+    // When the action is disabled (`enable: false`), we write a script-based
+    // passthrough stub at soldrPath instead of installing the real binary.
+    // The stub is a bash script on Unix and a .cmd shim on Windows — Windows
+    // cannot spawn a script via the .exe extension without a real PE, so
+    // soldrPath must end in .cmd in passthrough mode.
+    const enableRaw = inputs.enable.trim() || "true";
+    if (!TRUTHY_VALUES.has(enableRaw.toLowerCase()) && !FALSY_VALUES.has(enableRaw.toLowerCase())) {
+        throw new Error(`invalid 'enable' input: '${enableRaw}'. Allowed: true | false`);
+    }
+    const enabled = !FALSY_VALUES.has(enableRaw.toLowerCase());
+    const soldrBinary = enabled
+        ? process.platform === "win32"
+            ? "soldr.exe"
+            : "soldr"
+        : process.platform === "win32"
+            ? "soldr.cmd"
+            : "soldr";
+    const soldrPath = path.join(binDir, soldrBinary);
+    // ---- toolchain ----
+    // #302: sub-phase timing on the awaits inside resolve so we can see
+    // which step is dominating (toolchain-spec / rustup-probe / hash walks
+    // / soldr-version fetch). Cheap finally-block bookkeeping; no behavior
+    // change for callers.
+    const toolchain = await (0, phase_timing_js_1.timeSubPhase)("resolve", "toolchain-spec", () => (0, toolchain_js_1.loadToolchainSpec)({
+        workspace,
+        toolchainFile: inputs.toolchainFile || "rust-toolchain.toml",
+        toolchainOverride: inputs.toolchain,
+        log,
+    }));
+    const crossTarget = (0, blessed_cross_prepare_js_1.parseSingleCrossTarget)(inputs.crossTargets);
+    toolchain.targets = (0, blessed_cross_prepare_js_1.mergeToolchainTargets)(toolchain.targets, crossTarget);
+    // ---- rustup home selection ----
+    const explicitRustupHome = (env["RUSTUP_HOME"] ?? "").trim();
+    let rustupHome;
+    let rustupStrategy;
+    if (explicitRustupHome) {
+        rustupHome = resolveAbsolute(explicitRustupHome, env);
+        rustupStrategy = "explicit";
+    }
+    else {
+        const runnerRustupHome = defaultHomeDir(env, ".rustup");
+        let satisfied = false;
+        if (deps?.systemRustupOverride) {
+            satisfied = await (0, phase_timing_js_1.timeSubPhase)("resolve", "rustup-probe", () => deps.systemRustupOverride(cargoHome, runnerRustupHome, toolchain));
+        }
+        else {
+            satisfied = await (0, phase_timing_js_1.timeSubPhase)("resolve", "rustup-probe", () => (0, toolchain_js_1.systemRustupSatisfiesRequest)({
+                cargoHome,
+                rustupHome: runnerRustupHome,
+                toolchain,
+                env,
+                logger,
+                deps: deps?.systemRustup,
+            }));
+        }
+        if (satisfied) {
+            rustupHome = runnerRustupHome;
+            rustupStrategy = "system";
+        }
+        else {
+            rustupHome = path.join(cacheRoot, "rustup-home");
+            rustupStrategy = "managed";
+        }
+        // Platform override: macOS pre-installed rustup toolchains conflict with
+        // downstream component adds (setup-soldr#105). Force `managed` when the
+        // initial selection landed on `system` so we get a private rustup home.
+        const overridden = resolveRustupStrategy({
+            requested: rustupStrategy,
+            platform: process.platform,
+            warn: (msg) => logger.warning(msg),
+        });
+        if (overridden !== rustupStrategy) {
+            rustupStrategy = overridden;
+            if (rustupStrategy === "managed") {
+                rustupHome = path.join(cacheRoot, "rustup-home");
+            }
+        }
+    }
+    let setupCachePathsList = (0, cache_keys_js_1.setupCachePaths)(setupCachePath, binDir, soldrBinCachePath, rustupHome);
+    let setupCacheLayoutValue = (0, cache_keys_js_1.setupCacheLayout)(setupCachePath, rustupHome);
+    if (dylintModeEnabled) {
+        // The Dylint foundation owns exact nightly toolchain paths. Do not let
+        // setup-cache's broad rustup directories overlap that layer or carry a
+        // Dylint nightly into a later non-Dylint job.
+        const rustupOwnedPaths = new Set([
+            path.normalize(path.join(rustupHome, "update-hashes")),
+            path.normalize(path.join(rustupHome, "settings.toml")),
+            path.normalize(path.join(rustupHome, "toolchains")),
+        ]);
+        setupCachePathsList = setupCachePathsList
+            .split(/\r?\n/)
+            .filter((candidate) => !rustupOwnedPaths.has(path.normalize(candidate)))
+            .join("\n");
+        setupCacheLayoutValue = "bin+soldr-bin";
+    }
+    for (const dir of [
+        cacheRoot,
+        soldrRoot,
+        path.join(soldrRoot, "cache"),
+        soldrBinCachePath,
+        cargoHome,
+        path.join(cargoHome, "bin"),
+        rustupHome,
+        binDir,
+        zccacheCacheDir,
+        thinTargetCacheBundlePath,
+    ]) {
+        makeDirs(dir);
+    }
+    const soldrRepo = inputs.repo.trim() || "zackees/soldr";
+    const soldrRef = inputs.ref.trim();
+    const soldrVersionRequested = inputs.version.trim();
+    const soldrVersionResolved = await (0, phase_timing_js_1.timeSubPhase)("resolve", "soldr-version", () => (0, fetch_release_js_1.resolveSoldrReleaseVersion)(soldrRepo, soldrVersionRequested, soldrRef, env, deps));
+    const toolchainSignature = {
+        channel: toolchain.cacheChannel,
+        profile: toolchain.profile,
+        components: toolchain.components,
+        targets: toolchain.targets,
+        source: toolchain.source,
+        file_hash: toolchain.fileHash,
+        setup_cache_layout: setupCacheLayoutValue,
+        soldr_repo: soldrRepo,
+        soldr_ref: soldrRef || "release",
+        soldr_version: soldrVersionResolved || soldrRef || "source-ref",
+    };
+    // Python uses json.dumps(sort_keys=True) without compact separators here,
+    // so canonical_json_stringify is wrong; mirror Python's default separators
+    // (", " and ": ") to match byte-for-byte.
+    const signatureString = (0, python_json_js_1.pythonDefaultJson)(toolchainSignature);
+    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 281, 23));
+    const digest = createHash("sha256").update(signatureString, "utf8").digest("hex").slice(0, 16);
+    const runnerOs = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_OS"] ?? process.platform).toLowerCase());
+    const runnerArch = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_ARCH"] ?? "unknown").toLowerCase());
+    const cachePrefix = `setup-soldr-v4-${runnerOs}-${runnerArch}`;
+    let cacheKey = `${cachePrefix}-${digest}`;
+    // #295-followup: parallelize the two independent workspace-wide hash
+    // walks. Both traverse different subsets of `workspace` (manifests
+    // vs .cargo/config.toml) and have no shared state, so running them
+    // sequentially just wastes resolve-phase wall clock. Cheap correctness
+    // improvement; no behavior change.
+    const [wsManifestHash, cargoConfigHashValue] = await (0, phase_timing_js_1.timeSubPhase)("resolve", "ws-hash", () => Promise.all([(0, cache_keys_js_1.workspaceManifestHash)(workspace), (0, cache_keys_js_1.cargoConfigHash)(workspace)]));
+    const suffix = inputs.cacheKeySuffix.trim();
+    const sanitizedSuffix = suffix ? (0, cache_keys_js_1.sanitizeFragment)(suffix) : "";
+    if (suffix) {
+        cacheKey = `${cacheKey}-${sanitizedSuffix}`;
+    }
+    // ---- build cache ----
+    const githubSha = (env["GITHUB_SHA"] ?? "").trim() || "nosha";
+    let parentSha = (env["ACTION_PARENT_SHA"] ?? "").trim();
+    if (parentSha === githubSha) {
+        parentSha = "";
+    }
+    const buildCachePrefix = `setup-soldr-buildcache-v2-${runnerOs}-${runnerArch}`;
+    const buildCacheToolchainPrefix = `${buildCachePrefix}-${digest}-`;
+    // Build-cache key (setup-soldr#237): platform + toolchain (digest) + per-job
+    // suffix + Cargo.lock — but NOT the commit SHA. Dropping the SHA is the fix:
+    // it made the key exact-miss on every commit, after which the fallback grabbed
+    // a *different* job's archive → 0 hits. We KEEP the per-job suffix (and scope
+    // the fallback to it, see the BuildCachePlan below) so each job restores its
+    // OWN store, warm across commits — sharing one store across jobs that compile
+    // different things (check vs doc vs test) was over-broad and still hit 0%.
+    // Assembled below once `cargoLockHash` is known.
+    // ---- target cache ----
+    const targetDirInput = inputs.targetDir.trim() || "target";
+    let targetCachePath = expanduser(targetDirInput, env);
+    if (!path.isAbsolute(targetCachePath)) {
+        targetCachePath = path.join(workspace, targetCachePath);
+    }
+    targetCachePath = path.resolve(targetCachePath);
+    makeDirs(targetCachePath);
+    const lockfilePath = (0, cache_keys_js_1.resolveLockfilePath)(workspace, targetCachePath, inputs.lockfile);
+    const cargoLockHash = lockfilePath
+        ? await (0, phase_timing_js_1.timeSubPhase)("resolve", "lock-hash", () => (0, cache_keys_js_1.shortFileHash)(lockfilePath, "no-lock"))
+        : "no-lock";
+    // setup-soldr#237: per-job, SHA-independent build-cache key. The per-job
+    // suffix keeps each job restoring its own store; dropping the SHA makes it
+    // warm across commits. The fallback (BuildCachePlan below) is scoped to this
+    // job prefix only, never another job's store.
+    const buildCacheJobPrefix = `${buildCacheToolchainPrefix}${sanitizedSuffix ? `${sanitizedSuffix}-` : ""}`;
+    const buildCacheKey = `${buildCacheJobPrefix}${cargoLockHash}`;
+    const buildCacheParentKey = "";
+    const legacyTargetCacheModeInput = inputs.targetCacheMode;
+    const legacyTargetCacheMode = (0, cache_keys_js_1.normalizeLegacyTargetCacheMode)(legacyTargetCacheModeInput, log);
+    const targetCacheProfile = (0, cache_keys_js_1.normalizeTargetCacheProfile)(inputs.targetCacheProfile);
+    // #418: thin-v3 may select a cook-partitioned durable slice only once Soldr
+    // can prove every Cargo fingerprint/build-script path's package owner. That
+    // closure is not available yet, so the action and Soldr deliberately agree
+    // on the safe zccache-all fallback. The policy+mode are part of the cache
+    // namespace; do not let a v1/v2 bundle restore into this contract.
+    const targetCachePolicyKey = targetCacheProfile === "thin-v3"
+        ? "thin-v3-lifetime-partition-v1-zccache-all-v1"
+        : targetCacheProfile;
+    // `cache: "false"` is the umbrella switch. It originally only gated the
+    // action-managed setup-cache (soldr binary + rustup state), but consumers
+    // reasonably expect it to mean "no caching at all" — so when the umbrella
+    // is off we force every per-layer flag off too AND tell soldr to skip its
+    // zccache build-cache wrapper. See zccache#307 / zackees/setup-soldr#118
+    // follow-up.
+    const cacheUmbrellaEnabled = !isFalsy(inputs.cache.trim() || "true");
+    const explicitTargetCacheInput = inputs.targetCache.trim();
+    const targetCacheInputRaw = explicitTargetCacheInput ||
+        (legacyTargetCacheMode && legacyTargetCacheMode !== "off" ? "true" : "false");
+    const targetCacheRequested = cacheUmbrellaEnabled &&
+        !isFalsy(targetCacheInputRaw) &&
+        legacyTargetCacheMode !== "off";
+    const explicitBuildCacheMode = inputs.buildCacheMode.trim();
+    const buildCacheMode = (0, cache_keys_js_1.normalizeBuildCacheMode)(inputs.buildCacheMode, legacyTargetCacheModeInput, !explicitBuildCacheMode && targetCacheRequested, log);
+    const buildCacheInputRaw = inputs.buildCache.trim() || "true";
+    const buildCacheEnabled = cacheUmbrellaEnabled && !isFalsy(buildCacheInputRaw);
+    const buildCacheRuntimeMode = buildCacheMode === "once" ? "full" : buildCacheMode;
+    let targetCacheEnabled = buildCacheEnabled && targetCacheRequested;
+    if (buildCacheMode === "thin" && cargoLockHash === "no-lock") {
+        log("build-cache-mode 'thin' requires Cargo.lock; target artifact cache disabled.");
+        targetCacheEnabled = false;
+    }
+    const [targetCacheBudgetBytes, targetCacheBudgetFiles] = (0, cache_keys_js_1.targetCacheSoftBudget)(targetCacheEnabled, buildCacheMode);
+    const targetShapeHash = (0, cache_keys_js_1.shortJsonHash)({
+        target_dir: targetCachePath,
+        target_dir_input: targetDirInput,
+        target_env: (0, cache_keys_js_1.targetEnvHash)(env),
+    });
+    const targetInputsHash = (0, cache_keys_js_1.shortJsonHash)({
+        cargo_config: cargoConfigHashValue,
+        cargo_lock: cargoLockHash,
+        manifest: wsManifestHash,
+        target_shape: targetShapeHash,
+        toolchain: digest,
+    });
+    const lockfileOnlyHash = (0, cache_keys_js_1.shortJsonHash)({
+        cargo_lock: cargoLockHash,
+        toolchain: digest,
+    });
+    const targetCacheBundlePath = thinTargetCacheBundlePath;
+    const targetTreeCacheEnabled = targetCacheEnabled && buildCacheMode === "full";
+    let targetCachePaths;
+    let targetCacheEffectiveMode;
+    let targetCachePrefix;
+    let targetCacheLockPrefix;
+    let targetCacheLockfilePrefix;
+    let targetCacheKey;
+    let targetCacheParentKey;
+    if (!targetCacheEnabled) {
+        targetCachePaths = "";
+        targetCacheEffectiveMode = "off";
+        targetCachePrefix = `setup-soldr-targetcache-off-v1-${runnerOs}-${runnerArch}`;
+        targetCacheLockPrefix = "";
+        targetCacheLockfilePrefix = "";
+        targetCacheKey = `${targetCachePrefix}-${targetInputsHash}`;
+        targetCacheParentKey = "";
+    }
+    else if (targetTreeCacheEnabled) {
+        targetCachePaths = [targetCachePath, targetCacheBundlePath].join("\n");
+        targetCacheEffectiveMode = buildCacheMode;
+        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v2-${runnerOs}-${runnerArch}-${targetCachePolicyKey}`;
+        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
+        targetCacheLockPrefix = `${targetCachePrefix}-${digest}-${cargoLockHash}-${targetShapeHash}-${sf}`;
+        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
+        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
+        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
+    }
+    else {
+        targetCachePaths = targetCacheBundlePath;
+        targetCacheEffectiveMode = buildCacheMode;
+        targetCachePrefix = `setup-soldr-targetcache-${buildCacheMode}-v2-${runnerOs}-${runnerArch}-${targetCachePolicyKey}`;
+        const sf = sanitizedSuffix ? `${sanitizedSuffix}-` : "";
+        targetCacheLockPrefix = `${targetCachePrefix}-${targetInputsHash}-${sf}`;
+        targetCacheLockfilePrefix = `${targetCachePrefix}-${lockfileOnlyHash}-${sf}`;
+        targetCacheKey = `${targetCacheLockPrefix}${githubSha}`;
+        targetCacheParentKey = parentSha ? `${targetCacheLockPrefix}${parentSha}` : "";
+    }
+    // setup-soldr#237: the build-cache key intentionally does NOT include
+    // `cache-key-suffix`. Per-job suffixes fragmented the cache and made the
+    // restore-key fallback land on another job's archive (→ ~0% hits). The
+    // suffix still scopes the action-managed setup-cache (`cacheKey` above) and
+    // the target-cache, just not the content-addressed zccache build-cache.
+    // ---- cargo registry cache ----
+    // #267: when prebuild-deps includes `soldr-cook` AND the user (or a
+    // preset they're using) has NOT explicitly set cargo-registry-cache,
+    // default it to `true`. Cook restores `target/` build artifacts but
+    // does NOT restore `$CARGO_HOME/registry`, so cargo re-downloads every
+    // crate source on the next build — the "I set cook, why is it still
+    // downloading?" trap. Presets that explicitly set
+    // `cargoRegistryCache: "false"` (minimal, foundation) survive because
+    // `inputs.cargoRegistryCache` is non-empty after `fillFromPreset`
+    // runs; the `||` short-circuits before reaching the implicit default.
+    const cookPrebuildEnabled = inputs.prebuildDeps.trim().includes("soldr-cook");
+    const cargoRegistryDefault = cookPrebuildEnabled ? "true" : "false";
+    const cargoRegistryCacheRawInput = inputs.cargoRegistryCache.trim();
+    const cargoRegistryCachePaired = cookPrebuildEnabled && cargoRegistryCacheRawInput === "";
+    if (cargoRegistryCachePaired) {
+        log("setup-soldr: defaulting cargo-registry-cache=true because prebuild-deps=soldr-cook " +
+            "(see setup-soldr#267 — pairs to avoid re-downloading every crate source on next " +
+            "build). Set cargo-registry-cache=false explicitly to opt out.");
+    }
+    const cargoRegistryCacheRequested = isTruthy(cargoRegistryCacheRawInput || cargoRegistryDefault);
+    const cargoRegistryCachePath = path.join(cargoHome, "registry");
+    // setup-soldr#102: bundle additional `$CARGO_HOME` siblings into the same
+    // cargo-registry archive so we close the cache-retention gaps without
+    // introducing a new top-level cache layer or changing the cache key shape.
+    //   - `.global-cache` — cargo's RFC-3413 GC sqlite database. Without it the
+    //     per-job `cargo gc` sees fresh access times and conservatively keeps
+    //     everything. Shared read-only dep between setup-soldr (persists) and
+    //     soldr (reads via zackees/soldr#323). One-line leverage win.
+    //   - `git`           — `$CARGO_HOME/git/{db,checkouts}/`. `db/` holds the
+    //     bare mirrors of git-source crate deps and `checkouts/` holds the
+    //     per-commit working trees derived from `db/`; both are required for
+    //     cargo to build from a restored `db/`. Caching the parent `git/` dir
+    //     covers both subtrees and any future siblings cargo introduces.
+    // Siblings that don't exist on disk at save time (e.g. workspaces with no
+    // git-source deps) are silently skipped by compressCache — see #102.
+    const cargoRegistryCacheExtras = [".global-cache", "git"];
+    const cargoRegistryEncrypted = inputs.cacheEncryptKey.trim().length > 0;
+    const cargoRegistryViaSoldr = (0, soldr_load_shim_js_1.cargoRegistryViaSoldrEnvOn)();
+    const cargoRegistryRuntimeCompatible = semverAtLeast(soldrVersionResolved || soldrVersionRequested, soldr_load_shim_js_1.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP);
+    const cargoRegistryFormat = (0, cargo_registry_archive_js_1.cargoRegistryArchiveFormat)({
+        encrypted: cargoRegistryEncrypted,
+        viaSoldr: cargoRegistryViaSoldr,
+        sourceRef: soldrRef.trim().length > 0,
+        runtimeCompatible: cargoRegistryRuntimeCompatible,
+    });
+    if (cargoRegistryEncrypted && cargoRegistryViaSoldr) {
+        core.notice("setup-soldr: cargo-registry Soldr v2 is disabled for encrypted cache entries; using encrypted legacy-v1 until encrypted Soldr restore is available.");
+    }
+    else if (cargoRegistryViaSoldr && !soldrRef && !cargoRegistryRuntimeCompatible) {
+        core.notice(`setup-soldr: cargo-registry Soldr v2 requires soldr >= ${soldr_load_shim_js_1.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP}; using legacy-v1 for ${soldrVersionResolved || soldrVersionRequested || "unknown"}.`);
+    }
+    const cargoRegistryArchive = (0, cargo_registry_archive_js_1.planCargoRegistryArchive)({
+        format: cargoRegistryFormat,
+        cargoHome,
+        runnerTemp,
+    });
+    const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-${cargoRegistryFormat === "soldr-v2" ? "v2" : "v1"}-${runnerOs}-${runnerArch}`;
+    const cargoRegistryCacheRestorePrefix = `${cargoRegistryCachePrefix}-${cargoLockHash}-`;
+    // #371: drop git SHA from the exact key, same anti-pattern fix as
+    // #237 did for build-cache. With SHA, every commit produced a new
+    // exact-key entry that no future probe could ever hit (only same-
+    // commit retries). The restore-key prefix (sans SHA) already does
+    // the actual work via FALLBACK — observed in production. Dropping
+    // SHA lifts exact-key hit rate from ~0% toward ~100% per
+    // (lockHash, digest) generation, eliminates redundant ~56 MB
+    // saves per run, and reduces cache-budget churn.
+    //
+    // #375: also drop per-job suffix from cargo-registry. Unlike
+    // build-cache (#237 KEPT suffix because target/ content differs
+    // per job), cargo-registry content is just `$CARGO_HOME/registry/`
+    // — downloaded crate sources keyed on Cargo.lock, identical
+    // across (check, test, doc, msrv) matrix jobs. Per-job suffix
+    // means N redundant saves per CI cycle (~56 MB × N for zccache's
+    // 9-job matrix = ~500 MB wasted bandwidth). Sharing the key
+    // across jobs means: first job saves, rest exact-HIT.
+    const cargoRegistryCacheKey = `${cargoRegistryCacheRestorePrefix}${digest}`;
+    const cargoRegistryCacheEnabled = cacheUmbrellaEnabled && cargoRegistryCacheRequested;
+    if (cargoRegistryCacheEnabled) {
+        makeDirs(cargoRegistryCachePath);
+        for (const archivePath of cargoRegistryArchive.restorePaths)
+            makeDirs(path.dirname(archivePath));
+    }
+    // ---- Dylint tool/driver cache (explicit opt-in, setup-soldr#221) ----
+    const dylintFoundationRequested = dylintModeEnabled
+        ? parseOptInBool("dylint-foundation-cache", inputs.dylintFoundationCache, true)
+        : parseOptInBool("dylint-cache", inputs.dylintCache, false);
+    const dylintOutputCacheEnabled = dylintModeEnabled &&
+        cacheUmbrellaEnabled &&
+        parseOptInBool("dylint-output-cache", inputs.dylintOutputCache, true);
+    if (dylintOutputCacheEnabled && targetTreeCacheEnabled) {
+        throw new Error("dylint-output-cache cannot overlap build-cache-mode=full target caching; " +
+            "disable target-cache/full mode for Dylint jobs");
+    }
+    const dylintCacheEnabled = cacheUmbrellaEnabled && dylintFoundationRequested;
+    const dylintDriverPath = path.join(runnerTemp, "dylint-drivers");
+    const dylintHostTriple = rustHostTriple(ctx.runnerOs || env["ACTION_OS"] || process.platform, ctx.runnerArch || env["ACTION_ARCH"] || process.arch);
+    const nightlyIdentity = dylintModeEnabled
+        ? await (0, phase_timing_js_1.timeSubPhase)("resolve", "dylint-nightly-map", () => (deps?.resolveDylintNightly ?? dylint_nightly_js_1.resolveDylintNightly)(inputs.dylintToolchain.trim() || toolchain.channel, env))
+        : null;
+    const dylintToolchain = nightlyIdentity?.channel || inputs.dylintToolchain.trim() || toolchain.channel;
+    const dylintRustcRelease = nightlyIdentity?.rustcRelease || "unmapped";
+    const dylintRustcCommitHash = nightlyIdentity?.rustcCommitHash || "unmapped";
+    const dylintCacheIdentity = `${dylintToolchain}|${dylintRustcRelease}|${dylintRustcCommitHash}`;
+    const dylintRequiredComponents = ["rustc-dev", "rust-src", "llvm-tools-preview"];
+    const dylintFoundationRevision = "foundation-v2";
+    const dylintRunScope = [
+        env["GITHUB_RUN_ID"],
+        env["GITHUB_RUN_ATTEMPT"],
+        env["GITHUB_JOB"],
+        env["GITHUB_ACTION"],
+    ]
+        .filter(Boolean)
+        .join("|") || `local-${process.pid}`;
+    const dylintSuccessMarker = path.join(runnerTemp, "dylint-foundation-success", (0, cache_keys_js_1.shortJsonHash)({
+        identity: dylintCacheIdentity,
+        components: dylintRequiredComponents,
+        revision: dylintFoundationRevision,
+        runScope: dylintRunScope,
+    }), "success.txt");
+    const dylintDriverRev = inputs.dylintDriverRev.trim() || "none";
+    const cargoDylintVersion = inputs.cargoDylintVersion.trim() || "6.0.1";
+    const dylintLinkVersion = inputs.dylintLinkVersion.trim() || "6.0.1";
+    const customDylintPaths = splitPathInput(inputs.dylintCachePaths).map((p) => path.isAbsolute(expanduser(p, env)) ? resolveAbsolute(p, env) : path.resolve(workspace, p));
+    const dylintToolchainPath = path.join(rustupHome, "toolchains", `${dylintToolchain}-${dylintHostTriple}`);
+    const dylintUpdateHashPath = path.join(rustupHome, "update-hashes", `${dylintToolchain}-${dylintHostTriple}`);
+    const dylintCachePaths = customDylintPaths.length > 0
+        ? customDylintPaths
+        : [
+            ...defaultDylintCachePaths(cargoHome, dylintDriverPath),
+            ...(dylintModeEnabled ? [dylintToolchainPath, dylintUpdateHashPath] : []),
+        ];
+    const dylintCacheHash = dylintModeEnabled
+        ? (0, cache_keys_js_1.shortJsonHash)({
+            host_triple: dylintHostTriple,
+            cargo_dylint_version: cargoDylintVersion,
+            dylint_link_version: dylintLinkVersion,
+            dylint_toolchain: dylintToolchain,
+            dylint_rustc_release: dylintRustcRelease,
+            dylint_rustc_commit_hash: dylintRustcCommitHash,
+            dylint_driver_rev: dylintDriverRev,
+            required_components: dylintRequiredComponents,
+            foundation_revision: dylintFoundationRevision,
+        })
+        : (0, cache_keys_js_1.shortJsonHash)({
+            host_triple: dylintHostTriple,
+            cargo_dylint_version: cargoDylintVersion,
+            dylint_link_version: dylintLinkVersion,
+            dylint_toolchain: dylintToolchain,
+            dylint_driver_rev: dylintDriverRev,
+            cargo_config: cargoConfigHashValue,
+            cargo_lock: cargoLockHash,
+            manifest: wsManifestHash,
+            setup_toolchain: digest,
+        });
+    const dylintCacheSchema = dylintModeEnabled ? "v2" : "v1";
+    let dylintCacheKey = `setup-soldr-dylint-${dylintCacheSchema}-${runnerOs}-${runnerArch}-${(0, cache_keys_js_1.sanitizeFragment)(dylintHostTriple)}-${dylintCacheHash}`;
+    if (suffix) {
+        dylintCacheKey = `${dylintCacheKey}-${sanitizedSuffix}`;
+    }
+    const dylintOutputPaths = [
+        path.join(targetCachePath, "dylint", "libraries", dylintToolchain, "release"),
+        path.join(targetCachePath, "dylint", "target", dylintToolchain),
+    ];
+    const dylintOutputHash = (0, cache_keys_js_1.shortJsonHash)({
+        compiler_identity: dylintCacheIdentity,
+        driver_revision: dylintDriverRev,
+        cargo_config: cargoConfigHashValue,
+        cargo_lock: cargoLockHash,
+        manifests: wsManifestHash,
+        target_shape: targetShapeHash,
+        source_revision: githubSha,
+        cache_suffix: sanitizedSuffix,
+    });
+    const dylintOutputKey = `setup-soldr-dylint-output-v1-${runnerOs}-${runnerArch}-${dylintOutputHash}`;
+    if (dylintCacheEnabled) {
+        makeDirs(dylintDriverPath);
+    }
+    // ---- env exports ----
+    const cacheShutdownOnIdleSeconds = (0, input_parsers_js_1.parseCacheShutdownOnIdleSeconds)(inputs.cacheShutdownOnIdle);
+    const rustBacktraceValue = (0, input_parsers_js_1.parseRustBacktrace)(inputs.rustBacktrace);
+    const envExports = {};
+    const setEnv = (name, value) => {
+        if (GITHUB_ENV_DENY_LIST.has(name))
+            return;
+        envExports[name] = value;
+    };
+    setEnv("SOLDR_CACHE_DIR", soldrRoot);
+    setEnv("CARGO_HOME", cargoHome);
+    setEnv("RUSTUP_HOME", rustupHome);
+    setEnv("ZCCACHE_CACHE_DIR", zccacheCacheDir);
+    // soldr#807: warn when SOLDR_ZCCACHE_PRIVATE is truthy because the
+    // explicit ZCCACHE_CACHE_DIR above will silently win and the opt-in
+    // private-session path under <cwd>/.zccache won't be used.
+    const zccachePrivateOverlap = detectZccachePrivateOverlap(env);
+    if (zccachePrivateOverlap)
+        core.warning(zccachePrivateOverlap);
+    setEnv("SETUP_SOLDR_BUILD_CACHE_MODE", cacheUmbrellaEnabled ? buildCacheMode : "off");
+    setEnv("SOLDR_BUILD_CACHE_MODE", cacheUmbrellaEnabled ? buildCacheRuntimeMode : "off");
+    setEnv("SOLDR_TARGET_CACHE_MODE", targetCacheEnabled ? buildCacheRuntimeMode : "off");
+    setEnv("SOLDR_TARGET_CACHE_DIR", targetCachePath);
+    setEnv("SOLDR_TARGET_CACHE_BUNDLE_DIR", targetCacheBundlePath);
+    setEnv("SOLDR_TARGET_CACHE_PROFILE", targetCacheProfile);
+    const stripDebug = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-strip-debuginfo", inputs.targetCacheStripDebuginfo);
+    if (stripDebug !== null) {
+        setEnv("SOLDR_TARGET_CACHE_STRIP_DEBUGINFO", stripDebug);
+    }
+    const includeIncremental = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-incremental", inputs.targetCacheIncludeIncremental);
+    if (includeIncremental !== null) {
+        setEnv("SOLDR_TARGET_CACHE_INCLUDE_INCREMENTAL", includeIncremental);
+    }
+    const includeBuildScripts = (0, cache_keys_js_1.normalizeTargetCacheBool)("target-cache-include-build-script-binaries", inputs.targetCacheIncludeBuildScriptBinaries);
+    if (includeBuildScripts !== null) {
+        setEnv("SOLDR_TARGET_CACHE_INCLUDE_BUILD_SCRIPT_BINARIES", includeBuildScripts);
+    }
+    const targetCacheCompress = (0, cache_keys_js_1.normalizeTargetCacheCompress)(inputs.targetCacheCompress);
+    const targetCacheCompressLevel = (0, cache_keys_js_1.normalizeTargetCacheCompressLevel)(inputs.targetCacheCompressLevel);
+    setEnv("SOLDR_TARGET_CACHE_COMPRESS", targetCacheCompress);
+    setEnv("SOLDR_TARGET_CACHE_COMPRESS_LEVEL", targetCacheCompressLevel);
+    if (cargoRegistryCacheEnabled) {
+        setEnv("SOLDR_SKIP_CARGO_REGISTRY_SAVE", "1");
+    }
+    if (!soldrRef && semverAtLeast(soldrVersionResolved || soldrVersionRequested, "0.7.43")) {
+        setEnv("SOLDR_CARGO_CHEF_LOCAL_DIR", binDir);
+    }
+    if (dylintCacheEnabled) {
+        setEnv("DYLINT_DRIVER_PATH", dylintDriverPath);
+        setEnv("SETUP_SOLDR_DYLINT_CACHE_KEY", dylintCacheKey);
+        setEnv("SETUP_SOLDR_DYLINT_CACHE_PATHS", dylintCachePaths.join(path.delimiter));
+    }
+    if (dylintModeEnabled && nightlyIdentity) {
+        // These are configuration hints, not the active nested-Dylint scope.
+        // Soldr copies them to SOLDR_DYLINT_* only while launching cargo-dylint,
+        // so an ordinary stable `soldr cargo build` later in the job is unchanged.
+        setEnv("SOLDR_DYLINT_CONFIGURED_TOOLCHAIN", nightlyIdentity.channel);
+        setEnv("SOLDR_DYLINT_CONFIGURED_RUSTC_RELEASE", nightlyIdentity.rustcRelease);
+        setEnv("SOLDR_DYLINT_CONFIGURED_RUSTC_COMMIT_HASH", nightlyIdentity.rustcCommitHash);
+        setEnv("SOLDR_DYLINT_SUCCESS_MARKER", dylintSuccessMarker);
+    }
+    setEnv("SOLDR_TARGET_CACHE_BACKEND", "local");
+    setEnv("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain.channel);
+    setEnv("SETUP_SOLDR_TOOLCHAIN_CACHE_CHANNEL", toolchain.cacheChannel);
+    setEnv("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain.profile);
+    setEnv("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", JSON.stringify(toolchain.components));
+    setEnv("SETUP_SOLDR_TOOLCHAIN_TARGETS", JSON.stringify(toolchain.targets));
+    setEnv("SETUP_SOLDR_LOG_START_EPOCH", logStart);
+    setEnv("SETUP_SOLDR_TIMESTAMPS", timestamps);
+    setEnv("SETUP_SOLDR_TIMESTAMP_FORMAT", timestampFormat);
+    if (cacheEncryptKeyRaw) {
+        // #387 Feature 1: propagate to GITHUB_ENV so the post-step (which loads
+        // a fresh process) and any subsequent setup-soldr-using steps see the
+        // same key. The key has already been core.setSecret-marked above so
+        // GitHub Actions auto-redacts it from logs.
+        setEnv("SETUP_SOLDR_CACHE_ENCRYPT_KEY", cacheEncryptKeyRaw);
+        setEnv("SETUP_SOLDR_CACHE_ENCRYPT_ON_FAILURE", cacheEncryptOnFailure);
+    }
+    if (!FALSY_VALUES.has(timestamps.toLowerCase()) && env["NO_COLOR"] === undefined) {
+        if (!env["CARGO_TERM_COLOR"])
+            setEnv("CARGO_TERM_COLOR", "always");
+        if (!env["CLICOLOR_FORCE"])
+            setEnv("CLICOLOR_FORCE", "1");
+        if (!env["FORCE_COLOR"])
+            setEnv("FORCE_COLOR", "1");
+    }
+    if (inputs.trustMode.trim()) {
+        setEnv("SOLDR_TRUST_MODE", inputs.trustMode.trim());
+    }
+    const linkerRaw = inputs.linker.trim();
+    if (linkerRaw === "") {
+        const preset = (0, input_parsers_js_1.detectUserLinkerEnv)(env);
+        if (preset.length > 0) {
+            logger.info(`setup-soldr: deferring to user-set ${preset.join(", ")}; skipping default SOLDR_LINKER=fast injection. See https://github.com/zackees/setup-soldr/issues/108`);
+        }
+        else {
+            setEnv("SOLDR_LINKER", "fast");
+            logger.notice("setup-soldr: defaulting SOLDR_LINKER=fast (mold-if-on-PATH-else-rust-lld on Linux, rust-lld on macOS/Windows) for faster CI links. Soldr's native default is no injection, which produces a smaller build-cache and a slower link. Set `linker: platform-default` to opt out and keep cargo/rust-toolchain.toml in charge, or set `linker: <value>` to silence this notice.");
+        }
+    }
+    else if (!ALLOWED_LINKER_VALUES.includes(linkerRaw)) {
+        throw new Error(`invalid 'linker' input: '${linkerRaw}'. Allowed: default | platform-default | ld | mold | rust-lld | fast`);
+    }
+    else if (linkerRaw !== "default" && linkerRaw !== "platform-default") {
+        setEnv("SOLDR_LINKER", linkerRaw);
+    }
+    const compilePriorityRaw = inputs.compilePriority.trim();
+    if (compilePriorityRaw !== "") {
+        setEnv("ZCCACHE_COMPILE_PRIORITY", compilePriorityRaw);
+    }
+    if (cacheShutdownOnIdleSeconds !== null) {
+        // Set both env vars. zccache reads its own, sccache reads the
+        // SCCACHE_-prefixed one; exporting both means a zccache fork that
+        // still honors only the sccache name keeps working, and a vanilla
+        // sccache invoked via this action would too.
+        const seconds = String(cacheShutdownOnIdleSeconds);
+        setEnv("ZCCACHE_IDLE_TIMEOUT", seconds);
+        setEnv("SCCACHE_IDLE_TIMEOUT", seconds);
+    }
+    if (rustBacktraceValue !== null) {
+        setEnv("RUST_BACKTRACE", rustBacktraceValue);
+    }
+    // Auto-export cc-rs cross-compile env for *-unknown-linux-musl triples
+    // when the matching `<triple>-gcc/g++/ar` binaries are on PATH. cc-rs
+    // strips the "-unknown-" segment when looking up cross compilers, so
+    // archives that ship binaries with the full triple are missed without
+    // these per-target overrides. See setup-soldr#... and the cc-rs docs.
+    const muslCcHits = (0, detect_musl_cc_js_1.detectMuslCcEnv)(env);
+    for (const hit of muslCcHits) {
+        const suffix = (0, detect_musl_cc_js_1.tripleToCcRsSuffix)(hit.triple);
+        for (const [name, value] of Object.entries(hit.exports)) {
+            setEnv(name, value);
+        }
+        logger.warning(`setup-soldr: auto-exporting cc-rs cross-compile env for ${hit.triple} ` +
+            `(CC_${suffix}=${hit.exports[`CC_${suffix}`]}, ` +
+            `CXX_${suffix}=${hit.exports[`CXX_${suffix}`]}, ` +
+            `AR_${suffix}=${hit.exports[`AR_${suffix}`]}) ` +
+            "because cc-rs strips \"-unknown-\" from the triple when probing for a " +
+            "cross compiler and would otherwise fall back to the host gcc. " +
+            `Resolved: cc=${hit.resolvedPaths.cc}, cxx=${hit.resolvedPaths.cxx}, ar=${hit.resolvedPaths.ar}. ` +
+            `Pre-set CC_${suffix} yourself to opt out.`);
+    }
+    // ---- path additions ----
+    const pathAdditions = [binDir, path.join(cargoHome, "bin")];
+    // ---- logging summary ----
+    log("setup-soldr cache plan");
+    log(`cache key=${cacheKey}`);
+    log(`cache restore-key=${cachePrefix}-`);
+    log(`build-cache key=${buildCacheKey}`);
+    log(`build-cache mode=${buildCacheMode}`);
+    log(`build-cache soldr-mode=${buildCacheRuntimeMode}`);
+    if (buildCacheParentKey) {
+        log(`build-cache restore-key-parent=${buildCacheParentKey}`);
+    }
+    log(`build-cache restore-key-toolchain=${buildCacheToolchainPrefix}`);
+    log(`build-cache restore-key-os-arch=${buildCachePrefix}-`);
+    log(`target-cache key=${targetCacheKey}`);
+    log(`target-cache enabled=${targetCacheEnabled ? "true" : "false"}`);
+    log(`target-cache mode=${targetCacheEffectiveMode}`);
+    log("target-cache backend=local");
+    if (targetCacheEnabled) {
+        log(`target-cache soft-budget-bytes=${targetCacheBudgetBytes}`);
+        log(`target-cache soft-budget-files=${targetCacheBudgetFiles}`);
+    }
+    log(`soldr repo=${soldrRepo}`);
+    log(`soldr ref=${soldrRef || "release"}`);
+    if (soldrVersionResolved) {
+        log(`soldr version=${soldrVersionResolved}`);
+    }
+    log(`toolchain channel=${toolchain.channel}`);
+    log(`toolchain cache-channel=${toolchain.cacheChannel}`);
+    log(`rustup strategy=${rustupStrategy}`);
+    log(`setup-cache layout=${setupCacheLayoutValue}`);
+    if (targetCacheParentKey) {
+        log(`target-cache restore-key-parent=${targetCacheParentKey}`);
+    }
+    log(`target-cache restore-key-lock=${targetCacheLockPrefix}`);
+    log(`target-cache restore-key-lockfile=${targetCacheLockfilePrefix}`);
+    log(`target-cache paths=${targetCachePaths}`);
+    log(`target-cache bundle-dir=${targetCacheBundlePath}`);
+    log(`target-cache lockfile=${(0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath)}`);
+    log(`target-cache lockfile-hash=${cargoLockHash}`);
+    if (dylintCacheEnabled) {
+        log(`dylint-cache key=${dylintCacheKey}`);
+        log(`dylint-cache host-triple=${dylintHostTriple}`);
+        log(`dylint-cache toolchain=${dylintToolchain}`);
+        log(`dylint-cache cargo-dylint-version=${cargoDylintVersion}`);
+        log(`dylint-cache dylint-link-version=${dylintLinkVersion}`);
+        log(`dylint-cache driver-rev=${dylintDriverRev}`);
+        log(`dylint-cache driver-path=${dylintDriverPath}`);
+    }
+    // ---- assemble plans ----
+    const setupCache = {
+        key: cacheKey,
+        restorePrefix: `${cachePrefix}-`,
+        paths: setupCachePathsList ? setupCachePathsList.split("\n") : [],
+        setupCachePath,
+        layout: setupCacheLayoutValue,
+    };
+    const buildCache = {
+        enabled: buildCacheEnabled,
+        key: buildCacheKey,
+        restoreKeyParent: buildCacheParentKey,
+        // setup-soldr#237: job-scoped fallback only — newest entry for THIS job at
+        // any Cargo.lock, never another job's store. The old bare toolchain/os-arch
+        // restore-keys matched any job and caused cross-job restores → 0 hits.
+        restoreKeyToolchain: buildCacheJobPrefix,
+        restoreKeyOsArch: "",
+        path: zccacheCacheDir,
+        mode: buildCacheMode,
+    };
+    const targetCache = {
+        enabled: targetCacheEnabled,
+        key: targetCacheKey,
+        restoreKeyParent: targetCacheParentKey,
+        restoreKeyLock: targetCacheLockPrefix,
+        restoreKeyLockfile: targetCacheLockfilePrefix,
+        paths: targetCachePaths,
+        bundlePath: targetCacheBundlePath,
+        targetPath: targetCachePath,
+        effectiveMode: targetCacheEffectiveMode,
+        profile: targetCacheProfile,
+        budgetBytes: targetCacheBudgetBytes,
+        budgetFiles: targetCacheBudgetFiles,
+        lockfilePath: (0, cache_keys_js_1.pathForOutput)(workspace, lockfilePath),
+        lockfileHash: cargoLockHash,
+    };
+    const cargoRegistryCachePlan = {
+        enabled: cargoRegistryCacheEnabled,
+        key: cargoRegistryCacheKey,
+        restorePrefix: cargoRegistryCacheRestorePrefix,
+        path: cargoRegistryCachePath,
+        extraBasenames: cargoRegistryCacheExtras,
+        archive: cargoRegistryArchive,
+    };
+    const dylintCachePlan = {
+        enabled: dylintCacheEnabled,
+        outputCacheEnabled: dylintOutputCacheEnabled,
+        outputKey: dylintOutputCacheEnabled ? dylintOutputKey : "",
+        outputPaths: dylintOutputCacheEnabled ? dylintOutputPaths : [],
+        key: dylintCacheEnabled ? dylintCacheKey : "",
+        paths: dylintCacheEnabled ? dylintCachePaths : [],
+        driverPath: dylintCacheEnabled ? dylintDriverPath : "",
+        hostTriple: dylintCacheEnabled ? dylintHostTriple : "",
+        toolchain: dylintModeEnabled || dylintCacheEnabled ? dylintToolchain : "",
+        rustcRelease: dylintModeEnabled ? dylintRustcRelease : "",
+        rustcCommitHash: dylintModeEnabled ? dylintRustcCommitHash : "",
+        cacheIdentity: dylintModeEnabled ? dylintCacheIdentity : "",
+        successMarker: dylintModeEnabled ? dylintSuccessMarker : "",
+        driverRev: dylintCacheEnabled ? dylintDriverRev : "",
+        cargoDylintVersion: dylintCacheEnabled ? cargoDylintVersion : "",
+        dylintLinkVersion: dylintCacheEnabled ? dylintLinkVersion : "",
+    };
+    const blessedPrepareCache = (0, blessed_cross_prepare_js_1.planBlessedPrepareCache)({
+        enabled,
+        cacheEnabled: cacheUmbrellaEnabled,
+        ref: soldrRef,
+        runnerTemp,
+        runnerOs,
+        runnerArch,
+        target: crossTarget,
+        soldrRepo,
+        soldrVersion: soldrVersionResolved || soldrVersionRequested,
+    });
+    for (const archivePath of blessedPrepareCache.archivePaths)
+        makeDirs(path.dirname(archivePath));
+    // Avoid unused warnings on alias helper.
+    void toolchain_js_1.rollingToolchainAlias;
+    void cache_keys_js_1.canonicalJsonStringify;
+    const compileCacheStats = (0, input_parsers_js_1.normalizeCompileCacheStats)(inputs.compileCacheStats);
+    const stats = (0, input_parsers_js_1.normalizeStatsMode)(inputs.stats);
+    const debugMode = isTruthy(inputs.debugMode.trim() || "false");
+    // ---- shims ----
+    const shimsRaw = inputs.shims.trim() || "false";
+    const shimsEnabled = !isFalsy(shimsRaw);
+    const shimsDir = path.join(cacheRoot, "shims");
+    return {
+        enabled,
+        workspace,
+        cacheRoot,
+        soldrRoot,
+        binDir,
+        cargoHome,
+        rustupHome,
+        soldrPath,
+        soldrBinCachePath,
+        toolchain,
+        rustupStrategy,
+        soldrRepo,
+        soldrRef,
+        soldrVersionRequested,
+        soldrVersionResolved,
+        setupCache,
+        buildCache,
+        targetCache,
+        cargoRegistryCache: cargoRegistryCachePlan,
+        dylintCache: dylintCachePlan,
+        blessedPrepareCache,
+        targetCacheCompress,
+        targetCacheCompressLevel,
+        envExports,
+        pathAdditions,
+        logStartEpoch: logStart,
+        timestamps,
+        timestampFormat,
+        shimsEnabled,
+        shimsDir,
+        compileCacheStats,
+        stats,
+        debugMode,
+        cacheShutdownOnIdleSeconds,
+        cachePresetEffective,
+    };
+}
+/**
+ * Apply ResolveResult to the runner: write $GITHUB_ENV, $GITHUB_PATH, and
+ * $GITHUB_OUTPUT keys.
+ */
+async function applyResolveResult(result) {
+    for (const [name, value] of Object.entries(result.envExports)) {
+        if (GITHUB_ENV_DENY_LIST.has(name))
+            continue;
+        core.exportVariable(name, value);
+    }
+    for (const p of result.pathAdditions) {
+        core.addPath(p);
+    }
+    const outputs = (0, build_outputs_js_1.buildOutputs)(result);
+    for (const [key, value] of Object.entries(outputs)) {
+        core.setOutput(key, value);
+    }
+}
+// `buildOutputs` and `pythonDefaultJson` are re-exported at the top of
+// this file from their dedicated submodules.
+
+
+/***/ }),
+
+/***/ 357:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(415)
+const f = __nccwpck_require__(416)
 
 class Time extends Date {
   constructor (value) {
@@ -70538,14 +71619,14 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 359:
+/***/ 358:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(128)
-const Pool = __nccwpck_require__(346)
+const { promisify } = __nccwpck_require__(125)
+const Pool = __nccwpck_require__(344)
 const { buildMockDispatch } = __nccwpck_require__(8)
 const {
   kDispatches,
@@ -70555,10 +71636,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(487)
-const { MockInterceptor } = __nccwpck_require__(141)
-const Symbols = __nccwpck_require__(200)
-const { InvalidArgumentError } = __nccwpck_require__(504)
+} = __nccwpck_require__(488)
+const { MockInterceptor } = __nccwpck_require__(138)
+const Symbols = __nccwpck_require__(197)
+const { InvalidArgumentError } = __nccwpck_require__(505)
 
 /**
  * MockPool provides an API that extends the Pool to influence the mockDispatches.
@@ -70605,7 +71686,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 360:
+/***/ 359:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -70663,7 +71744,7 @@ exports.ClientStreamingCall = ClientStreamingCall;
 
 /***/ }),
 
-/***/ 361:
+/***/ 360:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -71426,7 +72507,7 @@ exports.Decompress = Decompress;
 
 /***/ }),
 
-/***/ 362:
+/***/ 361:
 /***/ ((module) => {
 
 module.exports = function (xs, fn) {
@@ -71446,7 +72527,7 @@ var isArray = Array.isArray || function (xs) {
 
 /***/ }),
 
-/***/ 363:
+/***/ 362:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -71472,7 +72553,7 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_ts_http_runtime = __nccwpck_require__(95);
+var import_ts_http_runtime = __nccwpck_require__(92);
 const RestError = import_ts_http_runtime.RestError;
 function isRestError(e) {
   return (0, import_ts_http_runtime.isRestError)(e);
@@ -71483,7 +72564,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 364:
+/***/ 363:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -71530,8 +72611,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.versionTuple = versionTuple;
 exports.parseVersionJsonOutput = parseVersionJsonOutput;
 exports.verifySoldr = verifySoldr;
-const exec = __importStar(__nccwpck_require__(20));
-const log_utils_js_1 = __nccwpck_require__(196);
+const exec = __importStar(__nccwpck_require__(19));
+const log_utils_js_1 = __nccwpck_require__(193);
 function versionTuple(value) {
     const cleaned = value.trim().replace(/^v/, "");
     const parts = cleaned.split(".");
@@ -71681,22 +72762,22 @@ async function verifySoldr(opts) {
 
 /***/ }),
 
-/***/ 365:
+/***/ 364:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { finished, PassThrough } = __nccwpck_require__(135)
+const { finished, PassThrough } = __nccwpck_require__(132)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(504)
-const util = __nccwpck_require__(75)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(193)
-const { AsyncResource } = __nccwpck_require__(441)
-const { addSignal, removeSignal } = __nccwpck_require__(109)
+} = __nccwpck_require__(505)
+const util = __nccwpck_require__(72)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(190)
+const { AsyncResource } = __nccwpck_require__(442)
+const { addSignal, removeSignal } = __nccwpck_require__(106)
 
 class StreamHandler extends AsyncResource {
   constructor (opts, factory, callback) {
@@ -71909,7 +72990,7 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 366:
+/***/ 365:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71923,10 +73004,10 @@ module.exports = stream
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(220);
-const coreClient = tslib_1.__importStar(__nccwpck_require__(452));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(184));
-const Parameters = tslib_1.__importStar(__nccwpck_require__(71));
+const tslib_1 = __nccwpck_require__(219);
+const coreClient = tslib_1.__importStar(__nccwpck_require__(453));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(181));
+const Parameters = tslib_1.__importStar(__nccwpck_require__(68));
 /** Class containing BlockBlob operations. */
 class BlockBlobImpl {
     client;
@@ -72289,7 +73370,7 @@ const getBlockListOperationSpec = {
 
 /***/ }),
 
-/***/ 367:
+/***/ 366:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -72334,7 +73415,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 368:
+/***/ 367:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72343,8 +73424,8 @@ function decompressResponsePolicy() {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GenericPollOperation = void 0;
-const operation_js_1 = __nccwpck_require__(56);
-const logger_js_1 = __nccwpck_require__(195);
+const operation_js_1 = __nccwpck_require__(53);
+const logger_js_1 = __nccwpck_require__(192);
 const createStateProxy = () => ({
     initState: (config) => ({ config, isStarted: true }),
     setCanceled: (state) => (state.isCancelled = true),
@@ -72429,7 +73510,7 @@ exports.GenericPollOperation = GenericPollOperation;
 
 /***/ }),
 
-/***/ 369:
+/***/ 368:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -72452,7 +73533,7 @@ function ipRangeToString(ipRange) {
 
 /***/ }),
 
-/***/ 370:
+/***/ 369:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -72478,7 +73559,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(264);
+var import_userAgent = __nccwpck_require__(262);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -72500,7 +73581,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 371:
+/***/ 370:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72508,7 +73589,7 @@ function userAgentPolicy(options = {}) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getUserAgentString = void 0;
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const packageJson = __nccwpck_require__(485);
+const packageJson = __nccwpck_require__(486);
 /**
  * Ensure that this User Agent String is used in all HTTP calls so that we can monitor telemetry between different versions of this package
  */
@@ -72517,6 +73598,266 @@ function getUserAgentString() {
 }
 exports.getUserAgentString = getUserAgentString;
 //# sourceMappingURL=user-agent.js.map
+
+/***/ }),
+
+/***/ 371:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Wire `soldr load` into the cargo-registry-cache restore path on Windows
+// runners where Defender's per-CreateFile scan + NTFS overhead dominate
+// the wall clock for serial tar extraction. See zackees/setup-soldr#260
+// and zackees/soldr#575.
+//
+// Strategy:
+// - Detect the archive's first tar entry. If it's `SOLDR_MANIFEST.pb`,
+//   the archive was produced by `soldr save` and we can use `soldr load`
+//   for parallel extraction.
+// - Otherwise fall through to the existing tar/zstd path so legacy
+//   archives keep working.
+//
+// The detection avoids fully decompressing the archive — we only read
+// the first ~2 KiB of decompressed bytes (one tar block of 512 bytes
+// minimum, plus zstd frame slack).
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.CARGO_REGISTRY_VIA_SOLDR_ENV = exports.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP = exports.MIN_SOLDR_VERSION_FOR_LOAD = void 0;
+exports.cargoRegistryViaSoldrEnvOn = cargoRegistryViaSoldrEnvOn;
+exports.semverGte = semverGte;
+exports.detectSoldrManifest = detectSoldrManifest;
+exports.tryLoadViaSoldr = tryLoadViaSoldr;
+exports.saveViaSoldr = saveViaSoldr;
+exports.trySaveViaSoldr = trySaveViaSoldr;
+const fs = __importStar(__nccwpck_require__(111));
+const exec = __importStar(__nccwpck_require__(19));
+/** Min soldr version with parallel-extract `soldr load`. Released in 0.7.46 alongside zackees/soldr#575. */
+exports.MIN_SOLDR_VERSION_FOR_LOAD = "0.7.46";
+/**
+ * Min soldr version safe to use for `soldr save`/`soldr load` round-trip
+ * on cargo-registry cache. 0.7.47 includes zackees/soldr#591 (+x bit
+ * preservation); 0.7.46 alone would corrupt executable cache files
+ * (cargo `build-script-build` failed `execve` with EACCES). (#263)
+ */
+exports.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP = "0.7.47";
+/**
+ * Env var that opts cargo-registry-cache into the `soldr save`/`soldr load`
+ * round-trip. Default off so the v0.9.20 wire-in stays dormant and the
+ * legacy tar+zstd path keeps running until #263's measurement validates
+ * the Windows wall-clock improvement.
+ */
+exports.CARGO_REGISTRY_VIA_SOLDR_ENV = "SOLDR_CARGO_REGISTRY_VIA_SOLDR";
+/** True when [[CARGO_REGISTRY_VIA_SOLDR_ENV]] is set to a truthy value. */
+function cargoRegistryViaSoldrEnvOn() {
+    const raw = (process.env[exports.CARGO_REGISTRY_VIA_SOLDR_ENV] ?? "").trim().toLowerCase();
+    return raw !== "" && raw !== "0" && raw !== "false" && raw !== "no" && raw !== "off";
+}
+/** Filename of the manifest at the root of every `soldr save` archive. */
+const SOLDR_MANIFEST_NAME = "SOLDR_MANIFEST.pb";
+/** Parse a `MAJOR.MINOR.PATCH` prefix from a version string. */
+function parseSemver(value) {
+    const m = value.trim().replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (!m)
+        return null;
+    return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+/** Compare two semvers; `true` if `value >= minimum`. */
+function semverGte(value, minimum) {
+    const got = parseSemver(value);
+    const want = parseSemver(minimum);
+    if (!got || !want)
+        return false;
+    for (let i = 0; i < 3; i += 1) {
+        if (got[i] > want[i])
+            return true;
+        if (got[i] < want[i])
+            return false;
+    }
+    return true;
+}
+/**
+ * Sniff whether the archive's first tar entry is `SOLDR_MANIFEST.pb`,
+ * indicating a `soldr save` archive. Returns `false` on any read or
+ * decode error — the caller should fall through to the legacy path.
+ *
+ * Uses synchronous `tar -tf` + `head -1` via `spawnSync` so the
+ * subprocesses are guaranteed to be reaped before this function
+ * returns (avoiding test-runner timeout from leaked descriptors).
+ */
+async function detectSoldrManifest(archivePath) {
+    const { spawnSync } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 199, 23));
+    // We invoke tar with `-tf <archive>` directly — bsdtar (Windows) and
+    // GNU tar (Linux/macOS) both auto-detect zstd by magic byte on modern
+    // versions. Bounded by `timeout: 5000ms`; if tar takes longer than
+    // that on a single header read, we treat the archive as not-soldr.
+    let res;
+    try {
+        res = spawnSync("tar", ["-tf", archivePath], {
+            encoding: "utf8",
+            timeout: 5000,
+            maxBuffer: 1024 * 1024,
+        });
+    }
+    catch {
+        return false;
+    }
+    if (res.error || res.status !== 0)
+        return false;
+    const first = (res.stdout ?? "").split(/\r?\n/, 2)[0]?.trim();
+    return first === SOLDR_MANIFEST_NAME;
+}
+/**
+ * Attempt to invoke `soldr load` for parallel extraction. Returns
+ * `{ used: false }` when the binary isn't available, the version is
+ * too old, or the archive isn't in soldr format. Throws only on a
+ * genuine extraction failure (so the caller can decide to fall back).
+ */
+async function tryLoadViaSoldr(opts) {
+    const t0 = Date.now();
+    const noOp = { used: false, durationMs: 0 };
+    const log = opts.log ?? (() => undefined);
+    if (!opts.soldrPath) {
+        if (opts.debug)
+            log(`[debug] soldr-load-shim: no soldr binary path supplied`);
+        return noOp;
+    }
+    if (!semverGte(opts.soldrVersion, exports.MIN_SOLDR_VERSION_FOR_LOAD)) {
+        if (opts.debug) {
+            log(`[debug] soldr-load-shim: soldr ${opts.soldrVersion} < ${exports.MIN_SOLDR_VERSION_FOR_LOAD}; falling back to tar+zstd`);
+        }
+        return noOp;
+    }
+    try {
+        const st = await fs.stat(opts.archivePath);
+        if (!st.isFile())
+            return noOp;
+    }
+    catch {
+        return noOp;
+    }
+    const isSoldrFormat = await detectSoldrManifest(opts.archivePath);
+    if (!isSoldrFormat) {
+        if (opts.debug) {
+            log(`[debug] soldr-load-shim: ${opts.archivePath} is not a soldr-format archive (no SOLDR_MANIFEST.pb); falling back to tar+zstd`);
+        }
+        return noOp;
+    }
+    const args = ["load", "--archive", opts.archivePath, "--cache-dir", opts.targetDir];
+    if (opts.autoDefenderExclude && process.platform === "win32") {
+        args.push("--auto-defender-exclude");
+    }
+    if (opts.profileExtract) {
+        args.push("--profile-extract");
+    }
+    if (opts.debug)
+        log(`[debug] soldr-load-shim: invoking ${opts.soldrPath} ${args.join(" ")}`);
+    await exec.exec(opts.soldrPath, args);
+    return { used: true, durationMs: Date.now() - t0 };
+}
+/**
+ * Bundle a cache directory via `soldr save` after the caller has selected a
+ * Soldr-format plan. This deliberately does not re-read the rollout env var:
+ * the persisted plan is authoritative across the main/post process boundary.
+ */
+async function saveViaSoldr(opts) {
+    const t0 = Date.now();
+    const noOp = { used: false, archivePath: null, archiveBytes: 0, durationMs: 0 };
+    const log = opts.log ?? (() => undefined);
+    if (!opts.soldrPath) {
+        if (opts.debug)
+            log(`[debug] soldr-save-shim: no soldr binary path supplied`);
+        return noOp;
+    }
+    if (!semverGte(opts.soldrVersion, exports.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP)) {
+        if (opts.debug) {
+            log(`[debug] soldr-save-shim: soldr ${opts.soldrVersion} < ${exports.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP}; falling back to legacy save`);
+        }
+        return noOp;
+    }
+    try {
+        const st = await fs.stat(opts.cacheDir);
+        if (!st.isDirectory())
+            return noOp;
+    }
+    catch {
+        return noOp;
+    }
+    const args = [
+        "save",
+        "--cache-dir",
+        opts.cacheDir,
+        "--out",
+        opts.archivePath,
+    ];
+    if (opts.debug)
+        log(`[debug] soldr-save-shim: invoking ${opts.soldrPath} ${args.join(" ")}`);
+    try {
+        await exec.exec(opts.soldrPath, args);
+    }
+    catch (err) {
+        if (opts.debug) {
+            log(`[debug] soldr-save-shim: invocation threw: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        return noOp;
+    }
+    let archiveBytes = 0;
+    try {
+        archiveBytes = (await fs.stat(opts.archivePath)).size;
+    }
+    catch {
+        // Soldr save claimed success but archive vanished — fall back.
+        return noOp;
+    }
+    return { used: true, archivePath: opts.archivePath, archiveBytes, durationMs: Date.now() - t0 };
+}
+/**
+ * Compatibility wrapper for callers that have not resolved an archive plan.
+ * The rollout env gate is checked once here; planned v2 callers use
+ * [[saveViaSoldr]] directly so post-job environment drift cannot change format.
+ */
+async function trySaveViaSoldr(opts) {
+    if (!cargoRegistryViaSoldrEnvOn()) {
+        if (opts.debug) {
+            (opts.log ?? (() => undefined))(`[debug] soldr-save-shim: ${exports.CARGO_REGISTRY_VIA_SOLDR_ENV} not set; deferring to legacy tar+zstd save`);
+        }
+        return { used: false, archivePath: null, archiveBytes: 0, durationMs: 0 };
+    }
+    return saveViaSoldr(opts);
+}
+
 
 /***/ }),
 
@@ -72529,8 +73870,8 @@ exports.getUserAgentString = getUserAgentString;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BufferScheduler = void 0;
-const events_1 = __nccwpck_require__(486);
-const PooledBuffer_js_1 = __nccwpck_require__(381);
+const events_1 = __nccwpck_require__(487);
+const PooledBuffer_js_1 = __nccwpck_require__(380);
 /**
  * This class accepts a Node.js Readable stream as input, and keeps reading data
  * from the stream into the internal buffer structure, until it reaches maxBuffers.
@@ -72815,13 +74156,13 @@ exports.BufferScheduler = BufferScheduler;
 "use strict";
 
 
-const { Blob, File: NativeFile } = __nccwpck_require__(124)
-const { types } = __nccwpck_require__(128)
-const { kState } = __nccwpck_require__(17)
-const { isBlobLike } = __nccwpck_require__(532)
-const { webidl } = __nccwpck_require__(470)
-const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(28)
-const { kEnumerableProperty } = __nccwpck_require__(75)
+const { Blob, File: NativeFile } = __nccwpck_require__(121)
+const { types } = __nccwpck_require__(125)
+const { kState } = __nccwpck_require__(16)
+const { isBlobLike } = __nccwpck_require__(533)
+const { webidl } = __nccwpck_require__(471)
+const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(27)
+const { kEnumerableProperty } = __nccwpck_require__(72)
 const encoder = new TextEncoder()
 
 class File extends Blob {
@@ -73167,21 +74508,21 @@ module.exports = { File, FileLike, isFileLike }
 "use strict";
 
 
-const diagnosticsChannel = __nccwpck_require__(147)
-const { uid, states } = __nccwpck_require__(482)
+const diagnosticsChannel = __nccwpck_require__(144)
+const { uid, states } = __nccwpck_require__(483)
 const {
   kReadyState,
   kSentClose,
   kByteParser,
   kReceivedClose
-} = __nccwpck_require__(104)
-const { fireEvent, failWebsocketConnection } = __nccwpck_require__(63)
-const { CloseEvent } = __nccwpck_require__(258)
-const { makeRequest } = __nccwpck_require__(88)
-const { fetching } = __nccwpck_require__(463)
-const { Headers } = __nccwpck_require__(530)
-const { getGlobalDispatcher } = __nccwpck_require__(386)
-const { kHeadersList } = __nccwpck_require__(200)
+} = __nccwpck_require__(101)
+const { fireEvent, failWebsocketConnection } = __nccwpck_require__(60)
+const { CloseEvent } = __nccwpck_require__(256)
+const { makeRequest } = __nccwpck_require__(85)
+const { fetching } = __nccwpck_require__(464)
+const { Headers } = __nccwpck_require__(531)
+const { getGlobalDispatcher } = __nccwpck_require__(385)
+const { kHeadersList } = __nccwpck_require__(197)
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -73191,7 +74532,7 @@ channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(299)
+  crypto = __nccwpck_require__(297)
 } catch {
 
 }
@@ -73483,7 +74824,7 @@ module.exports = (flag, argv = process.argv) => {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.resolveDylintNightly = resolveDylintNightly;
-const node_crypto_1 = __nccwpck_require__(282);
+const node_crypto_1 = __nccwpck_require__(281);
 async function defaultFetchBytes(url) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 30_000);
@@ -73616,8 +74957,8 @@ __export(restError_exports, {
   createRestError: () => createRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_restError = __nccwpck_require__(457);
-var import_httpHeaders = __nccwpck_require__(501);
+var import_restError = __nccwpck_require__(458);
+var import_httpHeaders = __nccwpck_require__(502);
 function createRestError(messageOrResponse, response) {
   const resp = typeof messageOrResponse === "string" ? response : messageOrResponse;
   const internalError = resp.body?.error ?? resp.body;
@@ -73653,10 +74994,10 @@ function statusCodeToNumber(statusCode) {
 "use strict";
 
 
-const DispatcherBase = __nccwpck_require__(68)
-const FixedQueue = __nccwpck_require__(201)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(200)
-const PoolStats = __nccwpck_require__(25)
+const DispatcherBase = __nccwpck_require__(65)
+const FixedQueue = __nccwpck_require__(198)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(197)
+const PoolStats = __nccwpck_require__(24)
 
 const kClients = Symbol('clients')
 const kNeedDrain = Symbol('needDrain')
@@ -73850,1448 +75191,6 @@ module.exports = {
 /***/ }),
 
 /***/ 379:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// setup-soldr entry point. Owned by Agent 2.
-//
-// Replaces the composite action's main-phase steps with a single JS
-// orchestrator. Calls the helpers in src/lib/* in the same order the
-// composite's steps fire.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(257));
-const os = __importStar(__nccwpck_require__(393));
-const path = __importStar(__nccwpck_require__(522));
-const core = __importStar(__nccwpck_require__(474));
-const cache = __importStar(__nccwpck_require__(218));
-const exec = __importStar(__nccwpck_require__(20));
-const log_utils_js_1 = __nccwpck_require__(196);
-const resolve_setup_js_1 = __nccwpck_require__(13);
-const phase_timing_js_1 = __nccwpck_require__(531);
-const ensure_rust_toolchain_js_1 = __nccwpck_require__(254);
-const ensure_soldr_js_1 = __nccwpck_require__(139);
-const verify_soldr_js_1 = __nccwpck_require__(364);
-const install_passthrough_js_1 = __nccwpck_require__(527);
-const normalize_source_mtime_js_1 = __nccwpck_require__(252);
-const detect_shared_target_warning_js_1 = __nccwpck_require__(228);
-const ensure_shims_js_1 = __nccwpck_require__(540);
-const zccache_seed_js_1 = __nccwpck_require__(90);
-const cache_compress_js_1 = __nccwpck_require__(480);
-const soldr_load_shim_js_1 = __nccwpck_require__(34);
-const seed_isolated_cache_js_1 = __nccwpck_require__(304);
-const stats_collector_js_1 = __nccwpck_require__(449);
-const toolchain_snapshot_js_1 = __nccwpck_require__(473);
-const solo_toolchain_cache_js_1 = __nccwpck_require__(355);
-const cook_cache_js_1 = __nccwpck_require__(59);
-const soldr_mini_cache_js_1 = __nccwpck_require__(6);
-const diagnostics_js_1 = __nccwpck_require__(53);
-const shim_bypass_check_js_1 = __nccwpck_require__(321);
-const blessed_cross_prepare_js_1 = __nccwpck_require__(435);
-const target_lifecycle_js_1 = __nccwpck_require__(249);
-const source_mtime_snapshot_js_1 = __nccwpck_require__(472);
-/**
- * Map (hit, matchedKey) → workflow-visible restore-status string.
- * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
- * for the `<layer>-cache-restore-status` outputs declared in action.yml.
- */
-function deriveRestoreStatus(hit, matchedKey) {
-    if (hit)
-        return "exact-hit";
-    if (matchedKey.trim())
-        return "restore-key-hit";
-    return "miss";
-}
-function writeCacheKeysManifest(result, runnerTemp, log) {
-    if (!runnerTemp)
-        return;
-    const keys = [
-        result.setupCache.key,
-        result.buildCache.key,
-        result.targetCache.key,
-        result.cargoRegistryCache.key,
-    ].filter((k) => Boolean(k));
-    if (keys.length === 0)
-        return;
-    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
-    try {
-        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
-        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
-    }
-    catch (err) {
-        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-const TRUTHY = new Set(["1", "true", "yes", "on"]);
-const FALSY = new Set(["0", "false", "no", "off"]);
-function isTruthy(value) {
-    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
-}
-function isFalsy(value) {
-    return FALSY.has(((value ?? "").trim().toLowerCase()));
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
-    }
-}
-async function queryTargetPlan(soldrPath, target, log) {
-    const output = await exec.getExecOutput(soldrPath, ["env", "--target", target, "--json"], {
-        silent: true,
-        ignoreReturnCode: true,
-    });
-    if (output.exitCode !== 0) {
-        log(`target-plan: soldr env failed with exit ${output.exitCode}`);
-        return null;
-    }
-    const line = output.stdout.split(/\r?\n/).map((value) => value.trim()).filter(Boolean).at(-1);
-    if (!line)
-        return null;
-    try {
-        return JSON.parse(line);
-    }
-    catch {
-        log("target-plan: soldr env returned non-JSON output");
-        return null;
-    }
-}
-function publishTargetContract(result, contract, logger) {
-    const target = result.blessedPrepareCache.target;
-    if (!target)
-        return;
-    if (!contract.cacheIdentity)
-        throw new Error(`Soldr target plan for ${target} has no cache identity`);
-    (0, target_lifecycle_js_1.assertTargetOperationSupported)(contract, "prepare");
-    result.targetContract = contract;
-    const mergedEnvironment = (0, target_lifecycle_js_1.mergeTargetEnvironment)(process.env, contract.environment);
-    for (const key of Object.keys(contract.environment)) {
-        core.exportVariable(key, mergedEnvironment[key] ?? contract.environment[key]);
-    }
-    const outputs = (0, target_lifecycle_js_1.buildTargetOperationOutputs)(result.workspace, contract);
-    core.setOutput("target-plan-json", JSON.stringify(contract));
-    core.setOutput("target-capabilities-json", JSON.stringify({
-        schemaVersion: contract.schemaVersion,
-        canonicalTarget: contract.canonicalTarget,
-        cacheIdentity: contract.cacheIdentity,
-        supportedOperations: contract.supportedOperations,
-        toolchain: contract.toolchain,
-        platform: contract.platform,
-    }));
-    core.setOutput("target-env-json", JSON.stringify(contract.environment));
-    core.setOutput("target-cache-identity", contract.cacheIdentity);
-    core.setOutput("target-artifact-dir", outputs.artifactDirectory);
-    core.setOutput("target-build-hook", outputs.build);
-    core.setOutput("target-clippy-hook", outputs.clippy);
-    core.setOutput("target-test-hook", outputs.testNoRun);
-    core.setOutput("target-wheel-hook", outputs.pep517Wheel);
-    core.setOutput("target-sdist-hook", outputs.pep517Sdist);
-    core.saveState("targetPlanJson", JSON.stringify(contract));
-    logger.log(`target-plan: canonical=${contract.canonicalTarget} cache=${contract.cacheIdentity} operations=${contract.supportedOperations.join(",")}`);
-}
-function dirHasContent(p) {
-    try {
-        return fs.readdirSync(p).length > 0;
-    }
-    catch {
-        return false;
-    }
-}
-async function runGitCapture(workspace, args) {
-    let stdout = "";
-    let stderr = "";
-    const code = await exec.exec("git", ["-C", workspace, ...args], {
-        silent: true,
-        ignoreReturnCode: true,
-        listeners: {
-            stdout: (data) => { stdout += data.toString("utf8"); },
-            stderr: (data) => { stderr += data.toString("utf8"); },
-        },
-    });
-    return { code, stdout, stderr };
-}
-async function deriveParentSha(workspace, githubSha, logger) {
-    // #365: derive parent SHA so cook-cache-delta + target-cache +
-    // cargo-registry can fall back to the prior commit's saved
-    // entry. Returns "" on any error (no regression from prior
-    // behavior — caller treats "" as "no fallback").
-    //
-    // Strategy: try `git log -1 --format=%P HEAD` first. On a
-    // shallow clone (actions/checkout default fetch-depth=1) this
-    // returns empty for grafted root commits — fall back to
-    // `git cat-file -p HEAD` and parse the `parent` header lines
-    // from the raw commit object, which are preserved even when
-    // the parent commit object isn't present in the local repo.
-    // Pass 1: git log %P (works on full-depth checkouts).
-    try {
-        const { code, stdout, stderr } = await runGitCapture(workspace, [
-            "log", "-1", "--format=%P", "HEAD",
-        ]);
-        if (code === 0) {
-            const first = stdout.trim().split(/\s+/)[0] ?? "";
-            if (/^[0-9a-f]{7,40}$/i.test(first)) {
-                if (first === githubSha)
-                    return "";
-                logger.log(`parent-sha: derived ${first.slice(0, 12)} from git log (#365)`);
-                return first;
-            }
-            // empty / unparseable → fall through to cat-file
-        }
-        else {
-            logger.log(`parent-sha: git log exit=${code} stderr=${stderr.trim().slice(0, 120)}; trying cat-file`);
-        }
-    }
-    catch (err) {
-        logger.log(`parent-sha: git log threw (${err instanceof Error ? err.message : String(err)}); trying cat-file`);
-    }
-    // Pass 2: git cat-file -p HEAD (works on shallow clones — the
-    // commit object's `parent` header is preserved even when the
-    // parent commit isn't fetched).
-    try {
-        const { code, stdout, stderr } = await runGitCapture(workspace, [
-            "cat-file", "-p", "HEAD",
-        ]);
-        if (code !== 0) {
-            logger.log(`parent-sha: cat-file exit=${code} stderr=${stderr.trim().slice(0, 120)}; leaving empty`);
-            return "";
-        }
-        // Raw commit object format:
-        //   tree <sha>
-        //   parent <sha>      ← first parent (mainline)
-        //   parent <sha>      ← second parent (only for merges)
-        //   author ...
-        //   committer ...
-        //
-        //   <message>
-        for (const line of stdout.split("\n")) {
-            if (line.startsWith("parent ")) {
-                const sha = line.slice("parent ".length).trim();
-                if (/^[0-9a-f]{7,40}$/i.test(sha) && sha !== githubSha) {
-                    logger.log(`parent-sha: derived ${sha.slice(0, 12)} from cat-file (#365, shallow-safe)`);
-                    return sha;
-                }
-            }
-            if (line === "")
-                break; // header section ended
-        }
-        logger.log(`parent-sha: cat-file produced no usable parent (root commit?); leaving empty`);
-        return "";
-    }
-    catch (err) {
-        logger.log(`parent-sha: cat-file threw (${err instanceof Error ? err.message : String(err)}); leaving empty`);
-        return "";
-    }
-}
-async function buildActionContext() {
-    const env = process.env;
-    const logger = (0, log_utils_js_1.createLogger)(env);
-    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
-    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
-    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
-    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
-    const githubSha = env["GITHUB_SHA"]?.trim() || "";
-    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
-    // #365: parentSha enables cook-cache-delta + target-cache + cargo-
-    // registry to share entries across consecutive commits. The env
-    // override (ACTION_PARENT_SHA) lets a workflow set it explicitly;
-    // otherwise we derive it from `git log -1 --format=%P HEAD` so the
-    // fallback works out of the box for any repo with non-shallow
-    // checkout. Without this, every push-event run had the delta key
-    // mismatch the prior save (0% hit rate observed on zccache).
-    let parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
-    if (!parentSha && githubSha) {
-        parentSha = await deriveParentSha(workspace, githubSha, logger);
-    }
-    return {
-        env: { ...env },
-        workspace,
-        runnerTemp,
-        runnerOs,
-        runnerArch,
-        githubSha,
-        githubToken,
-        parentSha,
-        logger,
-    };
-}
-function actionRoot() {
-    const explicit = process.env["GITHUB_ACTION_PATH"]?.trim() || process.env["SETUP_SOLDR_ACTION_ROOT"]?.trim();
-    if (explicit)
-        return path.resolve(explicit);
-    const moduleDir = typeof __dirname === "string" ? __dirname : process.cwd();
-    return path.resolve(moduleDir, "..");
-}
-async function restoreCacheSafe(paths, key, restoreKeys, logger) {
-    if (paths.length === 0 || !key) {
-        return { hit: false, matchedKey: "" };
-    }
-    try {
-        const matched = await cache.restoreCache(paths, key, restoreKeys);
-        return { hit: matched === key, matchedKey: matched ?? "" };
-    }
-    catch (err) {
-        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "" };
-    }
-}
-async function run() {
-    const ctx = await buildActionContext();
-    const logger = ctx.logger;
-    await (0, phase_timing_js_1.markPhase)("action");
-    // ---- resolve ----
-    await (0, phase_timing_js_1.markPhase)("resolve");
-    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
-    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
-    await (0, resolve_setup_js_1.applyResolveResult)(result);
-    await (0, phase_timing_js_1.finishPhase)("resolve");
-    // Always emit the cache-keys manifest right after resolve so workflow
-    // steps that run between main and post (e.g. actions/upload-artifact)
-    // can read it. The four keys are fully determined by resolveSetup and
-    // never change later in the run.
-    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
-    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            logger,
-            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
-        });
-    }
-    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
-    if (dryRun) {
-        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
-        await (0, phase_timing_js_1.finishPhase)("action");
-        return;
-    }
-    // Persist resolve state for the post-job step.
-    core.saveState("resolveResult", JSON.stringify(result));
-    core.saveState("buildCacheMode", result.buildCache.mode);
-    core.saveState("logging", logging ? "true" : "false");
-    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
-    const statsMode = result.stats;
-    const debugMode = result.debugMode;
-    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
-    const statsCollector = new stats_collector_js_1.StatsCollector();
-    // ---- source-mtime-normalize ----
-    if (isTruthy(inputs.sourceMtimeNormalize)) {
-        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
-    }
-    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
-    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
-    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
-    core.saveState("setupCacheExactHit", "false");
-    core.saveState("setupCacheMatchedKey", "");
-    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
-    core.saveState("targetCacheExactHit", "false");
-    core.saveState("targetCacheMatchedKey", "");
-    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
-    core.saveState("buildCacheExactHit", "false");
-    core.saveState("buildCacheMatchedKey", "");
-    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
-    core.saveState("cargoRegistryCacheExactHit", "false");
-    core.saveState("cargoRegistryCacheMatchedKey", "");
-    core.saveState("dylintCacheEnabled", result.dylintCache.enabled ? "true" : "false");
-    core.saveState("dylintCacheExactHit", "false");
-    core.saveState("dylintCacheMatchedKey", "");
-    core.saveState("dylintOutputCacheEnabled", result.dylintCache.outputCacheEnabled ? "true" : "false");
-    core.saveState("dylintOutputCacheExactHit", "false");
-    core.saveState("dylintOutputCacheMatchedKey", "");
-    core.saveState("blessedPrepareCacheEnabled", result.blessedPrepareCache.enabled ? "true" : "false");
-    core.saveState("blessedPrepareCacheExactHit", "false");
-    core.saveState("blessedPrepareCacheMatchedKey", "");
-    core.saveState("blessedPrepareComplete", "false");
-    // ---- parallel restores ----
-    // setup-cache, target-cache, build-cache, and cargo-registry write to
-    // disjoint paths and have no inter-dependencies, so they run concurrently.
-    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
-    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
-    //
-    // Layers that must stay sequential (wired below): solo-toolchain (writes
-    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
-    // install dir, must precede ensureSoldr), cook (writes target/ and needs
-    // the soldr binary). Cargo-registry was previously after-cook — it's been
-    // moved into this parallel block because nothing the soldr install path
-    // touches depends on its hydrated cargo registry state.
-    await (0, phase_timing_js_1.markPhase)("parallel-restore");
-    let setupCacheExactHit = false;
-    // Capture target-cache match status so we can skip the redundant cook restore.
-    // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
-    // (~2.5 GB inflated) also contains compiled deps. When target-cache matched
-    // at the lockfile/shape/toolchain level (exact OR parent-SHA OR lock-prefix
-    // fallback), we have target/deps/ already populated with identical content —
-    // cook restore would just overwrite. Skipping saves ~5–10 s per warm run.
-    // A looser restoreKeyLockfile-only match (different shape) is NOT enough to
-    // skip cook, since cook output may differ across shapes.
-    let targetCacheMatchedKey = "";
-    const setupRestorePromise = (async () => {
-        if (!(cacheEnabled && result.setupCache.paths.length > 0))
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
-        setupCacheExactHit = restore.hit;
-        core.setOutput("cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("setup_cache_matched_key", restore.matchedKey);
-        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("setupCacheMatchedKey", restore.matchedKey);
-        // Expose for ensure_rust_toolchain to read via env. Must be visible by
-        // the time toolchain phase runs — guaranteed by the Promise.all below.
-        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
-        statsCollector.record({
-            label: "setup-cache", operation: "restore", hit: restore.hit,
-            key: result.setupCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.setupCache.restorePrefix],
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const targetRestorePromise = (async () => {
-        if (!result.targetCache.enabled)
-            return;
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        if (targetPaths.length === 0)
-            return;
-        const restoreKeys = [];
-        if (result.targetCache.restoreKeyParent)
-            restoreKeys.push(result.targetCache.restoreKeyParent);
-        if (result.targetCache.restoreKeyLock)
-            restoreKeys.push(result.targetCache.restoreKeyLock);
-        if (result.targetCache.restoreKeyLockfile)
-            restoreKeys.push(result.targetCache.restoreKeyLockfile);
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
-        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("target_cache_matched_key", restore.matchedKey);
-        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("targetCacheMatchedKey", restore.matchedKey);
-        targetCacheMatchedKey = restore.matchedKey;
-        statsCollector.record({
-            label: "target-cache", operation: "restore", hit: restore.hit,
-            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const buildRestorePromise = (async () => {
-        if (!buildCacheEnabled)
-            return;
-        const buildCachePath = result.buildCache.path;
-        const archivePath = `${buildCachePath}.tar.zst`;
-        const restoreKeys = [];
-        if (result.buildCache.restoreKeyParent)
-            restoreKeys.push(result.buildCache.restoreKeyParent);
-        if (result.buildCache.restoreKeyToolchain)
-            restoreKeys.push(result.buildCache.restoreKeyToolchain);
-        if (result.buildCache.restoreKeyOsArch)
-            restoreKeys.push(result.buildCache.restoreKeyOsArch);
-        const t0 = Date.now();
-        // @actions/cache hashes the `paths` array into a "version" key — save and
-        // restore MUST pass the same array or the lookup misses even when the
-        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
-        // restore must use the same single-path array. The decompression below
-        // unpacks archivePath → buildCachePath afterwards.
-        const restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
-        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("build_cache_matched_key", restore.matchedKey);
-        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("buildCacheMatchedKey", restore.matchedKey);
-        let buildArchiveBytes = null;
-        let buildInflatedBytes = null;
-        let buildFileCount = null;
-        if (fileExists(archivePath)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-            const haveEncryptKey = (process.env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] ?? "").trim().length > 0;
-            if (magic === "zstd" || magic === "gzip" || haveEncryptKey) {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({
-                        archivePath,
-                        targetDir: buildCachePath,
-                        debug: debugMode,
-                        log: debugLog,
-                        cacheKey: restore.matchedKey || result.buildCache.key,
-                    });
-                    buildArchiveBytes = dr.archiveBytes;
-                    buildInflatedBytes = dr.inflatedBytes;
-                    buildFileCount = dr.fileCount;
-                }
-                catch (err) {
-                    logger.log(`build-cache decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
-        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
-        // dir on the cold side; if it's present after decompress, walk it and
-        // set each matching source file's mtime to what cold saw. The replay
-        // is gated by (size, content-hash) match so we never overwrite a
-        // genuinely modified file's mtime — that would underbuild.
-        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
-            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
-            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
-            if (snapshot) {
-                const rt0 = Date.now();
-                try {
-                    // Match the project-root selection that post.ts uses when
-                    // writing the snapshot — the parent of the resolved target-dir,
-                    // not the (outer) GITHUB_WORKSPACE.
-                    const projectRoot = path.dirname(result.targetCache.targetPath);
-                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
-                        workspace: projectRoot,
-                        snapshot,
-                        log: (msg) => logger.log(msg),
-                    });
-                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
-                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
-                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
-                }
-                catch (err) {
-                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-            else {
-                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
-            }
-        }
-        statsCollector.record({
-            label: "build-cache", operation: "restore", hit: restore.hit,
-            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        // Seed an isolated SOLDR_CACHE_DIR from the just-restored build-cache
-        // artifact store (issue #240). Opt-in: only fires when the consumer
-        // declares the isolated root(s) it switches its self-test phase to, so a
-        // daemon-isolated coverage/integration phase starts warm instead of cold.
-        const seedTargets = (0, seed_isolated_cache_js_1.parseIsolatedSeedTargets)(inputs.seedIsolatedBuildCache);
-        if (seedTargets.length > 0) {
-            try {
-                (0, seed_isolated_cache_js_1.seedIsolatedBuildCache)({
-                    sourceZccacheDir: buildCachePath,
-                    targetSoldrRoots: seedTargets,
-                    log: (msg) => logger.log(msg),
-                });
-            }
-            catch (err) {
-                logger.log(`seed-isolated-build-cache: failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    })();
-    // Cargo-registry restore moved here from after-cook. It writes only
-    // $CARGO_HOME/registry/ and has no dependency on soldr being installed;
-    // running it in parallel with target+build trims its ~5s off the critical
-    // path.
-    const cargoRegistryRestorePromise = (async () => {
-        if (!result.cargoRegistryCache.enabled)
-            return;
-        const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe([registryArchive], result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
-        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
-        let regArchiveBytes = null;
-        let regInflatedBytes = null;
-        let regFileCount = null;
-        if (fileExists(registryArchive)) {
-            // #260: try `soldr load` first for parallel extraction on Windows
-            // (Defender + NTFS bottleneck). Falls through to the legacy
-            // tar+zstd path when the archive isn't soldr-format or the
-            // installed soldr is too old.
-            let soldrLoadUsed = false;
-            try {
-                const sr = await (0, soldr_load_shim_js_1.tryLoadViaSoldr)({
-                    archivePath: registryArchive,
-                    targetDir: result.cargoRegistryCache.path,
-                    soldrPath: result.soldrPath,
-                    soldrVersion: result.soldrVersionResolved,
-                    debug: debugMode,
-                    log: debugLog,
-                    autoDefenderExclude: process.platform === "win32",
-                });
-                soldrLoadUsed = sr.used;
-            }
-            catch (err) {
-                logger.log(`cargo-registry soldr load failed (will fall back to tar+zstd): ${err instanceof Error ? err.message : String(err)}`);
-            }
-            if (soldrLoadUsed) {
-                try {
-                    regArchiveBytes = (await fs.promises.stat(registryArchive)).size;
-                }
-                catch { /* archive may have been removed mid-flight */ }
-            }
-            else {
-                const magic = await (0, cache_compress_js_1.detectCompressMagic)(registryArchive);
-                const haveEncryptKey = (process.env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] ?? "").trim().length > 0;
-                if (magic === "zstd" || magic === "gzip" || haveEncryptKey) {
-                    try {
-                        const dr = await (0, cache_compress_js_1.decompressCache)({
-                            archivePath: registryArchive,
-                            targetDir: result.cargoRegistryCache.path,
-                            debug: debugMode, log: debugLog,
-                            cacheKey: restore.matchedKey || result.cargoRegistryCache.key,
-                        });
-                        regArchiveBytes = dr.archiveBytes;
-                        regInflatedBytes = dr.inflatedBytes;
-                        regFileCount = dr.fileCount;
-                    }
-                    catch (err) {
-                        logger.log(`cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`);
-                    }
-                }
-            }
-        }
-        statsCollector.record({
-            label: "cargo-registry", operation: "restore", hit: restore.hit,
-            key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.cargoRegistryCache.restorePrefix],
-            archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    })();
-    const blessedPrepareRestorePromise = (async () => {
-        const plan = result.blessedPrepareCache;
-        if (!plan.enabled)
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(plan.archivePaths, plan.key, [], logger);
-        core.saveState("blessedPrepareCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("blessedPrepareCacheMatchedKey", restore.matchedKey);
-        core.setOutput("blessed-prepare-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("blessed-prepare-cache-key", plan.key);
-        statsCollector.record({
-            label: "blessed-prepare-cache", operation: "restore", hit: restore.hit,
-            key: plan.key, matchedKey: restore.matchedKey, restoreKeys: [],
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    })();
-    const dylintRestorePromise = (async () => {
-        if (!result.dylintCache.enabled)
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.dylintCache.paths, result.dylintCache.key, [], logger);
-        core.setOutput("dylint-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("dylint-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("dylint_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("dylint_cache_matched_key", restore.matchedKey);
-        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_HIT", restore.hit ? "true" : "false");
-        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_MATCHED_KEY", restore.matchedKey);
-        core.saveState("dylintCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("dylintCacheMatchedKey", restore.matchedKey);
-        statsCollector.record({
-            label: "dylint-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: result.dylintCache.key,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - t0,
-            timestamp: new Date().toISOString(),
-        });
-        logger.log(`dylint-cache: key=${result.dylintCache.key} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const dylintOutputRestorePromise = (async () => {
-        if (!result.dylintCache.outputCacheEnabled || result.dylintCache.outputPaths.length === 0) {
-            return;
-        }
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.dylintCache.outputPaths, result.dylintCache.outputKey, [], logger);
-        core.setOutput("dylint-output-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("dylint-output-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.saveState("dylintOutputCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("dylintOutputCacheMatchedKey", restore.matchedKey);
-        statsCollector.record({
-            label: "dylint-output-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: result.dylintCache.outputKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - t0,
-            timestamp: new Date().toISOString(),
-        });
-        logger.log(`dylint-output-cache: key=${result.dylintCache.outputKey} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
-    // try/catches, so this should only see rejections for genuine programming
-    // bugs.
-    await Promise.all([
-        setupRestorePromise,
-        targetRestorePromise,
-        buildRestorePromise,
-        cargoRegistryRestorePromise,
-        blessedPrepareRestorePromise,
-        dylintRestorePromise,
-        dylintOutputRestorePromise,
-    ]);
-    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
-    // ---- target-tree-cache (full mode) ----
-    // The bundle path is included in target-cache restore paths above when full
-    // mode is requested, so there's no separate restore here. We keep the phase
-    // marker for parity with the composite step ordering.
-    await (0, phase_timing_js_1.markPhase)("target-tree");
-    await (0, phase_timing_js_1.finishPhase)("target-tree");
-    // Plan soldr-mini-cache restore now, but perform the extract inside the
-    // install phase. Restoring this layer in the background can rewrite the
-    // install dir while later phases spawn PATH tools, which surfaced as Linux
-    // ETXTBSY on the warm demo after soldr-cook started invoking soldr earlier.
-    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
-    const miniInstallDir = path.dirname(result.soldrPath);
-    const miniArchive = `${miniInstallDir}.tar.zst`;
-    let miniHit = false;
-    let miniKey = "";
-    let miniSkipReason = "";
-    let miniRestoreEligible = false;
-    if (miniEnabled) {
-        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
-            hasRef: Boolean(result.soldrRef.trim()),
-            enable: result.enabled,
-            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
-        });
-        if (eligibility.eligible) {
-            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
-            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
-                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-                soldrVersion: version,
-            });
-            miniRestoreEligible = true;
-            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir}`);
-        }
-        else {
-            miniSkipReason = eligibility.reason;
-        }
-    }
-    // Kick off cook restore in the background. It overlaps with the
-    // sequential toolchain + soldr install + shims + verify steps that
-    // follow. By the time the cook phase runs, the restore is done — we
-    // just await the promise. Saves ~5–7 s of warm-build wall clock.
-    //
-    // Why this is safe (vs the disastrous PR #145 which added cook to the
-    // BIG parallel block): cook now races with SMALL ops (rust install
-    // ~1–2 s, soldr install ~2–3 s, shims/verify ~1–2 s). Those don't
-    // contend on disk write bandwidth the way target/build/cargo-registry
-    // restores did. Cook's 2.5 GB tar write becomes the long pole and
-    // hides behind the small ops.
-    //
-    // SAFETY: when target-cache writes to target/ (build-cache-mode: full),
-    // cook restore would race with target-cache restore on the same dir.
-    // The parallel-restore block above already finished target-cache, but
-    // we still want a runtime gate just in case the mode changes.
-    const cookGate = (0, cook_cache_js_1.decideCookGate)({
-        prebuildDeps: inputs.prebuildDeps,
-        cacheUmbrella: cacheEnabled,
-        lockfilePath: result.targetCache.lockfilePath,
-    });
-    const cookActive = cookGate.enabled && result.enabled;
-    let cookFlags = [];
-    let cookKey = "";
-    let cookBaseKey = "";
-    let cookDeltaKey = "";
-    let cookDeltaParentKey = "";
-    let cookDeltaRestoreKeys = [];
-    let cookProjectRoot = "";
-    let cookTargetDir = "";
-    let cookArchive = "";
-    let cookBaseArchive = "";
-    let cookDeltaArchive = "";
-    let cookBaseManifest = "";
-    let cookLayered = false;
-    let cookRestoreT0 = Date.now();
-    let cookRestorePromise = null;
-    let cookLayeredRestorePromise = null;
-    // Skip cook restore when target-cache matched at the lockfile/shape level.
-    // restoreKeyLock = `${prefix}-${targetInputsHash}-${suffix}-` where
-    // targetInputsHash = sha256(toolchain, lockfile, manifest, shape). A
-    // matchedKey starting with restoreKeyLock means the cached entry was built
-    // with the same toolchain + lockfile + shape — its target/deps/ matches
-    // what cook would restore. Covers:
-    //   - exact hit  (matchedKey === current key, also startsWith restoreKeyLock)
-    //   - parent-SHA hit (matchedKey === restoreKeyParent, also startsWith)
-    //   - lock-prefix fallback (any saved entry with same lockfile+shape)
-    // Does NOT cover restoreKeyLockfile fallback (shorter prefix that drops
-    // shape) — different shape may mean different cook output, so cook still
-    // runs there as the safety net.
-    const targetCacheLockMatch = !!targetCacheMatchedKey &&
-        !!result.targetCache.restoreKeyLock &&
-        targetCacheMatchedKey.startsWith(result.targetCache.restoreKeyLock);
-    const cookSkippedDueToTargetHit = cookActive && targetCacheLockMatch;
-    if (cookActive && !cookSkippedDueToTargetHit) {
-        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
-        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
-        const lockHash = result.targetCache.lockfileHash || "no-lock";
-        const cookKeyParts = {
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            flagsHash,
-            lockHash,
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        };
-        cookProjectRoot = path.dirname(result.targetCache.targetPath);
-        cookTargetDir = result.targetCache.targetPath;
-        cookRestoreT0 = Date.now();
-        const deltaInput = inputs.prebuildDepsDeltaCache.trim() || "true";
-        const deltaRequested = !isFalsy(deltaInput);
-        const soldrVersionForCook = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
-        cookLayered = deltaRequested && (0, cook_cache_js_1.supportsLayeredCookCache)(soldrVersionForCook);
-        if (cookLayered) {
-            const shapeHash = (0, cook_cache_js_1.hashCookBuildShape)(result.targetCache.restoreKeyLock || result.targetCache.key);
-            cookBaseKey = (0, cook_cache_js_1.buildCookBaseCacheKey)(cookKeyParts);
-            cookDeltaKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
-                ...cookKeyParts,
-                buildShapeHash: shapeHash,
-                githubSha: ctx.githubSha || "nosha",
-            });
-            if (ctx.parentSha && ctx.parentSha !== ctx.githubSha) {
-                cookDeltaParentKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
-                    ...cookKeyParts,
-                    buildShapeHash: shapeHash,
-                    githubSha: ctx.parentSha,
-                });
-            }
-            cookDeltaRestoreKeys = cookDeltaParentKey ? [cookDeltaParentKey] : [];
-            cookDeltaRestoreKeys.push((0, cook_cache_js_1.buildCookDeltaCacheRestorePrefix)({
-                ...cookKeyParts,
-                buildShapeHash: shapeHash,
-            }));
-            cookBaseArchive = `${cookTargetDir}.soldr-base.tar.zst`;
-            cookDeltaArchive = `${cookTargetDir}.soldr-delta.tar.zst`;
-            cookBaseManifest = `${cookTargetDir}.soldr-base-manifest.pb`;
-            logger.log(`cook: layered keys base=${cookBaseKey} delta=${cookDeltaKey}` +
-                (cookDeltaParentKey ? ` delta-fallback=${cookDeltaParentKey}` : ` (no parent-fallback — parentSha unavailable, #365)`) +
-                ` delta-prefix=${cookDeltaRestoreKeys.at(-1)}` +
-                ` starting archive restore concurrent with install`);
-            cookLayeredRestorePromise = (0, cook_cache_js_1.restoreLayeredCookCacheArchives)({
-                baseKey: cookBaseKey,
-                deltaKey: cookDeltaKey,
-                deltaRestoreKeys: cookDeltaRestoreKeys,
-                baseArchivePath: cookBaseArchive,
-                deltaArchivePath: cookDeltaArchive,
-                log: (msg) => logger.log(msg),
-            });
-        }
-        else {
-            if (deltaRequested) {
-                logger.log(`cook: layered cache requires soldr >=0.7.38; ` +
-                    `version=${soldrVersionForCook || "unknown"} falling back to legacy cook cache`);
-            }
-            else {
-                logger.log("cook: layered cache disabled via prebuild-deps-delta-cache=false");
-            }
-            cookKey = (0, cook_cache_js_1.buildCookCacheKey)(cookKeyParts);
-            cookArchive = `${cookTargetDir}.tar.zst`;
-            logger.log(`cook: key=${cookKey} starting background restore concurrent with install`);
-            cookRestorePromise = (0, cook_cache_js_1.restoreCookCache)({
-                exactKey: cookKey,
-                archivePath: cookArchive,
-                targetDir: cookTargetDir,
-                longWindow: 27,
-                debug: debugMode,
-                log: (msg) => logger.log(msg),
-            });
-        }
-    }
-    // ---- toolchain ----
-    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
-    // toolchain install so we can see which inodes setup-soldr added on
-    // top of the runner image. When solo-toolchain-cache is opted in, a
-    // third snapshot is taken *before* the cache restore so the saved
-    // tarball captures the full above-runner state — not just the
-    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
-    // lifetime axis".
-    await (0, phase_timing_js_1.markPhase)("toolchain");
-    const snapshotRoots = [
-        path.join(result.rustupHome, "toolchains"),
-        path.join(result.cargoHome, "bin"),
-    ];
-    const soloRootMap = {
-        "rustup-toolchains": snapshotRoots[0],
-        "cargo-bin": snapshotRoots[1],
-    };
-    const soloEnabled = isTruthy(inputs.soloToolchainCache);
-    // #310: default-changed from "19" → "9". Measured first-save cost
-    // dropped from ~104s → ~12s on 140 MB toolchain delta; restore stays
-    // bandwidth-bound either way.
-    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "9");
-    let soloKeys = null;
-    let soloMatchedKey = "";
-    let soloExactHit = false;
-    let forceToolchainRepair = false;
-    // Pre-restore snapshot — only needed when solo cache is enabled, so
-    // we can compute the full save-diff (post-install vs runner-image,
-    // not vs post-restore baseline). (#302: timed as sub-phase.)
-    const preRestoreSnapshot = soloEnabled
-        ? await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-pre", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots))
-        : null;
-    if (soloEnabled) {
-        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
-            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        });
-        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
-        const restoreT0 = Date.now();
-        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
-        const restored = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "solo-restore", () => (0, solo_toolchain_cache_js_1.restoreSoloCache)({
-            keys: soloKeys,
-            rootMap: soloRootMap,
-            stagingDir,
-            log: (msg) => logger.log(msg),
-            // #316 follow-up: pass canonical archive path explicitly so
-            // save and restore agree regardless of stagingDir layout.
-            cacheArchivePath: (0, solo_toolchain_cache_js_1.soloCacheArchivePath)(ctx.runnerTemp),
-        }));
-        soloMatchedKey = restored.matchedKey;
-        let verifiedMatch = true;
-        if (restored.verified && restored.matchedKey) {
-            const expected = result.toolchain.cacheChannel.trim();
-            // The rustup home is set up so `rustc` will resolve through the
-            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
-            // the cargo bin one.
-            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
-            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
-                expectedRelease: expected,
-                expectedTargets: result.toolchain.targets,
-                rustcCommand: rustcCmd,
-                log: (msg) => logger.log(msg),
-            });
-            verifiedMatch = verify.match;
-            forceToolchainRepair = restored.verified && !verify.match;
-        }
-        soloExactHit = restored.hit && verifiedMatch;
-        core.saveState("soloToolchainEnabled", "true");
-        core.saveState("soloToolchainExactKey", soloKeys.exact);
-        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
-        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
-        core.saveState("soloToolchainLevel", soloLevel);
-        statsCollector.record({
-            label: "solo-toolchain-cache",
-            operation: "restore",
-            hit: soloExactHit,
-            key: soloKeys.exact,
-            matchedKey: soloMatchedKey,
-            restoreKeys: soloKeys.fallbacks,
-            archiveBytes: restored.restoredBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - restoreT0,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else {
-        core.saveState("soloToolchainEnabled", "false");
-    }
-    const baselineSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-base", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
-    // #323: when solo-cache exact-hit AND verifyRestoredToolchain
-    // passed, the requested toolchain is already on disk from the
-    // restore. `rustup toolchain install` would be a no-op but still
-    // costs ~8s on hosted runners (self-update check, metadata fetch,
-    // profile diff). Skip the install entirely on the verified
-    // exact-hit path. The snapshot still runs so cache-save logic
-    // downstream sees an unchanged tree (install-delta empty).
-    if (soloExactHit) {
-        logger.log("toolchain: solo-cache exact-hit + verified — skipping rustup install (#323)");
-        // The restored tree is already valid, but the skipped installer is also
-        // where ensureRustToolchain normally exports the selected channel. Keep
-        // cache-hit jobs explicit so rustup proxies used by later probes never
-        // depend on a runner-global default toolchain.
-        core.exportVariable("RUSTUP_TOOLCHAIN", result.toolchain.channel);
-        process.env["RUSTUP_TOOLCHAIN"] = result.toolchain.channel;
-    }
-    else {
-        await (0, phase_timing_js_1.timeSubPhase)("toolchain", "rustup-install", () => (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({
-            resolveResult: result,
-            setupCacheExactHit,
-            forceRepair: forceToolchainRepair,
-        }));
-    }
-    const postInstallSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-post", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
-    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
-    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
-    // When solo cache is enabled, also compute the save-diff (post-install
-    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
-    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
-        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
-        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
-        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
-        try {
-            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
-            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
-            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
-            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
-                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
-                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
-                `incremental-empty=${toolchainDiff.added.length === 0}`);
-        }
-        catch (err) {
-            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
-    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
-        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
-    if (ctx.runnerTemp) {
-        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
-        try {
-            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
-            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
-        }
-        catch (err) {
-            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    await (0, phase_timing_js_1.finishPhase)("toolchain");
-    // ---- install soldr ----
-    // Restore soldr-mini-cache synchronously so the install dir is quiescent
-    // before ensureSoldr's installedVersion() check or any later soldr spawn.
-    await (0, phase_timing_js_1.markPhase)("install");
-    if (miniRestoreEligible) {
-        const miniT0 = Date.now();
-        const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
-            exactKey: miniKey,
-            installDir: miniInstallDir,
-            archivePath: miniArchive,
-            longWindow: 27,
-            debug: debugMode,
-            log: (msg) => logger.log(msg),
-        });
-        miniHit = restore.hit;
-        statsCollector.record({
-            label: "soldr-mini-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: miniKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - miniT0,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else if (miniSkipReason) {
-        logger.log(`soldr-mini-cache: skipped — ${miniSkipReason}`);
-    }
-    else if (!miniEnabled) {
-        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
-    }
-    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
-    core.saveState("soldrMiniExactKey", miniKey);
-    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
-    core.saveState("soldrMiniInstallDir", miniInstallDir);
-    core.saveState("soldrMiniArchive", miniArchive);
-    if (result.enabled) {
-        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
-        // restored binary at the expected path with the expected version and
-        // short-circuits — no GH fetch.
-        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
-    }
-    else {
-        (0, install_passthrough_js_1.installPassthrough)({
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
-            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
-            "verbatim, and soldr-aware caching/observability is disabled.");
-    }
-    await (0, phase_timing_js_1.finishPhase)("install");
-    // ---- zccache-seed ----
-    // Pin setup-soldr's zccache before user workflow steps. The pinned
-    // install is home-anchored inside soldr, so later self-tests can isolate
-    // SOLDR_CACHE_DIR without repeating release lookup or cargo-install fallback.
-    await (0, phase_timing_js_1.markPhase)("zccache-seed");
-    await (0, zccache_seed_js_1.seedZccache)({
-        soldrPath: result.soldrPath,
-        actionRoot: actionRoot(),
-        enabled: result.enabled,
-        strict: isTruthy(inputs.zccacheSeedStrict),
-        log: (msg) => logger.log(msg),
-        warn: (msg) => logger.warning(msg),
-    });
-    await (0, phase_timing_js_1.finishPhase)("zccache-seed");
-    // Export SOLDR_BINARY so shims can exec it directly
-    core.exportVariable("SOLDR_BINARY", result.soldrPath);
-    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
-    // ---- shims ----
-    if (result.shimsEnabled) {
-        await (0, ensure_shims_js_1.ensureShims)({
-            shimsDir: result.shimsDir,
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-    }
-    // ---- verify ----
-    await (0, phase_timing_js_1.markPhase)("verify");
-    if (result.enabled) {
-        const verify = await (0, verify_soldr_js_1.verifySoldr)({
-            soldrPath: result.soldrPath,
-            buildCacheMode: result.buildCache.mode,
-            requireRustPlan: result.targetCache.enabled,
-            minimumVersion: result.blessedPrepareCache.target ? "0.8.39" : undefined,
-        });
-        core.setOutput("soldr-version", verify.soldrVersion);
-        core.setOutput("soldr_version", verify.soldrVersion);
-    }
-    else {
-        core.setOutput("soldr-version", "passthrough");
-        core.setOutput("soldr_version", "passthrough");
-    }
-    await (0, phase_timing_js_1.finishPhase)("verify");
-    // ---- cross-prepare ----
-    await (0, phase_timing_js_1.markPhase)("cross-prepare");
-    const preparePlan = result.blessedPrepareCache;
-    if (preparePlan.target) {
-        if (!result.enabled)
-            throw new Error("cross-targets requires enable: true");
-        const installedVersion = result.soldrVersionResolved || result.soldrVersionRequested;
-        (0, blessed_cross_prepare_js_1.assertMinimumSoldrVersion)(installedVersion);
-        const exactHit = core.getState("blessedPrepareCacheExactHit") === "true";
-        const prepareTargets = (0, blessed_cross_prepare_js_1.prepareTargetsFor)(preparePlan.target);
-        const archivesExist = preparePlan.archivePaths.length === prepareTargets.length
-            && preparePlan.archivePaths.every((archivePath) => fs.existsSync(archivePath));
-        const effectiveExactHit = exactHit && archivesExist;
-        if (exactHit && !archivesExist) {
-            logger.log("cross-prepare: exact cache key restored without every prepared archive; reseeding");
-            core.saveState("blessedPrepareCacheExactHit", "false");
-            core.setOutput("blessed-prepare-cache-hit", "false");
-        }
-        logger.log(`cross-prepare: target=${preparePlan.target} cache=${preparePlan.enabled ? (effectiveExactHit ? "hit" : "miss") : "disabled"}`);
-        const contracts = [];
-        for (const [index, target] of prepareTargets.entries()) {
-            await (0, blessed_cross_prepare_js_1.executeBlessedPrepare)({
-                soldrPath: result.soldrPath,
-                target,
-                githubEnv: process.env["GITHUB_ENV"],
-                archivePath: preparePlan.archivePaths[index],
-                restore: preparePlan.enabled && effectiveExactHit,
-                save: preparePlan.enabled && !effectiveExactHit,
-            });
-            const targetPlan = await queryTargetPlan(result.soldrPath, target, (message) => logger.log(message));
-            if (!targetPlan) {
-                throw new Error(`Soldr did not report a machine-readable target plan for ${target}; target capability is unavailable`);
-            }
-            contracts.push((0, target_lifecycle_js_1.normalizeTargetPlan)(target, targetPlan));
-        }
-        const contract = preparePlan.target === "universal2-apple-darwin"
-            ? (0, target_lifecycle_js_1.buildUniversal2TargetContract)(contracts)
-            : contracts[0];
-        publishTargetContract(result, contract, logger);
-        core.saveState("blessedPrepareComplete", "true");
-    }
-    await (0, phase_timing_js_1.finishPhase)("cross-prepare");
-    // ---- cook (prebuild-deps via soldr-cook) ----
-    // The RESTORE was kicked off as a background promise right after the
-    // parallel-restore block above — we just await its result here. The
-    // RUN (`soldr cook`) still happens in this phase if
-    // the restore missed.
-    // Failures here are logged but never fail the action — the user's
-    // own cargo build will still work without the cooked deps.
-    await (0, phase_timing_js_1.markPhase)("cook");
-    if (cookActive && cookLayeredRestorePromise) {
-        const restore = await cookLayeredRestorePromise;
-        const loaded = await (0, cook_cache_js_1.loadLayeredCookCache)({
-            soldrBinary: result.soldrPath,
-            projectRoot: cookProjectRoot,
-            targetDir: cookTargetDir,
-            baseArchivePath: cookBaseArchive,
-            deltaArchivePath: cookDeltaArchive,
-            baseManifestPath: cookBaseManifest,
-            restore,
-            log: (msg) => logger.log(msg),
-        });
-        const baseReady = (0, cook_cache_js_1.layeredCookBaseReady)(restore, loaded);
-        const deltaReady = (0, cook_cache_js_1.layeredCookDeltaReady)(restore, loaded);
-        statsCollector.record({
-            label: "cook-cache-base",
-            operation: "restore",
-            hit: baseReady,
-            key: cookBaseKey,
-            matchedKey: restore.base.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.base.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: loaded.baseReport?.cacheFilesRestored ?? null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        statsCollector.record({
-            label: "cook-cache-delta",
-            operation: "restore",
-            hit: deltaReady,
-            key: cookDeltaKey,
-            matchedKey: restore.delta.matchedKey,
-            restoreKeys: cookDeltaRestoreKeys,
-            archiveBytes: restore.delta.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: loaded.deltaReport?.cacheFilesRestored ?? null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        let cookRan = false;
-        if (!deltaReady) {
-            const runRes = await (0, cook_cache_js_1.runCook)({
-                soldrBinary: result.soldrPath,
-                projectRoot: cookProjectRoot,
-                flags: cookFlags,
-                log: (msg) => logger.log(msg),
-            });
-            cookRan = runRes.exitCode === 0;
-        }
-        else {
-            logger.log("cook: base+delta cache hit - skipping cook run, target/deps already warm");
-        }
-        const cookSaveLayer = cookRan ? (baseReady ? "delta" : "base") : "none";
-        core.saveState("cookEnabled", "true");
-        core.saveState("cookLayered", "true");
-        core.saveState("cookBaseExactKey", cookBaseKey);
-        core.saveState("cookDeltaExactKey", cookDeltaKey);
-        core.saveState("cookBaseMatchedKey", restore.base.matchedKey);
-        core.saveState("cookDeltaMatchedKey", restore.delta.matchedKey);
-        core.saveState("cookBaseHit", baseReady ? "true" : "false");
-        core.saveState("cookDeltaHit", deltaReady ? "true" : "false");
-        core.saveState("cookHit", deltaReady ? "true" : "false");
-        core.saveState("cookRan", cookRan ? "true" : "false");
-        core.saveState("cookSaveLayer", cookSaveLayer);
-        core.saveState("cookProjectRoot", cookProjectRoot);
-        core.saveState("cookTargetDir", cookTargetDir);
-        core.saveState("cookBaseArchive", cookBaseArchive);
-        core.saveState("cookDeltaArchive", cookDeltaArchive);
-        core.saveState("cookBaseManifest", cookBaseManifest);
-        core.saveState("cookSoldrBinary", result.soldrPath);
-        // #268/#358: cook-cache-base previously used zstd-level 19, but
-        // production observation showed 165s of compress wall-clock per
-        // matrix job for ~224 MB output. In a 5-way matrix where 1 job
-        // wins the cache reservation and 4 lose the race, that's 660s
-        // of post-step CPU wasted per CI cycle. Lowering to -9 cuts the
-        // compress wall-clock ~4× (target ~40s) at the cost of ~25%
-        // larger archive (~280 MB) and ~1s extra upload wall-clock per
-        // save. zstd decompression speed is level-independent, so warm
-        // restores are unaffected. Net: ~125s win per save-attempt, big
-        // multiplier on race-loss scenarios.
-        core.saveState("cookCompressLevel", "9");
-        core.saveState("cookDeltaCompressLevel", "3");
-    }
-    else if (cookActive && cookRestorePromise) {
-        const restore = await cookRestorePromise;
-        statsCollector.record({
-            label: "cook-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: cookKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        let cookRan = false;
-        if (!restore.hit) {
-            const runRes = await (0, cook_cache_js_1.runCook)({
-                soldrBinary: result.soldrPath,
-                projectRoot: cookProjectRoot,
-                flags: cookFlags,
-                log: (msg) => logger.log(msg),
-            });
-            cookRan = runRes.exitCode === 0;
-        }
-        else {
-            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
-        }
-        core.saveState("cookEnabled", "true");
-        core.saveState("cookLayered", "false");
-        core.saveState("cookExactKey", cookKey);
-        core.saveState("cookMatchedKey", restore.matchedKey);
-        core.saveState("cookHit", restore.hit ? "true" : "false");
-        core.saveState("cookRan", cookRan ? "true" : "false");
-        core.saveState("cookTargetDir", cookTargetDir);
-        core.saveState("cookLongWindow", "27");
-        // #268/#358: see saveState("cookCompressLevel", "9") above for
-        // rationale on lowering from -19. Same logic applies to the
-        // non-layered path.
-        core.saveState("cookCompressLevel", "9");
-    }
-    else if (cookSkippedDueToTargetHit) {
-        logger.log(`cook: skipped - target-cache matched at lockfile/shape level (matched=${targetCacheMatchedKey}); cook output would be redundant`);
-        core.saveState("cookEnabled", "false");
-        core.saveState("cookLayered", "false");
-    }
-    else {
-        logger.log(`cook: skipped - ${cookGate.reason}`);
-        core.saveState("cookEnabled", "false");
-        core.saveState("cookLayered", "false");
-    }
-    await (0, phase_timing_js_1.finishPhase)("cook");
-    // ---- shared-target warning ----
-    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
-        buildCacheEnabled,
-        effectiveTargetCacheEnabled: result.targetCache.enabled,
-        buildCacheMode: result.buildCache.mode,
-        targetDir: result.targetCache.targetPath,
-        soldrPath: result.soldrPath,
-    });
-    // ---- shim-bypass diagnostic ----
-    // Issue #160: when shims: true is requested but the effective environment
-    // (PATH ordering, CARGO/RUSTC/RUSTC_WRAPPER overrides) would bypass them,
-    // caching looks configured but compile work runs through plain cargo.
-    // Emit advisory warnings naming each offender. Runs at the very end so it
-    // sees the final state of process.env after every prior phase.
-    if (result.shimsEnabled) {
-        const bypassWarnings = (0, shim_bypass_check_js_1.diagnoseShimBypass)({
-            shimsEnabled: true,
-            shimDir: result.shimsDir,
-            path: process.env["PATH"] ?? "",
-            cargoEnv: process.env["CARGO"],
-            rustcEnv: process.env["RUSTC"],
-            rustcWrapperEnv: process.env["RUSTC_WRAPPER"],
-            soldrBinary: result.soldrPath,
-        });
-        for (const msg of bypassWarnings) {
-            core.warning(msg);
-        }
-        if (bypassWarnings.length === 0) {
-            logger.log(`shim-bypass check clean: shim dir ${result.shimsDir} at PATH front, no competing CARGO/RUSTC/RUSTC_WRAPPER overrides`);
-        }
-    }
-    // ---- stats report ----
-    statsCollector.report(statsMode, (msg) => logger.log(msg));
-    if (statsMode === "detailed") {
-        try {
-            await statsCollector.writeFiles(ctx.runnerTemp);
-            statsCollector.setGithubOutputs();
-        }
-        catch (err) {
-            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    core.saveState("statsCollector", statsCollector.serialize());
-    core.saveState("statsMode", statsMode);
-    core.saveState("compileCacheStats", result.compileCacheStats);
-    core.saveState("runnerTemp", ctx.runnerTemp);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            cacheOutcomes: statsCollector.snapshot(),
-            logger,
-        });
-    }
-    // #269-companion (setup side): one-line aggregate of where each
-    // setup phase's wall-clock went, before we finish the `action`
-    // phase. Mirrors the post-step `cache save totals:` line that
-    // ships from `StatsCollector.saveSummaryOneLine()`. Operators see
-    // the pre-build budget at a glance without scrolling raw
-    // SETUP_SOLDR_PHASE_*_START_MS env vars or hunting through the
-    // timeline. Phases in declared serial order:
-    const setupPhaseSummary = (0, phase_timing_js_1.setupPhaseSummaryOneLine)([
-        "resolve",
-        "parallel-restore",
-        "target-tree",
-        "toolchain",
-        "install",
-        "zccache-seed",
-        "verify",
-        "cross-prepare",
-        "cook",
-    ]);
-    if (setupPhaseSummary)
-        core.info(setupPhaseSummary);
-    await (0, phase_timing_js_1.finishPhase)("action");
-    // dirHasContent is exported for tests; suppress unused warning here.
-    void dirHasContent;
-}
-// Auto-invoke only when this module is run as the main entry point. This lets
-// tests import `run` (and helpers) without triggering the side-effectful
-// orchestration. The dist/main.js produced by ncc is invoked directly by the
-// Actions runtime so the check trips and the action executes normally.
-if (typeof process !== "undefined" &&
-    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
-    // import.meta.url is the file URL of this module; argv[1] is the runner
-    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
-    // the dev path — we rely on the env-var opt-out for tests instead.
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.setFailed(`setup-soldr failed: ${message}`);
-    });
-}
-
-
-/***/ }),
-
-/***/ 380:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -75351,7 +75250,7 @@ exports.TracingContextImpl = TracingContextImpl;
 
 /***/ }),
 
-/***/ 381:
+/***/ 380:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75360,9 +75259,9 @@ exports.TracingContextImpl = TracingContextImpl;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
-const tslib_1 = __nccwpck_require__(220);
-const BuffersStream_js_1 = __nccwpck_require__(396);
-const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(272));
+const tslib_1 = __nccwpck_require__(219);
+const BuffersStream_js_1 = __nccwpck_require__(395);
+const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(270));
 /**
  * maxBufferLength is max size of each buffer in the pooled buffers.
  */
@@ -75458,7 +75357,7 @@ exports.PooledBuffer = PooledBuffer;
 
 /***/ }),
 
-/***/ 382:
+/***/ 381:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -75483,7 +75382,7 @@ __export(defaultHttpClient_exports, {
   createDefaultHttpClient: () => createDefaultHttpClient
 });
 module.exports = __toCommonJS(defaultHttpClient_exports);
-var import_nodeHttpClient = __nccwpck_require__(454);
+var import_nodeHttpClient = __nccwpck_require__(455);
 function createDefaultHttpClient() {
   return (0, import_nodeHttpClient.createNodeHttpClient)();
 }
@@ -75494,16 +75393,16 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 383:
+/***/ 382:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { AsyncResource } = __nccwpck_require__(441)
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(504)
-const util = __nccwpck_require__(75)
-const { addSignal, removeSignal } = __nccwpck_require__(109)
+const { AsyncResource } = __nccwpck_require__(442)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(505)
+const util = __nccwpck_require__(72)
+const { addSignal, removeSignal } = __nccwpck_require__(106)
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -75606,7 +75505,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 384:
+/***/ 383:
 /***/ ((module) => {
 
 /**
@@ -75775,7 +75674,7 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 385:
+/***/ 384:
 /***/ ((module) => {
 
 "use strict";
@@ -75783,7 +75682,7 @@ module.exports = require("node:util");
 
 /***/ }),
 
-/***/ 386:
+/***/ 385:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75792,7 +75691,7 @@ module.exports = require("node:util");
 // We include a version number for the Dispatcher API. In case of breaking changes,
 // this version number must be increased to avoid conflicts.
 const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
-const { InvalidArgumentError } = __nccwpck_require__(504)
+const { InvalidArgumentError } = __nccwpck_require__(505)
 const Agent = __nccwpck_require__(5)
 
 if (getGlobalDispatcher() === undefined) {
@@ -75823,13 +75722,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 387:
+/***/ 386:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(200)
+const { kClients } = __nccwpck_require__(197)
 const Agent = __nccwpck_require__(5)
 const {
   kAgent,
@@ -75841,14 +75740,14 @@ const {
   kGetNetConnect,
   kOptions,
   kFactory
-} = __nccwpck_require__(487)
-const MockClient = __nccwpck_require__(204)
-const MockPool = __nccwpck_require__(359)
+} = __nccwpck_require__(488)
+const MockClient = __nccwpck_require__(201)
+const MockPool = __nccwpck_require__(358)
 const { matchValue, buildMockOptions } = __nccwpck_require__(8)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(504)
-const Dispatcher = __nccwpck_require__(494)
-const Pluralizer = __nccwpck_require__(262)
-const PendingInterceptorsFormatter = __nccwpck_require__(238)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(505)
+const Dispatcher = __nccwpck_require__(495)
+const Pluralizer = __nccwpck_require__(260)
+const PendingInterceptorsFormatter = __nccwpck_require__(236)
 
 class FakeWeakRef {
   constructor (value) {
@@ -76002,7 +75901,7 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 388:
+/***/ 387:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -76079,7 +75978,7 @@ async function retryReleaseRequest(request, options = {}) {
 
 /***/ }),
 
-/***/ 389:
+/***/ 388:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76105,7 +76004,7 @@ __export(tlsPolicy_exports, {
   tlsPolicyName: () => tlsPolicyName
 });
 module.exports = __toCommonJS(tlsPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(292);
 const tlsPolicyName = import_policies.tlsPolicyName;
 function tlsPolicy(tlsSettings) {
   return (0, import_policies.tlsPolicy)(tlsSettings);
@@ -76116,7 +76015,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 390:
+/***/ 389:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -76205,7 +76104,7 @@ exports.AccountSASServices = AccountSASServices;
 
 /***/ }),
 
-/***/ 391:
+/***/ 390:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76231,7 +76130,7 @@ __export(bearerAuthenticationPolicy_exports, {
   bearerAuthenticationPolicyName: () => bearerAuthenticationPolicyName
 });
 module.exports = __toCommonJS(bearerAuthenticationPolicy_exports);
-var import_checkInsecureConnection = __nccwpck_require__(447);
+var import_checkInsecureConnection = __nccwpck_require__(448);
 const bearerAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function bearerAuthenticationPolicy(options) {
   return {
@@ -76259,7 +76158,7 @@ function bearerAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 392:
+/***/ 391:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76268,7 +76167,7 @@ function bearerAuthenticationPolicy(options) {
 const {
   BalancedPoolMissingUpstreamError,
   InvalidArgumentError
-} = __nccwpck_require__(504)
+} = __nccwpck_require__(505)
 const {
   PoolBase,
   kClients,
@@ -76277,9 +76176,9 @@ const {
   kRemoveClient,
   kGetDispatcher
 } = __nccwpck_require__(378)
-const Pool = __nccwpck_require__(346)
-const { kUrl, kInterceptors } = __nccwpck_require__(200)
-const { parseOrigin } = __nccwpck_require__(75)
+const Pool = __nccwpck_require__(344)
+const { kUrl, kInterceptors } = __nccwpck_require__(197)
+const { parseOrigin } = __nccwpck_require__(72)
 const kFactory = Symbol('factory')
 
 const kOptions = Symbol('options')
@@ -76457,7 +76356,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 393:
+/***/ 392:
 /***/ ((module) => {
 
 "use strict";
@@ -76465,7 +76364,7 @@ module.exports = require("node:os");
 
 /***/ }),
 
-/***/ 394:
+/***/ 393:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -76509,7 +76408,7 @@ function operationOptionsToRequestParameters(options) {
 
 /***/ }),
 
-/***/ 395:
+/***/ 394:
 /***/ ((module) => {
 
 "use strict";
@@ -76527,7 +76426,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 396:
+/***/ 395:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76536,7 +76435,7 @@ module.exports = value => {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BuffersStream = void 0;
-const node_stream_1 = __nccwpck_require__(442);
+const node_stream_1 = __nccwpck_require__(443);
 /**
  * This class generates a readable stream from the data in an array of buffers.
  */
@@ -76635,16 +76534,16 @@ exports.BuffersStream = BuffersStream;
 
 /***/ }),
 
-/***/ 397:
+/***/ 396:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { parseSetCookie } = __nccwpck_require__(434)
-const { stringify } = __nccwpck_require__(420)
-const { webidl } = __nccwpck_require__(470)
-const { Headers } = __nccwpck_require__(530)
+const { parseSetCookie } = __nccwpck_require__(435)
+const { stringify } = __nccwpck_require__(421)
+const { webidl } = __nccwpck_require__(471)
+const { Headers } = __nccwpck_require__(531)
 
 /**
  * @typedef {Object} Cookie
@@ -76826,7 +76725,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 398:
+/***/ 397:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -76842,7 +76741,7 @@ exports.AvroReadable = AvroReadable;
 
 /***/ }),
 
-/***/ 399:
+/***/ 398:
 /***/ ((module) => {
 
 "use strict";
@@ -76850,7 +76749,7 @@ module.exports = require("node:https");
 
 /***/ }),
 
-/***/ 400:
+/***/ 399:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76876,7 +76775,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(300);
+var import_userAgent = __nccwpck_require__(298);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -76897,17 +76796,176 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
+/***/ 400:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+// $GITHUB_OUTPUT key/value mapping for setup-soldr. Pure function of
+// the resolved state — split out of resolve-setup.ts to keep the
+// orchestration module focused on input parsing / cache-key derivation.
+// Mirrors resolve_setup.py's `_write_outputs()` call so tests can
+// assert byte-for-byte.
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.buildOutputs = buildOutputs;
+const target_lifecycle_js_1 = __nccwpck_require__(247);
+/**
+ * Build the $GITHUB_OUTPUT key/value map. Exposed for tests so they
+ * can assert byte-for-byte parity with the legacy Python action's
+ * `_write_outputs()` call.
+ *
+ * Naming: emits the kebab-case names declared in action.yml so that
+ * `${{ steps.<id>.outputs.<name> }}` references in downstream workflow
+ * steps resolve to non-empty values. zackees/setup-soldr#125 was a
+ * regression where this map used underscored Python-port keys that
+ * never matched the hyphenated action.yml declarations, leaving every
+ * scalar output empty in consuming workflows.
+ *
+ * A handful of underscored aliases are emitted in parallel for
+ * backwards compatibility with internal callers that hard-coded the
+ * old names (none known externally; action.yml only declared the
+ * hyphenated forms). Treat the underscored aliases as legacy — remove
+ * them after a deprecation window once we've confirmed nothing
+ * downstream relies on them.
+ */
+function buildOutputs(result) {
+    // Canonical kebab-case outputs (these are the ones declared in action.yml
+    // and the names users should reference). Adding a new output? Put it here.
+    const canonical = {
+        "enabled": result.enabled ? "true" : "false",
+        "soldr-path": result.soldrPath,
+        "cache-dir": result.cacheRoot,
+        "cache-key": result.setupCache.key,
+        "build-cache-key": result.buildCache.key,
+        "build-cache-path": result.buildCache.path,
+        "build-cache-mode": result.buildCache.mode,
+        "target-cache-key": result.targetCache.key,
+        "target-cache-path": result.targetCache.targetPath,
+        "target-cache-paths": result.targetCache.paths,
+        "target-cache-mode": result.targetCache.effectiveMode,
+        "target-cache-profile": result.targetCache.profile,
+        "target-cache-compress": result.targetCacheCompress,
+        "target-cache-compress-level": result.targetCacheCompressLevel,
+        "target-cache-budget-bytes": result.targetCache.budgetBytes,
+        "target-cache-budget-files": result.targetCache.budgetFiles,
+        "target-lockfile": result.targetCache.lockfilePath,
+        "target-lockfile-hash": result.targetCache.lockfileHash,
+        "dylint-cache-key": result.dylintCache.key,
+        "dylint-driver-path": result.dylintCache.driverPath,
+        "dylint-toolchain": result.dylintCache.toolchain,
+        "dylint-rustc-release": result.dylintCache.rustcRelease,
+        "dylint-rustc-commit-hash": result.dylintCache.rustcCommitHash,
+        "dylint-cache-identity": result.dylintCache.cacheIdentity,
+        "dylint-output-cache-key": result.dylintCache.outputKey,
+        "dylint-output-cache-paths": result.dylintCache.outputPaths.join("\n"),
+        "shims-dir": result.shimsDir,
+        "toolchain": result.toolchain.channel,
+        "cache-preset-effective": result.cachePresetEffective,
+        "prepared-target": result.blessedPrepareCache.target,
+        "blessed-prepare-cache-key": result.blessedPrepareCache.key,
+        "target-plan-json": result.targetContract ? JSON.stringify(result.targetContract) : "",
+        "target-capabilities-json": result.targetContract
+            ? JSON.stringify({
+                schemaVersion: result.targetContract.schemaVersion,
+                canonicalTarget: result.targetContract.canonicalTarget,
+                cacheIdentity: result.targetContract.cacheIdentity,
+                supportedOperations: result.targetContract.supportedOperations,
+                toolchain: result.targetContract.toolchain,
+                platform: result.targetContract.platform,
+            })
+            : "",
+        "target-env-json": result.targetContract ? JSON.stringify(result.targetContract.environment) : "",
+        "target-cache-identity": result.targetContract?.cacheIdentity ?? "",
+        "target-artifact-dir": result.targetContract
+            ? (0, target_lifecycle_js_1.targetArtifactDirectory)(result.workspace, result.targetContract.canonicalTarget)
+            : "",
+        "target-build-hook": result.targetContract ? (0, target_lifecycle_js_1.buildTargetHooks)(result.targetContract.canonicalTarget).build : "",
+        "target-clippy-hook": result.targetContract ? (0, target_lifecycle_js_1.buildTargetHooks)(result.targetContract.canonicalTarget).clippy : "",
+        "target-test-hook": result.targetContract ? (0, target_lifecycle_js_1.buildTargetHooks)(result.targetContract.canonicalTarget).testNoRun : "",
+        "target-wheel-hook": result.targetContract ? (0, target_lifecycle_js_1.buildTargetHooks)(result.targetContract.canonicalTarget).pep517Wheel : "",
+        "target-sdist-hook": result.targetContract ? (0, target_lifecycle_js_1.buildTargetHooks)(result.targetContract.canonicalTarget).pep517Sdist : "",
+    };
+    // Legacy underscored aliases retained for backwards compatibility with
+    // any consumer that latched onto the old Python-port output names from
+    // before #125 (most of these were never declared in action.yml so
+    // technically undocumented, but free to keep around).
+    const legacy = {
+        cache_root: result.cacheRoot,
+        setup_cache_path: result.setupCache.setupCachePath,
+        setup_cache_paths: result.setupCache.paths.join("\n"),
+        cache_key: result.setupCache.key,
+        cache_restore_prefix: result.setupCache.restorePrefix,
+        build_cache_key: result.buildCache.key,
+        build_cache_restore_key_parent: result.buildCache.restoreKeyParent,
+        build_cache_restore_key_toolchain: result.buildCache.restoreKeyToolchain,
+        build_cache_restore_key_os_arch: result.buildCache.restoreKeyOsArch,
+        build_cache_path: result.buildCache.path,
+        build_cache_mode: result.buildCache.mode,
+        target_cache_path: result.targetCache.targetPath,
+        target_cache_bundle_path: result.targetCache.bundlePath,
+        target_cache_paths: result.targetCache.paths,
+        target_cache_enabled: result.targetCache.enabled ? "true" : "false",
+        target_cache_mode: result.targetCache.effectiveMode,
+        target_cache_profile: result.targetCache.profile,
+        target_cache_compress: result.targetCacheCompress,
+        target_cache_compress_level: result.targetCacheCompressLevel,
+        target_cache_key: result.targetCache.key,
+        target_cache_restore_key_parent: result.targetCache.restoreKeyParent,
+        target_cache_restore_key_lock: result.targetCache.restoreKeyLock,
+        target_cache_restore_key_lockfile: result.targetCache.restoreKeyLockfile,
+        target_cache_budget_bytes: result.targetCache.budgetBytes,
+        target_cache_budget_files: result.targetCache.budgetFiles,
+        target_lockfile_path: result.targetCache.lockfilePath,
+        target_lockfile_hash: result.targetCache.lockfileHash,
+        cargo_registry_cache_enabled: result.cargoRegistryCache.enabled ? "true" : "false",
+        cargo_registry_cache_path: result.cargoRegistryCache.path,
+        cargo_registry_cache_key: result.cargoRegistryCache.key,
+        cargo_registry_cache_restore_prefix: result.cargoRegistryCache.restorePrefix,
+        cargo_registry_cache_archive_format: result.cargoRegistryCache.archive.format,
+        cargo_registry_cache_archive_paths: result.cargoRegistryCache.archive.restorePaths.join("\n"),
+        dylint_cache_enabled: result.dylintCache.enabled ? "true" : "false",
+        dylint_cache_key: result.dylintCache.key,
+        dylint_driver_path: result.dylintCache.driverPath,
+        dylint_host_triple: result.dylintCache.hostTriple,
+        dylint_toolchain: result.dylintCache.toolchain,
+        dylint_rustc_release: result.dylintCache.rustcRelease,
+        dylint_rustc_commit_hash: result.dylintCache.rustcCommitHash,
+        dylint_cache_identity: result.dylintCache.cacheIdentity,
+        dylint_driver_rev: result.dylintCache.driverRev,
+        soldr_root: result.soldrRoot,
+        soldr_bin_cache_path: result.soldrBinCachePath,
+        cargo_home: result.cargoHome,
+        rustup_home: result.rustupHome,
+        setup_cache_layout: result.setupCache.layout,
+        bin_dir: result.binDir,
+        shims_dir: result.shimsDir,
+        soldr_path: result.soldrPath,
+        soldr_repo: result.soldrRepo,
+        soldr_ref: result.soldrRef,
+        soldr_version_requested: result.soldrVersionRequested,
+        soldr_version_resolved: result.soldrVersionResolved,
+        toolchain_channel: result.toolchain.channel,
+        toolchain_cache_channel: result.toolchain.cacheChannel,
+        toolchain_profile: result.toolchain.profile,
+        toolchain_source: result.toolchain.source,
+    };
+    return { ...legacy, ...canonical };
+}
+
+
+/***/ }),
+
 /***/ 401:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const util = __nccwpck_require__(75)
-const { kBodyUsed } = __nccwpck_require__(200)
-const assert = __nccwpck_require__(542)
-const { InvalidArgumentError } = __nccwpck_require__(504)
-const EE = __nccwpck_require__(486)
+const util = __nccwpck_require__(72)
+const { kBodyUsed } = __nccwpck_require__(197)
+const assert = __nccwpck_require__(543)
+const { InvalidArgumentError } = __nccwpck_require__(505)
+const EE = __nccwpck_require__(487)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
 
@@ -77186,7 +77244,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(292);
 const exponentialRetryPolicyName = import_policies.exponentialRetryPolicyName;
 function exponentialRetryPolicy(options = {}) {
   return (0, import_policies.exponentialRetryPolicy)(options);
@@ -77233,6 +77291,399 @@ function randomUUID() {
 /***/ }),
 
 /***/ 406:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Verbose diagnostic dump emitted when the action receives `logging: true`.
+//
+// The goal is to make cache-behavior surprises trivially debuggable from a
+// single CI run. The dump bundles:
+//   - every observed INPUT_* env var (so the kebab-vs-underscore plumbing
+//     bug that motivated this module is visible without re-running)
+//   - the parsed RawInputs struct
+//   - every constructed cache key with restore-key fallbacks
+//   - resolved env exports (SOLDR_*, ZCCACHE_*, SETUP_SOLDR_*)
+//   - cache restore/save outcomes recorded so far
+//   - the final cache summary + compile-cache report in post phase
+//
+// Token-shaped values are redacted before printing.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.redactValue = redactValue;
+exports.captureProcessSnapshot = captureProcessSnapshot;
+exports.dumpDiagnostics = dumpDiagnostics;
+exports.loggingEnabled = loggingEnabled;
+const fs = __importStar(__nccwpck_require__(255));
+const node_child_process_1 = __nccwpck_require__(199);
+const compile_journal_js_1 = __nccwpck_require__(272);
+const ENV_KEY_PREFIXES = [
+    "INPUT_",
+    "SOLDR_",
+    "ZCCACHE_",
+    "SCCACHE_",
+    "SETUP_SOLDR_",
+    "GITHUB_",
+    "RUNNER_",
+    "ACTION_",
+    "CARGO_",
+    "RUSTUP_",
+    "RUSTC_",
+];
+const SECRET_KEY_PATTERN = /(token|secret|password|^.*_pass$|api[_-]?key|client[_-]?secret|webhook)/i;
+// Cache-key fields look secret-y but never are; never redact them.
+const NEVER_REDACT_PATTERN = /(_key$|cache[-_]key|cache[-_]keys$|key[-_]suffix$|public[-_]key)/i;
+// #387 Feature 1: cache-encrypt-key IS a secret even though its name
+// matches NEVER_REDACT_PATTERN's `_key$`. core.setSecret() in resolve-setup
+// already marks the value for runtime log redaction by the Actions runner,
+// but the diagnostics dump has its own writer — belt-and-suspenders here.
+const FORCE_REDACT_PATTERN = /(encrypt[-_]?key|cache[-_]encrypt[-_]key|cipher[-_]key|aes[-_]key)/i;
+function redactValue(key, value) {
+    if (FORCE_REDACT_PATTERN.test(key))
+        return value ? "<redacted>" : "";
+    if (NEVER_REDACT_PATTERN.test(key))
+        return value;
+    if (SECRET_KEY_PATTERN.test(key))
+        return value ? "<redacted>" : "";
+    return value;
+}
+function pickEnv(env) {
+    const pairs = [];
+    for (const [k, v] of Object.entries(env)) {
+        if (v === undefined)
+            continue;
+        if (!ENV_KEY_PREFIXES.some((p) => k.startsWith(p)))
+            continue;
+        pairs.push([k, redactValue(k, v)]);
+    }
+    pairs.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+    return pairs;
+}
+function rawInputsLines(inputs) {
+    const lines = [];
+    const entries = Object.entries(inputs).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+    for (const [k, v] of entries) {
+        // #387 Feature 1: parsed RawInputs needs the same redaction as raw env —
+        // otherwise `cacheEncryptKey` lands here verbatim.
+        const safe = typeof v === "string" ? redactValue(k, v) : v;
+        lines.push(`  ${k}=${JSON.stringify(safe)}`);
+    }
+    return lines;
+}
+function cachePlanLines(result) {
+    const lines = [];
+    lines.push("  setup_cache:");
+    lines.push(`    key=${result.setupCache.key}`);
+    lines.push(`    restore_prefix=${result.setupCache.restorePrefix}`);
+    lines.push(`    paths=${JSON.stringify(result.setupCache.paths)}`);
+    lines.push(`    layout=${result.setupCache.layout}`);
+    lines.push("  build_cache:");
+    lines.push(`    key=${result.buildCache.key}`);
+    lines.push(`    restore_key_parent=${result.buildCache.restoreKeyParent || "(none)"}`);
+    lines.push(`    restore_key_toolchain=${result.buildCache.restoreKeyToolchain}`);
+    lines.push(`    restore_key_os_arch=${result.buildCache.restoreKeyOsArch}`);
+    lines.push(`    path=${result.buildCache.path}`);
+    lines.push(`    mode=${result.buildCache.mode}`);
+    lines.push("  target_cache:");
+    lines.push(`    enabled=${result.targetCache.enabled}`);
+    lines.push(`    key=${result.targetCache.key}`);
+    lines.push(`    restore_key_parent=${result.targetCache.restoreKeyParent || "(none)"}`);
+    lines.push(`    restore_key_lock=${result.targetCache.restoreKeyLock || "(none)"}`);
+    lines.push(`    restore_key_lockfile=${result.targetCache.restoreKeyLockfile || "(none)"}`);
+    lines.push(`    paths=${result.targetCache.paths}`);
+    lines.push(`    bundle_path=${result.targetCache.bundlePath}`);
+    lines.push(`    target_path=${result.targetCache.targetPath}`);
+    lines.push(`    effective_mode=${result.targetCache.effectiveMode}`);
+    lines.push(`    profile=${result.targetCache.profile}`);
+    lines.push("  cargo_registry_cache:");
+    lines.push(`    enabled=${result.cargoRegistryCache.enabled}`);
+    lines.push(`    key=${result.cargoRegistryCache.key}`);
+    lines.push(`    restore_prefix=${result.cargoRegistryCache.restorePrefix}`);
+    lines.push(`    path=${result.cargoRegistryCache.path}`);
+    lines.push(`    archive_format=${result.cargoRegistryCache.archive.format}`);
+    lines.push(`    archive_paths=${JSON.stringify(result.cargoRegistryCache.archive.restorePaths)}`);
+    // setup-soldr#102: sibling basenames bundled into the same archive.
+    const extras = result.cargoRegistryCache.extraBasenames;
+    lines.push(`    extra_basenames=${extras.length > 0 ? extras.join(",") : "(none)"}`);
+    return lines;
+}
+function envExportLines(result) {
+    const entries = Object.entries(result.envExports).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+    return entries.map(([k, v]) => `  ${k}=${redactValue(k, v)}`);
+}
+function cacheOutcomeLines(outcomes) {
+    if (outcomes.length === 0)
+        return ["  (no outcomes recorded yet)"];
+    const lines = [];
+    for (const o of outcomes) {
+        lines.push(`  [${o.operation}] ${o.label}: hit=${o.hit} matched=${o.matchedKey || "(none)"} ` +
+            `key=${o.key}${o.status ? ` status=${o.status}` : ""} duration_ms=${o.durationMs}`);
+        if (o.archiveBytes !== null) {
+            lines.push(`    archive_bytes=${o.archiveBytes} inflated_bytes=${o.inflatedBytes ?? "?"} files=${o.fileCount ?? "?"}`);
+        }
+        if (o.payload) {
+            lines.push(`    payload_bytes=${o.payload.bytes} payload_files=${o.payload.files} ` +
+                `symlinks=${o.payload.symlinks} dirs=${o.payload.directories}`);
+            if (o.payload.topFiles.length > 0) {
+                lines.push(`    top_files=${o.payload.topFiles.map((entry) => `${entry.path}:${entry.bytes}`).join(",")}`);
+            }
+            if (o.payload.skipped.length > 0) {
+                lines.push(`    skipped=${o.payload.skipped.map((entry) => `${entry.reason}:${entry.count}`).join(",")}`);
+            }
+        }
+    }
+    return lines;
+}
+/**
+ * Capture a runtime process snapshot via `ps` (Unix) or `tasklist`
+ * (Windows). Returns null only on an actual exec failure (binary
+ * missing, etc.); a non-zero exit is reported in the result so the
+ * stderr can be inspected.
+ *
+ * Why this lives here: the post step uses it to expose orphan daemons
+ * (e.g. zccache-daemon processes that survive `soldr cache shutdown`
+ * and get SIGKILL'd by the runner) so root-cause analysis doesn't
+ * require another build.
+ */
+function captureProcessSnapshot() {
+    const isWindows = process.platform === "win32";
+    const cmd = isWindows ? "tasklist" : "ps";
+    // Unix: print pid, ppid, user, state, command-name, full-args.
+    // BSD ps (macOS) supports the same -o keys but uses `command` instead
+    // of `args` — accept both via the column listing.
+    const args = isWindows
+        ? ["/V", "/FO", "CSV", "/NH"]
+        : ["-eo", "pid,ppid,user,stat,comm,args"];
+    try {
+        const result = (0, node_child_process_1.spawnSync)(cmd, args, {
+            encoding: "utf8",
+            maxBuffer: 8 * 1024 * 1024,
+            timeout: 15_000,
+        });
+        return {
+            cmd: `${cmd} ${args.join(" ")}`,
+            stdout: result.stdout ?? "",
+            stderr: result.stderr ?? "",
+            exitCode: result.status,
+        };
+    }
+    catch {
+        return null;
+    }
+}
+/**
+ * Emit the full diagnostic dump to the logger and (optionally) the step summary.
+ * Safe to call when `result`, `cacheOutcomes`, or `finalSummary` are missing —
+ * each section is independent.
+ */
+function dumpDiagnostics(opts) {
+    const lines = [];
+    const header = `=== DIAGNOSTIC DUMP (phase=${opts.phase}) ===`;
+    const footer = "=== END DIAGNOSTIC DUMP ===";
+    lines.push(header);
+    lines.push("[env: observed INPUT_/SOLDR_/ZCCACHE_/SETUP_SOLDR_/GITHUB_/RUNNER_/ACTION_/CARGO_/RUSTUP_/RUSTC_]");
+    const envPairs = pickEnv(opts.env);
+    if (envPairs.length === 0) {
+        lines.push("  (none observed)");
+    }
+    else {
+        for (const [k, v] of envPairs) {
+            lines.push(`  ${k}=${v}`);
+        }
+    }
+    if (opts.rawInputs) {
+        lines.push("[raw_inputs: parsed RawInputs after kebab-case lookup]");
+        lines.push(...rawInputsLines(opts.rawInputs));
+    }
+    if (opts.result) {
+        lines.push("[cache_plans: every constructed cache key + restore-key fallbacks]");
+        lines.push(...cachePlanLines(opts.result));
+        lines.push("[env_exports: resolved SOLDR_/ZCCACHE_/etc env exports]");
+        if (Object.keys(opts.result.envExports).length === 0) {
+            lines.push("  (none)");
+        }
+        else {
+            lines.push(...envExportLines(opts.result));
+        }
+        lines.push("[resolved_state]");
+        lines.push(`  enabled=${opts.result.enabled}`);
+        lines.push(`  workspace=${opts.result.workspace}`);
+        lines.push(`  cache_root=${opts.result.cacheRoot}`);
+        lines.push(`  soldr_root=${opts.result.soldrRoot}`);
+        lines.push(`  cargo_home=${opts.result.cargoHome}`);
+        lines.push(`  rustup_home=${opts.result.rustupHome}`);
+        lines.push(`  soldr_path=${opts.result.soldrPath}`);
+        lines.push(`  soldr_repo=${opts.result.soldrRepo}`);
+        lines.push(`  soldr_ref=${opts.result.soldrRef || "(release)"}`);
+        lines.push(`  soldr_version_requested=${opts.result.soldrVersionRequested}`);
+        lines.push(`  soldr_version_resolved=${opts.result.soldrVersionResolved}`);
+        lines.push(`  toolchain_channel=${opts.result.toolchain.channel}`);
+        lines.push(`  toolchain_cache_channel=${opts.result.toolchain.cacheChannel}`);
+        lines.push(`  rustup_strategy=${opts.result.rustupStrategy}`);
+        lines.push(`  shims_enabled=${opts.result.shimsEnabled}`);
+        lines.push(`  shims_dir=${opts.result.shimsDir}`);
+        lines.push(`  stats=${opts.result.stats}`);
+        lines.push(`  compile_cache_stats=${opts.result.compileCacheStats}`);
+        lines.push(`  debug_mode=${opts.result.debugMode}`);
+        lines.push(`  cache_shutdown_on_idle_seconds=${opts.result.cacheShutdownOnIdleSeconds ?? "(unset)"}`);
+    }
+    if (opts.cacheOutcomes !== undefined) {
+        lines.push("[cache_outcomes: per-layer restore/save results]");
+        lines.push(...cacheOutcomeLines(opts.cacheOutcomes));
+    }
+    if (opts.finalSummary) {
+        lines.push("[final_cache_summary]");
+        const json = JSON.stringify(opts.finalSummary, null, 2);
+        for (const line of json.split("\n")) {
+            lines.push(`  ${line}`);
+        }
+    }
+    // Per-compilation zccache journal — the answer to "warm reports
+    // hits=0; WHY did each lookup miss?". Reads the JSONL emitted by
+    // zccache for the just-finished session, summarizes it (outcome +
+    // miss_reason histograms, slowest misses with their miss_diff, a
+    // handful of verbatim records), and prints. Silently no-ops when
+    // the journal file isn't present.
+    if (opts.journalPath) {
+        try {
+            const records = (0, compile_journal_js_1.readJournal)(opts.journalPath);
+            if (records === null) {
+                lines.push(`[compile_journal]`);
+                lines.push(`  (journal file not found at ${opts.journalPath})`);
+            }
+            else if (records.length === 0) {
+                lines.push(`[compile_journal]`);
+                lines.push(`  (journal file empty at ${opts.journalPath})`);
+            }
+            else {
+                lines.push(...(0, compile_journal_js_1.formatJournalSection)((0, compile_journal_js_1.summarize)(records)));
+            }
+        }
+        catch (err) {
+            lines.push(`[compile_journal]`);
+            lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
+        }
+        // Raw JSONL dump — verbatim file contents under the summary. Only
+        // emitted when the caller opts in (debug=true) because it's huge
+        // (one record per rustc invocation, frequently MBs of output).
+        if (opts.journalPrintRaw) {
+            try {
+                const raw = fs.readFileSync(opts.journalPath, "utf8");
+                const rawLines = raw.split(/\r?\n/).filter((l) => l.length > 0);
+                lines.push(`[compile_journal_raw: verbatim JSONL from ${opts.journalPath} — ${rawLines.length} records]`);
+                for (const rawLine of rawLines) {
+                    lines.push(`  ${rawLine}`);
+                }
+            }
+            catch (err) {
+                const code = err.code;
+                if (code === "ENOENT") {
+                    // Already noted by the summary section above; no need to repeat.
+                }
+                else {
+                    lines.push(`[compile_journal_raw]`);
+                    lines.push(`  (failed to read ${opts.journalPath}: ${err instanceof Error ? err.message : String(err)})`);
+                }
+            }
+        }
+    }
+    // Rollups (per-extension / per-crate) from `soldr cache report --json`.
+    // The raw report is already parsed into finalSummary's
+    // compile_cache_report.report; we accept it as a separate
+    // `cacheReport` so callers can pass it without rebuilding the
+    // FinalCacheSummary shape.
+    if (opts.cacheReport) {
+        lines.push(...(0, compile_journal_js_1.formatRollupsSection)(opts.cacheReport));
+    }
+    // Process snapshot — captured by the caller via captureProcessSnapshot()
+    // when debug mode is on. Useful for spotting orphan daemons (e.g.
+    // zccache-daemon survivors after `soldr cache shutdown`) that the runner
+    // SIGKILLs at job cleanup.
+    if (opts.processSnapshot) {
+        const snap = opts.processSnapshot;
+        lines.push(`[processes: snapshot via \`${snap.cmd}\` exit=${snap.exitCode ?? "null"}]`);
+        if (snap.stderr.trim().length > 0) {
+            lines.push(`  stderr: ${snap.stderr.trim().replace(/\n+/g, " | ")}`);
+        }
+        const trimmed = snap.stdout.replace(/\r\n/g, "\n").trimEnd();
+        if (trimmed.length === 0) {
+            lines.push("  (no stdout)");
+        }
+        else {
+            for (const line of trimmed.split("\n")) {
+                lines.push(`  ${line}`);
+            }
+        }
+    }
+    lines.push(footer);
+    for (const line of lines) {
+        opts.logger.log(line);
+    }
+    if (opts.stepSummaryPath) {
+        appendToStepSummary(opts.stepSummaryPath, opts.phase, lines, opts.logger);
+    }
+}
+function appendToStepSummary(summaryPath, phase, lines, logger) {
+    const block = [
+        `### setup-soldr diagnostic dump (phase=${phase})`,
+        "",
+        "```",
+        ...lines,
+        "```",
+        "",
+    ];
+    try {
+        fs.appendFileSync(summaryPath, block.join("\n") + "\n", "utf8");
+    }
+    catch (err) {
+        logger.log(`diagnostics: failed to append to step summary: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+/**
+ * Truthy check matching the rest of the action: "1", "true", "yes", "on".
+ * Empty / unset / anything else is false.
+ */
+function loggingEnabled(value) {
+    const v = (value ?? "").trim().toLowerCase();
+    return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+
+/***/ }),
+
+/***/ 407:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -77265,7 +77716,7 @@ exports.isJsonObject = isJsonObject;
 
 /***/ }),
 
-/***/ 407:
+/***/ 408:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -77292,8 +77743,8 @@ __export(exponentialRetryStrategy_exports, {
   isSystemError: () => isSystemError
 });
 module.exports = __toCommonJS(exponentialRetryStrategy_exports);
-var import_delay = __nccwpck_require__(491);
-var import_throttlingRetryStrategy = __nccwpck_require__(39);
+var import_delay = __nccwpck_require__(492);
+var import_throttlingRetryStrategy = __nccwpck_require__(37);
 const DEFAULT_CLIENT_RETRY_INTERVAL = 1e3;
 const DEFAULT_CLIENT_MAX_RETRY_INTERVAL = 1e3 * 64;
 function exponentialRetryStrategy(options = {}) {
@@ -77338,18 +77789,18 @@ function isSystemError(err) {
 
 /***/ }),
 
-/***/ 408:
+/***/ 409:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CacheScope = void 0;
-const runtime_1 = __nccwpck_require__(21);
-const runtime_2 = __nccwpck_require__(21);
-const runtime_3 = __nccwpck_require__(21);
-const runtime_4 = __nccwpck_require__(21);
-const runtime_5 = __nccwpck_require__(21);
+const runtime_1 = __nccwpck_require__(20);
+const runtime_2 = __nccwpck_require__(20);
+const runtime_3 = __nccwpck_require__(20);
+const runtime_4 = __nccwpck_require__(20);
+const runtime_5 = __nccwpck_require__(20);
 // @generated message type with reflection information, may provide speed optimized methods
 class CacheScope$Type extends runtime_5.MessageType {
     constructor() {
@@ -77408,7 +77859,7 @@ exports.CacheScope = new CacheScope$Type();
 
 /***/ }),
 
-/***/ 409:
+/***/ 410:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77417,8 +77868,8 @@ exports.CacheScope = new CacheScope$Type();
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredential = void 0;
-const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(99);
-const Credential_js_1 = __nccwpck_require__(101);
+const AnonymousCredentialPolicy_js_1 = __nccwpck_require__(96);
+const Credential_js_1 = __nccwpck_require__(98);
 /**
  * AnonymousCredential provides a credentialPolicyCreator member used to create
  * AnonymousCredentialPolicy objects. AnonymousCredentialPolicy is used with
@@ -77441,7 +77892,7 @@ exports.AnonymousCredential = AnonymousCredential;
 
 /***/ }),
 
-/***/ 410:
+/***/ 411:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77450,7 +77901,7 @@ exports.AnonymousCredential = AnonymousCredential;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCachedDefaultHttpClient = getCachedDefaultHttpClient;
-const core_rest_pipeline_1 = __nccwpck_require__(107);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
 let cachedHttpClient;
 function getCachedDefaultHttpClient() {
     if (!cachedHttpClient) {
@@ -77462,7 +77913,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 411:
+/***/ 412:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77472,7 +77923,7 @@ function getCachedDefaultHttpClient() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getStreamingResponseStatusCodes = getStreamingResponseStatusCodes;
 exports.getPathStringFromParameter = getPathStringFromParameter;
-const serializer_js_1 = __nccwpck_require__(496);
+const serializer_js_1 = __nccwpck_require__(497);
 /**
  * Gets the list of status codes for streaming responses.
  * @internal
@@ -77512,38 +77963,38 @@ function getPathStringFromParameter(parameter) {
 
 /***/ }),
 
-/***/ 412:
+/***/ 413:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-exports.parse = __nccwpck_require__(227)
-exports.stringify = __nccwpck_require__(308)
+exports.parse = __nccwpck_require__(225)
+exports.stringify = __nccwpck_require__(306)
 
 
 /***/ }),
 
-/***/ 413:
+/***/ 414:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobServiceClient = void 0;
-const core_auth_1 = __nccwpck_require__(528);
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const core_util_1 = __nccwpck_require__(16);
-const Pipeline_js_1 = __nccwpck_require__(187);
-const ContainerClient_js_1 = __nccwpck_require__(70);
-const utils_common_js_1 = __nccwpck_require__(161);
-const storage_common_1 = __nccwpck_require__(285);
-const utils_common_js_2 = __nccwpck_require__(161);
-const tracing_js_1 = __nccwpck_require__(35);
-const BlobBatchClient_js_1 = __nccwpck_require__(414);
-const StorageClient_js_1 = __nccwpck_require__(468);
-const AccountSASPermissions_js_1 = __nccwpck_require__(64);
-const AccountSASSignatureValues_js_1 = __nccwpck_require__(297);
-const AccountSASServices_js_1 = __nccwpck_require__(390);
+const core_auth_1 = __nccwpck_require__(529);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const core_util_1 = __nccwpck_require__(15);
+const Pipeline_js_1 = __nccwpck_require__(184);
+const ContainerClient_js_1 = __nccwpck_require__(67);
+const utils_common_js_1 = __nccwpck_require__(158);
+const storage_common_1 = __nccwpck_require__(283);
+const utils_common_js_2 = __nccwpck_require__(158);
+const tracing_js_1 = __nccwpck_require__(33);
+const BlobBatchClient_js_1 = __nccwpck_require__(415);
+const StorageClient_js_1 = __nccwpck_require__(469);
+const AccountSASPermissions_js_1 = __nccwpck_require__(61);
+const AccountSASSignatureValues_js_1 = __nccwpck_require__(295);
+const AccountSASServices_js_1 = __nccwpck_require__(389);
 /**
  * A BlobServiceClient represents a Client to the Azure Storage Blob service allowing you
  * to manipulate blob containers.
@@ -78236,7 +78687,7 @@ exports.BlobServiceClient = BlobServiceClient;
 
 /***/ }),
 
-/***/ 414:
+/***/ 415:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -78245,14 +78696,14 @@ exports.BlobServiceClient = BlobServiceClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatchClient = void 0;
-const BatchResponseParser_js_1 = __nccwpck_require__(319);
-const BatchUtils_js_1 = __nccwpck_require__(266);
-const BlobBatch_js_1 = __nccwpck_require__(343);
-const tracing_js_1 = __nccwpck_require__(35);
-const storage_common_1 = __nccwpck_require__(285);
-const StorageContextClient_js_1 = __nccwpck_require__(275);
-const Pipeline_js_1 = __nccwpck_require__(187);
-const utils_common_js_1 = __nccwpck_require__(161);
+const BatchResponseParser_js_1 = __nccwpck_require__(317);
+const BatchUtils_js_1 = __nccwpck_require__(264);
+const BlobBatch_js_1 = __nccwpck_require__(341);
+const tracing_js_1 = __nccwpck_require__(33);
+const storage_common_1 = __nccwpck_require__(283);
+const StorageContextClient_js_1 = __nccwpck_require__(274);
+const Pipeline_js_1 = __nccwpck_require__(184);
+const utils_common_js_1 = __nccwpck_require__(158);
 /**
  * A BlobBatchClient allows you to make batched requests to the Azure Storage Blob service.
  *
@@ -78419,7 +78870,7 @@ exports.BlobBatchClient = BlobBatchClient;
 
 /***/ }),
 
-/***/ 415:
+/***/ 416:
 /***/ ((module) => {
 
 "use strict";
@@ -78433,15 +78884,15 @@ module.exports = (d, num) => {
 
 /***/ }),
 
-/***/ 416:
+/***/ 417:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Decoder = __nccwpck_require__(46)
-const decodeText = __nccwpck_require__(283)
-const getLimit = __nccwpck_require__(499)
+const Decoder = __nccwpck_require__(44)
+const decodeText = __nccwpck_require__(282)
+const getLimit = __nccwpck_require__(500)
 
 const RE_CHARSET = /^charset$/i
 
@@ -78631,7 +79082,7 @@ module.exports = UrlEncoded
 
 /***/ }),
 
-/***/ 417:
+/***/ 418:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -78649,7 +79100,7 @@ exports.MESSAGE_TYPE = Symbol.for("protobuf-ts/message-type");
 
 /***/ }),
 
-/***/ 418:
+/***/ 419:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -78661,8 +79112,8 @@ exports.createDefaultTracingSpan = createDefaultTracingSpan;
 exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
-const tracingContext_js_1 = __nccwpck_require__(380);
-const state_js_1 = __nccwpck_require__(102);
+const tracingContext_js_1 = __nccwpck_require__(379);
+const state_js_1 = __nccwpck_require__(99);
 function createDefaultTracingSpan() {
     return {
         end: () => {
@@ -78725,17 +79176,17 @@ function getInstrumenter() {
 
 /***/ }),
 
-/***/ 419:
+/***/ 420:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
-const binary_format_contract_1 = __nccwpck_require__(342);
-const reflection_info_1 = __nccwpck_require__(466);
-const reflection_long_convert_1 = __nccwpck_require__(164);
-const reflection_scalar_default_1 = __nccwpck_require__(478);
+const binary_format_contract_1 = __nccwpck_require__(340);
+const reflection_info_1 = __nccwpck_require__(467);
+const reflection_long_convert_1 = __nccwpck_require__(161);
+const reflection_scalar_default_1 = __nccwpck_require__(479);
 /**
  * Reads proto3 messages in binary format using reflection information.
  *
@@ -78916,7 +79367,7 @@ exports.ReflectionBinaryReader = ReflectionBinaryReader;
 
 /***/ }),
 
-/***/ 420:
+/***/ 421:
 /***/ ((module) => {
 
 "use strict";
@@ -79198,7 +79649,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 421:
+/***/ 422:
 /***/ ((module) => {
 
 "use strict";
@@ -79206,15 +79657,15 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 422:
+/***/ 423:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseAsync
 
-const TOMLParser = __nccwpck_require__(356)
-const prettyError = __nccwpck_require__(287)
+const TOMLParser = __nccwpck_require__(354)
+const prettyError = __nccwpck_require__(285)
 
 function parseAsync (str, opts) {
   if (!opts) opts = {}
@@ -79244,7 +79695,7 @@ function parseAsync (str, opts) {
 
 /***/ }),
 
-/***/ 423:
+/***/ 424:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -79270,8 +79721,8 @@ __export(response_exports, {
   toPipelineResponse: () => toPipelineResponse
 });
 module.exports = __toCommonJS(response_exports);
-var import_core_rest_pipeline = __nccwpck_require__(107);
-var import_util = __nccwpck_require__(115);
+var import_core_rest_pipeline = __nccwpck_require__(104);
+var import_util = __nccwpck_require__(112);
 const originalResponse = /* @__PURE__ */ Symbol("Original FullOperationResponse");
 function toCompatResponse(response, options) {
   let request = (0, import_util.toWebResourceLike)(response.request);
@@ -79327,7 +79778,7 @@ function toPipelineResponse(compatResponse) {
 
 /***/ }),
 
-/***/ 424:
+/***/ 425:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -79353,7 +79804,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOptions = void 0;
-const core = __importStar(__nccwpck_require__(474));
+const core = __importStar(__nccwpck_require__(475));
 /**
  * Returns a copy with defaults filled in.
  */
@@ -79384,7 +79835,7 @@ exports.getOptions = getOptions;
 
 /***/ }),
 
-/***/ 425:
+/***/ 426:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -79392,7 +79843,7 @@ exports.getOptions = getOptions;
 
 /* istanbul ignore file: only for Node 12 */
 
-const { kConnected, kSize } = __nccwpck_require__(200)
+const { kConnected, kSize } = __nccwpck_require__(197)
 
 class CompatWeakRef {
   constructor (value) {
@@ -79440,7 +79891,7 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 426:
+/***/ 427:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -79452,7 +79903,7 @@ exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTie
 exports.toAccessTier = toAccessTier;
 exports.ensureCpkIfSpecified = ensureCpkIfSpecified;
 exports.getBlobServiceAccountAudience = getBlobServiceAccountAudience;
-const constants_js_1 = __nccwpck_require__(155);
+const constants_js_1 = __nccwpck_require__(152);
 /**
  * Represents the access tier on a blob.
  * For detailed information about block blob level tiering see {@link https://learn.microsoft.com/azure/storage/blobs/storage-blob-storage-tiers|Hot, cool and archive storage tiers.}
@@ -79568,19 +80019,19 @@ function getBlobServiceAccountAudience(storageAccountName) {
 
 /***/ }),
 
-/***/ 427:
+/***/ 428:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const WritableStream = (__nccwpck_require__(442).Writable)
-const { inherits } = __nccwpck_require__(385)
-const Dicer = __nccwpck_require__(15)
+const WritableStream = (__nccwpck_require__(443).Writable)
+const { inherits } = __nccwpck_require__(384)
+const Dicer = __nccwpck_require__(14)
 
 const MultipartParser = __nccwpck_require__(0)
-const UrlencodedParser = __nccwpck_require__(416)
-const parseParams = __nccwpck_require__(197)
+const UrlencodedParser = __nccwpck_require__(417)
+const parseParams = __nccwpck_require__(194)
 
 function Busboy (opts) {
   if (!(this instanceof Busboy)) { return new Busboy(opts) }
@@ -79661,7 +80112,7 @@ module.exports.Dicer = Dicer
 
 /***/ }),
 
-/***/ 428:
+/***/ 429:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -79688,7 +80139,7 @@ var StorageRetryPolicyType;
 
 /***/ }),
 
-/***/ 429:
+/***/ 430:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -79730,8 +80181,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDetails = exports.isLinux = exports.isMacOS = exports.isWindows = exports.arch = exports.platform = void 0;
-const os_1 = __importDefault(__nccwpck_require__(98));
-const exec = __importStar(__nccwpck_require__(20));
+const os_1 = __importDefault(__nccwpck_require__(95));
+const exec = __importStar(__nccwpck_require__(19));
 const getWindowsInfo = () => __awaiter(void 0, void 0, void 0, function* () {
     const { stdout: version } = yield exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Version"', undefined, {
         silent: true
@@ -79789,7 +80240,7 @@ exports.getDetails = getDetails;
 
 /***/ }),
 
-/***/ 430:
+/***/ 431:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -79799,7 +80250,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseProxyResponse = void 0;
-const debug_1 = __importDefault(__nccwpck_require__(529));
+const debug_1 = __importDefault(__nccwpck_require__(530));
 const debug = (0, debug_1.default)('https-proxy-agent:parse-proxy-response');
 function parseProxyResponse(socket) {
     return new Promise((resolve, reject) => {
@@ -79897,15 +80348,15 @@ exports.parseProxyResponse = parseProxyResponse;
 
 /***/ }),
 
-/***/ 431:
+/***/ 432:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseStream
 
-const stream = __nccwpck_require__(135)
-const TOMLParser = __nccwpck_require__(356)
+const stream = __nccwpck_require__(132)
+const TOMLParser = __nccwpck_require__(354)
 
 function parseStream (stm) {
   if (stm) {
@@ -79985,7 +80436,7 @@ function parseTransform () {
 
 /***/ }),
 
-/***/ 432:
+/***/ 433:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -79996,8 +80447,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReader = void 0;
 // TODO: Do a review of non-interfaces
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
-const AvroConstants_js_1 = __nccwpck_require__(234);
-const AvroParser_js_1 = __nccwpck_require__(311);
+const AvroConstants_js_1 = __nccwpck_require__(232);
+const AvroParser_js_1 = __nccwpck_require__(309);
 const utils_common_js_1 = __nccwpck_require__(403);
 class AvroReader {
     _dataStream;
@@ -80112,7 +80563,7 @@ exports.AvroReader = AvroReader;
 
 /***/ }),
 
-/***/ 433:
+/***/ 434:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80122,13 +80573,13 @@ exports.CacheService = exports.GetCacheEntryDownloadURLResponse = exports.GetCac
 // @generated by protobuf-ts 2.9.1 with parameter long_type_string,client_none,generate_dependencies
 // @generated from protobuf file "results/api/v1/cache.proto" (package "github.actions.results.api.v1", syntax proto3)
 // tslint:disable
-const runtime_rpc_1 = __nccwpck_require__(179);
-const runtime_1 = __nccwpck_require__(21);
-const runtime_2 = __nccwpck_require__(21);
-const runtime_3 = __nccwpck_require__(21);
-const runtime_4 = __nccwpck_require__(21);
-const runtime_5 = __nccwpck_require__(21);
-const cachemetadata_1 = __nccwpck_require__(239);
+const runtime_rpc_1 = __nccwpck_require__(176);
+const runtime_1 = __nccwpck_require__(20);
+const runtime_2 = __nccwpck_require__(20);
+const runtime_3 = __nccwpck_require__(20);
+const runtime_4 = __nccwpck_require__(20);
+const runtime_5 = __nccwpck_require__(20);
+const cachemetadata_1 = __nccwpck_require__(237);
 // @generated message type with reflection information, may provide speed optimized methods
 class CreateCacheEntryRequest$Type extends runtime_5.MessageType {
     constructor() {
@@ -80521,16 +80972,16 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 
 /***/ }),
 
-/***/ 434:
+/***/ 435:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(132)
-const { isCTLExcludingHtab } = __nccwpck_require__(420)
-const { collectASequenceOfCodePointsFast } = __nccwpck_require__(28)
-const assert = __nccwpck_require__(542)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(129)
+const { isCTLExcludingHtab } = __nccwpck_require__(421)
+const { collectASequenceOfCodePointsFast } = __nccwpck_require__(27)
+const assert = __nccwpck_require__(543)
 
 /**
  * @description Parses the field-value attributes of a set-cookie header string.
@@ -80846,7 +81297,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 435:
+/***/ 436:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -80893,10 +81344,10 @@ exports.planBlessedPrepareCache = planBlessedPrepareCache;
 exports.buildPrepareArgs = buildPrepareArgs;
 exports.assertMinimumSoldrVersion = assertMinimumSoldrVersion;
 exports.executeBlessedPrepare = executeBlessedPrepare;
-const fs = __importStar(__nccwpck_require__(257));
-const path = __importStar(__nccwpck_require__(522));
-const exec = __importStar(__nccwpck_require__(20));
-const cache_keys_js_1 = __nccwpck_require__(24);
+const fs = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(523));
+const exec = __importStar(__nccwpck_require__(19));
+const cache_keys_js_1 = __nccwpck_require__(23);
 const TRIPLE = /^[a-z0-9]+(?:_[a-z0-9]+)*-[a-z0-9]+(?:-[a-z0-9]+)+$/;
 function parseSingleCrossTarget(raw) {
     const values = [...new Set(raw.split(/[\s,]+/).map((v) => v.trim().toLowerCase()).filter(Boolean))].sort();
@@ -80975,7 +81426,7 @@ async function executeBlessedPrepare(input) {
 
 /***/ }),
 
-/***/ 436:
+/***/ 437:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -81043,7 +81494,7 @@ exports.ServerCallContextController = ServerCallContextController;
 
 /***/ }),
 
-/***/ 437:
+/***/ 438:
 /***/ ((module) => {
 
 "use strict";
@@ -81178,7 +81629,7 @@ module.exports = Parser
 
 /***/ }),
 
-/***/ 438:
+/***/ 439:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -81187,8 +81638,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobDownloadResponse = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const core_util_1 = __nccwpck_require__(16);
-const RetriableReadableStream_js_1 = __nccwpck_require__(508);
+const core_util_1 = __nccwpck_require__(15);
+const RetriableReadableStream_js_1 = __nccwpck_require__(509);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -81654,7 +82105,7 @@ exports.BlobDownloadResponse = BlobDownloadResponse;
 
 /***/ }),
 
-/***/ 439:
+/***/ 440:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -81699,7 +82150,7 @@ function storageRequestFailureDetailsParserPolicy() {
 
 /***/ }),
 
-/***/ 440:
+/***/ 441:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -81735,8 +82186,8 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(393));
-var import_node_process = __toESM(__nccwpck_require__(242));
+var import_node_os = __toESM(__nccwpck_require__(392));
+var import_node_process = __toESM(__nccwpck_require__(240));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -81759,7 +82210,7 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 441:
+/***/ 442:
 /***/ ((module) => {
 
 "use strict";
@@ -81767,7 +82218,7 @@ module.exports = require("async_hooks");
 
 /***/ }),
 
-/***/ 442:
+/***/ 443:
 /***/ ((module) => {
 
 "use strict";
@@ -81775,7 +82226,7 @@ module.exports = require("node:stream");
 
 /***/ }),
 
-/***/ 443:
+/***/ 444:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -81829,13 +82280,13 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DefaultGlobber = void 0;
-const core = __importStar(__nccwpck_require__(474));
-const fs = __importStar(__nccwpck_require__(546));
-const globOptionsHelper = __importStar(__nccwpck_require__(424));
-const path = __importStar(__nccwpck_require__(256));
-const patternHelper = __importStar(__nccwpck_require__(47));
-const internal_match_kind_1 = __nccwpck_require__(544);
-const internal_pattern_1 = __nccwpck_require__(517);
+const core = __importStar(__nccwpck_require__(475));
+const fs = __importStar(__nccwpck_require__(547));
+const globOptionsHelper = __importStar(__nccwpck_require__(425));
+const path = __importStar(__nccwpck_require__(254));
+const patternHelper = __importStar(__nccwpck_require__(45));
+const internal_match_kind_1 = __nccwpck_require__(545);
+const internal_pattern_1 = __nccwpck_require__(518);
 const internal_search_state_1 = __nccwpck_require__(4);
 const IS_WINDOWS = process.platform === 'win32';
 class DefaultGlobber {
@@ -82017,7 +82468,7 @@ exports.DefaultGlobber = DefaultGlobber;
 
 /***/ }),
 
-/***/ 444:
+/***/ 445:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82027,7 +82478,7 @@ exports.DefaultGlobber = DefaultGlobber;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOperationArgumentValueFromParameter = getOperationArgumentValueFromParameter;
 exports.getOperationRequestInfo = getOperationRequestInfo;
-const state_js_1 = __nccwpck_require__(339);
+const state_js_1 = __nccwpck_require__(337);
 /**
  * @internal
  * Retrieves the value to use for a given operation argument
@@ -82122,17 +82573,17 @@ function getOperationRequestInfo(request) {
 
 /***/ }),
 
-/***/ 445:
+/***/ 446:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(504)
-const { AsyncResource } = __nccwpck_require__(441)
-const util = __nccwpck_require__(75)
-const { addSignal, removeSignal } = __nccwpck_require__(109)
-const assert = __nccwpck_require__(542)
+const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_require__(505)
+const { AsyncResource } = __nccwpck_require__(442)
+const util = __nccwpck_require__(72)
+const { addSignal, removeSignal } = __nccwpck_require__(106)
+const assert = __nccwpck_require__(543)
 
 class UpgradeHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -82235,13 +82686,13 @@ module.exports = upgrade
 
 /***/ }),
 
-/***/ 446:
+/***/ 447:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const os = __nccwpck_require__(98);
-const tty = __nccwpck_require__(186);
+const os = __nccwpck_require__(95);
+const tty = __nccwpck_require__(183);
 const hasFlag = __nccwpck_require__(375);
 
 const {env} = process;
@@ -82378,7 +82829,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 447:
+/***/ 448:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -82403,7 +82854,7 @@ __export(checkInsecureConnection_exports, {
   ensureSecureConnection: () => ensureSecureConnection
 });
 module.exports = __toCommonJS(checkInsecureConnection_exports);
-var import_log = __nccwpck_require__(158);
+var import_log = __nccwpck_require__(155);
 let insecureConnectionWarningEmmitted = false;
 function allowInsecureConnection(request, options) {
   if (options.allowInsecureConnection && request.allowInsecureConnection) {
@@ -82440,14 +82891,14 @@ function ensureSecureConnection(request, options) {
 
 /***/ }),
 
-/***/ 448:
+/***/ 449:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CacheServiceClientProtobuf = exports.CacheServiceClientJSON = void 0;
-const cache_1 = __nccwpck_require__(433);
+const cache_1 = __nccwpck_require__(434);
 class CacheServiceClientJSON {
     constructor(rpc) {
         this.rpc = rpc;
@@ -82515,7 +82966,7 @@ exports.CacheServiceClientProtobuf = CacheServiceClientProtobuf;
 
 /***/ }),
 
-/***/ 449:
+/***/ 450:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -82555,9 +83006,9 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StatsCollector = void 0;
-const fs = __importStar(__nccwpck_require__(114));
-const path = __importStar(__nccwpck_require__(522));
-const core = __importStar(__nccwpck_require__(474));
+const fs = __importStar(__nccwpck_require__(111));
+const path = __importStar(__nccwpck_require__(523));
+const core = __importStar(__nccwpck_require__(475));
 function fmtBytes(n) {
     if (n === null)
         return "-";
@@ -82823,7 +83274,7 @@ exports.StatsCollector = StatsCollector;
 
 /***/ }),
 
-/***/ 450:
+/***/ 451:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -82872,7 +83323,7 @@ function decodeStringToString(value) {
 
 /***/ }),
 
-/***/ 451:
+/***/ 452:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -82917,7 +83368,7 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 
 /***/ }),
 
-/***/ 452:
+/***/ 453:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -82926,31 +83377,31 @@ const isReactNative = typeof navigator !== "undefined" && navigator?.product ===
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.authorizeRequestOnTenantChallenge = exports.authorizeRequestOnClaimChallenge = exports.serializationPolicyName = exports.serializationPolicy = exports.deserializationPolicyName = exports.deserializationPolicy = exports.XML_CHARKEY = exports.XML_ATTRKEY = exports.createClientPipeline = exports.ServiceClient = exports.MapperTypeNames = exports.createSerializer = void 0;
-var serializer_js_1 = __nccwpck_require__(496);
+var serializer_js_1 = __nccwpck_require__(497);
 Object.defineProperty(exports, "createSerializer", ({ enumerable: true, get: function () { return serializer_js_1.createSerializer; } }));
 Object.defineProperty(exports, "MapperTypeNames", ({ enumerable: true, get: function () { return serializer_js_1.MapperTypeNames; } }));
-var serviceClient_js_1 = __nccwpck_require__(324);
+var serviceClient_js_1 = __nccwpck_require__(322);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
-var pipeline_js_1 = __nccwpck_require__(292);
+var pipeline_js_1 = __nccwpck_require__(290);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
-var interfaces_js_1 = __nccwpck_require__(105);
+var interfaces_js_1 = __nccwpck_require__(102);
 Object.defineProperty(exports, "XML_ATTRKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_ATTRKEY; } }));
 Object.defineProperty(exports, "XML_CHARKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_CHARKEY; } }));
-var deserializationPolicy_js_1 = __nccwpck_require__(92);
+var deserializationPolicy_js_1 = __nccwpck_require__(89);
 Object.defineProperty(exports, "deserializationPolicy", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicy; } }));
 Object.defineProperty(exports, "deserializationPolicyName", ({ enumerable: true, get: function () { return deserializationPolicy_js_1.deserializationPolicyName; } }));
-var serializationPolicy_js_1 = __nccwpck_require__(505);
+var serializationPolicy_js_1 = __nccwpck_require__(506);
 Object.defineProperty(exports, "serializationPolicy", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicy; } }));
 Object.defineProperty(exports, "serializationPolicyName", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicyName; } }));
-var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(117);
+var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(114);
 Object.defineProperty(exports, "authorizeRequestOnClaimChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnClaimChallenge_js_1.authorizeRequestOnClaimChallenge; } }));
-var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(177);
+var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(174);
 Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnTenantChallenge_js_1.authorizeRequestOnTenantChallenge; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 453:
+/***/ 454:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -82989,12 +83440,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTar = exports.extractTar = exports.listTar = void 0;
-const exec_1 = __nccwpck_require__(20);
-const io = __importStar(__nccwpck_require__(302));
-const fs_1 = __nccwpck_require__(546);
-const path = __importStar(__nccwpck_require__(256));
-const utils = __importStar(__nccwpck_require__(81));
-const constants_1 = __nccwpck_require__(49);
+const exec_1 = __nccwpck_require__(19);
+const io = __importStar(__nccwpck_require__(300));
+const fs_1 = __nccwpck_require__(547);
+const path = __importStar(__nccwpck_require__(254));
+const utils = __importStar(__nccwpck_require__(78));
+const constants_1 = __nccwpck_require__(47);
 const IS_WINDOWS = process.platform === 'win32';
 // Returns tar path and type: BSD or GNU
 function getTarPath() {
@@ -83229,7 +83680,7 @@ exports.createTar = createTar;
 
 /***/ }),
 
-/***/ 454:
+/***/ 455:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -83265,15 +83716,15 @@ __export(nodeHttpClient_exports, {
   getBodyLength: () => getBodyLength
 });
 module.exports = __toCommonJS(nodeHttpClient_exports);
-var import_node_http = __toESM(__nccwpck_require__(271));
-var import_node_https = __toESM(__nccwpck_require__(399));
-var import_node_zlib = __toESM(__nccwpck_require__(534));
-var import_node_stream = __nccwpck_require__(442);
+var import_node_http = __toESM(__nccwpck_require__(269));
+var import_node_https = __toESM(__nccwpck_require__(398));
+var import_node_zlib = __toESM(__nccwpck_require__(535));
+var import_node_stream = __nccwpck_require__(443);
 var import_AbortError = __nccwpck_require__(11);
-var import_httpHeaders = __nccwpck_require__(501);
-var import_restError = __nccwpck_require__(457);
-var import_log = __nccwpck_require__(158);
-var import_sanitizer = __nccwpck_require__(126);
+var import_httpHeaders = __nccwpck_require__(502);
+var import_restError = __nccwpck_require__(458);
+var import_log = __nccwpck_require__(155);
+var import_sanitizer = __nccwpck_require__(123);
 const DEFAULT_TLS_SETTINGS = {};
 function isReadableStream(body) {
   return body && typeof body.pipe === "function";
@@ -83578,13 +84029,13 @@ function createNodeHttpClient() {
 
 /***/ }),
 
-/***/ 455:
+/***/ 456:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(470)
+const { webidl } = __nccwpck_require__(471)
 
 const kState = Symbol('ProgressEvent state')
 
@@ -83664,7 +84115,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 456:
+/***/ 457:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -83697,10 +84148,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const crypto = __importStar(__nccwpck_require__(299));
-const fs = __importStar(__nccwpck_require__(546));
-const os = __importStar(__nccwpck_require__(98));
-const utils_1 = __nccwpck_require__(519);
+const crypto = __importStar(__nccwpck_require__(297));
+const fs = __importStar(__nccwpck_require__(547));
+const os = __importStar(__nccwpck_require__(95));
+const utils_1 = __nccwpck_require__(520);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -83733,7 +84184,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 457:
+/***/ 458:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -83759,9 +84210,9 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_error = __nccwpck_require__(160);
+var import_error = __nccwpck_require__(157);
 var import_inspect = __nccwpck_require__(1);
-var import_sanitizer = __nccwpck_require__(126);
+var import_sanitizer = __nccwpck_require__(123);
 const errorSanitizer = new import_sanitizer.Sanitizer();
 class RestError extends Error {
   /**
@@ -83835,7 +84286,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 458:
+/***/ 459:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -83888,7 +84339,7 @@ function wrapAbortSignalLike(abortSignalLike) {
 
 /***/ }),
 
-/***/ 459:
+/***/ 460:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -83902,9 +84353,9 @@ function wrapAbortSignalLike(abortSignalLike) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(220);
-const coreHttpCompat = tslib_1.__importStar(__nccwpck_require__(78));
-const index_js_1 = __nccwpck_require__(286);
+const tslib_1 = __nccwpck_require__(219);
+const coreHttpCompat = tslib_1.__importStar(__nccwpck_require__(75));
+const index_js_1 = __nccwpck_require__(284);
 class StorageClient extends coreHttpCompat.ExtendedServiceClient {
     url;
     version;
@@ -83961,7 +84412,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 460:
+/***/ 461:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -83970,36 +84421,36 @@ exports.StorageClient = StorageClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = exports.StorageSharedKeyCredentialPolicy = exports.StorageSharedKeyCredential = exports.StorageRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = exports.Credential = exports.CredentialPolicy = exports.BaseRequestPolicy = exports.AnonymousCredentialPolicy = exports.AnonymousCredential = exports.StorageOAuthScopes = exports.newPipeline = exports.isPipelineLike = exports.Pipeline = exports.getBlobServiceAccountAudience = exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTier = exports.generateBlobSASQueryParameters = exports.generateAccountSASQueryParameters = void 0;
-const tslib_1 = __nccwpck_require__(220);
-const core_rest_pipeline_1 = __nccwpck_require__(107);
+const tslib_1 = __nccwpck_require__(219);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
-tslib_1.__exportStar(__nccwpck_require__(413), exports);
-tslib_1.__exportStar(__nccwpck_require__(189), exports);
-tslib_1.__exportStar(__nccwpck_require__(70), exports);
-tslib_1.__exportStar(__nccwpck_require__(209), exports);
-tslib_1.__exportStar(__nccwpck_require__(64), exports);
-tslib_1.__exportStar(__nccwpck_require__(2), exports);
-tslib_1.__exportStar(__nccwpck_require__(390), exports);
-var AccountSASSignatureValues_js_1 = __nccwpck_require__(297);
-Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(343), exports);
 tslib_1.__exportStar(__nccwpck_require__(414), exports);
-tslib_1.__exportStar(__nccwpck_require__(178), exports);
-tslib_1.__exportStar(__nccwpck_require__(518), exports);
-var BlobSASSignatureValues_js_1 = __nccwpck_require__(74);
+tslib_1.__exportStar(__nccwpck_require__(186), exports);
+tslib_1.__exportStar(__nccwpck_require__(67), exports);
+tslib_1.__exportStar(__nccwpck_require__(206), exports);
+tslib_1.__exportStar(__nccwpck_require__(61), exports);
+tslib_1.__exportStar(__nccwpck_require__(2), exports);
+tslib_1.__exportStar(__nccwpck_require__(389), exports);
+var AccountSASSignatureValues_js_1 = __nccwpck_require__(295);
+Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
+tslib_1.__exportStar(__nccwpck_require__(341), exports);
+tslib_1.__exportStar(__nccwpck_require__(415), exports);
+tslib_1.__exportStar(__nccwpck_require__(175), exports);
+tslib_1.__exportStar(__nccwpck_require__(519), exports);
+var BlobSASSignatureValues_js_1 = __nccwpck_require__(71);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(288), exports);
-var models_js_1 = __nccwpck_require__(426);
+tslib_1.__exportStar(__nccwpck_require__(286), exports);
+var models_js_1 = __nccwpck_require__(427);
 Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: function () { return models_js_1.BlockBlobTier; } }));
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
 Object.defineProperty(exports, "getBlobServiceAccountAudience", ({ enumerable: true, get: function () { return models_js_1.getBlobServiceAccountAudience; } }));
-var Pipeline_js_1 = __nccwpck_require__(187);
+var Pipeline_js_1 = __nccwpck_require__(184);
 Object.defineProperty(exports, "Pipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.Pipeline; } }));
 Object.defineProperty(exports, "isPipelineLike", ({ enumerable: true, get: function () { return Pipeline_js_1.isPipelineLike; } }));
 Object.defineProperty(exports, "newPipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.newPipeline; } }));
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return Pipeline_js_1.StorageOAuthScopes; } }));
-var storage_common_1 = __nccwpck_require__(285);
+var storage_common_1 = __nccwpck_require__(283);
 Object.defineProperty(exports, "AnonymousCredential", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredential; } }));
 Object.defineProperty(exports, "AnonymousCredentialPolicy", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredentialPolicy; } }));
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return storage_common_1.BaseRequestPolicy; } }));
@@ -84012,22 +84463,22 @@ Object.defineProperty(exports, "StorageSharedKeyCredential", ({ enumerable: true
 Object.defineProperty(exports, "StorageSharedKeyCredentialPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageSharedKeyCredentialPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
-tslib_1.__exportStar(__nccwpck_require__(541), exports);
-tslib_1.__exportStar(__nccwpck_require__(332), exports);
-var log_js_1 = __nccwpck_require__(112);
+tslib_1.__exportStar(__nccwpck_require__(542), exports);
+tslib_1.__exportStar(__nccwpck_require__(330), exports);
+var log_js_1 = __nccwpck_require__(109);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 461:
+/***/ 462:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SPECIAL_HEADERS = exports.HEADER_STATE = exports.MINOR = exports.MAJOR = exports.CONNECTION_TOKEN_CHARS = exports.HEADER_CHARS = exports.TOKEN = exports.STRICT_TOKEN = exports.HEX = exports.URL_CHAR = exports.STRICT_URL_CHAR = exports.USERINFO_CHARS = exports.MARK = exports.ALPHANUM = exports.NUM = exports.HEX_MAP = exports.NUM_MAP = exports.ALPHA = exports.FINISH = exports.H_METHOD_MAP = exports.METHOD_MAP = exports.METHODS_RTSP = exports.METHODS_ICE = exports.METHODS_HTTP = exports.METHODS = exports.LENIENT_FLAGS = exports.FLAGS = exports.TYPE = exports.ERROR = void 0;
-const utils_1 = __nccwpck_require__(317);
+const utils_1 = __nccwpck_require__(315);
 // C headers
 var ERROR;
 (function (ERROR) {
@@ -84305,7 +84756,7 @@ exports.SPECIAL_HEADERS = {
 
 /***/ }),
 
-/***/ 462:
+/***/ 463:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -84331,12 +84782,12 @@ __export(sendRequest_exports, {
   sendRequest: () => sendRequest
 });
 module.exports = __toCommonJS(sendRequest_exports);
-var import_restError = __nccwpck_require__(457);
-var import_httpHeaders = __nccwpck_require__(501);
-var import_pipelineRequest = __nccwpck_require__(120);
-var import_clientHelpers = __nccwpck_require__(507);
-var import_typeGuards = __nccwpck_require__(512);
-var import_multipart = __nccwpck_require__(277);
+var import_restError = __nccwpck_require__(458);
+var import_httpHeaders = __nccwpck_require__(502);
+var import_pipelineRequest = __nccwpck_require__(117);
+var import_clientHelpers = __nccwpck_require__(508);
+var import_typeGuards = __nccwpck_require__(513);
+var import_multipart = __nccwpck_require__(276);
 async function sendRequest(method, url, pipeline, options = {}, customHttpClient) {
   const httpClient = customHttpClient ?? (0, import_clientHelpers.getCachedDefaultHttpsClient)();
   const request = buildPipelineRequest(method, url, options);
@@ -84489,7 +84940,7 @@ function createParseError(response, err) {
 
 /***/ }),
 
-/***/ 463:
+/***/ 464:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -84503,10 +84954,10 @@ const {
   makeAppropriateNetworkError,
   filterResponse,
   makeResponse
-} = __nccwpck_require__(45)
-const { Headers } = __nccwpck_require__(530)
-const { Request, makeRequest } = __nccwpck_require__(88)
-const zlib = __nccwpck_require__(421)
+} = __nccwpck_require__(43)
+const { Headers } = __nccwpck_require__(531)
+const { Request, makeRequest } = __nccwpck_require__(85)
+const zlib = __nccwpck_require__(422)
 const {
   bytesMatch,
   makePolicyContainer,
@@ -84536,10 +84987,10 @@ const {
   urlIsLocal,
   urlIsHttpHttpsScheme,
   urlHasHttpsScheme
-} = __nccwpck_require__(532)
-const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(17)
-const assert = __nccwpck_require__(542)
-const { safelyExtractBody } = __nccwpck_require__(27)
+} = __nccwpck_require__(533)
+const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(16)
+const assert = __nccwpck_require__(543)
+const { safelyExtractBody } = __nccwpck_require__(26)
 const {
   redirectStatusSet,
   nullBodyStatus,
@@ -84547,16 +84998,16 @@ const {
   requestBodyHeader,
   subresourceSet,
   DOMException
-} = __nccwpck_require__(33)
-const { kHeadersList } = __nccwpck_require__(200)
-const EE = __nccwpck_require__(486)
-const { Readable, pipeline } = __nccwpck_require__(135)
-const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(75)
-const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(28)
-const { TransformStream } = __nccwpck_require__(265)
-const { getGlobalDispatcher } = __nccwpck_require__(386)
-const { webidl } = __nccwpck_require__(470)
-const { STATUS_CODES } = __nccwpck_require__(338)
+} = __nccwpck_require__(32)
+const { kHeadersList } = __nccwpck_require__(197)
+const EE = __nccwpck_require__(487)
+const { Readable, pipeline } = __nccwpck_require__(132)
+const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(72)
+const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(27)
+const { TransformStream } = __nccwpck_require__(263)
+const { getGlobalDispatcher } = __nccwpck_require__(385)
+const { webidl } = __nccwpck_require__(471)
+const { STATUS_CODES } = __nccwpck_require__(336)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
 /** @type {import('buffer').resolveObjectURL} */
@@ -85298,7 +85749,7 @@ function schemeFetch (fetchParams) {
     }
     case 'blob:': {
       if (!resolveObjectURL) {
-        resolveObjectURL = (__nccwpck_require__(124).resolveObjectURL)
+        resolveObjectURL = (__nccwpck_require__(121).resolveObjectURL)
       }
 
       // 1. Let blobURLEntry be request’s current URL’s blob URL entry.
@@ -86297,7 +86748,7 @@ async function httpNetworkFetch (
   // cancelAlgorithm set to cancelAlgorithm, highWaterMark set to
   // highWaterMark, and sizeAlgorithm set to sizeAlgorithm.
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(265).ReadableStream)
+    ReadableStream = (__nccwpck_require__(263).ReadableStream)
   }
 
   const stream = new ReadableStream(
@@ -86645,7 +87096,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 464:
+/***/ 465:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -86703,7 +87154,7 @@ exports.ServerStreamingCall = ServerStreamingCall;
 
 /***/ }),
 
-/***/ 465:
+/***/ 466:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -86798,14 +87249,14 @@ function readRawInputs(env) {
 
 /***/ }),
 
-/***/ 466:
+/***/ 467:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.readMessageOption = exports.readFieldOption = exports.readFieldOptions = exports.normalizeFieldInfo = exports.RepeatType = exports.LongType = exports.ScalarType = void 0;
-const lower_camel_case_1 = __nccwpck_require__(467);
+const lower_camel_case_1 = __nccwpck_require__(468);
 /**
  * Scalar value types. This is a subset of field types declared by protobuf
  * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
@@ -86964,7 +87415,7 @@ exports.readMessageOption = readMessageOption;
 
 /***/ }),
 
-/***/ 467:
+/***/ 468:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -87007,7 +87458,7 @@ exports.lowerCamelCase = lowerCamelCase;
 
 /***/ }),
 
-/***/ 468:
+/***/ 469:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -87016,9 +87467,9 @@ exports.lowerCamelCase = lowerCamelCase;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const StorageContextClient_js_1 = __nccwpck_require__(275);
-const Pipeline_js_1 = __nccwpck_require__(187);
-const utils_common_js_1 = __nccwpck_require__(161);
+const StorageContextClient_js_1 = __nccwpck_require__(274);
+const Pipeline_js_1 = __nccwpck_require__(184);
+const utils_common_js_1 = __nccwpck_require__(158);
 /**
  * A StorageClient represents a based URL class for {@link BlobServiceClient}, {@link ContainerClient}
  * and etc.
@@ -87070,7 +87521,7 @@ exports.StorageClient = StorageClient;
 
 /***/ }),
 
-/***/ 469:
+/***/ 470:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -87145,14 +87596,14 @@ function parseHeaderValueAsNumber(response, headerName) {
 
 /***/ }),
 
-/***/ 470:
+/***/ 471:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { types } = __nccwpck_require__(128)
-const { hasOwn, toUSVString } = __nccwpck_require__(532)
+const { types } = __nccwpck_require__(125)
+const { hasOwn, toUSVString } = __nccwpck_require__(533)
 
 /** @type {import('../../types/webidl').Webidl} */
 const webidl = {}
@@ -87799,15 +88250,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 471:
+/***/ 472:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /**
  * Module dependencies.
  */
 
-const tty = __nccwpck_require__(186);
-const util = __nccwpck_require__(128);
+const tty = __nccwpck_require__(183);
+const util = __nccwpck_require__(125);
 
 /**
  * This is the Node.js implementation of `debug()`.
@@ -87833,7 +88284,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = __nccwpck_require__(446);
+	const supportsColor = __nccwpck_require__(447);
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [
@@ -88041,7 +88492,7 @@ function init(debug) {
 	}
 }
 
-module.exports = __nccwpck_require__(149)(exports);
+module.exports = __nccwpck_require__(146)(exports);
 
 const {formatters} = module.exports;
 
@@ -88069,7 +88520,7 @@ formatters.O = function (v) {
 
 /***/ }),
 
-/***/ 472:
+/***/ 473:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -88134,10 +88585,10 @@ exports.snapshotSourceMtimes = snapshotSourceMtimes;
 exports.replaySourceMtimes = replaySourceMtimes;
 exports.writeSnapshotFile = writeSnapshotFile;
 exports.readSnapshotFile = readSnapshotFile;
-const fs = __importStar(__nccwpck_require__(257));
-const path = __importStar(__nccwpck_require__(522));
-const node_crypto_1 = __nccwpck_require__(282);
-const normalize_source_mtime_js_1 = __nccwpck_require__(252);
+const fs = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(523));
+const node_crypto_1 = __nccwpck_require__(281);
+const normalize_source_mtime_js_1 = __nccwpck_require__(250);
 exports.SNAPSHOT_FILENAME = "setup-soldr-source-mtimes.json";
 async function hashFile(absolute) {
     // sha256 prefix (first 32 hex = 128 bits). Streaming so we don't load
@@ -88306,7 +88757,7 @@ function readSnapshotFile(filePath) {
 
 /***/ }),
 
-/***/ 473:
+/***/ 474:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -88360,8 +88811,8 @@ exports.walkSnapshot = walkSnapshot;
 exports.diffSnapshots = diffSnapshots;
 exports.diffStats = diffStats;
 exports.serializeManifest = serializeManifest;
-const fs = __importStar(__nccwpck_require__(114));
-const path = __importStar(__nccwpck_require__(522));
+const fs = __importStar(__nccwpck_require__(111));
+const path = __importStar(__nccwpck_require__(523));
 function entryKey(root, relpath) {
     return `${root}#${relpath}`;
 }
@@ -88472,7 +88923,7 @@ function serializeManifest(diff, stats) {
 
 /***/ }),
 
-/***/ 474:
+/***/ 475:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -88511,12 +88962,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.platform = exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = exports.markdownSummary = exports.summary = exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(548);
-const file_command_1 = __nccwpck_require__(456);
-const utils_1 = __nccwpck_require__(519);
-const os = __importStar(__nccwpck_require__(98));
-const path = __importStar(__nccwpck_require__(256));
-const oidc_utils_1 = __nccwpck_require__(138);
+const command_1 = __nccwpck_require__(549);
+const file_command_1 = __nccwpck_require__(457);
+const utils_1 = __nccwpck_require__(520);
+const os = __importStar(__nccwpck_require__(95));
+const path = __importStar(__nccwpck_require__(254));
+const oidc_utils_1 = __nccwpck_require__(135);
 /**
  * The code to exit an action
  */
@@ -88801,29 +89252,29 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(353);
+var summary_1 = __nccwpck_require__(351);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(353);
+var summary_2 = __nccwpck_require__(351);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(341);
+var path_utils_1 = __nccwpck_require__(339);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
 /**
  * Platform utilities exports
  */
-exports.platform = __importStar(__nccwpck_require__(429));
+exports.platform = __importStar(__nccwpck_require__(430));
 //# sourceMappingURL=core.js.map
 
 /***/ }),
 
-/***/ 475:
+/***/ 476:
 /***/ ((module) => {
 
 "use strict";
@@ -88841,14 +89292,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 476:
+/***/ 477:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionEquals = void 0;
-const reflection_info_1 = __nccwpck_require__(466);
+const reflection_info_1 = __nccwpck_require__(467);
 /**
  * Determines whether two message of the same type have the same field values.
  * Checks for deep equality, traversing repeated fields, oneof groups, maps
@@ -88926,7 +89377,7 @@ function repeatedMsgEq(type, a, b) {
 
 /***/ }),
 
-/***/ 477:
+/***/ 478:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -88980,9 +89431,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tripleToCcRsSuffix = tripleToCcRsSuffix;
 exports.detectMuslCcEnv = detectMuslCcEnv;
 exports.tryDelegateToSoldrDoctorMuslCc = tryDelegateToSoldrDoctorMuslCc;
-const fs = __importStar(__nccwpck_require__(257));
-const path = __importStar(__nccwpck_require__(522));
-const soldr_toolchain_client_js_1 = __nccwpck_require__(349);
+const fs = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(523));
+const soldr_toolchain_client_js_1 = __nccwpck_require__(347);
 const MUSL_TRIPLE_RE = /^[a-z0-9_]+-unknown-linux-musl$/;
 function tripleToCcRsSuffix(triple) {
     return triple.replace(/-/g, "_");
@@ -89160,16 +89611,16 @@ async function tryDelegateToSoldrDoctorMuslCc(opts) {
 
 /***/ }),
 
-/***/ 478:
+/***/ 479:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
-const reflection_info_1 = __nccwpck_require__(466);
-const reflection_long_convert_1 = __nccwpck_require__(164);
-const pb_long_1 = __nccwpck_require__(122);
+const reflection_info_1 = __nccwpck_require__(467);
+const reflection_long_convert_1 = __nccwpck_require__(161);
+const pb_long_1 = __nccwpck_require__(119);
 /**
  * Creates the default value for a scalar type.
  */
@@ -89205,7 +89656,7 @@ exports.reflectionScalarDefault = reflectionScalarDefault;
 
 /***/ }),
 
-/***/ 479:
+/***/ 480:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -89215,7 +89666,7 @@ exports.reflectionScalarDefault = reflectionScalarDefault;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageCorrectContentLengthPolicyName = void 0;
 exports.storageCorrectContentLengthPolicy = storageCorrectContentLengthPolicy;
-const constants_js_1 = __nccwpck_require__(40);
+const constants_js_1 = __nccwpck_require__(38);
 /**
  * The programmatic identifier of the storageCorrectContentLengthPolicy.
  */
@@ -89243,7 +89694,7 @@ function storageCorrectContentLengthPolicy() {
 
 /***/ }),
 
-/***/ 480:
+/***/ 481:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -89297,13 +89748,13 @@ exports.detectCompressMagic = detectCompressMagic;
 exports.planTarPayload = planTarPayload;
 exports.decompressCache = decompressCache;
 exports.compressCache = compressCache;
-const fs = __importStar(__nccwpck_require__(114));
-const os = __importStar(__nccwpck_require__(393));
-const path = __importStar(__nccwpck_require__(522));
-const core = __importStar(__nccwpck_require__(474));
-const exec = __importStar(__nccwpck_require__(20));
-const io = __importStar(__nccwpck_require__(302));
-const cache_encrypt_js_1 = __nccwpck_require__(241);
+const fs = __importStar(__nccwpck_require__(111));
+const os = __importStar(__nccwpck_require__(392));
+const path = __importStar(__nccwpck_require__(523));
+const core = __importStar(__nccwpck_require__(475));
+const exec = __importStar(__nccwpck_require__(19));
+const io = __importStar(__nccwpck_require__(300));
+const cache_encrypt_js_1 = __nccwpck_require__(239);
 /**
  * Resolve the encryption config for a cache call. Callers pass `encryption`
  * explicitly for tests; in production they pass `cacheKey` and let the
@@ -90078,7 +90529,7 @@ function parseLevel(value) {
  * Bubbles non-zero exit codes from either side.
  */
 async function runPipe(producer, consumer) {
-    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 202, 23));
+    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 199, 23));
     const [pCmd, pArgs] = producer;
     const [cCmd, cArgs] = consumer;
     await new Promise((resolve, reject) => {
@@ -90118,7 +90569,7 @@ async function runPipe(producer, consumer) {
 
 /***/ }),
 
-/***/ 481:
+/***/ 482:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -90163,7 +90614,7 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 482:
+/***/ 483:
 /***/ ((module) => {
 
 "use strict";
@@ -90222,7 +90673,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 483:
+/***/ 484:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -90247,7 +90698,7 @@ __export(debug_exports, {
   default: () => debug_default
 });
 module.exports = __toCommonJS(debug_exports);
-var import_log = __nccwpck_require__(503);
+var import_log = __nccwpck_require__(504);
 const debugEnvVariable = typeof process !== "undefined" && process.env && process.env.DEBUG || void 0;
 let enabledString;
 let enabledNamespaces = [];
@@ -90412,7 +90863,7 @@ var debug_default = debugObj;
 
 /***/ }),
 
-/***/ 484:
+/***/ 485:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* eslint-env browser */
@@ -90672,7 +91123,7 @@ function localstorage() {
 	}
 }
 
-module.exports = __nccwpck_require__(149)(exports);
+module.exports = __nccwpck_require__(146)(exports);
 
 const {formatters} = module.exports;
 
@@ -90691,7 +91142,7 @@ formatters.j = function (v) {
 
 /***/ }),
 
-/***/ 485:
+/***/ 486:
 /***/ ((module) => {
 
 "use strict";
@@ -90699,7 +91150,7 @@ module.exports = /*#__PURE__*/JSON.parse('{"name":"@actions/cache","version":"4.
 
 /***/ }),
 
-/***/ 486:
+/***/ 487:
 /***/ ((module) => {
 
 "use strict";
@@ -90707,7 +91158,7 @@ module.exports = require("events");
 
 /***/ }),
 
-/***/ 487:
+/***/ 488:
 /***/ ((module) => {
 
 "use strict";
@@ -90738,7 +91189,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 488:
+/***/ 489:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -91012,7 +91463,7 @@ var KnownStorageErrorCode;
 
 /***/ }),
 
-/***/ 489:
+/***/ 490:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -91039,7 +91490,7 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_policies = __nccwpck_require__(294);
+var import_policies = __nccwpck_require__(292);
 const proxyPolicyName = import_policies.proxyPolicyName;
 function getDefaultProxySettings(proxyUrl) {
   return (0, import_policies.getDefaultProxySettings)(proxyUrl);
@@ -91053,7 +91504,7 @@ function proxyPolicy(proxySettings, options) {
 
 /***/ }),
 
-/***/ 490:
+/***/ 491:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -91088,9 +91539,9 @@ exports.attachCredential = attachCredential;
 exports.httpAuthorizationToString = httpAuthorizationToString;
 exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
-const core_rest_pipeline_1 = __nccwpck_require__(107);
-const core_util_1 = __nccwpck_require__(16);
-const constants_js_1 = __nccwpck_require__(40);
+const core_rest_pipeline_1 = __nccwpck_require__(104);
+const core_util_1 = __nccwpck_require__(15);
+const constants_js_1 = __nccwpck_require__(38);
 /**
  * Reserved URL characters must be properly escaped for Storage services like Blob or File.
  *
@@ -91633,7 +92084,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 491:
+/***/ 492:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -91658,7 +92109,7 @@ __export(delay_exports, {
   calculateRetryDelay: () => calculateRetryDelay
 });
 module.exports = __toCommonJS(delay_exports);
-var import_random = __nccwpck_require__(521);
+var import_random = __nccwpck_require__(522);
 function calculateRetryDelay(retryAttempt, config) {
   const exponentialDelay = config.retryDelayInMs * Math.pow(2, retryAttempt);
   const clampedDelay = Math.min(config.maxRetryDelayInMs, exponentialDelay);
@@ -91672,7 +92123,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 492:
+/***/ 493:
 /***/ ((module) => {
 
 "use strict";
@@ -91715,7 +92166,7 @@ module.exports = class DecoratorHandler {
 
 /***/ }),
 
-/***/ 493:
+/***/ 494:
 /***/ ((module) => {
 
 "use strict";
@@ -91737,13 +92188,13 @@ module.exports = function basename (path) {
 
 /***/ }),
 
-/***/ 494:
+/***/ 495:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = __nccwpck_require__(486)
+const EventEmitter = __nccwpck_require__(487)
 
 class Dispatcher extends EventEmitter {
   dispatch () {
@@ -91764,14 +92215,14 @@ module.exports = Dispatcher
 
 /***/ }),
 
-/***/ 495:
+/***/ 496:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceType = void 0;
-const reflection_info_1 = __nccwpck_require__(543);
+const reflection_info_1 = __nccwpck_require__(544);
 class ServiceType {
     constructor(typeName, methods, options) {
         this.typeName = typeName;
@@ -91784,7 +92235,7 @@ exports.ServiceType = ServiceType;
 
 /***/ }),
 
-/***/ 496:
+/***/ 497:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -91794,10 +92245,10 @@ exports.ServiceType = ServiceType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
-const tslib_1 = __nccwpck_require__(220);
-const base64 = tslib_1.__importStar(__nccwpck_require__(450));
-const interfaces_js_1 = __nccwpck_require__(105);
-const utils_js_1 = __nccwpck_require__(322);
+const tslib_1 = __nccwpck_require__(219);
+const base64 = tslib_1.__importStar(__nccwpck_require__(451));
+const interfaces_js_1 = __nccwpck_require__(102);
+const utils_js_1 = __nccwpck_require__(320);
 class SerializerImpl {
     modelMappers;
     isXML;
@@ -92717,7 +93168,7 @@ exports.MapperTypeNames = {
 
 /***/ }),
 
-/***/ 497:
+/***/ 498:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -92726,24 +93177,24 @@ exports.MapperTypeNames = {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = void 0;
-const logger_1 = __nccwpck_require__(48);
+const logger_1 = __nccwpck_require__(46);
 exports.logger = (0, logger_1.createClientLogger)("core-client");
 //# sourceMappingURL=log.js.map
 
 /***/ }),
 
-/***/ 498:
+/***/ 499:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Writable } = __nccwpck_require__(135)
-const diagnosticsChannel = __nccwpck_require__(147)
-const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(482)
-const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(104)
-const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(63)
-const { WebsocketFrameSend } = __nccwpck_require__(191)
+const { Writable } = __nccwpck_require__(132)
+const diagnosticsChannel = __nccwpck_require__(144)
+const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(483)
+const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(101)
+const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(60)
+const { WebsocketFrameSend } = __nccwpck_require__(188)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -93084,7 +93535,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 499:
+/***/ 500:
 /***/ ((module) => {
 
 "use strict";
@@ -93108,7 +93559,7 @@ module.exports = function getLimit (limits, name, defaultLimit) {
 
 /***/ }),
 
-/***/ 500:
+/***/ 501:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -93159,7 +93610,7 @@ exports.assertFloat32 = assertFloat32;
 
 /***/ }),
 
-/***/ 501:
+/***/ 502:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -93272,11 +93723,11 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 502:
+/***/ 503:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __nccwpck_require__(362);
-var balanced = __nccwpck_require__(136);
+var concatMap = __nccwpck_require__(361);
+var balanced = __nccwpck_require__(133);
 
 module.exports = expandTop;
 
@@ -93482,7 +93933,7 @@ function expand(str, max, isTop) {
 
 /***/ }),
 
-/***/ 503:
+/***/ 504:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -93517,9 +93968,9 @@ __export(log_exports, {
   log: () => log
 });
 module.exports = __toCommonJS(log_exports);
-var import_node_os = __nccwpck_require__(393);
-var import_node_util = __toESM(__nccwpck_require__(385));
-var import_node_process = __toESM(__nccwpck_require__(242));
+var import_node_os = __nccwpck_require__(392);
+var import_node_util = __toESM(__nccwpck_require__(384));
+var import_node_process = __toESM(__nccwpck_require__(240));
 function log(message, ...args) {
   import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
 }
@@ -93530,7 +93981,7 @@ function log(message, ...args) {
 
 /***/ }),
 
-/***/ 504:
+/***/ 505:
 /***/ ((module) => {
 
 "use strict";
@@ -93768,7 +94219,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 505:
+/***/ 506:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -93780,10 +94231,10 @@ exports.serializationPolicyName = void 0;
 exports.serializationPolicy = serializationPolicy;
 exports.serializeHeaders = serializeHeaders;
 exports.serializeRequestBody = serializeRequestBody;
-const interfaces_js_1 = __nccwpck_require__(105);
-const operationHelpers_js_1 = __nccwpck_require__(444);
-const serializer_js_1 = __nccwpck_require__(496);
-const interfaceHelpers_js_1 = __nccwpck_require__(411);
+const interfaces_js_1 = __nccwpck_require__(102);
+const operationHelpers_js_1 = __nccwpck_require__(445);
+const serializer_js_1 = __nccwpck_require__(497);
+const interfaceHelpers_js_1 = __nccwpck_require__(412);
 /**
  * The programmatic identifier of the serializationPolicy.
  */
@@ -93932,19 +94383,19 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 /***/ }),
 
-/***/ 506:
+/***/ 507:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(523);
-var tls = __nccwpck_require__(520);
-var http = __nccwpck_require__(338);
-var https = __nccwpck_require__(76);
-var events = __nccwpck_require__(486);
-var assert = __nccwpck_require__(542);
-var util = __nccwpck_require__(128);
+var net = __nccwpck_require__(524);
+var tls = __nccwpck_require__(521);
+var http = __nccwpck_require__(336);
+var https = __nccwpck_require__(73);
+var events = __nccwpck_require__(487);
+var assert = __nccwpck_require__(543);
+var util = __nccwpck_require__(125);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -94204,7 +94655,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 507:
+/***/ 508:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -94230,14 +94681,14 @@ __export(clientHelpers_exports, {
   getCachedDefaultHttpsClient: () => getCachedDefaultHttpsClient
 });
 module.exports = __toCommonJS(clientHelpers_exports);
-var import_defaultHttpClient = __nccwpck_require__(382);
-var import_createPipelineFromOptions = __nccwpck_require__(325);
-var import_apiVersionPolicy = __nccwpck_require__(232);
-var import_credentials = __nccwpck_require__(192);
-var import_apiKeyAuthenticationPolicy = __nccwpck_require__(93);
-var import_basicAuthenticationPolicy = __nccwpck_require__(159);
-var import_bearerAuthenticationPolicy = __nccwpck_require__(391);
-var import_oauth2AuthenticationPolicy = __nccwpck_require__(347);
+var import_defaultHttpClient = __nccwpck_require__(381);
+var import_createPipelineFromOptions = __nccwpck_require__(323);
+var import_apiVersionPolicy = __nccwpck_require__(230);
+var import_credentials = __nccwpck_require__(189);
+var import_apiKeyAuthenticationPolicy = __nccwpck_require__(90);
+var import_basicAuthenticationPolicy = __nccwpck_require__(156);
+var import_bearerAuthenticationPolicy = __nccwpck_require__(390);
+var import_oauth2AuthenticationPolicy = __nccwpck_require__(345);
 let cachedHttpClient;
 function createDefaultPipeline(options = {}) {
   const pipeline = (0, import_createPipelineFromOptions.createPipelineFromOptions)(options);
@@ -94277,7 +94728,7 @@ function getCachedDefaultHttpsClient() {
 
 /***/ }),
 
-/***/ 508:
+/***/ 509:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -94286,8 +94737,8 @@ function getCachedDefaultHttpsClient() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetriableReadableStream = void 0;
-const abort_controller_1 = __nccwpck_require__(511);
-const node_stream_1 = __nccwpck_require__(442);
+const abort_controller_1 = __nccwpck_require__(512);
+const node_stream_1 = __nccwpck_require__(443);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -94415,21 +94866,6 @@ exports.RetriableReadableStream = RetriableReadableStream;
 
 /***/ }),
 
-/***/ 509:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(515);
-Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
-//# sourceMappingURL=index.js.map
-
-/***/ }),
-
 /***/ 510:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -94439,7 +94875,7 @@ Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function 
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AbortError = void 0;
-var AbortError_js_1 = __nccwpck_require__(513);
+var AbortError_js_1 = __nccwpck_require__(516);
 Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
 //# sourceMappingURL=index.js.map
 
@@ -94461,6 +94897,21 @@ Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function 
 /***/ }),
 
 /***/ 512:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.AbortError = void 0;
+var AbortError_js_1 = __nccwpck_require__(515);
+Object.defineProperty(exports, "AbortError", ({ enumerable: true, get: function () { return AbortError_js_1.AbortError; } }));
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 513:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -94510,44 +94961,6 @@ function isBlob(x) {
 0 && (0);
 //# sourceMappingURL=typeGuards.js.map
 
-
-/***/ }),
-
-/***/ 513:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AbortError = void 0;
-/**
- * This error is thrown when an asynchronous operation has been aborted.
- * Check for this error by testing the `name` that the name property of the
- * error matches `"AbortError"`.
- *
- * @example
- * ```ts
- * const controller = new AbortController();
- * controller.abort();
- * try {
- *   doAsyncWork(controller.signal)
- * } catch (e) {
- *   if (e.name === 'AbortError') {
- *     // handle abort error here.
- *   }
- * }
- * ```
- */
-class AbortError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = "AbortError";
-    }
-}
-exports.AbortError = AbortError;
-//# sourceMappingURL=AbortError.js.map
 
 /***/ }),
 
@@ -94628,6 +95041,44 @@ exports.AbortError = AbortError;
 /***/ }),
 
 /***/ 516:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.AbortError = void 0;
+/**
+ * This error is thrown when an asynchronous operation has been aborted.
+ * Check for this error by testing the `name` that the name property of the
+ * error matches `"AbortError"`.
+ *
+ * @example
+ * ```ts
+ * const controller = new AbortController();
+ * controller.abort();
+ * try {
+ *   doAsyncWork(controller.signal)
+ * } catch (e) {
+ *   if (e.name === 'AbortError') {
+ *     // handle abort error here.
+ *   }
+ * }
+ * ```
+ */
+class AbortError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "AbortError";
+    }
+}
+exports.AbortError = AbortError;
+//# sourceMappingURL=AbortError.js.map
+
+/***/ }),
+
+/***/ 517:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -94636,8 +95087,8 @@ exports.AbortError = AbortError;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQuickQueryStream = void 0;
-const node_stream_1 = __nccwpck_require__(442);
-const index_js_1 = __nccwpck_require__(344);
+const node_stream_1 = __nccwpck_require__(443);
+const index_js_1 = __nccwpck_require__(342);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -94754,7 +95205,7 @@ exports.BlobQuickQueryStream = BlobQuickQueryStream;
 
 /***/ }),
 
-/***/ 517:
+/***/ 518:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -94783,13 +95234,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
-const os = __importStar(__nccwpck_require__(98));
-const path = __importStar(__nccwpck_require__(256));
-const pathHelper = __importStar(__nccwpck_require__(226));
-const assert_1 = __importDefault(__nccwpck_require__(542));
-const minimatch_1 = __nccwpck_require__(129);
-const internal_match_kind_1 = __nccwpck_require__(544);
-const internal_path_1 = __nccwpck_require__(125);
+const os = __importStar(__nccwpck_require__(95));
+const path = __importStar(__nccwpck_require__(254));
+const pathHelper = __importStar(__nccwpck_require__(224));
+const assert_1 = __importDefault(__nccwpck_require__(543));
+const minimatch_1 = __nccwpck_require__(126);
+const internal_match_kind_1 = __nccwpck_require__(545);
+const internal_path_1 = __nccwpck_require__(122);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, isImplicitPattern = false, segments, homedir) {
@@ -95016,7 +95467,7 @@ exports.Pattern = Pattern;
 
 /***/ }),
 
-/***/ 518:
+/***/ 519:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -95220,7 +95671,7 @@ exports.BlobSASPermissions = BlobSASPermissions;
 
 /***/ }),
 
-/***/ 519:
+/***/ 520:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -95267,7 +95718,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 520:
+/***/ 521:
 /***/ ((module) => {
 
 "use strict";
@@ -95275,7 +95726,7 @@ module.exports = require("tls");
 
 /***/ }),
 
-/***/ 521:
+/***/ 522:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -95313,7 +95764,7 @@ function getRandomIntegerInclusive(min, max) {
 
 /***/ }),
 
-/***/ 522:
+/***/ 523:
 /***/ ((module) => {
 
 "use strict";
@@ -95321,7 +95772,7 @@ module.exports = require("node:path");
 
 /***/ }),
 
-/***/ 523:
+/***/ 524:
 /***/ ((module) => {
 
 "use strict";
@@ -95329,7 +95780,7 @@ module.exports = require("net");
 
 /***/ }),
 
-/***/ 524:
+/***/ 525:
 /***/ ((module) => {
 
 "use strict";
@@ -95337,21 +95788,21 @@ module.exports = require("timers");
 
 /***/ }),
 
-/***/ 525:
+/***/ 526:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Readable = __nccwpck_require__(133)
+const Readable = __nccwpck_require__(130)
 const {
   InvalidArgumentError,
   RequestAbortedError
-} = __nccwpck_require__(504)
-const util = __nccwpck_require__(75)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(193)
-const { AsyncResource } = __nccwpck_require__(441)
-const { addSignal, removeSignal } = __nccwpck_require__(109)
+} = __nccwpck_require__(505)
+const util = __nccwpck_require__(72)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(190)
+const { AsyncResource } = __nccwpck_require__(442)
+const { addSignal, removeSignal } = __nccwpck_require__(106)
 
 class RequestHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -95525,7 +95976,7 @@ module.exports.RequestHandler = RequestHandler
 
 /***/ }),
 
-/***/ 526:
+/***/ 527:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -95541,14 +95992,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TestTransport = void 0;
-const rpc_error_1 = __nccwpck_require__(180);
-const runtime_1 = __nccwpck_require__(21);
-const rpc_output_stream_1 = __nccwpck_require__(316);
-const rpc_options_1 = __nccwpck_require__(301);
-const unary_call_1 = __nccwpck_require__(62);
-const server_streaming_call_1 = __nccwpck_require__(464);
-const client_streaming_call_1 = __nccwpck_require__(360);
-const duplex_streaming_call_1 = __nccwpck_require__(315);
+const rpc_error_1 = __nccwpck_require__(177);
+const runtime_1 = __nccwpck_require__(20);
+const rpc_output_stream_1 = __nccwpck_require__(314);
+const rpc_options_1 = __nccwpck_require__(299);
+const unary_call_1 = __nccwpck_require__(59);
+const server_streaming_call_1 = __nccwpck_require__(465);
+const client_streaming_call_1 = __nccwpck_require__(359);
+const duplex_streaming_call_1 = __nccwpck_require__(313);
 /**
  * Transport for testing.
  */
@@ -95854,7 +96305,7 @@ class TestInputStream {
 
 /***/ }),
 
-/***/ 527:
+/***/ 528:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -95902,8 +96353,8 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._internal = void 0;
 exports.installPassthrough = installPassthrough;
-const fs = __importStar(__nccwpck_require__(257));
-const path = __importStar(__nccwpck_require__(522));
+const fs = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(523));
 const STUB_VERSION = "passthrough";
 function bashStub() {
     return `#!/usr/bin/env bash
@@ -96012,30 +96463,30 @@ exports._internal = { bashStub, cmdStub, STUB_VERSION };
 
 /***/ }),
 
-/***/ 528:
+/***/ 529:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isTokenCredential = exports.isSASCredential = exports.AzureSASCredential = exports.isNamedKeyCredential = exports.AzureNamedKeyCredential = exports.isKeyCredential = exports.AzureKeyCredential = void 0;
-var azureKeyCredential_js_1 = __nccwpck_require__(306);
+var azureKeyCredential_js_1 = __nccwpck_require__(304);
 Object.defineProperty(exports, "AzureKeyCredential", ({ enumerable: true, get: function () { return azureKeyCredential_js_1.AzureKeyCredential; } }));
-var keyCredential_js_1 = __nccwpck_require__(42);
+var keyCredential_js_1 = __nccwpck_require__(40);
 Object.defineProperty(exports, "isKeyCredential", ({ enumerable: true, get: function () { return keyCredential_js_1.isKeyCredential; } }));
 var azureNamedKeyCredential_js_1 = __nccwpck_require__(7);
 Object.defineProperty(exports, "AzureNamedKeyCredential", ({ enumerable: true, get: function () { return azureNamedKeyCredential_js_1.AzureNamedKeyCredential; } }));
 Object.defineProperty(exports, "isNamedKeyCredential", ({ enumerable: true, get: function () { return azureNamedKeyCredential_js_1.isNamedKeyCredential; } }));
-var azureSASCredential_js_1 = __nccwpck_require__(37);
+var azureSASCredential_js_1 = __nccwpck_require__(35);
 Object.defineProperty(exports, "AzureSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.AzureSASCredential; } }));
 Object.defineProperty(exports, "isSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.isSASCredential; } }));
-var tokenCredential_js_1 = __nccwpck_require__(255);
+var tokenCredential_js_1 = __nccwpck_require__(253);
 Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: function () { return tokenCredential_js_1.isTokenCredential; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 529:
+/***/ 530:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /**
@@ -96044,15 +96495,15 @@ Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: fu
  */
 
 if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
-	module.exports = __nccwpck_require__(484);
+	module.exports = __nccwpck_require__(485);
 } else {
-	module.exports = __nccwpck_require__(471);
+	module.exports = __nccwpck_require__(472);
 }
 
 
 /***/ }),
 
-/***/ 530:
+/***/ 531:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -96060,17 +96511,17 @@ if (typeof process === 'undefined' || process.type === 'renderer' || process.bro
 
 
 
-const { kHeadersList, kConstruct } = __nccwpck_require__(200)
-const { kGuard } = __nccwpck_require__(17)
-const { kEnumerableProperty } = __nccwpck_require__(75)
+const { kHeadersList, kConstruct } = __nccwpck_require__(197)
+const { kGuard } = __nccwpck_require__(16)
+const { kEnumerableProperty } = __nccwpck_require__(72)
 const {
   makeIterator,
   isValidHeaderName,
   isValidHeaderValue
-} = __nccwpck_require__(532)
-const util = __nccwpck_require__(128)
-const { webidl } = __nccwpck_require__(470)
-const assert = __nccwpck_require__(542)
+} = __nccwpck_require__(533)
+const util = __nccwpck_require__(125)
+const { webidl } = __nccwpck_require__(471)
+const assert = __nccwpck_require__(543)
 
 const kHeadersMap = Symbol('headers map')
 const kHeadersSortedMap = Symbol('headers map sorted')
@@ -96653,7 +97104,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 531:
+/***/ 532:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -96701,7 +97152,7 @@ exports.markPhase = markPhase;
 exports.finishPhase = finishPhase;
 exports.setupPhaseSummaryOneLine = setupPhaseSummaryOneLine;
 exports.timeSubPhase = timeSubPhase;
-const core = __importStar(__nccwpck_require__(474));
+const core = __importStar(__nccwpck_require__(475));
 function phaseEnvName(name) {
     const cleaned = name.replace(/[^A-Za-z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase() || "PHASE";
     return `SETUP_SOLDR_PHASE_${cleaned}_START_MS`;
@@ -96839,18 +97290,18 @@ function readSubPhaseDurations(parent) {
 
 /***/ }),
 
-/***/ 532:
+/***/ 533:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(33)
-const { getGlobalOrigin } = __nccwpck_require__(145)
-const { performance } = __nccwpck_require__(330)
-const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(75)
-const assert = __nccwpck_require__(542)
-const { isUint8Array } = __nccwpck_require__(203)
+const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(32)
+const { getGlobalOrigin } = __nccwpck_require__(142)
+const { performance } = __nccwpck_require__(328)
+const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(72)
+const assert = __nccwpck_require__(543)
+const { isUint8Array } = __nccwpck_require__(200)
 
 let supportedHashes = []
 
@@ -96859,7 +97310,7 @@ let supportedHashes = []
 let crypto
 
 try {
-  crypto = __nccwpck_require__(299)
+  crypto = __nccwpck_require__(297)
   const possibleRelevantHashes = ['sha256', 'sha384', 'sha512']
   supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
 /* c8 ignore next 3 */
@@ -97812,7 +98263,7 @@ let ReadableStream = globalThis.ReadableStream
 
 function isReadableStreamLike (stream) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(265).ReadableStream)
+    ReadableStream = (__nccwpck_require__(263).ReadableStream)
   }
 
   return stream instanceof ReadableStream || (
@@ -97991,7 +98442,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 533:
+/***/ 534:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -98067,7 +98518,7 @@ exports.Mutex = Mutex;
 
 /***/ }),
 
-/***/ 534:
+/***/ 535:
 /***/ ((module) => {
 
 "use strict";
@@ -98075,15 +98526,15 @@ module.exports = require("node:zlib");
 
 /***/ }),
 
-/***/ 535:
+/***/ 536:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(506);
+module.exports = __nccwpck_require__(507);
 
 
 /***/ }),
 
-/***/ 536:
+/***/ 537:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -98109,9 +98560,9 @@ __export(throttlingRetryPolicy_exports, {
   throttlingRetryPolicyName: () => throttlingRetryPolicyName
 });
 module.exports = __toCommonJS(throttlingRetryPolicy_exports);
-var import_throttlingRetryStrategy = __nccwpck_require__(39);
-var import_retryPolicy = __nccwpck_require__(18);
-var import_constants = __nccwpck_require__(52);
+var import_throttlingRetryStrategy = __nccwpck_require__(37);
+var import_retryPolicy = __nccwpck_require__(17);
+var import_constants = __nccwpck_require__(50);
 const throttlingRetryPolicyName = "throttlingRetryPolicy";
 function throttlingRetryPolicy(options = {}) {
   return {
@@ -98128,7 +98579,7 @@ function throttlingRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 537:
+/***/ 538:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -98167,19 +98618,19 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.evaluateVersions = exports.isExplicitVersion = exports.findFromManifest = exports.getManifestFromRepo = exports.findAllVersions = exports.find = exports.cacheFile = exports.cacheDir = exports.extractZip = exports.extractXar = exports.extractTar = exports.extract7z = exports.downloadTool = exports.HTTPError = void 0;
-const core = __importStar(__nccwpck_require__(474));
-const io = __importStar(__nccwpck_require__(302));
-const crypto = __importStar(__nccwpck_require__(299));
-const fs = __importStar(__nccwpck_require__(546));
-const mm = __importStar(__nccwpck_require__(340));
-const os = __importStar(__nccwpck_require__(98));
-const path = __importStar(__nccwpck_require__(256));
-const httpm = __importStar(__nccwpck_require__(293));
-const semver = __importStar(__nccwpck_require__(183));
-const stream = __importStar(__nccwpck_require__(135));
-const util = __importStar(__nccwpck_require__(128));
-const assert_1 = __nccwpck_require__(542);
-const exec_1 = __nccwpck_require__(20);
+const core = __importStar(__nccwpck_require__(475));
+const io = __importStar(__nccwpck_require__(300));
+const crypto = __importStar(__nccwpck_require__(297));
+const fs = __importStar(__nccwpck_require__(547));
+const mm = __importStar(__nccwpck_require__(338));
+const os = __importStar(__nccwpck_require__(95));
+const path = __importStar(__nccwpck_require__(254));
+const httpm = __importStar(__nccwpck_require__(291));
+const semver = __importStar(__nccwpck_require__(180));
+const stream = __importStar(__nccwpck_require__(132));
+const util = __importStar(__nccwpck_require__(125));
+const assert_1 = __nccwpck_require__(543);
+const exec_1 = __nccwpck_require__(19);
 const retry_helper_1 = __nccwpck_require__(10);
 class HTTPError extends Error {
     constructor(httpStatusCode) {
@@ -98801,7 +99252,7 @@ function _unique(values) {
 
 /***/ }),
 
-/***/ 538:
+/***/ 539:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -98827,9 +99278,9 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(407);
-var import_retryPolicy = __nccwpck_require__(18);
-var import_constants = __nccwpck_require__(52);
+var import_exponentialRetryStrategy = __nccwpck_require__(408);
+var import_retryPolicy = __nccwpck_require__(17);
+var import_constants = __nccwpck_require__(50);
 const exponentialRetryPolicyName = "exponentialRetryPolicy";
 function exponentialRetryPolicy(options = {}) {
   return (0, import_retryPolicy.retryPolicy)(
@@ -98851,7 +99302,7 @@ function exponentialRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 539:
+/***/ 540:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -99065,7 +99516,7 @@ function createEmptyPipeline() {
 
 /***/ }),
 
-/***/ 540:
+/***/ 541:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -99118,10 +99569,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureShimsLegacy = ensureShimsLegacy;
 exports.tryDelegateToSoldrToolchainLink = tryDelegateToSoldrToolchainLink;
 exports.ensureShims = ensureShims;
-const fs = __importStar(__nccwpck_require__(257));
-const path = __importStar(__nccwpck_require__(522));
-const core = __importStar(__nccwpck_require__(474));
-const soldr_toolchain_client_js_1 = __nccwpck_require__(349);
+const fs = __importStar(__nccwpck_require__(255));
+const path = __importStar(__nccwpck_require__(523));
+const core = __importStar(__nccwpck_require__(475));
+const soldr_toolchain_client_js_1 = __nccwpck_require__(347);
 // Tools that route through `soldr <tool>`:
 const ROUTED_TOOLS = ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"];
 // Unix bash shim template (per tool):
@@ -99225,7 +99676,7 @@ async function ensureShims(opts) {
 
 /***/ }),
 
-/***/ 541:
+/***/ 542:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -99234,8 +99685,8 @@ async function ensureShims(opts) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SASQueryParameters = exports.SASProtocol = void 0;
-const SasIPRange_js_1 = __nccwpck_require__(369);
-const utils_common_js_1 = __nccwpck_require__(161);
+const SasIPRange_js_1 = __nccwpck_require__(368);
+const utils_common_js_1 = __nccwpck_require__(158);
 /**
  * Protocols for generated SAS.
  */
@@ -99599,7 +100050,7 @@ exports.SASQueryParameters = SASQueryParameters;
 
 /***/ }),
 
-/***/ 542:
+/***/ 543:
 /***/ ((module) => {
 
 "use strict";
@@ -99607,14 +100058,14 @@ module.exports = require("assert");
 
 /***/ }),
 
-/***/ 543:
+/***/ 544:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.readServiceOption = exports.readMethodOption = exports.readMethodOptions = exports.normalizeMethodInfo = void 0;
-const runtime_1 = __nccwpck_require__(21);
+const runtime_1 = __nccwpck_require__(20);
 /**
  * Turns PartialMethodInfo into MethodInfo.
  */
@@ -99672,7 +100123,7 @@ exports.readServiceOption = readServiceOption;
 
 /***/ }),
 
-/***/ 544:
+/***/ 545:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -99697,27 +100148,27 @@ var MatchKind;
 
 /***/ }),
 
-/***/ 545:
+/***/ 546:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(417);
-const reflection_info_1 = __nccwpck_require__(466);
-const reflection_type_check_1 = __nccwpck_require__(298);
-const reflection_json_reader_1 = __nccwpck_require__(352);
-const reflection_json_writer_1 = __nccwpck_require__(96);
-const reflection_binary_reader_1 = __nccwpck_require__(419);
-const reflection_binary_writer_1 = __nccwpck_require__(190);
-const reflection_create_1 = __nccwpck_require__(210);
-const reflection_merge_partial_1 = __nccwpck_require__(142);
-const json_typings_1 = __nccwpck_require__(406);
-const json_format_contract_1 = __nccwpck_require__(247);
-const reflection_equals_1 = __nccwpck_require__(476);
-const binary_writer_1 = __nccwpck_require__(259);
-const binary_reader_1 = __nccwpck_require__(140);
+const message_type_contract_1 = __nccwpck_require__(418);
+const reflection_info_1 = __nccwpck_require__(467);
+const reflection_type_check_1 = __nccwpck_require__(296);
+const reflection_json_reader_1 = __nccwpck_require__(350);
+const reflection_json_writer_1 = __nccwpck_require__(93);
+const reflection_binary_reader_1 = __nccwpck_require__(420);
+const reflection_binary_writer_1 = __nccwpck_require__(187);
+const reflection_create_1 = __nccwpck_require__(207);
+const reflection_merge_partial_1 = __nccwpck_require__(139);
+const json_typings_1 = __nccwpck_require__(407);
+const json_format_contract_1 = __nccwpck_require__(245);
+const reflection_equals_1 = __nccwpck_require__(477);
+const binary_writer_1 = __nccwpck_require__(257);
+const binary_reader_1 = __nccwpck_require__(137);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
 const messageTypeDescriptor = baseDescriptors[message_type_contract_1.MESSAGE_TYPE] = {};
 /**
@@ -99882,7 +100333,7 @@ exports.MessageType = MessageType;
 
 /***/ }),
 
-/***/ 546:
+/***/ 547:
 /***/ ((module) => {
 
 "use strict";
@@ -99890,14 +100341,14 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 547:
+/***/ 548:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.stackDuplexStreamingInterceptors = exports.stackClientStreamingInterceptors = exports.stackServerStreamingInterceptors = exports.stackUnaryInterceptors = exports.stackIntercept = void 0;
-const runtime_1 = __nccwpck_require__(21);
+const runtime_1 = __nccwpck_require__(20);
 /**
  * Creates a "stack" of of all interceptors specified in the given `RpcOptions`.
  * Used by generated client implementations.
@@ -99972,7 +100423,7 @@ exports.stackDuplexStreamingInterceptors = stackDuplexStreamingInterceptors;
 
 /***/ }),
 
-/***/ 548:
+/***/ 549:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -100002,8 +100453,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(98));
-const utils_1 = __nccwpck_require__(519);
+const os = __importStar(__nccwpck_require__(95));
+const utils_1 = __nccwpck_require__(520);
 /**
  * Commands
  *
@@ -100075,7 +100526,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 549:
+/***/ 550:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -100084,8 +100535,8 @@ function escapeProperty(s) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBeginCopyFromUrlPoller = void 0;
-const core_util_1 = __nccwpck_require__(16);
-const core_lro_1 = __nccwpck_require__(231);
+const core_util_1 = __nccwpck_require__(15);
+const core_lro_1 = __nccwpck_require__(229);
 /**
  * This is the poller returned by {@link BlobClient.beginCopyFromURL}.
  * This can not be instantiated directly outside of this package.
@@ -100320,7 +100771,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(379);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(216);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/dist/post.js
+++ b/dist/post.js
@@ -11293,6 +11293,909 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
+/***/ 58036:
+/***/ (function(module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports._readLinuxVersionFile = exports._getOsVersion = exports._findMatch = void 0;
+const semver = __importStar(__nccwpck_require__(39318));
+const core_1 = __nccwpck_require__(37484);
+// needs to be require for core node modules to be mocked
+/* eslint @typescript-eslint/no-require-imports: 0 */
+const os = __nccwpck_require__(70857);
+const cp = __nccwpck_require__(35317);
+const fs = __nccwpck_require__(79896);
+function _findMatch(versionSpec, stable, candidates, archFilter) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const platFilter = os.platform();
+        let result;
+        let match;
+        let file;
+        for (const candidate of candidates) {
+            const version = candidate.version;
+            (0, core_1.debug)(`check ${version} satisfies ${versionSpec}`);
+            if (semver.satisfies(version, versionSpec) &&
+                (!stable || candidate.stable === stable)) {
+                file = candidate.files.find(item => {
+                    (0, core_1.debug)(`${item.arch}===${archFilter} && ${item.platform}===${platFilter}`);
+                    let chk = item.arch === archFilter && item.platform === platFilter;
+                    if (chk && item.platform_version) {
+                        const osVersion = module.exports._getOsVersion();
+                        if (osVersion === item.platform_version) {
+                            chk = true;
+                        }
+                        else {
+                            chk = semver.satisfies(osVersion, item.platform_version);
+                        }
+                    }
+                    return chk;
+                });
+                if (file) {
+                    (0, core_1.debug)(`matched ${candidate.version}`);
+                    match = candidate;
+                    break;
+                }
+            }
+        }
+        if (match && file) {
+            // clone since we're mutating the file list to be only the file that matches
+            result = Object.assign({}, match);
+            result.files = [file];
+        }
+        return result;
+    });
+}
+exports._findMatch = _findMatch;
+function _getOsVersion() {
+    // TODO: add windows and other linux, arm variants
+    // right now filtering on version is only an ubuntu and macos scenario for tools we build for hosted (python)
+    const plat = os.platform();
+    let version = '';
+    if (plat === 'darwin') {
+        version = cp.execSync('sw_vers -productVersion').toString();
+    }
+    else if (plat === 'linux') {
+        // lsb_release process not in some containers, readfile
+        // Run cat /etc/lsb-release
+        // DISTRIB_ID=Ubuntu
+        // DISTRIB_RELEASE=18.04
+        // DISTRIB_CODENAME=bionic
+        // DISTRIB_DESCRIPTION="Ubuntu 18.04.4 LTS"
+        const lsbContents = module.exports._readLinuxVersionFile();
+        if (lsbContents) {
+            const lines = lsbContents.split('\n');
+            for (const line of lines) {
+                const parts = line.split('=');
+                if (parts.length === 2 &&
+                    (parts[0].trim() === 'VERSION_ID' ||
+                        parts[0].trim() === 'DISTRIB_RELEASE')) {
+                    version = parts[1].trim().replace(/^"/, '').replace(/"$/, '');
+                    break;
+                }
+            }
+        }
+    }
+    return version;
+}
+exports._getOsVersion = _getOsVersion;
+function _readLinuxVersionFile() {
+    const lsbReleaseFile = '/etc/lsb-release';
+    const osReleaseFile = '/etc/os-release';
+    let contents = '';
+    if (fs.existsSync(lsbReleaseFile)) {
+        contents = fs.readFileSync(lsbReleaseFile).toString();
+    }
+    else if (fs.existsSync(osReleaseFile)) {
+        contents = fs.readFileSync(osReleaseFile).toString();
+    }
+    return contents;
+}
+exports._readLinuxVersionFile = _readLinuxVersionFile;
+//# sourceMappingURL=manifest.js.map
+
+/***/ }),
+
+/***/ 67380:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.RetryHelper = void 0;
+const core = __importStar(__nccwpck_require__(37484));
+/**
+ * Internal class for retries
+ */
+class RetryHelper {
+    constructor(maxAttempts, minSeconds, maxSeconds) {
+        if (maxAttempts < 1) {
+            throw new Error('max attempts should be greater than or equal to 1');
+        }
+        this.maxAttempts = maxAttempts;
+        this.minSeconds = Math.floor(minSeconds);
+        this.maxSeconds = Math.floor(maxSeconds);
+        if (this.minSeconds > this.maxSeconds) {
+            throw new Error('min seconds should be less than or equal to max seconds');
+        }
+    }
+    execute(action, isRetryable) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let attempt = 1;
+            while (attempt < this.maxAttempts) {
+                // Try
+                try {
+                    return yield action();
+                }
+                catch (err) {
+                    if (isRetryable && !isRetryable(err)) {
+                        throw err;
+                    }
+                    core.info(err.message);
+                }
+                // Sleep
+                const seconds = this.getSleepAmount();
+                core.info(`Waiting ${seconds} seconds before trying again`);
+                yield this.sleep(seconds);
+                attempt++;
+            }
+            // Last attempt
+            return yield action();
+        });
+    }
+    getSleepAmount() {
+        return (Math.floor(Math.random() * (this.maxSeconds - this.minSeconds + 1)) +
+            this.minSeconds);
+    }
+    sleep(seconds) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return new Promise(resolve => setTimeout(resolve, seconds * 1000));
+        });
+    }
+}
+exports.RetryHelper = RetryHelper;
+//# sourceMappingURL=retry-helper.js.map
+
+/***/ }),
+
+/***/ 33472:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.evaluateVersions = exports.isExplicitVersion = exports.findFromManifest = exports.getManifestFromRepo = exports.findAllVersions = exports.find = exports.cacheFile = exports.cacheDir = exports.extractZip = exports.extractXar = exports.extractTar = exports.extract7z = exports.downloadTool = exports.HTTPError = void 0;
+const core = __importStar(__nccwpck_require__(37484));
+const io = __importStar(__nccwpck_require__(94994));
+const crypto = __importStar(__nccwpck_require__(76982));
+const fs = __importStar(__nccwpck_require__(79896));
+const mm = __importStar(__nccwpck_require__(58036));
+const os = __importStar(__nccwpck_require__(70857));
+const path = __importStar(__nccwpck_require__(16928));
+const httpm = __importStar(__nccwpck_require__(54844));
+const semver = __importStar(__nccwpck_require__(39318));
+const stream = __importStar(__nccwpck_require__(2203));
+const util = __importStar(__nccwpck_require__(39023));
+const assert_1 = __nccwpck_require__(42613);
+const exec_1 = __nccwpck_require__(95236);
+const retry_helper_1 = __nccwpck_require__(67380);
+class HTTPError extends Error {
+    constructor(httpStatusCode) {
+        super(`Unexpected HTTP response: ${httpStatusCode}`);
+        this.httpStatusCode = httpStatusCode;
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
+}
+exports.HTTPError = HTTPError;
+const IS_WINDOWS = process.platform === 'win32';
+const IS_MAC = process.platform === 'darwin';
+const userAgent = 'actions/tool-cache';
+/**
+ * Download a tool from an url and stream it into a file
+ *
+ * @param url       url of tool to download
+ * @param dest      path to download tool
+ * @param auth      authorization header
+ * @param headers   other headers
+ * @returns         path to downloaded tool
+ */
+function downloadTool(url, dest, auth, headers) {
+    return __awaiter(this, void 0, void 0, function* () {
+        dest = dest || path.join(_getTempDirectory(), crypto.randomUUID());
+        yield io.mkdirP(path.dirname(dest));
+        core.debug(`Downloading ${url}`);
+        core.debug(`Destination ${dest}`);
+        const maxAttempts = 3;
+        const minSeconds = _getGlobal('TEST_DOWNLOAD_TOOL_RETRY_MIN_SECONDS', 10);
+        const maxSeconds = _getGlobal('TEST_DOWNLOAD_TOOL_RETRY_MAX_SECONDS', 20);
+        const retryHelper = new retry_helper_1.RetryHelper(maxAttempts, minSeconds, maxSeconds);
+        return yield retryHelper.execute(() => __awaiter(this, void 0, void 0, function* () {
+            return yield downloadToolAttempt(url, dest || '', auth, headers);
+        }), (err) => {
+            if (err instanceof HTTPError && err.httpStatusCode) {
+                // Don't retry anything less than 500, except 408 Request Timeout and 429 Too Many Requests
+                if (err.httpStatusCode < 500 &&
+                    err.httpStatusCode !== 408 &&
+                    err.httpStatusCode !== 429) {
+                    return false;
+                }
+            }
+            // Otherwise retry
+            return true;
+        });
+    });
+}
+exports.downloadTool = downloadTool;
+function downloadToolAttempt(url, dest, auth, headers) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (fs.existsSync(dest)) {
+            throw new Error(`Destination file path ${dest} already exists`);
+        }
+        // Get the response headers
+        const http = new httpm.HttpClient(userAgent, [], {
+            allowRetries: false
+        });
+        if (auth) {
+            core.debug('set auth');
+            if (headers === undefined) {
+                headers = {};
+            }
+            headers.authorization = auth;
+        }
+        const response = yield http.get(url, headers);
+        if (response.message.statusCode !== 200) {
+            const err = new HTTPError(response.message.statusCode);
+            core.debug(`Failed to download from "${url}". Code(${response.message.statusCode}) Message(${response.message.statusMessage})`);
+            throw err;
+        }
+        // Download the response body
+        const pipeline = util.promisify(stream.pipeline);
+        const responseMessageFactory = _getGlobal('TEST_DOWNLOAD_TOOL_RESPONSE_MESSAGE_FACTORY', () => response.message);
+        const readStream = responseMessageFactory();
+        let succeeded = false;
+        try {
+            yield pipeline(readStream, fs.createWriteStream(dest));
+            core.debug('download complete');
+            succeeded = true;
+            return dest;
+        }
+        finally {
+            // Error, delete dest before retry
+            if (!succeeded) {
+                core.debug('download failed');
+                try {
+                    yield io.rmRF(dest);
+                }
+                catch (err) {
+                    core.debug(`Failed to delete '${dest}'. ${err.message}`);
+                }
+            }
+        }
+    });
+}
+/**
+ * Extract a .7z file
+ *
+ * @param file     path to the .7z file
+ * @param dest     destination directory. Optional.
+ * @param _7zPath  path to 7zr.exe. Optional, for long path support. Most .7z archives do not have this
+ * problem. If your .7z archive contains very long paths, you can pass the path to 7zr.exe which will
+ * gracefully handle long paths. By default 7zdec.exe is used because it is a very small program and is
+ * bundled with the tool lib. However it does not support long paths. 7zr.exe is the reduced command line
+ * interface, it is smaller than the full command line interface, and it does support long paths. At the
+ * time of this writing, it is freely available from the LZMA SDK that is available on the 7zip website.
+ * Be sure to check the current license agreement. If 7zr.exe is bundled with your action, then the path
+ * to 7zr.exe can be pass to this function.
+ * @returns        path to the destination directory
+ */
+function extract7z(file, dest, _7zPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        (0, assert_1.ok)(IS_WINDOWS, 'extract7z() not supported on current OS');
+        (0, assert_1.ok)(file, 'parameter "file" is required');
+        dest = yield _createExtractFolder(dest);
+        const originalCwd = process.cwd();
+        process.chdir(dest);
+        if (_7zPath) {
+            try {
+                const logLevel = core.isDebug() ? '-bb1' : '-bb0';
+                const args = [
+                    'x',
+                    logLevel,
+                    '-bd',
+                    '-sccUTF-8',
+                    file
+                ];
+                const options = {
+                    silent: true
+                };
+                yield (0, exec_1.exec)(`"${_7zPath}"`, args, options);
+            }
+            finally {
+                process.chdir(originalCwd);
+            }
+        }
+        else {
+            const escapedScript = path
+                .join(__dirname, '..', 'scripts', 'Invoke-7zdec.ps1')
+                .replace(/'/g, "''")
+                .replace(/"|\n|\r/g, ''); // double-up single quotes, remove double quotes and newlines
+            const escapedFile = file.replace(/'/g, "''").replace(/"|\n|\r/g, '');
+            const escapedTarget = dest.replace(/'/g, "''").replace(/"|\n|\r/g, '');
+            const command = `& '${escapedScript}' -Source '${escapedFile}' -Target '${escapedTarget}'`;
+            const args = [
+                '-NoLogo',
+                '-Sta',
+                '-NoProfile',
+                '-NonInteractive',
+                '-ExecutionPolicy',
+                'Unrestricted',
+                '-Command',
+                command
+            ];
+            const options = {
+                silent: true
+            };
+            try {
+                const powershellPath = yield io.which('powershell', true);
+                yield (0, exec_1.exec)(`"${powershellPath}"`, args, options);
+            }
+            finally {
+                process.chdir(originalCwd);
+            }
+        }
+        return dest;
+    });
+}
+exports.extract7z = extract7z;
+/**
+ * Extract a compressed tar archive
+ *
+ * @param file     path to the tar
+ * @param dest     destination directory. Optional.
+ * @param flags    flags for the tar command to use for extraction. Defaults to 'xz' (extracting gzipped tars). Optional.
+ * @returns        path to the destination directory
+ */
+function extractTar(file, dest, flags = 'xz') {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!file) {
+            throw new Error("parameter 'file' is required");
+        }
+        // Create dest
+        dest = yield _createExtractFolder(dest);
+        // Determine whether GNU tar
+        core.debug('Checking tar --version');
+        let versionOutput = '';
+        yield (0, exec_1.exec)('tar --version', [], {
+            ignoreReturnCode: true,
+            silent: true,
+            listeners: {
+                stdout: (data) => (versionOutput += data.toString()),
+                stderr: (data) => (versionOutput += data.toString())
+            }
+        });
+        core.debug(versionOutput.trim());
+        const isGnuTar = versionOutput.toUpperCase().includes('GNU TAR');
+        // Initialize args
+        let args;
+        if (flags instanceof Array) {
+            args = flags;
+        }
+        else {
+            args = [flags];
+        }
+        if (core.isDebug() && !flags.includes('v')) {
+            args.push('-v');
+        }
+        let destArg = dest;
+        let fileArg = file;
+        if (IS_WINDOWS && isGnuTar) {
+            args.push('--force-local');
+            destArg = dest.replace(/\\/g, '/');
+            // Technically only the dest needs to have `/` but for aesthetic consistency
+            // convert slashes in the file arg too.
+            fileArg = file.replace(/\\/g, '/');
+        }
+        if (isGnuTar) {
+            // Suppress warnings when using GNU tar to extract archives created by BSD tar
+            args.push('--warning=no-unknown-keyword');
+            args.push('--overwrite');
+        }
+        args.push('-C', destArg, '-f', fileArg);
+        yield (0, exec_1.exec)(`tar`, args);
+        return dest;
+    });
+}
+exports.extractTar = extractTar;
+/**
+ * Extract a xar compatible archive
+ *
+ * @param file     path to the archive
+ * @param dest     destination directory. Optional.
+ * @param flags    flags for the xar. Optional.
+ * @returns        path to the destination directory
+ */
+function extractXar(file, dest, flags = []) {
+    return __awaiter(this, void 0, void 0, function* () {
+        (0, assert_1.ok)(IS_MAC, 'extractXar() not supported on current OS');
+        (0, assert_1.ok)(file, 'parameter "file" is required');
+        dest = yield _createExtractFolder(dest);
+        let args;
+        if (flags instanceof Array) {
+            args = flags;
+        }
+        else {
+            args = [flags];
+        }
+        args.push('-x', '-C', dest, '-f', file);
+        if (core.isDebug()) {
+            args.push('-v');
+        }
+        const xarPath = yield io.which('xar', true);
+        yield (0, exec_1.exec)(`"${xarPath}"`, _unique(args));
+        return dest;
+    });
+}
+exports.extractXar = extractXar;
+/**
+ * Extract a zip
+ *
+ * @param file     path to the zip
+ * @param dest     destination directory. Optional.
+ * @returns        path to the destination directory
+ */
+function extractZip(file, dest) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!file) {
+            throw new Error("parameter 'file' is required");
+        }
+        dest = yield _createExtractFolder(dest);
+        if (IS_WINDOWS) {
+            yield extractZipWin(file, dest);
+        }
+        else {
+            yield extractZipNix(file, dest);
+        }
+        return dest;
+    });
+}
+exports.extractZip = extractZip;
+function extractZipWin(file, dest) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // build the powershell command
+        const escapedFile = file.replace(/'/g, "''").replace(/"|\n|\r/g, ''); // double-up single quotes, remove double quotes and newlines
+        const escapedDest = dest.replace(/'/g, "''").replace(/"|\n|\r/g, '');
+        const pwshPath = yield io.which('pwsh', false);
+        //To match the file overwrite behavior on nix systems, we use the overwrite = true flag for ExtractToDirectory
+        //and the -Force flag for Expand-Archive as a fallback
+        if (pwshPath) {
+            //attempt to use pwsh with ExtractToDirectory, if this fails attempt Expand-Archive
+            const pwshCommand = [
+                `$ErrorActionPreference = 'Stop' ;`,
+                `try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ;`,
+                `try { [System.IO.Compression.ZipFile]::ExtractToDirectory('${escapedFile}', '${escapedDest}', $true) }`,
+                `catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath '${escapedFile}' -DestinationPath '${escapedDest}' -Force } else { throw $_ } } ;`
+            ].join(' ');
+            const args = [
+                '-NoLogo',
+                '-NoProfile',
+                '-NonInteractive',
+                '-ExecutionPolicy',
+                'Unrestricted',
+                '-Command',
+                pwshCommand
+            ];
+            core.debug(`Using pwsh at path: ${pwshPath}`);
+            yield (0, exec_1.exec)(`"${pwshPath}"`, args);
+        }
+        else {
+            const powershellCommand = [
+                `$ErrorActionPreference = 'Stop' ;`,
+                `try { Add-Type -AssemblyName System.IO.Compression.FileSystem } catch { } ;`,
+                `if ((Get-Command -Name Expand-Archive -Module Microsoft.PowerShell.Archive -ErrorAction Ignore)) { Expand-Archive -LiteralPath '${escapedFile}' -DestinationPath '${escapedDest}' -Force }`,
+                `else {[System.IO.Compression.ZipFile]::ExtractToDirectory('${escapedFile}', '${escapedDest}', $true) }`
+            ].join(' ');
+            const args = [
+                '-NoLogo',
+                '-Sta',
+                '-NoProfile',
+                '-NonInteractive',
+                '-ExecutionPolicy',
+                'Unrestricted',
+                '-Command',
+                powershellCommand
+            ];
+            const powershellPath = yield io.which('powershell', true);
+            core.debug(`Using powershell at path: ${powershellPath}`);
+            yield (0, exec_1.exec)(`"${powershellPath}"`, args);
+        }
+    });
+}
+function extractZipNix(file, dest) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const unzipPath = yield io.which('unzip', true);
+        const args = [file];
+        if (!core.isDebug()) {
+            args.unshift('-q');
+        }
+        args.unshift('-o'); //overwrite with -o, otherwise a prompt is shown which freezes the run
+        yield (0, exec_1.exec)(`"${unzipPath}"`, args, { cwd: dest });
+    });
+}
+/**
+ * Caches a directory and installs it into the tool cacheDir
+ *
+ * @param sourceDir    the directory to cache into tools
+ * @param tool          tool name
+ * @param version       version of the tool.  semver format
+ * @param arch          architecture of the tool.  Optional.  Defaults to machine architecture
+ */
+function cacheDir(sourceDir, tool, version, arch) {
+    return __awaiter(this, void 0, void 0, function* () {
+        version = semver.clean(version) || version;
+        arch = arch || os.arch();
+        core.debug(`Caching tool ${tool} ${version} ${arch}`);
+        core.debug(`source dir: ${sourceDir}`);
+        if (!fs.statSync(sourceDir).isDirectory()) {
+            throw new Error('sourceDir is not a directory');
+        }
+        // Create the tool dir
+        const destPath = yield _createToolPath(tool, version, arch);
+        // copy each child item. do not move. move can fail on Windows
+        // due to anti-virus software having an open handle on a file.
+        for (const itemName of fs.readdirSync(sourceDir)) {
+            const s = path.join(sourceDir, itemName);
+            yield io.cp(s, destPath, { recursive: true });
+        }
+        // write .complete
+        _completeToolPath(tool, version, arch);
+        return destPath;
+    });
+}
+exports.cacheDir = cacheDir;
+/**
+ * Caches a downloaded file (GUID) and installs it
+ * into the tool cache with a given targetName
+ *
+ * @param sourceFile    the file to cache into tools.  Typically a result of downloadTool which is a guid.
+ * @param targetFile    the name of the file name in the tools directory
+ * @param tool          tool name
+ * @param version       version of the tool.  semver format
+ * @param arch          architecture of the tool.  Optional.  Defaults to machine architecture
+ */
+function cacheFile(sourceFile, targetFile, tool, version, arch) {
+    return __awaiter(this, void 0, void 0, function* () {
+        version = semver.clean(version) || version;
+        arch = arch || os.arch();
+        core.debug(`Caching tool ${tool} ${version} ${arch}`);
+        core.debug(`source file: ${sourceFile}`);
+        if (!fs.statSync(sourceFile).isFile()) {
+            throw new Error('sourceFile is not a file');
+        }
+        // create the tool dir
+        const destFolder = yield _createToolPath(tool, version, arch);
+        // copy instead of move. move can fail on Windows due to
+        // anti-virus software having an open handle on a file.
+        const destPath = path.join(destFolder, targetFile);
+        core.debug(`destination file ${destPath}`);
+        yield io.cp(sourceFile, destPath);
+        // write .complete
+        _completeToolPath(tool, version, arch);
+        return destFolder;
+    });
+}
+exports.cacheFile = cacheFile;
+/**
+ * Finds the path to a tool version in the local installed tool cache
+ *
+ * @param toolName      name of the tool
+ * @param versionSpec   version of the tool
+ * @param arch          optional arch.  defaults to arch of computer
+ */
+function find(toolName, versionSpec, arch) {
+    if (!toolName) {
+        throw new Error('toolName parameter is required');
+    }
+    if (!versionSpec) {
+        throw new Error('versionSpec parameter is required');
+    }
+    arch = arch || os.arch();
+    // attempt to resolve an explicit version
+    if (!isExplicitVersion(versionSpec)) {
+        const localVersions = findAllVersions(toolName, arch);
+        const match = evaluateVersions(localVersions, versionSpec);
+        versionSpec = match;
+    }
+    // check for the explicit version in the cache
+    let toolPath = '';
+    if (versionSpec) {
+        versionSpec = semver.clean(versionSpec) || '';
+        const cachePath = path.join(_getCacheDirectory(), toolName, versionSpec, arch);
+        core.debug(`checking cache: ${cachePath}`);
+        if (fs.existsSync(cachePath) && fs.existsSync(`${cachePath}.complete`)) {
+            core.debug(`Found tool in cache ${toolName} ${versionSpec} ${arch}`);
+            toolPath = cachePath;
+        }
+        else {
+            core.debug('not found');
+        }
+    }
+    return toolPath;
+}
+exports.find = find;
+/**
+ * Finds the paths to all versions of a tool that are installed in the local tool cache
+ *
+ * @param toolName  name of the tool
+ * @param arch      optional arch.  defaults to arch of computer
+ */
+function findAllVersions(toolName, arch) {
+    const versions = [];
+    arch = arch || os.arch();
+    const toolPath = path.join(_getCacheDirectory(), toolName);
+    if (fs.existsSync(toolPath)) {
+        const children = fs.readdirSync(toolPath);
+        for (const child of children) {
+            if (isExplicitVersion(child)) {
+                const fullPath = path.join(toolPath, child, arch || '');
+                if (fs.existsSync(fullPath) && fs.existsSync(`${fullPath}.complete`)) {
+                    versions.push(child);
+                }
+            }
+        }
+    }
+    return versions;
+}
+exports.findAllVersions = findAllVersions;
+function getManifestFromRepo(owner, repo, auth, branch = 'master') {
+    return __awaiter(this, void 0, void 0, function* () {
+        let releases = [];
+        const treeUrl = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}`;
+        const http = new httpm.HttpClient('tool-cache');
+        const headers = {};
+        if (auth) {
+            core.debug('set auth');
+            headers.authorization = auth;
+        }
+        const response = yield http.getJson(treeUrl, headers);
+        if (!response.result) {
+            return releases;
+        }
+        let manifestUrl = '';
+        for (const item of response.result.tree) {
+            if (item.path === 'versions-manifest.json') {
+                manifestUrl = item.url;
+                break;
+            }
+        }
+        headers['accept'] = 'application/vnd.github.VERSION.raw';
+        let versionsRaw = yield (yield http.get(manifestUrl, headers)).readBody();
+        if (versionsRaw) {
+            // shouldn't be needed but protects against invalid json saved with BOM
+            versionsRaw = versionsRaw.replace(/^\uFEFF/, '');
+            try {
+                releases = JSON.parse(versionsRaw);
+            }
+            catch (_a) {
+                core.debug('Invalid json');
+            }
+        }
+        return releases;
+    });
+}
+exports.getManifestFromRepo = getManifestFromRepo;
+function findFromManifest(versionSpec, stable, manifest, archFilter = os.arch()) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // wrap the internal impl
+        const match = yield mm._findMatch(versionSpec, stable, manifest, archFilter);
+        return match;
+    });
+}
+exports.findFromManifest = findFromManifest;
+function _createExtractFolder(dest) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!dest) {
+            // create a temp dir
+            dest = path.join(_getTempDirectory(), crypto.randomUUID());
+        }
+        yield io.mkdirP(dest);
+        return dest;
+    });
+}
+function _createToolPath(tool, version, arch) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const folderPath = path.join(_getCacheDirectory(), tool, semver.clean(version) || version, arch || '');
+        core.debug(`destination ${folderPath}`);
+        const markerPath = `${folderPath}.complete`;
+        yield io.rmRF(folderPath);
+        yield io.rmRF(markerPath);
+        yield io.mkdirP(folderPath);
+        return folderPath;
+    });
+}
+function _completeToolPath(tool, version, arch) {
+    const folderPath = path.join(_getCacheDirectory(), tool, semver.clean(version) || version, arch || '');
+    const markerPath = `${folderPath}.complete`;
+    fs.writeFileSync(markerPath, '');
+    core.debug('finished caching tool');
+}
+/**
+ * Check if version string is explicit
+ *
+ * @param versionSpec      version string to check
+ */
+function isExplicitVersion(versionSpec) {
+    const c = semver.clean(versionSpec) || '';
+    core.debug(`isExplicit: ${c}`);
+    const valid = semver.valid(c) != null;
+    core.debug(`explicit? ${valid}`);
+    return valid;
+}
+exports.isExplicitVersion = isExplicitVersion;
+/**
+ * Get the highest satisfiying semantic version in `versions` which satisfies `versionSpec`
+ *
+ * @param versions        array of versions to evaluate
+ * @param versionSpec     semantic version spec to satisfy
+ */
+function evaluateVersions(versions, versionSpec) {
+    let version = '';
+    core.debug(`evaluating ${versions.length} versions`);
+    versions = versions.sort((a, b) => {
+        if (semver.gt(a, b)) {
+            return 1;
+        }
+        return -1;
+    });
+    for (let i = versions.length - 1; i >= 0; i--) {
+        const potential = versions[i];
+        const satisfied = semver.satisfies(potential, versionSpec);
+        if (satisfied) {
+            version = potential;
+            break;
+        }
+    }
+    if (version) {
+        core.debug(`matched: ${version}`);
+    }
+    else {
+        core.debug('match not found');
+    }
+    return version;
+}
+exports.evaluateVersions = evaluateVersions;
+/**
+ * Gets RUNNER_TOOL_CACHE
+ */
+function _getCacheDirectory() {
+    const cacheDirectory = process.env['RUNNER_TOOL_CACHE'] || '';
+    (0, assert_1.ok)(cacheDirectory, 'Expected RUNNER_TOOL_CACHE to be defined');
+    return cacheDirectory;
+}
+/**
+ * Gets RUNNER_TEMP
+ */
+function _getTempDirectory() {
+    const tempDirectory = process.env['RUNNER_TEMP'] || '';
+    (0, assert_1.ok)(tempDirectory, 'Expected RUNNER_TEMP to be defined');
+    return tempDirectory;
+}
+/**
+ * Gets a global variable
+ */
+function _getGlobal(key, defaultValue) {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const value = global[key];
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    return value !== undefined ? value : defaultValue;
+}
+/**
+ * Returns an array of unique values.
+ * @param values Values to make unique.
+ */
+function _unique(values) {
+    return Array.from(new Set(values));
+}
+//# sourceMappingURL=tool-cache.js.map
+
+/***/ }),
+
 /***/ 68110:
 /***/ ((__unused_webpack_module, exports) => {
 
@@ -46203,6 +47106,407 @@ async function evictIfOverBudget(policy, deps) {
 
 /***/ }),
 
+/***/ 43408:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.cargoRegistryArchiveFormat = cargoRegistryArchiveFormat;
+exports.planCargoRegistryArchive = planCargoRegistryArchive;
+exports.cargoRegistryPayloadPaths = cargoRegistryPayloadPaths;
+exports.cargoRegistryZstdAsset = cargoRegistryZstdAsset;
+exports.resolveCargoRegistryZstd = resolveCargoRegistryZstd;
+exports.writeCargoRegistryExtrasArchive = writeCargoRegistryExtrasArchive;
+exports.extractCargoRegistryExtrasArchive = extractCargoRegistryExtrasArchive;
+exports.cargoRegistryPayloadCensus = cargoRegistryPayloadCensus;
+exports.saveCargoRegistryArchive = saveCargoRegistryArchive;
+exports.restoreCargoRegistryArchive = restoreCargoRegistryArchive;
+const fs = __importStar(__nccwpck_require__(51455));
+const os = __importStar(__nccwpck_require__(48161));
+const path = __importStar(__nccwpck_require__(76760));
+const node_crypto_1 = __nccwpck_require__(77598);
+const node_child_process_1 = __nccwpck_require__(31421);
+const io = __importStar(__nccwpck_require__(94994));
+const tc = __importStar(__nccwpck_require__(33472));
+const cache_compress_js_1 = __nccwpck_require__(24978);
+const soldr_load_shim_js_1 = __nccwpck_require__(18084);
+const OPTIONAL_EXTRA_BASENAMES = [".global-cache", "git"];
+function cargoRegistryArchiveFormat(input) {
+    return input.viaSoldr && !input.encrypted && !input.sourceRef && input.runtimeCompatible !== false
+        ? "soldr-v2"
+        : "legacy-v1";
+}
+function planCargoRegistryArchive(input) {
+    if (input.format === "legacy-v1") {
+        const registryArchivePath = `${path.join(input.cargoHome, "registry")}.tar.zst`;
+        return {
+            format: input.format,
+            registryArchivePath,
+            extrasArchivePath: "",
+            restorePaths: [registryArchivePath],
+        };
+    }
+    const root = path.join(input.runnerTemp, "setup-soldr-cargo-registry", "v2");
+    const registryArchivePath = path.join(root, "registry.soldr.tar.zst");
+    const extrasArchivePath = path.join(root, "extras.tar.zst");
+    return {
+        format: input.format,
+        registryArchivePath,
+        extrasArchivePath,
+        restorePaths: [registryArchivePath, extrasArchivePath],
+    };
+}
+async function exists(target) {
+    try {
+        await fs.stat(target);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+async function cargoRegistryPayloadPaths(cargoHome) {
+    const registry = path.join(cargoHome, "registry");
+    const extras = [];
+    for (const basename of OPTIONAL_EXTRA_BASENAMES) {
+        const candidate = path.join(cargoHome, basename);
+        if (await exists(candidate))
+            extras.push(candidate);
+    }
+    return { registry, extras };
+}
+function runPipe(producer, consumer) {
+    return new Promise((resolve, reject) => {
+        const prod = (0, node_child_process_1.spawn)(producer[0], producer[1], { stdio: ["ignore", "pipe", "inherit"] });
+        const cons = (0, node_child_process_1.spawn)(consumer[0], consumer[1], { stdio: ["pipe", "inherit", "inherit"] });
+        prod.once("error", reject);
+        cons.once("error", reject);
+        prod.stdout?.pipe(cons.stdin);
+        let producerExit = null;
+        let consumerExit = null;
+        const done = () => {
+            if (producerExit === null || consumerExit === null)
+                return;
+            if (producerExit !== 0)
+                reject(new Error(`${producer[0]} exited with code ${producerExit}`));
+            else if (consumerExit !== 0)
+                reject(new Error(`${consumer[0]} exited with code ${consumerExit}`));
+            else
+                resolve();
+        };
+        prod.once("close", (code) => { producerExit = code ?? 0; done(); });
+        cons.once("close", (code) => { consumerExit = code ?? 0; done(); });
+    });
+}
+const CARGO_REGISTRY_ZSTD_VERSION = "1.5.7";
+const CARGO_REGISTRY_ZSTD_WIN64_SHA256 = "acb4e8111511749dc7a3ebedca9b04190e37a17afeb73f55d4425dbf0b90fad9";
+function cargoRegistryZstdAsset(arch = process.arch) {
+    if (arch === "ia32") {
+        throw new Error("cargo-registry Soldr v2 does not support 32-bit Windows runners");
+    }
+    return `https://github.com/facebook/zstd/releases/download/v${CARGO_REGISTRY_ZSTD_VERSION}/zstd-v${CARGO_REGISTRY_ZSTD_VERSION}-win64.zip`;
+}
+async function findNamedFile(root, basename) {
+    let entries;
+    try {
+        entries = await fs.readdir(root, { withFileTypes: true });
+    }
+    catch {
+        return null;
+    }
+    for (const entry of entries) {
+        const full = path.join(root, entry.name);
+        if (entry.isFile() && entry.name.toLowerCase() === basename.toLowerCase())
+            return full;
+        if (entry.isDirectory()) {
+            const nested = await findNamedFile(full, basename);
+            if (nested)
+                return nested;
+        }
+    }
+    return null;
+}
+async function resolveCargoRegistryZstd() {
+    const existing = await io.which("zstd", false);
+    if (existing)
+        return existing;
+    if (process.platform !== "win32") {
+        throw new Error("cargo-registry Soldr v2 requires zstd on PATH outside Windows");
+    }
+    const root = path.join(process.env["RUNNER_TEMP"] || os.tmpdir(), "setup-soldr-tools", `zstd-${CARGO_REGISTRY_ZSTD_VERSION}-${process.arch}`);
+    const cached = await findNamedFile(root, "zstd.exe");
+    if (cached)
+        return cached;
+    await fs.mkdir(root, { recursive: true });
+    const zipPath = path.join(root, "zstd.zip");
+    await tc.downloadTool(cargoRegistryZstdAsset(), zipPath);
+    const digest = (0, node_crypto_1.createHash)("sha256").update(await fs.readFile(zipPath)).digest("hex");
+    if (digest !== CARGO_REGISTRY_ZSTD_WIN64_SHA256) {
+        throw new Error(`downloaded zstd archive failed SHA-256 verification (got ${digest})`);
+    }
+    const extracted = await tc.extractZip(zipPath, path.join(root, "extracted"));
+    const downloaded = await findNamedFile(extracted, "zstd.exe");
+    if (!downloaded)
+        throw new Error("downloaded zstd archive did not contain zstd.exe");
+    return downloaded;
+}
+async function writeCargoRegistryExtrasArchive(cargoHome, extras, archivePath) {
+    await fs.mkdir(path.dirname(archivePath), { recursive: true });
+    const manifestRoot = await fs.mkdtemp(path.join(os.tmpdir(), "setup-soldr-cargo-extras-"));
+    const manifestPath = path.join(manifestRoot, "manifest.txt");
+    try {
+        const basenames = extras.map((entry) => path.basename(entry));
+        await fs.writeFile(manifestPath, basenames.map((entry) => `${entry}\n`).join(""), "utf8");
+        const zstd = await resolveCargoRegistryZstd();
+        await runPipe(["tar", ["-cf", "-", "-C", cargoHome, "-T", manifestPath]], [zstd, ["-T0", "-3", "-f", "-o", archivePath]]);
+    }
+    finally {
+        await fs.rm(manifestRoot, { recursive: true, force: true }).catch(() => undefined);
+    }
+}
+async function extractCargoRegistryExtrasArchive(cargoHome, archivePath) {
+    const zstd = await resolveCargoRegistryZstd();
+    await fs.mkdir(cargoHome, { recursive: true });
+    await runPipe([zstd, ["-d", "-T0", "-c", archivePath]], ["tar", ["-xf", "-", "-C", cargoHome]]);
+}
+async function cargoRegistryPayloadCensus(cargoHome, topN) {
+    const payload = await cargoRegistryPayloadPaths(cargoHome);
+    const roots = [payload.registry, ...payload.extras];
+    const topFiles = [];
+    const topDirectories = [];
+    const topSubtrees = [];
+    let bytes = 0;
+    let files = 0;
+    let symlinks = 0;
+    let directories = 0;
+    const walk = async (entry, relative) => {
+        let stat;
+        try {
+            stat = await fs.lstat(entry);
+        }
+        catch {
+            return { bytes: 0, files: 0 };
+        }
+        if (stat.isSymbolicLink()) {
+            symlinks += 1;
+            return { bytes: 0, files: 0 };
+        }
+        if (stat.isFile()) {
+            bytes += stat.size;
+            files += 1;
+            topFiles.push({ path: relative, bytes: stat.size });
+            return { bytes: stat.size, files: 1 };
+        }
+        if (!stat.isDirectory())
+            return { bytes: 0, files: 0 };
+        directories += 1;
+        let directoryBytes = 0;
+        let directoryFiles = 0;
+        for (const child of await fs.readdir(entry)) {
+            const childStats = await walk(path.join(entry, child), path.join(relative, child));
+            directoryBytes += childStats.bytes;
+            directoryFiles += childStats.files;
+        }
+        topDirectories.push({ path: relative, bytes: directoryBytes });
+        return { bytes: directoryBytes, files: directoryFiles };
+    };
+    for (const root of roots) {
+        const basename = path.basename(root);
+        const subtree = await walk(root, basename);
+        topSubtrees.push({ path: basename, bytes: subtree.bytes, files: subtree.files });
+    }
+    const limit = Math.max(0, Math.min(50, Math.floor(topN)));
+    topFiles.sort((a, b) => b.bytes - a.bytes || a.path.localeCompare(b.path));
+    topDirectories.sort((a, b) => b.bytes - a.bytes || a.path.localeCompare(b.path));
+    topSubtrees.sort((a, b) => b.bytes - a.bytes || a.path.localeCompare(b.path));
+    return {
+        bytes,
+        files,
+        symlinks,
+        directories,
+        inputs: roots.map((entry) => path.basename(entry)),
+        topFiles: topFiles.slice(0, limit),
+        topDirectories: topDirectories.slice(0, limit),
+        topSubtrees: topSubtrees.slice(0, limit),
+        skipped: [],
+    };
+}
+async function treeStats(target) {
+    let bytes = 0;
+    let files = 0;
+    const walk = async (entry) => {
+        let stat;
+        try {
+            stat = await fs.lstat(entry);
+        }
+        catch {
+            return;
+        }
+        if (stat.isDirectory()) {
+            for (const child of await fs.readdir(entry))
+                await walk(path.join(entry, child));
+        }
+        else if (stat.isFile()) {
+            bytes += stat.size;
+            files += 1;
+        }
+    };
+    await walk(target);
+    return { bytes, files };
+}
+async function payloadStats(cargoHome) {
+    const payload = await cargoRegistryPayloadPaths(cargoHome);
+    const roots = [payload.registry, ...payload.extras];
+    let bytes = 0;
+    let files = 0;
+    for (const root of roots) {
+        const stats = await treeStats(root);
+        bytes += stats.bytes;
+        files += stats.files;
+    }
+    return { bytes, files };
+}
+async function saveCargoRegistryArchive(input) {
+    const started = Date.now();
+    const payload = await cargoRegistryPayloadPaths(input.cargoHome);
+    if (input.plan.format !== "soldr-v2") {
+        return { used: false, codecPath: "legacy-v1", archiveBytes: 0, restoredBytes: 0, restoredFiles: 0, durationMs: 0 };
+    }
+    if (!(0, soldr_load_shim_js_1.semverGte)(input.soldrVersion, soldr_load_shim_js_1.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP)) {
+        return { used: false, codecPath: "unsupported", archiveBytes: 0, restoredBytes: 0, restoredFiles: 0, durationMs: 0 };
+    }
+    await fs.mkdir(path.dirname(input.plan.registryArchivePath), { recursive: true });
+    await Promise.all([
+        fs.rm(input.plan.registryArchivePath, { force: true }),
+        fs.rm(input.plan.extrasArchivePath, { force: true }),
+    ]);
+    const registrySaved = input.operations?.saveRegistry
+        ? await input.operations.saveRegistry(payload.registry, input.plan.registryArchivePath)
+        : (await (0, soldr_load_shim_js_1.saveViaSoldr)({
+            cacheDir: payload.registry,
+            archivePath: input.plan.registryArchivePath,
+            soldrPath: input.soldrPath,
+            soldrVersion: input.soldrVersion,
+            debug: input.debug,
+            log: input.log,
+        })).used;
+    if (!registrySaved) {
+        throw new Error("Soldr v2 cargo-registry save did not produce a registry archive");
+    }
+    if (input.operations?.saveExtras) {
+        await input.operations.saveExtras(input.cargoHome, payload.extras, input.plan.extrasArchivePath);
+    }
+    else {
+        await writeCargoRegistryExtrasArchive(input.cargoHome, payload.extras, input.plan.extrasArchivePath);
+    }
+    const registryBytes = (await fs.stat(input.plan.registryArchivePath)).size;
+    const extrasBytes = (await fs.stat(input.plan.extrasArchivePath)).size;
+    const stats = await payloadStats(input.cargoHome);
+    return {
+        used: true,
+        codecPath: "soldr-v2",
+        archiveBytes: registryBytes + extrasBytes,
+        restoredBytes: stats.bytes,
+        restoredFiles: stats.files,
+        durationMs: Date.now() - started,
+    };
+}
+async function restoreCargoRegistryArchive(input) {
+    const started = Date.now();
+    if (input.plan.format === "legacy-v1") {
+        const result = await (0, cache_compress_js_1.decompressCache)({
+            archivePath: input.plan.registryArchivePath,
+            targetDir: path.join(input.cargoHome, "registry"),
+            cacheKey: input.cacheKey,
+            debug: input.debug,
+            log: input.log,
+        });
+        return {
+            used: true,
+            codecPath: "legacy-v1",
+            archiveBytes: result.archiveBytes,
+            restoredBytes: result.inflatedBytes,
+            restoredFiles: result.fileCount,
+            durationMs: Date.now() - started,
+        };
+    }
+    if (!(0, soldr_load_shim_js_1.semverGte)(input.soldrVersion, soldr_load_shim_js_1.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP)) {
+        return { used: false, codecPath: "unsupported", archiveBytes: 0, restoredBytes: 0, restoredFiles: 0, durationMs: 0 };
+    }
+    const registryLoaded = input.operations?.restoreRegistry
+        ? await input.operations.restoreRegistry(input.plan.registryArchivePath, path.join(input.cargoHome, "registry"))
+        : (await (0, soldr_load_shim_js_1.tryLoadViaSoldr)({
+            archivePath: input.plan.registryArchivePath,
+            targetDir: path.join(input.cargoHome, "registry"),
+            soldrPath: input.soldrPath,
+            soldrVersion: input.soldrVersion,
+            autoDefenderExclude: input.autoDefenderExclude,
+            debug: input.debug,
+            log: input.log,
+        })).used;
+    if (!registryLoaded) {
+        throw new Error("Soldr v2 cargo-registry archive is corrupt or incompatible");
+    }
+    if (await exists(input.plan.extrasArchivePath)) {
+        if (input.operations?.restoreExtras) {
+            await input.operations.restoreExtras(input.cargoHome, input.plan.extrasArchivePath);
+        }
+        else {
+            await extractCargoRegistryExtrasArchive(input.cargoHome, input.plan.extrasArchivePath);
+        }
+    }
+    const registryBytes = (await fs.stat(input.plan.registryArchivePath)).size;
+    const extrasBytes = await exists(input.plan.extrasArchivePath)
+        ? (await fs.stat(input.plan.extrasArchivePath)).size
+        : 0;
+    const stats = await payloadStats(input.cargoHome);
+    return {
+        used: true,
+        codecPath: "soldr-v2",
+        archiveBytes: registryBytes + extrasBytes,
+        restoredBytes: stats.bytes,
+        restoredFiles: stats.files,
+        durationMs: Date.now() - started,
+    };
+}
+
+
+/***/ }),
+
 /***/ 63355:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -48253,6 +49557,8 @@ function cachePlanLines(result) {
     lines.push(`    key=${result.cargoRegistryCache.key}`);
     lines.push(`    restore_prefix=${result.cargoRegistryCache.restorePrefix}`);
     lines.push(`    path=${result.cargoRegistryCache.path}`);
+    lines.push(`    archive_format=${result.cargoRegistryCache.archive.format}`);
+    lines.push(`    archive_paths=${JSON.stringify(result.cargoRegistryCache.archive.restorePaths)}`);
     // setup-soldr#102: sibling basenames bundled into the same archive.
     const extras = result.cargoRegistryCache.extraBasenames;
     lines.push(`    extra_basenames=${extras.length > 0 ? extras.join(",") : "(none)"}`);
@@ -49391,6 +50697,7 @@ exports.cargoRegistryViaSoldrEnvOn = cargoRegistryViaSoldrEnvOn;
 exports.semverGte = semverGte;
 exports.detectSoldrManifest = detectSoldrManifest;
 exports.tryLoadViaSoldr = tryLoadViaSoldr;
+exports.saveViaSoldr = saveViaSoldr;
 exports.trySaveViaSoldr = trySaveViaSoldr;
 const fs = __importStar(__nccwpck_require__(51455));
 const exec = __importStar(__nccwpck_require__(95236));
@@ -49518,22 +50825,14 @@ async function tryLoadViaSoldr(opts) {
     return { used: true, durationMs: Date.now() - t0 };
 }
 /**
- * Attempt to bundle the cache directory via `soldr save` so the matching
- * `soldr load` (in main.ts) can pick up the parallel-extract path. Returns
- * `{ used: false }` when gated off (env var, missing binary, too-old
- * version, extras present, or any throw). Produces a soldr-format archive
- * with `SOLDR_MANIFEST.pb` at the root + `cache/...` entries. (#263)
+ * Bundle a cache directory via `soldr save` after the caller has selected a
+ * Soldr-format plan. This deliberately does not re-read the rollout env var:
+ * the persisted plan is authoritative across the main/post process boundary.
  */
-async function trySaveViaSoldr(opts) {
+async function saveViaSoldr(opts) {
     const t0 = Date.now();
     const noOp = { used: false, archivePath: null, archiveBytes: 0, durationMs: 0 };
     const log = opts.log ?? (() => undefined);
-    if (!cargoRegistryViaSoldrEnvOn()) {
-        if (opts.debug) {
-            log(`[debug] soldr-save-shim: ${exports.CARGO_REGISTRY_VIA_SOLDR_ENV} not set; deferring to legacy tar+zstd save`);
-        }
-        return noOp;
-    }
     if (!opts.soldrPath) {
         if (opts.debug)
             log(`[debug] soldr-save-shim: no soldr binary path supplied`);
@@ -49542,12 +50841,6 @@ async function trySaveViaSoldr(opts) {
     if (!semverGte(opts.soldrVersion, exports.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP)) {
         if (opts.debug) {
             log(`[debug] soldr-save-shim: soldr ${opts.soldrVersion} < ${exports.MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP}; falling back to legacy save`);
-        }
-        return noOp;
-    }
-    if (opts.extraBasenames && opts.extraBasenames.length > 0) {
-        if (opts.debug) {
-            log(`[debug] soldr-save-shim: extraBasenames=[${opts.extraBasenames.join(",")}] not yet supported by soldr save; falling back to legacy`);
         }
         return noOp;
     }
@@ -49586,6 +50879,20 @@ async function trySaveViaSoldr(opts) {
         return noOp;
     }
     return { used: true, archivePath: opts.archivePath, archiveBytes, durationMs: Date.now() - t0 };
+}
+/**
+ * Compatibility wrapper for callers that have not resolved an archive plan.
+ * The rollout env gate is checked once here; planned v2 callers use
+ * [[saveViaSoldr]] directly so post-job environment drift cannot change format.
+ */
+async function trySaveViaSoldr(opts) {
+    if (!cargoRegistryViaSoldrEnvOn()) {
+        if (opts.debug) {
+            (opts.log ?? (() => undefined))(`[debug] soldr-save-shim: ${exports.CARGO_REGISTRY_VIA_SOLDR_ENV} not set; deferring to legacy tar+zstd save`);
+        }
+        return { used: false, archivePath: null, archiveBytes: 0, durationMs: 0 };
+    }
+    return saveViaSoldr(opts);
 }
 
 
@@ -51141,6 +52448,8 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.resolveJournalPrintRaw = resolveJournalPrintRaw;
+exports.applyCachePayloadOversizeAction = applyCachePayloadOversizeAction;
+exports.classifyCacheSaveReservation = classifyCacheSaveReservation;
 exports.resolveZccacheSessionJournalPath = resolveZccacheSessionJournalPath;
 exports.buildFinalCacheSummary = buildFinalCacheSummary;
 exports.formatFinalCacheSummaryMarkdown = formatFinalCacheSummaryMarkdown;
@@ -51162,7 +52471,7 @@ const soldr_mini_cache_js_1 = __nccwpck_require__(83756);
 // chunk files (e.g. @actions/artifact → @azure/identity inner chunks)
 // into `dist/` so they resolve at runtime — but converting our own
 // dynamic import to static is the cleaner shape regardless.
-const soldr_load_shim_js_1 = __nccwpck_require__(18084);
+const cargo_registry_archive_js_1 = __nccwpck_require__(43408);
 const log_utils_js_1 = __nccwpck_require__(28129);
 const shutdown_cache_js_1 = __nccwpck_require__(35326);
 const stats_collector_js_1 = __nccwpck_require__(51002);
@@ -51328,8 +52637,25 @@ function resolveCachePayloadPolicy(inputs, log) {
         topN: parseTopN(inputs.cachePayloadTopN, log),
     };
 }
+function applyCachePayloadOversizeAction(action, message, setFailed = core.setFailed) {
+    if (action === "fail") {
+        setFailed(message);
+        return "failed";
+    }
+    return "oversize-skip";
+}
+async function classifyCacheSaveReservation(id, key, probeExactKey) {
+    if (id > 0)
+        return "saved";
+    try {
+        return (await probeExactKey()) === key ? "race-skip" : "failed";
+    }
+    catch {
+        return "failed";
+    }
+}
 async function saveOne(opts) {
-    const { cacheDir, codec, level, key, matchedKey, label, debug, log, extraBasenames, payloadProfile, payloadPolicy, soldrSave } = opts;
+    const { cacheDir, codec, level, key, matchedKey, label, debug, log, extraBasenames, payloadProfile, payloadPolicy } = opts;
     const withStats = (r) => Object.assign(r, {
         archiveBytes: null,
         inflatedBytes: null,
@@ -51356,32 +52682,6 @@ async function saveOne(opts) {
     const compressStart = Date.now();
     let skippedReason;
     try {
-        // #263: try `soldr save` first when the caller opted in (env-gated
-        // inside trySaveViaSoldr). Produces a soldr-format archive that the
-        // matching `soldr load` on restore picks up for parallel extract.
-        // Falls through to legacy compressCache on any miss (no env, no
-        // binary, too-old version, extras present, throw).
-        if (soldrSave) {
-            const candidateArchive = `${cacheDir}.tar.zst`;
-            const sr = await (0, soldr_load_shim_js_1.trySaveViaSoldr)({
-                cacheDir,
-                archivePath: candidateArchive,
-                soldrPath: soldrSave.soldrPath,
-                soldrVersion: soldrSave.soldrVersion,
-                extraBasenames,
-                debug,
-                log,
-            });
-            if (sr.used) {
-                archivePath = sr.archivePath;
-                archiveBytes = sr.archiveBytes;
-                // inflatedBytes/fileCount/payload not collected on the soldr path —
-                // keep them null; postCollector accepts that shape.
-                compressMs = Date.now() - compressStart;
-                if (debug)
-                    log(`${label}: soldr save produced ${candidateArchive} (${archiveBytes} bytes, ${compressMs} ms)`);
-            }
-        }
         if (archivePath === null) {
             const result = await (0, cache_compress_js_1.compressCache)({
                 cacheDir,
@@ -51421,6 +52721,10 @@ async function saveOne(opts) {
     }
     catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        if (payloadPolicy.oversizeAction === "fail" &&
+            message.includes("exceeding cache-payload-max-bytes")) {
+            applyCachePayloadOversizeAction("fail", message);
+        }
         log(`${label}: compression failed: ${message}`);
         return withStats({ status: "failed", cache_dir: cacheDir, error: message });
     }
@@ -51719,6 +53023,8 @@ function saveText(save) {
             return "skipped missing dir";
         case "oversize-skip":
             return "skipped oversize payload";
+        case "race-skip":
+            return "skipped cache reservation race";
         case "tiny-delta-skip":
             return save.skip_reason ? `skipped tiny delta (${save.skip_reason})` : "skipped tiny delta";
         case "failed":
@@ -52397,11 +53703,9 @@ async function run() {
             }
         }
     }
-    // Cargo registry cache (only when enabled).
-    // setup-soldr#102: bundle `.global-cache` (cargo's RFC-3413 GC db) and the
-    // `git/` directory (bare mirrors + checkouts for git-source crate deps)
-    // into the same archive alongside `registry/`. Cache key + archive path
-    // are unchanged — the extras simply ride inside the existing tarball.
+    // Cargo registry cache (only when enabled). Legacy-v1 bundles registry plus
+    // optional siblings into one tarball. Soldr-v2 owns registry in a Soldr
+    // archive and keeps only `.global-cache`/`git` in the companion tarball.
     let cargoRegistrySave = Object.assign(disabledSave(), {
         archiveBytes: null,
         inflatedBytes: null,
@@ -52410,35 +53714,140 @@ async function run() {
     });
     if (result.cargoRegistryCache.enabled) {
         const regSaveStart = Date.now();
-        cargoRegistrySave = await saveOne({
-            cacheDir: result.cargoRegistryCache.path,
-            codec: result.targetCacheCompress,
-            level: result.targetCacheCompressLevel,
-            key: result.cargoRegistryCache.key,
-            matchedKey: registryMatched,
-            label: "cargo-registry-cache",
-            debug: debugMode,
-            log: debugLog,
-            extraBasenames: result.cargoRegistryCache.extraBasenames,
-            payloadPolicy,
-            // #263: opt the cargo-registry layer into `soldr save`/`soldr load`
-            // round-trip (env-gated inside trySaveViaSoldr — default off until
-            // the Windows wall-clock measurement validates the win).
-            soldrSave: {
-                soldrPath: result.soldrPath || process.env["SOLDR_BINARY"]?.trim() || "",
-                soldrVersion: result.soldrVersionResolved || "",
-            },
-        });
+        if (registryMatched === result.cargoRegistryCache.key) {
+            cargoRegistrySave = Object.assign({ status: "exact-hit-skip", cache_dir: result.cargoRegistryCache.path }, { archiveBytes: null, inflatedBytes: null, fileCount: null, payload: null });
+        }
+        else if (result.cargoRegistryCache.archive.format === "soldr-v2") {
+            const compressStart = Date.now();
+            const payload = await (0, cargo_registry_archive_js_1.cargoRegistryPayloadCensus)(result.cargoHome, payloadPolicy.topN);
+            if (payloadPolicy.warnBytes !== null && payload.bytes > payloadPolicy.warnBytes) {
+                const largest = payload.topFiles
+                    .slice(0, 5)
+                    .map((entry) => `${entry.path} (${fmtBytes(entry.bytes)})`)
+                    .join(", ");
+                core.notice(`setup-soldr: cargo-registry-cache payload is ${fmtBytes(payload.bytes)} before compression ` +
+                    `(>${fmtBytes(payloadPolicy.warnBytes)}). Largest files: ${largest || "none"}`);
+            }
+            if (payloadPolicy.maxBytes !== null && payload.bytes > payloadPolicy.maxBytes) {
+                const message = `setup-soldr: cargo-registry-cache payload is ${fmtBytes(payload.bytes)} before compression, ` +
+                    `exceeding cache-payload-max-bytes=${fmtBytes(payloadPolicy.maxBytes)}`;
+                const status = applyCachePayloadOversizeAction(payloadPolicy.oversizeAction, message);
+                log(`${message}; ${status === "failed" ? "failing" : "skipping"} v2 save`);
+                cargoRegistrySave = Object.assign({
+                    status,
+                    cache_dir: result.cargoRegistryCache.path,
+                    ...(status === "failed" ? { error: message } : {}),
+                }, {
+                    archiveBytes: null,
+                    inflatedBytes: payload.bytes,
+                    fileCount: payload.files,
+                    payload,
+                    phaseTimings: { compressMs: Date.now() - compressStart },
+                });
+            }
+            else {
+                try {
+                    const archiveResult = await (0, cargo_registry_archive_js_1.saveCargoRegistryArchive)({
+                        plan: result.cargoRegistryCache.archive,
+                        cargoHome: result.cargoHome,
+                        soldrPath: result.soldrPath || process.env["SOLDR_BINARY"]?.trim() || "",
+                        soldrVersion: core.getState("soldrRuntimeVersion") || result.soldrVersionResolved,
+                        debug: debugMode,
+                        log: debugLog,
+                    });
+                    if (!archiveResult.used) {
+                        throw new Error(`cargo-registry soldr-v2 save unavailable: ${archiveResult.codecPath}`);
+                    }
+                    const compressMs = Date.now() - compressStart;
+                    const uploadStart = Date.now();
+                    try {
+                        const id = await cache.saveCache(result.cargoRegistryCache.archive.restorePaths, result.cargoRegistryCache.key);
+                        const uploadMs = Date.now() - uploadStart;
+                        const status = await classifyCacheSaveReservation(id, result.cargoRegistryCache.key, () => cache.restoreCache(result.cargoRegistryCache.archive.restorePaths, result.cargoRegistryCache.key, [], { lookupOnly: true }));
+                        if (status === "race-skip") {
+                            log(`cargo-registry-cache: save returned id=${id}, and an exact-key probe confirmed ` +
+                                `a parallel job saved key=${result.cargoRegistryCache.key}`);
+                        }
+                        else if (status === "failed") {
+                            log(`cargo-registry-cache: save returned id=${id}, but no exact-key entry exists; ` +
+                                "reporting the save as failed");
+                        }
+                        cargoRegistrySave = Object.assign({
+                            status,
+                            cache_dir: result.cargoRegistryCache.path,
+                            cache_id: id,
+                            saved_paths: result.cargoRegistryCache.archive.restorePaths,
+                            ...(status === "failed"
+                                ? { error: `saveCache returned id=${id} and exact-key verification missed` }
+                                : {}),
+                        }, {
+                            archiveBytes: archiveResult.archiveBytes,
+                            inflatedBytes: archiveResult.restoredBytes,
+                            fileCount: archiveResult.restoredFiles,
+                            payload,
+                            phaseTimings: { compressMs, uploadMs },
+                        });
+                    }
+                    catch (err) {
+                        const uploadMs = Date.now() - uploadStart;
+                        const message = err instanceof Error ? err.message : String(err);
+                        log(`cargo-registry-cache: v2 save failed: ${message}`);
+                        cargoRegistrySave = Object.assign({
+                            status: "failed",
+                            cache_dir: result.cargoRegistryCache.path,
+                            saved_paths: result.cargoRegistryCache.archive.restorePaths,
+                            error: message,
+                        }, {
+                            archiveBytes: archiveResult.archiveBytes,
+                            inflatedBytes: archiveResult.restoredBytes,
+                            fileCount: archiveResult.restoredFiles,
+                            payload,
+                            phaseTimings: { compressMs, uploadMs },
+                        });
+                    }
+                }
+                catch (err) {
+                    const message = err instanceof Error ? err.message : String(err);
+                    const compressMs = Date.now() - compressStart;
+                    log(`cargo-registry-cache: v2 archive creation failed: ${message}`);
+                    cargoRegistrySave = Object.assign({
+                        status: "failed",
+                        cache_dir: result.cargoRegistryCache.path,
+                        error: message,
+                    }, {
+                        archiveBytes: null,
+                        inflatedBytes: payload.bytes,
+                        fileCount: payload.files,
+                        payload,
+                        phaseTimings: { compressMs },
+                    });
+                }
+            }
+        }
+        else {
+            cargoRegistrySave = await saveOne({
+                cacheDir: result.cargoRegistryCache.path,
+                codec: result.targetCacheCompress,
+                level: result.targetCacheCompressLevel,
+                key: result.cargoRegistryCache.key,
+                matchedKey: registryMatched,
+                label: "cargo-registry-cache",
+                debug: debugMode,
+                log: debugLog,
+                extraBasenames: result.cargoRegistryCache.extraBasenames,
+                payloadPolicy,
+            });
+        }
         // #287 follow-up: record EVERY outcome so the post-step save
         // table shows the layer no matter what its disposition.
         postCollector.record({
             label: "cargo-registry", operation: "save", hit: false,
             key: result.cargoRegistryCache.key, matchedKey: registryMatched, restoreKeys: [],
             status: cargoRegistrySave.status,
-            archiveBytes: cargoRegistrySave.status === "saved" || cargoRegistrySave.status === "oversize-skip" ? cargoRegistrySave.archiveBytes : null,
-            inflatedBytes: cargoRegistrySave.status === "saved" || cargoRegistrySave.status === "oversize-skip" ? cargoRegistrySave.inflatedBytes : null,
-            fileCount: cargoRegistrySave.status === "saved" || cargoRegistrySave.status === "oversize-skip" ? cargoRegistrySave.fileCount : null,
-            payload: cargoRegistrySave.status === "saved" || cargoRegistrySave.status === "oversize-skip" ? cargoRegistrySave.payload : null,
+            archiveBytes: ["saved", "oversize-skip", "race-skip"].includes(cargoRegistrySave.status) ? cargoRegistrySave.archiveBytes : null,
+            inflatedBytes: ["saved", "oversize-skip", "race-skip"].includes(cargoRegistrySave.status) ? cargoRegistrySave.inflatedBytes : null,
+            fileCount: ["saved", "oversize-skip", "race-skip"].includes(cargoRegistrySave.status) ? cargoRegistrySave.fileCount : null,
+            payload: ["saved", "oversize-skip", "race-skip"].includes(cargoRegistrySave.status) ? cargoRegistrySave.payload : null,
             durationMs: Date.now() - regSaveStart,
             compressMs: cargoRegistrySave.phaseTimings?.compressMs,
             uploadMs: cargoRegistrySave.phaseTimings?.uploadMs,

--- a/scripts/bench-cargo-registry-archives.mjs
+++ b/scripts/bench-cargo-registry-archives.mjs
@@ -1,0 +1,235 @@
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { createReadStream } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+function arg(name, fallback) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+const reps = Number.parseInt(arg("reps", "3"), 10);
+const requestedFileCount = Number.parseInt(arg("file-count", "50000"), 10);
+const outputDir = path.resolve(arg("output-dir", "benchmark-output"));
+const soldr = process.env.SOLDR_BIN?.trim() || "soldr";
+const runnerOs = process.env.RUNNER_OS || os.platform();
+const runnerImage = process.env.ImageOS || process.env.BENCH_RUNNER || "unknown";
+const assertThresholds = /^(1|true|yes|on)$/i.test(process.env.BENCH_ASSERT_THRESHOLDS || "false");
+
+if (!Number.isInteger(reps) || reps < 3) throw new Error("--reps must be an integer >= 3");
+if (!Number.isInteger(requestedFileCount) || requestedFileCount < 1) {
+  throw new Error("--file-count must be a positive integer");
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "inherit", windowsHide: true, ...options });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+}
+
+function runPipe(producer, producerArgs, consumer, consumerArgs) {
+  return new Promise((resolve, reject) => {
+    const left = spawn(producer, producerArgs, { stdio: ["ignore", "pipe", "inherit"], windowsHide: true });
+    const right = spawn(consumer, consumerArgs, { stdio: ["pipe", "inherit", "inherit"], windowsHide: true });
+    left.once("error", reject);
+    right.once("error", reject);
+    left.stdout.pipe(right.stdin);
+    let leftCode = null;
+    let rightCode = null;
+    const finish = () => {
+      if (leftCode === null || rightCode === null) return;
+      if (leftCode !== 0) reject(new Error(`${producer} exited with code ${leftCode}`));
+      else if (rightCode !== 0) reject(new Error(`${consumer} exited with code ${rightCode}`));
+      else resolve();
+    };
+    left.once("close", (code) => { leftCode = code ?? 0; finish(); });
+    right.once("close", (code) => { rightCode = code ?? 0; finish(); });
+  });
+}
+
+async function createFixture(cargoHome) {
+  const registry = path.join(cargoHome, "registry");
+  await fs.mkdir(registry, { recursive: true });
+  const batchSize = 250;
+  for (let start = 0; start < requestedFileCount; start += batchSize) {
+    const writes = [];
+    for (let i = start; i < Math.min(start + batchSize, requestedFileCount); i += 1) {
+      const bucket = (i % 256).toString(16).padStart(2, "0");
+      const target = path.join(registry, bucket, `crate-${i.toString().padStart(6, "0")}.cache`);
+      const content = `setup-soldr cargo registry benchmark\nindex=${i}\nchecksum=${createHash("sha256").update(String(i)).digest("hex")}\n`;
+      writes.push(fs.mkdir(path.dirname(target), { recursive: true }).then(() => fs.writeFile(target, content)));
+    }
+    await Promise.all(writes);
+  }
+  await fs.mkdir(path.join(cargoHome, ".global-cache"), { recursive: true });
+  await fs.writeFile(path.join(cargoHome, ".global-cache", "state.json"), '{"fixture":true}\n');
+  await fs.mkdir(path.join(cargoHome, "git", "db", "fixture.git"), { recursive: true });
+  await fs.writeFile(path.join(cargoHome, "git", "db", "fixture.git", "HEAD"), "ref: refs/heads/main\n");
+}
+
+async function listFiles(root, current = root) {
+  const entries = await fs.readdir(current, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(current, entry.name);
+    if (entry.isDirectory()) files.push(...await listFiles(root, full));
+    else if (entry.isFile()) files.push(path.relative(root, full).split(path.sep).join("/"));
+  }
+  return files;
+}
+
+async function contentIdentity(root) {
+  const files = (await listFiles(root)).sort();
+  const digest = createHash("sha256");
+  for (const relative of files) {
+    digest.update(relative);
+    digest.update("\0");
+    await new Promise((resolve, reject) => {
+      const stream = createReadStream(path.join(root, ...relative.split("/")));
+      stream.on("data", (chunk) => digest.update(chunk));
+      stream.once("error", reject);
+      stream.once("end", resolve);
+    });
+    digest.update("\0");
+  }
+  return { fileCount: files.length, contentHash: digest.digest("hex") };
+}
+
+async function archiveLegacy(cargoHome, archive) {
+  await runPipe(
+    "tar", ["-cf", "-", "-C", cargoHome, "registry", ".global-cache", "git"],
+    "zstd", ["-T0", "-3", "-f", "-o", archive],
+  );
+}
+
+async function archiveSoldr(cargoHome, registryArchive, extrasArchive) {
+  await run(soldr, ["save", "--cache-dir", path.join(cargoHome, "registry"), "--out", registryArchive]);
+  await runPipe(
+    "tar", ["-cf", "-", "-C", cargoHome, ".global-cache", "git"],
+    "zstd", ["-T0", "-3", "-f", "-o", extrasArchive],
+  );
+}
+
+async function restoreLegacy(archive, cargoHome) {
+  await fs.mkdir(cargoHome, { recursive: true });
+  await runPipe("zstd", ["-d", "-T0", "-c", archive], "tar", ["-xf", "-", "-C", cargoHome]);
+}
+
+async function restoreSoldr(registryArchive, extrasArchive, cargoHome) {
+  const args = ["load", "--archive", registryArchive, "--cache-dir", path.join(cargoHome, "registry")];
+  if (process.platform === "win32") args.push("--auto-defender-exclude");
+  await run(soldr, args);
+  await fs.mkdir(cargoHome, { recursive: true });
+  await runPipe("zstd", ["-d", "-T0", "-c", extrasArchive], "tar", ["-xf", "-", "-C", cargoHome]);
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function csvCell(value) {
+  const text = String(value);
+  return /[",\r\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+const root = await fs.mkdtemp(path.join(process.env.RUNNER_TEMP || os.tmpdir(), "setup-soldr-registry-bench-"));
+const fixture = path.join(root, "fixture", "cargo-home");
+const restoreRoot = path.join(root, "restore", "cargo-home");
+const legacyArchive = path.join(root, "legacy.tar.zst");
+const registryArchive = path.join(root, "registry.soldr.tar.zst");
+const extrasArchive = path.join(root, "extras.tar.zst");
+const rows = [];
+
+try {
+  await fs.mkdir(outputDir, { recursive: true });
+  console.log(`Creating deterministic ${requestedFileCount}-file registry fixture...`);
+  await createFixture(fixture);
+  const expected = await contentIdentity(fixture);
+  await archiveLegacy(fixture, legacyArchive);
+  await archiveSoldr(fixture, registryArchive, extrasArchive);
+  const archiveBytes = {
+    legacy: (await fs.stat(legacyArchive)).size,
+    soldr: (await fs.stat(registryArchive)).size + (await fs.stat(extrasArchive)).size,
+  };
+
+  for (let rep = 1; rep <= reps; rep += 1) {
+    const order = rep % 2 === 1 ? "legacy,soldr" : "soldr,legacy";
+    for (const codecPath of order.split(",")) {
+      await fs.rm(path.dirname(restoreRoot), { recursive: true, force: true });
+      const started = process.hrtime.bigint();
+      let restoreMs = 0;
+      let success = false;
+      let actual = { fileCount: 0, contentHash: "" };
+      let error = "";
+      try {
+        if (codecPath === "legacy") await restoreLegacy(legacyArchive, restoreRoot);
+        else await restoreSoldr(registryArchive, extrasArchive, restoreRoot);
+        restoreMs = Number(process.hrtime.bigint() - started) / 1_000_000;
+        actual = await contentIdentity(restoreRoot);
+        success = actual.fileCount === expected.fileCount && actual.contentHash === expected.contentHash;
+        if (!success) error = "content hash or file count mismatch";
+      } catch (caught) {
+        restoreMs = Number(process.hrtime.bigint() - started) / 1_000_000;
+        error = caught instanceof Error ? caught.message : String(caught);
+      }
+      rows.push({
+        runner_os: runnerOs,
+        runner_image: runnerImage,
+        rep,
+        codec_path: codecPath,
+        archive_bytes: archiveBytes[codecPath],
+        file_count: actual.fileCount,
+        restore_ms: restoreMs.toFixed(3),
+        content_hash: actual.contentHash,
+        success,
+        error,
+      });
+      console.log(`rep=${rep} codec=${codecPath} restore_ms=${restoreMs.toFixed(3)} success=${success}`);
+    }
+  }
+
+  const headers = ["runner_os", "runner_image", "rep", "codec_path", "archive_bytes", "file_count", "restore_ms", "content_hash", "success", "error"];
+  const csv = [headers.join(","), ...rows.map((row) => headers.map((header) => csvCell(row[header])).join(","))].join("\n") + "\n";
+  const csvPath = path.join(outputDir, "cargo-registry-archive-benchmark.csv");
+  await fs.writeFile(csvPath, csv);
+
+  const valid = rows.every((row) => row.success);
+  const legacyMedian = median(rows.filter((row) => row.codec_path === "legacy").map((row) => Number(row.restore_ms)));
+  const soldrMedian = median(rows.filter((row) => row.codec_path === "soldr").map((row) => Number(row.restore_ms)));
+  const speedup = legacyMedian / soldrMedian;
+  const gatePassed = valid && soldrMedian < 25000 && legacyMedian >= 3 * soldrMedian;
+  const summary = [
+    "# Cargo-registry archive restore benchmark",
+    "",
+    `- Runner: \`${runnerOs}\` / \`${runnerImage}\``,
+    `- Fixture: ${expected.fileCount} total files (${requestedFileCount} registry files)`,
+    `- Repetitions: ${reps}; order alternates between \`legacy,soldr\` and \`soldr,legacy\``,
+    `- Legacy median restore: ${legacyMedian.toFixed(3)} ms`,
+    `- Soldr median restore: ${soldrMedian.toFixed(3)} ms`,
+    `- Speedup: ${speedup.toFixed(2)}x`,
+    `- Content validation: ${valid ? "PASS" : "FAIL"} (file count and SHA-256 content hash after every restore)`,
+    `- Default-on gate: ${gatePassed ? "PASS" : "FAIL"} (Soldr < 25000 ms and legacy >= 3 * Soldr)`,
+    "",
+    "| rep | codec | restore ms | archive bytes | files | valid |",
+    "| ---: | :--- | ---: | ---: | ---: | :---: |",
+    ...rows.map((row) => `| ${row.rep} | ${row.codec_path} | ${row.restore_ms} | ${row.archive_bytes} | ${row.file_count} | ${row.success ? "yes" : "no"} |`),
+    "",
+  ].join("\n");
+  const summaryPath = path.join(outputDir, "cargo-registry-archive-benchmark.md");
+  await fs.writeFile(summaryPath, summary);
+  if (process.env.GITHUB_STEP_SUMMARY) await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, summary);
+  console.log(summary);
+  if (!valid) throw new Error("benchmark content hash validation failed");
+  if (assertThresholds && !gatePassed) throw new Error("Soldr default-on performance thresholds were not met");
+} finally {
+  await fs.rm(root, { recursive: true, force: true });
+}

--- a/src/lib/build-outputs.ts
+++ b/src/lib/build-outputs.ts
@@ -120,6 +120,8 @@ export function buildOutputs(result: ResolveResult): Record<string, string> {
     cargo_registry_cache_path: result.cargoRegistryCache.path,
     cargo_registry_cache_key: result.cargoRegistryCache.key,
     cargo_registry_cache_restore_prefix: result.cargoRegistryCache.restorePrefix,
+    cargo_registry_cache_archive_format: result.cargoRegistryCache.archive.format,
+    cargo_registry_cache_archive_paths: result.cargoRegistryCache.archive.restorePaths.join("\n"),
     dylint_cache_enabled: result.dylintCache.enabled ? "true" : "false",
     dylint_cache_key: result.dylintCache.key,
     dylint_driver_path: result.dylintCache.driverPath,

--- a/src/lib/cargo-registry-archive.ts
+++ b/src/lib/cargo-registry-archive.ts
@@ -1,0 +1,440 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import * as io from "@actions/io";
+import * as tc from "@actions/tool-cache";
+
+import type {
+  CachePayloadCensus,
+  CargoRegistryArchiveFormat,
+  CargoRegistryArchivePlan,
+} from "./types.js";
+import { decompressCache } from "./cache-compress.js";
+import {
+  MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP,
+  saveViaSoldr,
+  semverGte,
+  tryLoadViaSoldr,
+} from "./soldr-load-shim.js";
+
+const OPTIONAL_EXTRA_BASENAMES = [".global-cache", "git"] as const;
+
+export function cargoRegistryArchiveFormat(input: {
+  encrypted: boolean;
+  viaSoldr: boolean;
+  sourceRef: boolean;
+  runtimeCompatible?: boolean;
+}): CargoRegistryArchiveFormat {
+  return input.viaSoldr && !input.encrypted && !input.sourceRef && input.runtimeCompatible !== false
+    ? "soldr-v2"
+    : "legacy-v1";
+}
+
+export function planCargoRegistryArchive(input: {
+  format: CargoRegistryArchiveFormat;
+  cargoHome: string;
+  runnerTemp: string;
+}): CargoRegistryArchivePlan {
+  if (input.format === "legacy-v1") {
+    const registryArchivePath = `${path.join(input.cargoHome, "registry")}.tar.zst`;
+    return {
+      format: input.format,
+      registryArchivePath,
+      extrasArchivePath: "",
+      restorePaths: [registryArchivePath],
+    };
+  }
+  const root = path.join(input.runnerTemp, "setup-soldr-cargo-registry", "v2");
+  const registryArchivePath = path.join(root, "registry.soldr.tar.zst");
+  const extrasArchivePath = path.join(root, "extras.tar.zst");
+  return {
+    format: input.format,
+    registryArchivePath,
+    extrasArchivePath,
+    restorePaths: [registryArchivePath, extrasArchivePath],
+  };
+}
+
+async function exists(target: string): Promise<boolean> {
+  try {
+    await fs.stat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function cargoRegistryPayloadPaths(cargoHome: string): Promise<{
+  registry: string;
+  extras: string[];
+}> {
+  const registry = path.join(cargoHome, "registry");
+  const extras: string[] = [];
+  for (const basename of OPTIONAL_EXTRA_BASENAMES) {
+    const candidate = path.join(cargoHome, basename);
+    if (await exists(candidate)) extras.push(candidate);
+  }
+  return { registry, extras };
+}
+
+function runPipe(
+  producer: [string, string[]],
+  consumer: [string, string[]],
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const prod = spawn(producer[0], producer[1], { stdio: ["ignore", "pipe", "inherit"] });
+    const cons = spawn(consumer[0], consumer[1], { stdio: ["pipe", "inherit", "inherit"] });
+    prod.once("error", reject);
+    cons.once("error", reject);
+    prod.stdout?.pipe(cons.stdin!);
+    let producerExit: number | null = null;
+    let consumerExit: number | null = null;
+    const done = (): void => {
+      if (producerExit === null || consumerExit === null) return;
+      if (producerExit !== 0) reject(new Error(`${producer[0]} exited with code ${producerExit}`));
+      else if (consumerExit !== 0) reject(new Error(`${consumer[0]} exited with code ${consumerExit}`));
+      else resolve();
+    };
+    prod.once("close", (code) => { producerExit = code ?? 0; done(); });
+    cons.once("close", (code) => { consumerExit = code ?? 0; done(); });
+  });
+}
+
+const CARGO_REGISTRY_ZSTD_VERSION = "1.5.7";
+const CARGO_REGISTRY_ZSTD_WIN64_SHA256 =
+  "acb4e8111511749dc7a3ebedca9b04190e37a17afeb73f55d4425dbf0b90fad9";
+
+export function cargoRegistryZstdAsset(arch = process.arch): string {
+  if (arch === "ia32") {
+    throw new Error("cargo-registry Soldr v2 does not support 32-bit Windows runners");
+  }
+  return `https://github.com/facebook/zstd/releases/download/v${CARGO_REGISTRY_ZSTD_VERSION}/zstd-v${CARGO_REGISTRY_ZSTD_VERSION}-win64.zip`;
+}
+
+async function findNamedFile(root: string, basename: string): Promise<string | null> {
+  let entries;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const full = path.join(root, entry.name);
+    if (entry.isFile() && entry.name.toLowerCase() === basename.toLowerCase()) return full;
+    if (entry.isDirectory()) {
+      const nested = await findNamedFile(full, basename);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+export async function resolveCargoRegistryZstd(): Promise<string> {
+  const existing = await io.which("zstd", false);
+  if (existing) return existing;
+  if (process.platform !== "win32") {
+    throw new Error("cargo-registry Soldr v2 requires zstd on PATH outside Windows");
+  }
+  const root = path.join(
+    process.env["RUNNER_TEMP"] || os.tmpdir(),
+    "setup-soldr-tools",
+    `zstd-${CARGO_REGISTRY_ZSTD_VERSION}-${process.arch}`,
+  );
+  const cached = await findNamedFile(root, "zstd.exe");
+  if (cached) return cached;
+  await fs.mkdir(root, { recursive: true });
+  const zipPath = path.join(root, "zstd.zip");
+  await tc.downloadTool(cargoRegistryZstdAsset(), zipPath);
+  const digest = createHash("sha256").update(await fs.readFile(zipPath)).digest("hex");
+  if (digest !== CARGO_REGISTRY_ZSTD_WIN64_SHA256) {
+    throw new Error(`downloaded zstd archive failed SHA-256 verification (got ${digest})`);
+  }
+  const extracted = await tc.extractZip(zipPath, path.join(root, "extracted"));
+  const downloaded = await findNamedFile(extracted, "zstd.exe");
+  if (!downloaded) throw new Error("downloaded zstd archive did not contain zstd.exe");
+  return downloaded;
+}
+
+export async function writeCargoRegistryExtrasArchive(
+  cargoHome: string,
+  extras: string[],
+  archivePath: string,
+): Promise<void> {
+  await fs.mkdir(path.dirname(archivePath), { recursive: true });
+  const manifestRoot = await fs.mkdtemp(path.join(os.tmpdir(), "setup-soldr-cargo-extras-"));
+  const manifestPath = path.join(manifestRoot, "manifest.txt");
+  try {
+    const basenames = extras.map((entry) => path.basename(entry));
+    await fs.writeFile(manifestPath, basenames.map((entry) => `${entry}\n`).join(""), "utf8");
+    const zstd = await resolveCargoRegistryZstd();
+    await runPipe(
+      ["tar", ["-cf", "-", "-C", cargoHome, "-T", manifestPath]],
+      [zstd, ["-T0", "-3", "-f", "-o", archivePath]],
+    );
+  } finally {
+    await fs.rm(manifestRoot, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+export async function extractCargoRegistryExtrasArchive(
+  cargoHome: string,
+  archivePath: string,
+): Promise<void> {
+  const zstd = await resolveCargoRegistryZstd();
+  await fs.mkdir(cargoHome, { recursive: true });
+  await runPipe(
+    [zstd, ["-d", "-T0", "-c", archivePath]],
+    ["tar", ["-xf", "-", "-C", cargoHome]],
+  );
+}
+
+export async function cargoRegistryPayloadCensus(
+  cargoHome: string,
+  topN: number,
+): Promise<CachePayloadCensus> {
+  const payload = await cargoRegistryPayloadPaths(cargoHome);
+  const roots = [payload.registry, ...payload.extras];
+  const topFiles: Array<{ path: string; bytes: number }> = [];
+  const topDirectories: Array<{ path: string; bytes: number }> = [];
+  const topSubtrees: Array<{ path: string; bytes: number; files: number }> = [];
+  let bytes = 0;
+  let files = 0;
+  let symlinks = 0;
+  let directories = 0;
+
+  const walk = async (entry: string, relative: string): Promise<{ bytes: number; files: number }> => {
+    let stat;
+    try {
+      stat = await fs.lstat(entry);
+    } catch {
+      return { bytes: 0, files: 0 };
+    }
+    if (stat.isSymbolicLink()) {
+      symlinks += 1;
+      return { bytes: 0, files: 0 };
+    }
+    if (stat.isFile()) {
+      bytes += stat.size;
+      files += 1;
+      topFiles.push({ path: relative, bytes: stat.size });
+      return { bytes: stat.size, files: 1 };
+    }
+    if (!stat.isDirectory()) return { bytes: 0, files: 0 };
+    directories += 1;
+    let directoryBytes = 0;
+    let directoryFiles = 0;
+    for (const child of await fs.readdir(entry)) {
+      const childStats = await walk(path.join(entry, child), path.join(relative, child));
+      directoryBytes += childStats.bytes;
+      directoryFiles += childStats.files;
+    }
+    topDirectories.push({ path: relative, bytes: directoryBytes });
+    return { bytes: directoryBytes, files: directoryFiles };
+  };
+
+  for (const root of roots) {
+    const basename = path.basename(root);
+    const subtree = await walk(root, basename);
+    topSubtrees.push({ path: basename, bytes: subtree.bytes, files: subtree.files });
+  }
+  const limit = Math.max(0, Math.min(50, Math.floor(topN)));
+  topFiles.sort((a, b) => b.bytes - a.bytes || a.path.localeCompare(b.path));
+  topDirectories.sort((a, b) => b.bytes - a.bytes || a.path.localeCompare(b.path));
+  topSubtrees.sort((a, b) => b.bytes - a.bytes || a.path.localeCompare(b.path));
+  return {
+    bytes,
+    files,
+    symlinks,
+    directories,
+    inputs: roots.map((entry) => path.basename(entry)),
+    topFiles: topFiles.slice(0, limit),
+    topDirectories: topDirectories.slice(0, limit),
+    topSubtrees: topSubtrees.slice(0, limit),
+    skipped: [],
+  };
+}
+
+async function treeStats(target: string): Promise<{ bytes: number; files: number }> {
+  let bytes = 0;
+  let files = 0;
+  const walk = async (entry: string): Promise<void> => {
+    let stat;
+    try { stat = await fs.lstat(entry); } catch { return; }
+    if (stat.isDirectory()) {
+      for (const child of await fs.readdir(entry)) await walk(path.join(entry, child));
+    } else if (stat.isFile()) {
+      bytes += stat.size;
+      files += 1;
+    }
+  };
+  await walk(target);
+  return { bytes, files };
+}
+
+async function payloadStats(cargoHome: string): Promise<{ bytes: number; files: number }> {
+  const payload = await cargoRegistryPayloadPaths(cargoHome);
+  const roots = [payload.registry, ...payload.extras];
+  let bytes = 0;
+  let files = 0;
+  for (const root of roots) {
+    const stats = await treeStats(root);
+    bytes += stats.bytes;
+    files += stats.files;
+  }
+  return { bytes, files };
+}
+
+export interface CargoRegistryArchiveResult {
+  used: boolean;
+  codecPath: "legacy-v1" | "soldr-v2" | "unsupported";
+  archiveBytes: number;
+  restoredBytes: number;
+  restoredFiles: number;
+  durationMs: number;
+}
+
+/** Injectable archive primitives keep payload orchestration independently testable. */
+export interface CargoRegistryArchiveOperations {
+  saveRegistry: (cacheDir: string, archivePath: string) => Promise<boolean>;
+  restoreRegistry: (archivePath: string, targetDir: string) => Promise<boolean>;
+  saveExtras: (cargoHome: string, extras: string[], archivePath: string) => Promise<void>;
+  restoreExtras: (cargoHome: string, archivePath: string) => Promise<void>;
+}
+
+export async function saveCargoRegistryArchive(input: {
+  plan: CargoRegistryArchivePlan;
+  cargoHome: string;
+  soldrPath: string;
+  soldrVersion: string;
+  debug?: boolean;
+  log?: (message: string) => void;
+  operations?: Partial<CargoRegistryArchiveOperations>;
+}): Promise<CargoRegistryArchiveResult> {
+  const started = Date.now();
+  const payload = await cargoRegistryPayloadPaths(input.cargoHome);
+  if (input.plan.format !== "soldr-v2") {
+    return { used: false, codecPath: "legacy-v1", archiveBytes: 0, restoredBytes: 0, restoredFiles: 0, durationMs: 0 };
+  }
+  if (!semverGte(input.soldrVersion, MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP)) {
+    return { used: false, codecPath: "unsupported", archiveBytes: 0, restoredBytes: 0, restoredFiles: 0, durationMs: 0 };
+  }
+  await fs.mkdir(path.dirname(input.plan.registryArchivePath), { recursive: true });
+  await Promise.all([
+    fs.rm(input.plan.registryArchivePath, { force: true }),
+    fs.rm(input.plan.extrasArchivePath, { force: true }),
+  ]);
+  const registrySaved = input.operations?.saveRegistry
+    ? await input.operations.saveRegistry(payload.registry, input.plan.registryArchivePath)
+    : (
+        await saveViaSoldr({
+          cacheDir: payload.registry,
+          archivePath: input.plan.registryArchivePath,
+          soldrPath: input.soldrPath,
+          soldrVersion: input.soldrVersion,
+          debug: input.debug,
+          log: input.log,
+        })
+      ).used;
+  if (!registrySaved) {
+    throw new Error("Soldr v2 cargo-registry save did not produce a registry archive");
+  }
+  if (input.operations?.saveExtras) {
+    await input.operations.saveExtras(
+      input.cargoHome,
+      payload.extras,
+      input.plan.extrasArchivePath,
+    );
+  } else {
+    await writeCargoRegistryExtrasArchive(
+      input.cargoHome,
+      payload.extras,
+      input.plan.extrasArchivePath,
+    );
+  }
+  const registryBytes = (await fs.stat(input.plan.registryArchivePath)).size;
+  const extrasBytes = (await fs.stat(input.plan.extrasArchivePath)).size;
+  const stats = await payloadStats(input.cargoHome);
+  return {
+    used: true,
+    codecPath: "soldr-v2",
+    archiveBytes: registryBytes + extrasBytes,
+    restoredBytes: stats.bytes,
+    restoredFiles: stats.files,
+    durationMs: Date.now() - started,
+  };
+}
+
+export async function restoreCargoRegistryArchive(input: {
+  plan: CargoRegistryArchivePlan;
+  cargoHome: string;
+  soldrPath: string;
+  soldrVersion: string;
+  cacheKey: string;
+  autoDefenderExclude?: boolean;
+  debug?: boolean;
+  log?: (message: string) => void;
+  operations?: Partial<CargoRegistryArchiveOperations>;
+}): Promise<CargoRegistryArchiveResult> {
+  const started = Date.now();
+  if (input.plan.format === "legacy-v1") {
+    const result = await decompressCache({
+      archivePath: input.plan.registryArchivePath,
+      targetDir: path.join(input.cargoHome, "registry"),
+      cacheKey: input.cacheKey,
+      debug: input.debug,
+      log: input.log,
+    });
+    return {
+      used: true,
+      codecPath: "legacy-v1",
+      archiveBytes: result.archiveBytes,
+      restoredBytes: result.inflatedBytes,
+      restoredFiles: result.fileCount,
+      durationMs: Date.now() - started,
+    };
+  }
+  if (!semverGte(input.soldrVersion, MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP)) {
+    return { used: false, codecPath: "unsupported", archiveBytes: 0, restoredBytes: 0, restoredFiles: 0, durationMs: 0 };
+  }
+  const registryLoaded = input.operations?.restoreRegistry
+    ? await input.operations.restoreRegistry(
+        input.plan.registryArchivePath,
+        path.join(input.cargoHome, "registry"),
+      )
+    : (
+        await tryLoadViaSoldr({
+          archivePath: input.plan.registryArchivePath,
+          targetDir: path.join(input.cargoHome, "registry"),
+          soldrPath: input.soldrPath,
+          soldrVersion: input.soldrVersion,
+          autoDefenderExclude: input.autoDefenderExclude,
+          debug: input.debug,
+          log: input.log,
+        })
+      ).used;
+  if (!registryLoaded) {
+    throw new Error("Soldr v2 cargo-registry archive is corrupt or incompatible");
+  }
+  if (await exists(input.plan.extrasArchivePath)) {
+    if (input.operations?.restoreExtras) {
+      await input.operations.restoreExtras(input.cargoHome, input.plan.extrasArchivePath);
+    } else {
+      await extractCargoRegistryExtrasArchive(input.cargoHome, input.plan.extrasArchivePath);
+    }
+  }
+  const registryBytes = (await fs.stat(input.plan.registryArchivePath)).size;
+  const extrasBytes = await exists(input.plan.extrasArchivePath)
+    ? (await fs.stat(input.plan.extrasArchivePath)).size
+    : 0;
+  const stats = await payloadStats(input.cargoHome);
+  return {
+    used: true,
+    codecPath: "soldr-v2",
+    archiveBytes: registryBytes + extrasBytes,
+    restoredBytes: stats.bytes,
+    restoredFiles: stats.files,
+    durationMs: Date.now() - started,
+  };
+}

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -107,6 +107,8 @@ function cachePlanLines(result: ResolveResult): string[] {
   lines.push(`    key=${result.cargoRegistryCache.key}`);
   lines.push(`    restore_prefix=${result.cargoRegistryCache.restorePrefix}`);
   lines.push(`    path=${result.cargoRegistryCache.path}`);
+  lines.push(`    archive_format=${result.cargoRegistryCache.archive.format}`);
+  lines.push(`    archive_paths=${JSON.stringify(result.cargoRegistryCache.archive.restorePaths)}`);
   // setup-soldr#102: sibling basenames bundled into the same archive.
   const extras = result.cargoRegistryCache.extraBasenames;
   lines.push(`    extra_basenames=${extras.length > 0 ? extras.join(",") : "(none)"}`);

--- a/src/lib/resolve-setup.ts
+++ b/src/lib/resolve-setup.ts
@@ -53,6 +53,11 @@ import {
   resolveSoldrReleaseVersion,
   type ResolveSetupDeps,
 } from "./fetch-release.js";
+import { cargoRegistryArchiveFormat, planCargoRegistryArchive } from "./cargo-registry-archive.js";
+import {
+  cargoRegistryViaSoldrEnvOn,
+  MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP,
+} from "./soldr-load-shim.js";
 import { pythonDefaultJson } from "./python-json.js";
 import {
   loadToolchainSpec,
@@ -792,7 +797,33 @@ export async function resolveSetup(
   // Siblings that don't exist on disk at save time (e.g. workspaces with no
   // git-source deps) are silently skipped by compressCache — see #102.
   const cargoRegistryCacheExtras = [".global-cache", "git"];
-  const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-v1-${runnerOs}-${runnerArch}`;
+  const cargoRegistryEncrypted = inputs.cacheEncryptKey.trim().length > 0;
+  const cargoRegistryViaSoldr = cargoRegistryViaSoldrEnvOn();
+  const cargoRegistryRuntimeCompatible = semverAtLeast(
+    soldrVersionResolved || soldrVersionRequested,
+    MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP,
+  );
+  const cargoRegistryFormat = cargoRegistryArchiveFormat({
+    encrypted: cargoRegistryEncrypted,
+    viaSoldr: cargoRegistryViaSoldr,
+    sourceRef: soldrRef.trim().length > 0,
+    runtimeCompatible: cargoRegistryRuntimeCompatible,
+  });
+  if (cargoRegistryEncrypted && cargoRegistryViaSoldr) {
+    core.notice(
+      "setup-soldr: cargo-registry Soldr v2 is disabled for encrypted cache entries; using encrypted legacy-v1 until encrypted Soldr restore is available.",
+    );
+  } else if (cargoRegistryViaSoldr && !soldrRef && !cargoRegistryRuntimeCompatible) {
+    core.notice(
+      `setup-soldr: cargo-registry Soldr v2 requires soldr >= ${MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP}; using legacy-v1 for ${soldrVersionResolved || soldrVersionRequested || "unknown"}.`,
+    );
+  }
+  const cargoRegistryArchive = planCargoRegistryArchive({
+    format: cargoRegistryFormat,
+    cargoHome,
+    runnerTemp,
+  });
+  const cargoRegistryCachePrefix = `setup-soldr-cargoregistry-${cargoRegistryFormat === "soldr-v2" ? "v2" : "v1"}-${runnerOs}-${runnerArch}`;
   const cargoRegistryCacheRestorePrefix = `${cargoRegistryCachePrefix}-${cargoLockHash}-`;
   // #371: drop git SHA from the exact key, same anti-pattern fix as
   // #237 did for build-cache. With SHA, every commit produced a new
@@ -815,6 +846,7 @@ export async function resolveSetup(
   const cargoRegistryCacheEnabled = cacheUmbrellaEnabled && cargoRegistryCacheRequested;
   if (cargoRegistryCacheEnabled) {
     makeDirs(cargoRegistryCachePath);
+    for (const archivePath of cargoRegistryArchive.restorePaths) makeDirs(path.dirname(archivePath));
   }
 
   // ---- Dylint tool/driver cache (explicit opt-in, setup-soldr#221) ----
@@ -1195,6 +1227,7 @@ export async function resolveSetup(
     restorePrefix: cargoRegistryCacheRestorePrefix,
     path: cargoRegistryCachePath,
     extraBasenames: cargoRegistryCacheExtras,
+    archive: cargoRegistryArchive,
   };
   const dylintCachePlan = {
     enabled: dylintCacheEnabled,

--- a/src/lib/soldr-load-shim.ts
+++ b/src/lib/soldr-load-shim.ts
@@ -173,35 +173,19 @@ export interface SoldrSaveOpts {
   archivePath: string;
   soldrPath: string;
   soldrVersion: string;
-  /**
-   * If non-empty, fall back to legacy compression. soldr save bundles
-   * one directory; extras (cargo's `.global-cache`, `git/`) require
-   * pre-staging that this helper doesn't do today. (#263)
-   */
-  extraBasenames?: string[];
   debug?: boolean;
   log?: (msg: string) => void;
 }
 
 /**
- * Attempt to bundle the cache directory via `soldr save` so the matching
- * `soldr load` (in main.ts) can pick up the parallel-extract path. Returns
- * `{ used: false }` when gated off (env var, missing binary, too-old
- * version, extras present, or any throw). Produces a soldr-format archive
- * with `SOLDR_MANIFEST.pb` at the root + `cache/...` entries. (#263)
+ * Bundle a cache directory via `soldr save` after the caller has selected a
+ * Soldr-format plan. This deliberately does not re-read the rollout env var:
+ * the persisted plan is authoritative across the main/post process boundary.
  */
-export async function trySaveViaSoldr(opts: SoldrSaveOpts): Promise<SoldrSaveResult> {
+export async function saveViaSoldr(opts: SoldrSaveOpts): Promise<SoldrSaveResult> {
   const t0 = Date.now();
   const noOp: SoldrSaveResult = { used: false, archivePath: null, archiveBytes: 0, durationMs: 0 };
   const log = opts.log ?? ((): void => undefined);
-  if (!cargoRegistryViaSoldrEnvOn()) {
-    if (opts.debug) {
-      log(
-        `[debug] soldr-save-shim: ${CARGO_REGISTRY_VIA_SOLDR_ENV} not set; deferring to legacy tar+zstd save`,
-      );
-    }
-    return noOp;
-  }
   if (!opts.soldrPath) {
     if (opts.debug) log(`[debug] soldr-save-shim: no soldr binary path supplied`);
     return noOp;
@@ -210,14 +194,6 @@ export async function trySaveViaSoldr(opts: SoldrSaveOpts): Promise<SoldrSaveRes
     if (opts.debug) {
       log(
         `[debug] soldr-save-shim: soldr ${opts.soldrVersion} < ${MIN_SOLDR_VERSION_FOR_SAVE_ROUNDTRIP}; falling back to legacy save`,
-      );
-    }
-    return noOp;
-  }
-  if (opts.extraBasenames && opts.extraBasenames.length > 0) {
-    if (opts.debug) {
-      log(
-        `[debug] soldr-save-shim: extraBasenames=[${opts.extraBasenames.join(",")}] not yet supported by soldr save; falling back to legacy`,
       );
     }
     return noOp;
@@ -254,4 +230,21 @@ export async function trySaveViaSoldr(opts: SoldrSaveOpts): Promise<SoldrSaveRes
     return noOp;
   }
   return { used: true, archivePath: opts.archivePath, archiveBytes, durationMs: Date.now() - t0 };
+}
+
+/**
+ * Compatibility wrapper for callers that have not resolved an archive plan.
+ * The rollout env gate is checked once here; planned v2 callers use
+ * [[saveViaSoldr]] directly so post-job environment drift cannot change format.
+ */
+export async function trySaveViaSoldr(opts: SoldrSaveOpts): Promise<SoldrSaveResult> {
+  if (!cargoRegistryViaSoldrEnvOn()) {
+    if (opts.debug) {
+      (opts.log ?? ((): void => undefined))(
+        `[debug] soldr-save-shim: ${CARGO_REGISTRY_VIA_SOLDR_ENV} not set; deferring to legacy tar+zstd save`,
+      );
+    }
+    return { used: false, archivePath: null, archiveBytes: 0, durationMs: 0 };
+  }
+  return saveViaSoldr(opts);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -218,12 +218,22 @@ export interface TargetCachePlan {
  * Missing siblings are silently skipped on save so a cold checkout (no
  * `git/` deps cloned yet) still produces a valid archive.
  */
+export type CargoRegistryArchiveFormat = "legacy-v1" | "soldr-v2";
+
+export interface CargoRegistryArchivePlan {
+  format: CargoRegistryArchiveFormat;
+  registryArchivePath: string;
+  extrasArchivePath: string;
+  restorePaths: string[];
+}
+
 export interface CargoRegistryCachePlan {
   enabled: boolean;
   key: string;
   restorePrefix: string;
   path: string;
   extraBasenames: string[];
+  archive: CargoRegistryArchivePlan;
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ import { detectSharedTargetWarning } from "./lib/detect-shared-target-warning.js
 import { ensureShims } from "./lib/ensure-shims.js";
 import { seedZccache } from "./lib/zccache-seed.js";
 import { detectCompressMagic, decompressCache } from "./lib/cache-compress.js";
-import { tryLoadViaSoldr } from "./lib/soldr-load-shim.js";
+import { restoreCargoRegistryArchive } from "./lib/cargo-registry-archive.js";
 import { parseIsolatedSeedTargets, seedIsolatedBuildCache } from "./lib/seed-isolated-cache.js";
 import { StatsCollector } from "./lib/stats-collector.js";
 import {
@@ -84,7 +84,11 @@ import {
   readSnapshotFile,
   SNAPSHOT_FILENAME,
 } from "./lib/source-mtime-snapshot.js";
-import type { ActionContext, ResolveResult } from "./lib/types.js";
+import type {
+  ActionContext,
+  CargoRegistryArchiveFormat,
+  ResolveResult,
+} from "./lib/types.js";
 
 /**
  * Map (hit, matchedKey) → workflow-visible restore-status string.
@@ -95,6 +99,16 @@ function deriveRestoreStatus(hit: boolean, matchedKey: string): "exact-hit" | "r
   if (hit) return "exact-hit";
   if (matchedKey.trim()) return "restore-key-hit";
   return "miss";
+}
+
+export function shouldSkipCargoRegistryExtractionError(
+  err: unknown,
+  format: CargoRegistryArchiveFormat,
+  onFailure: string | undefined,
+): boolean {
+  if (format !== "legacy-v1" || onFailure?.trim().toLowerCase() !== "skip") return false;
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === "EAUTHFAIL" || code === "EENCNOKEY";
 }
 
 function writeCacheKeysManifest(
@@ -627,16 +641,19 @@ export async function run(): Promise<void> {
     }
   })();
 
-  // Cargo-registry restore moved here from after-cook. It writes only
-  // $CARGO_HOME/registry/ and has no dependency on soldr being installed;
-  // running it in parallel with target+build trims its ~5s off the critical
-  // path.
+  let cargoRegistryDownload: {
+    hit: boolean;
+    matchedKey: string;
+    startedMs: number;
+  } | null = null;
+  // Download only. Archive extraction is deliberately deferred until after
+  // ensureSoldr() + runtime verification because soldr-v2 needs the installed
+  // binary and must never race its setup-cache/mini-cache restore.
   const cargoRegistryRestorePromise = (async (): Promise<void> => {
     if (!result.cargoRegistryCache.enabled) return;
-    const registryArchive = `${result.cargoRegistryCache.path}.tar.zst`;
     const t0 = Date.now();
     const restore = await restoreCacheSafe(
-      [registryArchive],
+      result.cargoRegistryCache.archive.restorePaths,
       result.cargoRegistryCache.key,
       [result.cargoRegistryCache.restorePrefix],
       logger,
@@ -645,64 +662,7 @@ export async function run(): Promise<void> {
     core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
     core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
     core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
-    let regArchiveBytes: number | null = null;
-    let regInflatedBytes: number | null = null;
-    let regFileCount: number | null = null;
-    if (fileExists(registryArchive)) {
-      // #260: try `soldr load` first for parallel extraction on Windows
-      // (Defender + NTFS bottleneck). Falls through to the legacy
-      // tar+zstd path when the archive isn't soldr-format or the
-      // installed soldr is too old.
-      let soldrLoadUsed = false;
-      try {
-        const sr = await tryLoadViaSoldr({
-          archivePath: registryArchive,
-          targetDir: result.cargoRegistryCache.path,
-          soldrPath: result.soldrPath,
-          soldrVersion: result.soldrVersionResolved,
-          debug: debugMode,
-          log: debugLog,
-          autoDefenderExclude: process.platform === "win32",
-        });
-        soldrLoadUsed = sr.used;
-      } catch (err) {
-        logger.log(
-          `cargo-registry soldr load failed (will fall back to tar+zstd): ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-      if (soldrLoadUsed) {
-        try {
-          regArchiveBytes = (await fs.promises.stat(registryArchive)).size;
-        } catch { /* archive may have been removed mid-flight */ }
-      } else {
-        const magic = await detectCompressMagic(registryArchive);
-        const haveEncryptKey = (process.env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] ?? "").trim().length > 0;
-        if (magic === "zstd" || magic === "gzip" || haveEncryptKey) {
-          try {
-            const dr = await decompressCache({
-              archivePath: registryArchive,
-              targetDir: result.cargoRegistryCache.path,
-              debug: debugMode, log: debugLog,
-              cacheKey: restore.matchedKey || result.cargoRegistryCache.key,
-            });
-            regArchiveBytes = dr.archiveBytes;
-            regInflatedBytes = dr.inflatedBytes;
-            regFileCount = dr.fileCount;
-          } catch (err) {
-            logger.log(
-              `cargo-registry decompress failed: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
-        }
-      }
-    }
-    statsCollector.record({
-      label: "cargo-registry", operation: "restore", hit: restore.hit,
-      key: result.cargoRegistryCache.key, matchedKey: restore.matchedKey,
-      restoreKeys: [result.cargoRegistryCache.restorePrefix],
-      archiveBytes: regArchiveBytes, inflatedBytes: regInflatedBytes, fileCount: regFileCount,
-      durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-    });
+    cargoRegistryDownload = { hit: restore.hit, matchedKey: restore.matchedKey, startedMs: t0 };
   })();
 
   const blessedPrepareRestorePromise = (async (): Promise<void> => {
@@ -1255,6 +1215,7 @@ export async function run(): Promise<void> {
 
   // ---- verify ----
   await markPhase("verify");
+  let soldrRuntimeVersion = "passthrough";
   if (result.enabled) {
     const verify = await verifySoldr({
       soldrPath: result.soldrPath,
@@ -1264,11 +1225,96 @@ export async function run(): Promise<void> {
     });
     core.setOutput("soldr-version", verify.soldrVersion);
     core.setOutput("soldr_version", verify.soldrVersion);
+    soldrRuntimeVersion = verify.soldrVersion;
+    core.saveState("soldrRuntimeVersion", verify.soldrVersion);
   } else {
     core.setOutput("soldr-version", "passthrough");
     core.setOutput("soldr_version", "passthrough");
   }
   await finishPhase("verify");
+
+  // ---- cargo-registry extraction ----
+  // Network download overlapped other layers in parallel-restore. Extraction
+  // starts only after the Soldr binary has been installed and runtime-verified.
+  await markPhase("cargo-registry-extract");
+  const registryDownload = cargoRegistryDownload as {
+    hit: boolean;
+    matchedKey: string;
+    startedMs: number;
+  } | null;
+  if (registryDownload) {
+    let archiveBytes: number | null = null;
+    let restoredBytes: number | null = null;
+    let restoredFiles: number | null = null;
+    let restoredHit = registryDownload.hit;
+    let matched = registryDownload.matchedKey;
+    const markRegistryMiss = (): void => {
+      restoredHit = false;
+      matched = "";
+      core.setOutput("cargo-registry-cache-hit", "false");
+      core.setOutput("cargo_registry_cache_hit", "false");
+      core.saveState("cargoRegistryCacheExactHit", "false");
+      core.saveState("cargoRegistryCacheMatchedKey", "");
+    };
+    if (matched) {
+      try {
+        const archiveResult = await restoreCargoRegistryArchive({
+          plan: result.cargoRegistryCache.archive,
+          cargoHome: result.cargoHome,
+          soldrPath: result.soldrPath,
+          soldrVersion: soldrRuntimeVersion,
+          cacheKey: matched,
+          autoDefenderExclude: process.platform === "win32",
+          debug: debugMode,
+          log: debugLog,
+        });
+        if (!archiveResult.used) {
+          logger.log(
+            `cargo-registry: ${archiveResult.codecPath} unavailable for runtime Soldr ${soldrRuntimeVersion}; treating restored entry as a miss`,
+          );
+          markRegistryMiss();
+        } else {
+          archiveBytes = archiveResult.archiveBytes;
+          restoredBytes = archiveResult.restoredBytes;
+          restoredFiles = archiveResult.restoredFiles;
+          logger.log(
+            `cargo-registry: extracted format=${archiveResult.codecPath} archive_bytes=${archiveBytes} restored_bytes=${restoredBytes} files=${restoredFiles} duration_ms=${archiveResult.durationMs}`,
+          );
+        }
+      } catch (err) {
+        if (
+          shouldSkipCargoRegistryExtractionError(
+            err,
+            result.cargoRegistryCache.archive.format,
+            process.env["SETUP_SOLDR_CACHE_ENCRYPT_ON_FAILURE"],
+          )
+        ) {
+          core.warning(
+            `cargo-registry encrypted archive could not be restored; cache-encrypt-on-failure=skip treats it as a cold miss: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          markRegistryMiss();
+        } else {
+          throw new Error(
+            `cargo-registry archive extraction failed for ${registryDownload.hit ? "exact-hit" : "fallback-hit"} ${matched}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+    statsCollector.record({
+      label: `cargo-registry-${result.cargoRegistryCache.archive.format}`,
+      operation: "restore",
+      hit: restoredHit,
+      key: result.cargoRegistryCache.key,
+      matchedKey: matched,
+      restoreKeys: [result.cargoRegistryCache.restorePrefix],
+      archiveBytes,
+      inflatedBytes: restoredBytes,
+      fileCount: restoredFiles,
+      durationMs: Date.now() - registryDownload.startedMs,
+      timestamp: new Date().toISOString(),
+    });
+  }
+  await finishPhase("cargo-registry-extract");
 
   // ---- cross-prepare ----
   await markPhase("cross-prepare");
@@ -1530,6 +1576,7 @@ export async function run(): Promise<void> {
     "install",
     "zccache-seed",
     "verify",
+    "cargo-registry-extract",
     "cross-prepare",
     "cook",
   ]);

--- a/src/post.ts
+++ b/src/post.ts
@@ -29,7 +29,10 @@ import { saveMiniCache } from "./lib/soldr-mini-cache.js";
 // chunk files (e.g. @actions/artifact → @azure/identity inner chunks)
 // into `dist/` so they resolve at runtime — but converting our own
 // dynamic import to static is the cleaner shape regardless.
-import { trySaveViaSoldr } from "./lib/soldr-load-shim.js";
+import {
+  cargoRegistryPayloadCensus,
+  saveCargoRegistryArchive,
+} from "./lib/cargo-registry-archive.js";
 import { createLogger } from "./lib/log-utils.js";
 import { shutdownCacheDaemons } from "./lib/shutdown-cache.js";
 import { StatsCollector } from "./lib/stats-collector.js";
@@ -69,6 +72,7 @@ type SaveStatus =
   | "exact-hit-skip"
   | "missing-dir-skip"
   | "oversize-skip"
+  | "race-skip"
   | "tiny-delta-skip"
   | "saved"
   | "failed";
@@ -331,6 +335,31 @@ function resolveCachePayloadPolicy(inputs: RawInputs, log: (msg: string) => void
   };
 }
 
+export function applyCachePayloadOversizeAction(
+  action: "skip" | "fail",
+  message: string,
+  setFailed: (message: string) => void = core.setFailed,
+): "oversize-skip" | "failed" {
+  if (action === "fail") {
+    setFailed(message);
+    return "failed";
+  }
+  return "oversize-skip";
+}
+
+export async function classifyCacheSaveReservation(
+  id: number,
+  key: string,
+  probeExactKey: () => Promise<string | undefined>,
+): Promise<"saved" | "race-skip" | "failed"> {
+  if (id > 0) return "saved";
+  try {
+    return (await probeExactKey()) === key ? "race-skip" : "failed";
+  } catch {
+    return "failed";
+  }
+}
+
 type CacheSaveResultWithStats = CacheSaveResult & {
   archiveBytes: number | null;
   inflatedBytes: number | null;
@@ -355,15 +384,8 @@ async function saveOne(opts: {
   extraBasenames?: string[];
   payloadProfile?: CachePayloadProfile;
   payloadPolicy: CachePayloadPolicy;
-  /**
-   * When set, attempt to bundle the cache via `soldr save` so the matching
-   * `soldr load` on restore can use parallel-extract. Only meaningful for
-   * the cargo-registry layer today; gated on env + version inside
-   * `trySaveViaSoldr`. Falls through to legacy compression otherwise. (#263)
-   */
-  soldrSave?: { soldrPath: string; soldrVersion: string };
 }): Promise<CacheSaveResultWithStats> {
-  const { cacheDir, codec, level, key, matchedKey, label, debug, log, extraBasenames, payloadProfile, payloadPolicy, soldrSave } = opts;
+  const { cacheDir, codec, level, key, matchedKey, label, debug, log, extraBasenames, payloadProfile, payloadPolicy } = opts;
   const withStats = (r: CacheSaveResult): CacheSaveResultWithStats =>
     Object.assign(r, {
       archiveBytes: null,
@@ -391,31 +413,6 @@ async function saveOne(opts: {
   const compressStart = Date.now();
   let skippedReason: "payload-too-large" | undefined;
   try {
-    // #263: try `soldr save` first when the caller opted in (env-gated
-    // inside trySaveViaSoldr). Produces a soldr-format archive that the
-    // matching `soldr load` on restore picks up for parallel extract.
-    // Falls through to legacy compressCache on any miss (no env, no
-    // binary, too-old version, extras present, throw).
-    if (soldrSave) {
-      const candidateArchive = `${cacheDir}.tar.zst`;
-      const sr = await trySaveViaSoldr({
-        cacheDir,
-        archivePath: candidateArchive,
-        soldrPath: soldrSave.soldrPath,
-        soldrVersion: soldrSave.soldrVersion,
-        extraBasenames,
-        debug,
-        log,
-      });
-      if (sr.used) {
-        archivePath = sr.archivePath;
-        archiveBytes = sr.archiveBytes;
-        // inflatedBytes/fileCount/payload not collected on the soldr path —
-        // keep them null; postCollector accepts that shape.
-        compressMs = Date.now() - compressStart;
-        if (debug) log(`${label}: soldr save produced ${candidateArchive} (${archiveBytes} bytes, ${compressMs} ms)`);
-      }
-    }
     if (archivePath === null) {
       const result = await compressCache({
         cacheDir,
@@ -454,6 +451,12 @@ async function saveOne(opts: {
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    if (
+      payloadPolicy.oversizeAction === "fail" &&
+      message.includes("exceeding cache-payload-max-bytes")
+    ) {
+      applyCachePayloadOversizeAction("fail", message);
+    }
     log(`${label}: compression failed: ${message}`);
     return withStats({ status: "failed", cache_dir: cacheDir, error: message });
   }
@@ -783,6 +786,8 @@ function saveText(save: CacheSaveResult): string {
       return "skipped missing dir";
     case "oversize-skip":
       return "skipped oversize payload";
+    case "race-skip":
+      return "skipped cache reservation race";
     case "tiny-delta-skip":
       return save.skip_reason ? `skipped tiny delta (${save.skip_reason})` : "skipped tiny delta";
     case "failed":
@@ -1530,11 +1535,9 @@ export async function run(): Promise<void> {
     }
   }
 
-  // Cargo registry cache (only when enabled).
-  // setup-soldr#102: bundle `.global-cache` (cargo's RFC-3413 GC db) and the
-  // `git/` directory (bare mirrors + checkouts for git-source crate deps)
-  // into the same archive alongside `registry/`. Cache key + archive path
-  // are unchanged — the extras simply ride inside the existing tarball.
+  // Cargo registry cache (only when enabled). Legacy-v1 bundles registry plus
+  // optional siblings into one tarball. Soldr-v2 owns registry in a Soldr
+  // archive and keeps only `.global-cache`/`git` in the companion tarball.
   let cargoRegistrySave: CacheSaveResultWithStats = Object.assign(disabledSave(), {
     archiveBytes: null as number | null,
     inflatedBytes: null as number | null,
@@ -1543,35 +1546,172 @@ export async function run(): Promise<void> {
   });
   if (result.cargoRegistryCache.enabled) {
     const regSaveStart = Date.now();
-    cargoRegistrySave = await saveOne({
-      cacheDir: result.cargoRegistryCache.path,
-      codec: result.targetCacheCompress,
-      level: result.targetCacheCompressLevel,
-      key: result.cargoRegistryCache.key,
-      matchedKey: registryMatched,
-      label: "cargo-registry-cache",
-      debug: debugMode,
-      log: debugLog,
-      extraBasenames: result.cargoRegistryCache.extraBasenames,
-      payloadPolicy,
-      // #263: opt the cargo-registry layer into `soldr save`/`soldr load`
-      // round-trip (env-gated inside trySaveViaSoldr — default off until
-      // the Windows wall-clock measurement validates the win).
-      soldrSave: {
-        soldrPath: result.soldrPath || process.env["SOLDR_BINARY"]?.trim() || "",
-        soldrVersion: result.soldrVersionResolved || "",
-      },
-    });
+    if (registryMatched === result.cargoRegistryCache.key) {
+      cargoRegistrySave = Object.assign(
+        { status: "exact-hit-skip" as const, cache_dir: result.cargoRegistryCache.path },
+        { archiveBytes: null, inflatedBytes: null, fileCount: null, payload: null },
+      );
+    } else if (result.cargoRegistryCache.archive.format === "soldr-v2") {
+      const compressStart = Date.now();
+      const payload = await cargoRegistryPayloadCensus(result.cargoHome, payloadPolicy.topN);
+      if (payloadPolicy.warnBytes !== null && payload.bytes > payloadPolicy.warnBytes) {
+        const largest = payload.topFiles
+          .slice(0, 5)
+          .map((entry) => `${entry.path} (${fmtBytes(entry.bytes)})`)
+          .join(", ");
+        core.notice(
+          `setup-soldr: cargo-registry-cache payload is ${fmtBytes(payload.bytes)} before compression ` +
+            `(>${fmtBytes(payloadPolicy.warnBytes)}). Largest files: ${largest || "none"}`,
+        );
+      }
+      if (payloadPolicy.maxBytes !== null && payload.bytes > payloadPolicy.maxBytes) {
+        const message =
+          `setup-soldr: cargo-registry-cache payload is ${fmtBytes(payload.bytes)} before compression, ` +
+          `exceeding cache-payload-max-bytes=${fmtBytes(payloadPolicy.maxBytes)}`;
+        const status: SaveStatus = applyCachePayloadOversizeAction(
+          payloadPolicy.oversizeAction,
+          message,
+        );
+        log(`${message}; ${status === "failed" ? "failing" : "skipping"} v2 save`);
+        cargoRegistrySave = Object.assign(
+          {
+            status,
+            cache_dir: result.cargoRegistryCache.path,
+            ...(status === "failed" ? { error: message } : {}),
+          },
+          {
+            archiveBytes: null,
+            inflatedBytes: payload.bytes,
+            fileCount: payload.files,
+            payload,
+            phaseTimings: { compressMs: Date.now() - compressStart },
+          },
+        );
+      } else {
+        try {
+          const archiveResult = await saveCargoRegistryArchive({
+            plan: result.cargoRegistryCache.archive,
+            cargoHome: result.cargoHome,
+            soldrPath: result.soldrPath || process.env["SOLDR_BINARY"]?.trim() || "",
+            soldrVersion: core.getState("soldrRuntimeVersion") || result.soldrVersionResolved,
+            debug: debugMode,
+            log: debugLog,
+          });
+          if (!archiveResult.used) {
+            throw new Error(`cargo-registry soldr-v2 save unavailable: ${archiveResult.codecPath}`);
+          }
+          const compressMs = Date.now() - compressStart;
+          const uploadStart = Date.now();
+          try {
+            const id = await cache.saveCache(
+              result.cargoRegistryCache.archive.restorePaths,
+              result.cargoRegistryCache.key,
+            );
+            const uploadMs = Date.now() - uploadStart;
+            const status = await classifyCacheSaveReservation(
+              id,
+              result.cargoRegistryCache.key,
+              () =>
+                cache.restoreCache(
+                  result.cargoRegistryCache.archive.restorePaths,
+                  result.cargoRegistryCache.key,
+                  [],
+                  { lookupOnly: true },
+                ),
+            );
+            if (status === "race-skip") {
+              log(
+                `cargo-registry-cache: save returned id=${id}, and an exact-key probe confirmed ` +
+                  `a parallel job saved key=${result.cargoRegistryCache.key}`,
+              );
+            } else if (status === "failed") {
+              log(
+                `cargo-registry-cache: save returned id=${id}, but no exact-key entry exists; ` +
+                  "reporting the save as failed",
+              );
+            }
+            cargoRegistrySave = Object.assign(
+              {
+                status,
+                cache_dir: result.cargoRegistryCache.path,
+                cache_id: id,
+                saved_paths: result.cargoRegistryCache.archive.restorePaths,
+                ...(status === "failed"
+                  ? { error: `saveCache returned id=${id} and exact-key verification missed` }
+                  : {}),
+              },
+              {
+                archiveBytes: archiveResult.archiveBytes,
+                inflatedBytes: archiveResult.restoredBytes,
+                fileCount: archiveResult.restoredFiles,
+                payload,
+                phaseTimings: { compressMs, uploadMs },
+              },
+            );
+          } catch (err) {
+            const uploadMs = Date.now() - uploadStart;
+            const message = err instanceof Error ? err.message : String(err);
+            log(`cargo-registry-cache: v2 save failed: ${message}`);
+            cargoRegistrySave = Object.assign(
+              {
+                status: "failed" as const,
+                cache_dir: result.cargoRegistryCache.path,
+                saved_paths: result.cargoRegistryCache.archive.restorePaths,
+                error: message,
+              },
+              {
+                archiveBytes: archiveResult.archiveBytes,
+                inflatedBytes: archiveResult.restoredBytes,
+                fileCount: archiveResult.restoredFiles,
+                payload,
+                phaseTimings: { compressMs, uploadMs },
+              },
+            );
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          const compressMs = Date.now() - compressStart;
+          log(`cargo-registry-cache: v2 archive creation failed: ${message}`);
+          cargoRegistrySave = Object.assign(
+            {
+              status: "failed" as const,
+              cache_dir: result.cargoRegistryCache.path,
+              error: message,
+            },
+            {
+              archiveBytes: null,
+              inflatedBytes: payload.bytes,
+              fileCount: payload.files,
+              payload,
+              phaseTimings: { compressMs },
+            },
+          );
+        }
+      }
+    } else {
+      cargoRegistrySave = await saveOne({
+        cacheDir: result.cargoRegistryCache.path,
+        codec: result.targetCacheCompress,
+        level: result.targetCacheCompressLevel,
+        key: result.cargoRegistryCache.key,
+        matchedKey: registryMatched,
+        label: "cargo-registry-cache",
+        debug: debugMode,
+        log: debugLog,
+        extraBasenames: result.cargoRegistryCache.extraBasenames,
+        payloadPolicy,
+      });
+    }
     // #287 follow-up: record EVERY outcome so the post-step save
     // table shows the layer no matter what its disposition.
     postCollector.record({
       label: "cargo-registry", operation: "save", hit: false,
       key: result.cargoRegistryCache.key, matchedKey: registryMatched, restoreKeys: [],
       status: cargoRegistrySave.status,
-      archiveBytes: cargoRegistrySave.status === "saved" || cargoRegistrySave.status === "oversize-skip" ? cargoRegistrySave.archiveBytes : null,
-      inflatedBytes: cargoRegistrySave.status === "saved" || cargoRegistrySave.status === "oversize-skip" ? cargoRegistrySave.inflatedBytes : null,
-      fileCount: cargoRegistrySave.status === "saved" || cargoRegistrySave.status === "oversize-skip" ? cargoRegistrySave.fileCount : null,
-      payload: cargoRegistrySave.status === "saved" || cargoRegistrySave.status === "oversize-skip" ? cargoRegistrySave.payload : null,
+      archiveBytes: ["saved", "oversize-skip", "race-skip"].includes(cargoRegistrySave.status) ? cargoRegistrySave.archiveBytes : null,
+      inflatedBytes: ["saved", "oversize-skip", "race-skip"].includes(cargoRegistrySave.status) ? cargoRegistrySave.inflatedBytes : null,
+      fileCount: ["saved", "oversize-skip", "race-skip"].includes(cargoRegistrySave.status) ? cargoRegistrySave.fileCount : null,
+      payload: ["saved", "oversize-skip", "race-skip"].includes(cargoRegistrySave.status) ? cargoRegistrySave.payload : null,
       durationMs: Date.now() - regSaveStart,
       compressMs: cargoRegistrySave.phaseTimings?.compressMs,
       uploadMs: cargoRegistrySave.phaseTimings?.uploadMs,

--- a/tests/test_cargo_registry_soldr_workflow.py
+++ b/tests/test_cargo_registry_soldr_workflow.py
@@ -1,0 +1,100 @@
+"""Contracts for the cargo-registry Soldr v2 benchmark and ordering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "cargo-registry-soldr-benchmark.yml"
+SCRIPT = ROOT / "scripts" / "bench-cargo-registry-archives.mjs"
+MAIN = ROOT / "src" / "main.ts"
+POST = ROOT / "src" / "post.ts"
+
+
+def _triggers(workflow: dict) -> dict:
+    return workflow.get("on") or workflow.get(True)
+
+
+def test_benchmark_is_manual_windows_2025_with_reproducible_inputs() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    triggers = _triggers(workflow)
+    assert set(triggers) == {"workflow_dispatch"}
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert inputs["reps"]["default"] == "3"
+    assert inputs["runner"]["default"] == "windows-2025"
+    assert inputs["file-count"]["default"] == "50000"
+    assert inputs["assert-thresholds"]["default"] is False
+    job = workflow["jobs"]["benchmark"]
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert job["runs-on"] == "${{ inputs.runner }}"
+    assert "scripts/bench-cargo-registry-archives.mjs" in text
+    assert "if: always()" in text
+    assert "actions/upload-artifact@v4" in text
+    assert "cargo-registry-archive-benchmark.csv" in text
+
+
+def test_benchmark_script_has_raw_fields_alternation_validation_and_fixed_gates() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    for field in (
+        "runner_os",
+        "runner_image",
+        "rep",
+        "codec_path",
+        "archive_bytes",
+        "file_count",
+        "restore_ms",
+        "content_hash",
+        "success",
+    ):
+        assert field in source
+    assert "legacy,soldr" in source
+    assert "soldr,legacy" in source
+    assert "25000" in source
+    assert "3 *" in source or "* 3" in source
+    assert "content hash" in source.lower()
+
+
+def test_registry_download_and_post_verify_extraction_are_separate_phases() -> None:
+    source = MAIN.read_text(encoding="utf-8")
+    parallel = source.index('await markPhase("parallel-restore")')
+    verify = source.index('await markPhase("verify")')
+    extract = source.index('await markPhase("cargo-registry-extract")')
+    cross_prepare = source.index('await markPhase("cross-prepare")')
+    assert parallel < verify < extract < cross_prepare
+    parallel_block = source[parallel:source.index('await finishPhase("parallel-restore")')]
+    registry_download = parallel_block[
+        parallel_block.index("const cargoRegistryRestorePromise"):
+        parallel_block.index("const blessedPrepareRestorePromise")
+    ]
+    assert "restoreCacheSafe" in registry_download
+    assert "tryLoadViaSoldr" not in registry_download
+    assert "decompressCache" not in registry_download
+    extract_block = source[extract:cross_prepare]
+    assert "restoreCargoRegistryArchive" in extract_block
+    assert "soldrRuntimeVersion" in extract_block
+    assert "cargo-registry archive extraction failed" in extract_block
+
+
+def test_post_v2_save_owns_both_archive_paths_without_generic_compression() -> None:
+    source = POST.read_text(encoding="utf-8")
+    start = source.index(
+        'result.cargoRegistryCache.archive.format === "soldr-v2"'
+    )
+    end = source.index("cargoRegistrySave = await saveOne", start)
+    block = source[start:end]
+    assert "saveCargoRegistryArchive" in block
+    assert "cargoRegistryCache.archive.restorePaths" in block
+    assert "cache.saveCache" in block
+    assert "compressCache" not in block
+    helper = (ROOT / "src" / "lib" / "cargo-registry-archive.ts").read_text(
+        encoding="utf-8"
+    )
+    save_start = helper.index("export async function saveCargoRegistryArchive")
+    save_end = helper.index("export async function restoreCargoRegistryArchive")
+    assert "saveViaSoldr" in helper[save_start:save_end]
+    assert "trySaveViaSoldr" not in helper[save_start:save_end]
+    assert "id <= 0" in source
+    assert '"race-skip"' in source


### PR DESCRIPTION
## Summary
- add an explicit v2 Cargo registry cache format split between registry.soldr.tar.zst and a legacy tar+zstd extras archive
- download both cache objects in parallel, then verify and extract before cross/cook consumers run
- enforce exact-payload limits, corruption failures, runtime compatibility, encryption fallback, and exact-key reservation-race detection
- add a reproducible Windows benchmark workflow and raw CSV/Markdown evidence artifact

## Rollout
This intentionally keeps cache-cargo-registry-via-soldr opt-in. After this lands on main, the benchmark will run on windows-2025 with 50,000 files and at least three repetitions. A follow-up PR will record the evidence and either flip the default if every fixed gate passes or retain the legacy default with the measured reason.

Part of #266
Parent: #457

## Validation
- npm run typecheck
- npm test
- python -m pytest -q (35 passed)
- npm run lint:vendor-prose
- actionlint .github/workflows/cargo-registry-soldr-benchmark.yml
- node --check scripts/bench-cargo-registry-archives.mjs
- Linux node:24-bookworm rebuild of dist/main.js and dist/post.js
- node --check dist/main.js
- node --check dist/post.js
- git diff --check
- clud-review clean