### PR TITLE
chore(release): consume soldr 0.8.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- Default to soldr `0.8.44` (was `0.8.39`), picking up five releases of fixes.
+  Notable for setup-soldr consumers: `fix(fetch)` streams large release assets
+  with progress-aware, stall-aware retries and finishes the segmented
+  downloader (soldr#2274, soldr#2281, soldr#2331) — steadier installs on cold
+  runners for the `.tar.zst` assets this action fetches; `fix(fetch)`
+  materializes tar symlinks with the correct NTFS flavor on Windows
+  (soldr#2308); `fix(cache)` keeps Windows compiler staging paths short
+  (soldr#2284); `fix(target-lifecycle)` pins the C++ stdlib for blessed
+  linux-gnu (soldr#2311) and `feat(win-gnu)` enables Linux-hosted win-gnu
+  cross builds (soldr#2341) — both widen the blessed cross-compile surface;
+  `fix(toolchain)` fails `rust-objcopy` strip errors instead of shipping an
+  unstripped binary (soldr#2277). Release asset shapes are unchanged from
+  `0.8.39`, so no install-path changes were required.
+
 - Make the cargo-registry Soldr path reachable behind
   `SOLDR_CARGO_REGISTRY_VIA_SOLDR=1` (#266). The v2 cache owns a Soldr archive
   for `registry/` plus a separate tar+zstd archive containing only

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.39`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.8.44`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -435,7 +435,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.8.39`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.8.44`. |
 | `cross-targets` | One canonical target per job for Soldr blessed preparation; use a matrix for multiple targets. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
 | `cache` | Restore and save the action-managed cache/state root. |
@@ -537,7 +537,7 @@ preferred for new workflows.
 
 ## Notes
 
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.39`.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.8.44`.
 - For soldr `0.7.43+`, the action copies the bundled `cargo-chef` binary from
   the soldr release archive and exports `SOLDR_CARGO_CHEF_LOCAL_DIR` so
   `soldr cook` does not need a live upstream cargo-chef release lookup.

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.8.39.
+    description: Soldr version or tag to install. Defaults to 0.8.44.
     required: false
-    default: "0.8.39"
+    default: "0.8.44"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -169,7 +169,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.39"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.8.44"
 
 
 def _load_action() -> dict:

--- a/tests/test_cross_target_public_contract.py
+++ b/tests/test_cross_target_public_contract.py
@@ -35,7 +35,7 @@ def test_cross_target_action_description_has_only_blessed_contract() -> None:
 def test_readme_recommends_only_target_driven_cross_compilation() -> None:
     readme = README_PATH.read_text(encoding="utf-8")
 
-    assert "The default Soldr version is `0.8.39`." in readme
+    assert "The default Soldr version is `0.8.44`." in readme
     assert "### Legacy cross-compile auto-bootstrap" not in readme
     assert "soldr cargo zigbuild" not in readme
     assert "cross-tool:" not in readme
@@ -50,7 +50,7 @@ def test_default_soldr_version_is_one_public_constant() -> None:
     readme = README_PATH.read_text(encoding="utf-8")
     contract = CONTRACT_PATH.read_text(encoding="utf-8")
 
-    assert version == "0.8.39"
+    assert version == "0.8.44"
     assert f"The default Soldr version is `{version}`." in readme
     assert f'EXPECTED_SOLDR_DEFAULT_VERSION = "{version}"' in contract
 


### PR DESCRIPTION
Bumps the default soldr version from `0.8.39` to `0.8.44` — the single public default constant validated across `action.yml`, `README.md`, and the target-cache-wiring contract test.

## What changed
- `action.yml` — default `version` + description
- `README.md` — three default-version references
- `tests/test_action_target_cache_wiring.py` — `EXPECTED_SOLDR_DEFAULT_VERSION`
- `tests/test_cross_target_public_contract.py` — README + action default assertions
- `CHANGELOG.md` — Unreleased entry

## Notable upstream fixes picked up (0.8.40 → 0.8.44)
- **fix(fetch)** — stall-aware large-artifact downloads, progress-aware retries, finished segmented downloader (soldr#2274, #2281, #2331); correct NTFS symlink flavor on Windows (soldr#2308). Directly steadies the `.tar.zst` install path this action drives.
- **fix(cache)** — keep Windows compiler staging paths short (soldr#2284).
- **fix(target-lifecycle)** — pin C++ stdlib for blessed linux-gnu (soldr#2311); **feat(win-gnu)** Linux-hosted win-gnu cross builds (soldr#2341) — widen the blessed cross-compile surface.
- **fix(toolchain)** — fail `rust-objcopy` strip errors rather than ship an unstripped binary (soldr#2277).

Release asset shapes are **unchanged** from `0.8.39` (identical 8 `tar.zst` targets + `SHA256SUMS`), so no install-path code changes were required.

## Verification
- `node scripts/check-default-release-readiness.mjs` → **release readiness passed for v0.8.44 (5 supported targets)**
- `tsc --noEmit` clean
- Affected python tests (`test_cross_target_public_contract`, `test_action_target_cache_wiring`, `test_release_lane_workflow`) — 15 passed
- Full node suite — 667 pass / 12 skip. The one failure (`cargo-registry-archive` companion-archive zstd-fallback test) is **pre-existing on clean `main`** and unrelated to this bump (local zstd-executable environment issue; that file is not part of the `npm test` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)