### PR TITLE
docs(cargo-registry): record Windows benchmark decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@
   state remain excluded. Cache download still overlaps the other layers, while
   extraction now waits for the installed Soldr runtime to be verified. Add a
   Windows 2025 benchmark workflow with alternating legacy/Soldr restores, raw
-  CSV, content validation, and fixed 25-second/3x decision gates. Legacy-v1
-  remains the default until that evidence passes; encrypted entries and Soldr
-  versions older than 0.7.47 also remain on v1. Windows v2 restores bootstrap
-  pinned, SHA-256-verified zstd 1.5.7 when no zstd executable is on PATH.
+  CSV, content validation, and fixed 25-second/3x decision gates. In benchmark
+  run 31089551078, all six 50,002-file restores passed count and SHA-256
+  validation, but Soldr-v2's 25,881.275 ms median was slower than legacy-v1's
+  9,669.428 ms median (0.37x), so it failed both performance gates. Legacy-v1
+  therefore remains the default and `SOLDR_CARGO_REGISTRY_VIA_SOLDR=1` remains
+  the explicit v2 opt-in; encrypted entries and Soldr versions older than
+  0.7.47 also remain on v1. Windows v2 restores bootstrap pinned,
+  SHA-256-verified zstd 1.5.7 when no zstd executable is on PATH.
 
 - Default to soldr `0.8.6` (was `0.8.5`). This release restores the managed
   Windows MSVC cross-build lanes, including ARM64 target provisioning and

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ preferred for new workflows.
 | `cache-encrypt-key` | Optional 256-bit AES key (64-char hex, 44-char base64, or 43-char base64url). When set, every managed cache layer's `.tar.zst` archive is wrapped with AES-256-GCM before upload and verified+decrypted on restore. Pass via a GitHub Actions secret. See "Release-grade usage: encrypted cache" below. (#387) |
 | `cache-encrypt-on-failure` | Behavior when an encrypted entry fails GCM authentication (wrong key, tampered ciphertext, or AAD mismatch). Default `error` stops the run; `skip` logs the failure and treats the entry as a cold miss. Has no effect when `cache-encrypt-key` is empty. (#387) |
 | `source-mtime-normalize` | Opt-in. When `true`, rewrite the mtime of tracked Rust build-input files under `${{ github.workspace }}` to each file's last-commit timestamp before the target-cache restore. Default `false`. See "Source mtime normalization" below. |
-| `cargo-registry-cache` | When `true`, setup-soldr caches `~/.cargo/registry`, `.global-cache`, and `git/` and exports `SOLDR_SKIP_CARGO_REGISTRY_SAVE=1` so zccache CLI's built-in registry save no-ops. The codec defaults to legacy tar+zstd while the Soldr-v2 Windows benchmark is collected; `SOLDR_CARGO_REGISTRY_VIA_SOLDR=1` opts into the split parallel-extract format. Requires zccache `>=1.4.4` (skip-flag support). Default `false` keeps the layer itself off. |
+| `cargo-registry-cache` | When `true`, setup-soldr caches `~/.cargo/registry`, `.global-cache`, and `git/` and exports `SOLDR_SKIP_CARGO_REGISTRY_SAVE=1` so zccache CLI's built-in registry save no-ops. Legacy-v1 remains the codec default because Windows 2025 run 31089551078 failed both fixed performance gates; `SOLDR_CARGO_REGISTRY_VIA_SOLDR=1` opts into the split parallel-extract format where compatible. Requires zccache `>=1.4.4` (skip-flag support). Default `false` keeps the layer itself off. |
 | `dylint` | Enable Dylint mode. Default `false`, so normal jobs do not fetch the nightly map, restore or install a nightly, substitute toolchains, or prepare Dylint caches. When `true`, setup-soldr maps the configured exact Rust release to the newest compatible dated nightly and scopes that identity to Soldr's Dylint subprocesses. |
 | `dylint-foundation-cache` | Cache the exact Dylint nightly/components plus cargo-dylint, dylint-link, and compatible driver. Default `true` in Dylint mode and inert otherwise. The key includes the dated nightly, compiler release, and full compiler commit. |
 | `dylint-output-cache` | Restore and save the isolated custom-library and workspace-check trees separately from the long-lived foundation. Default `true` in Dylint mode and inert otherwise; a save requires a successful Dylint run. |
@@ -688,10 +688,11 @@ larger-cache behavior re-enables it explicitly:
   bundle.
 - `cargo-registry-cache: true` caches `~/.cargo/registry` plus Cargo's
   `.global-cache` and `git/` companion state. The legacy-v1 codec is the
-  default until the checked-in Windows 2025 benchmark passes both fixed gates.
-  Set `SOLDR_CARGO_REGISTRY_VIA_SOLDR=1` to opt into the v2 split layout now;
-  set it to `0`, `false`, `no`, or `off` for an explicit legacy rollback.
-  Encrypted entries and Soldr versions older than `0.7.47` always use v1.
+  default because the initial Windows 2025 evidence failed both fixed
+  performance gates. Set `SOLDR_CARGO_REGISTRY_VIA_SOLDR=1` to opt into the v2
+  split layout; unset or `0`, `false`, `no`, or `off` selects legacy-v1.
+  Encrypted entries, source-ref Soldr builds, and Soldr versions older than
+  `0.7.47` always use v1.
   On Windows, v2 bootstraps a pinned, SHA-256-verified zstd 1.5.7 executable
   under `RUNNER_TEMP` when the runner does not already provide one.
 
@@ -704,7 +705,11 @@ cost. Run the manual `cargo-registry-soldr-benchmark.yml` workflow to compare
 three or more alternating restores from one deterministic fixture. It emits raw
 CSV and a Markdown median summary; the default-on gate is Soldr under 25 seconds,
 at least 3x faster than legacy, with every file-count and SHA-256 validation
-passing.
+passing. [Windows 2025 run 31089551078](https://github.com/zackees/setup-soldr/actions/runs/31089551078)
+used 50,000 registry files and three alternating repetitions per codec. All
+six restores passed count and content-hash validation, but Soldr-v2's median
+was 25,881.275 ms versus 9,669.428 ms for legacy-v1 (0.37x), so the codec stays
+opt-in without weakening either gate.
 
 ### Cache policy presets
 

--- a/action.yml
+++ b/action.yml
@@ -382,10 +382,12 @@ inputs:
       companion ~/.cargo/.global-cache and ~/.cargo/git payloads in one
       tar+zstd archive. The opt-in Soldr-v2 codec stores registry in a Soldr
       archive for parallel extraction and keeps only those two companions in
-      a second tar+zstd archive; set SOLDR_CARGO_REGISTRY_VIA_SOLDR=1 to use
-      it while Windows benchmark evidence is collected. Encryption, an
-      explicit false-like env value, a source-ref build, or Soldr older than
-      0.7.47 retains legacy-v1. When zstd is absent on Windows, v2 fetches the
+      a second tar+zstd archive. Windows 2025 benchmark run 31089551078 measured
+      Soldr-v2 at 25,881.275 ms versus legacy-v1 at 9,669.428 ms (0.37x), so
+      legacy-v1 remains the default. Set SOLDR_CARGO_REGISTRY_VIA_SOLDR=1 to
+      opt into v2; unset or 0/false/no/off selects legacy-v1. Encryption, a
+      source-ref build, or Soldr older than 0.7.47 retains legacy-v1. When zstd
+      is absent on Windows, v2 fetches the
       pinned, SHA-256-verified upstream zstd 1.5.7 executable into RUNNER_TEMP.
       The Cargo GC database prevents each job from
       seeing fresh access times and conservatively retaining everything;


### PR DESCRIPTION
## Summary
- record the completed Windows 2025 benchmark evidence in README, action metadata, and changelog
- retain legacy-v1 as the default because Soldr-v2 failed both immutable rollout gates
- document the explicit v2 opt-in and every compatibility fallback

## Evidence
Run: https://github.com/zackees/setup-soldr/actions/runs/31089551078

- fixture: 50,000 registry files / 50,002 total restored files
- repetitions: 3 per codec, alternating order
- validation: all six restores passed file-count and SHA-256 content checks
- legacy-v1 median: 9,669.428 ms
- Soldr-v2 median: 25,881.275 ms
- relative result: 0.37x
- decision: FAIL; Soldr was not under 25,000 ms and was not at least 3x faster

The thresholds were not weakened. SOLDR_CARGO_REGISTRY_VIA_SOLDR=1 remains an explicit opt-in; unset and false-like values retain legacy-v1. Encryption, source-ref builds, and runtime versions older than 0.7.47 retain v1.

Closes #266
Parent: #457

## Validation
- npm run typecheck
- npm test
- python -m pytest -q (35 passed)
- npm run lint:vendor-prose
- git diff --check
- clud-review clean