### PR TITLE
chore: default to Soldr 0.9.5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.9.4.
+    description: Soldr version or tag to install. Defaults to 0.9.5.
     required: false
-    default: "0.9.4"
+    default: "0.9.5"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false


### PR DESCRIPTION
## Summary
- update the action's default Soldr release to 0.9.5
- make multipart catalogue-v2 support available to setup-soldr consumers by default

## Verification
- Soldr v0.9.5 GitHub release is published
- PyPI reports 0.9.5
- npm @zackees/soldr reports 0.9.5
- npm run build completed (no source bundle change required for action metadata)