### PR TITLE
chore: default to Soldr 0.9.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or rustup homes by default. The default Soldr version is `0.9.2`.
 
 -->
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or toolchain homes by default. The default Soldr version is `0.9.4`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or toolchain homes by default. The default Soldr version is `0.9.7`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -439,7 +439,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.9.4`. |
+| `version` | Soldr release tag or version to install. Defaults to `0.9.7`. |
 | `source-path` | Internal development override that builds Soldr from a pinned local Git checkout such as `_vender/soldr`; the checkout must include required submodules. Release assets remain the production default. |
 | `cross-targets` | One canonical target per job for Soldr blessed preparation; use a matrix for multiple targets. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
@@ -550,7 +550,7 @@ preferred for new workflows.
 
 - Development branches may pin the tracked `_vender/soldr` checkout and pass `source-path: _vender/soldr`; setup-soldr keys the build on the checkout's exact `HEAD`; commit local edits before expecting a new source identity. Production installs remain release-asset based.
 - `soldr-cook` rematerialization is a two-part dependency closure: the cooked `target/` base (fingerprints, dep-info, rlibs/proc macros, build-script executables and outputs) plus Cargo registry/git sources. The action restores both by default and reports transport/load status through the `cook-cache-*` outputs.
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.9.4`. Combined GitHub release archives remain preferred; for explicitly supported wheel-compatible releases (currently `0.9.0` through `0.9.4`), a missing exact target archive falls back to the matching hash-verified wheel from the same version on PyPI.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.9.7`. Combined GitHub release archives remain preferred; for explicitly supported wheel-compatible releases (currently `0.9.0` through `0.9.4`), a missing exact target archive falls back to the matching hash-verified wheel from the same version on PyPI.
 - For soldr `0.7.43+`, the action installs the release-pinned `cargo-chef`
   binary and exports `SOLDR_CARGO_CHEF_LOCAL_DIR`, so `soldr cook` does not
   need a live upstream GitHub lookup. Combined archives bundle the helper;

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.9.5.
+    description: Soldr version or tag to install. Defaults to 0.9.7.
     required: false
-    default: "0.9.5"
+    default: "0.9.7"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -176,7 +176,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.9.4"
+EXPECTED_SOLDR_DEFAULT_VERSION = "0.9.7"
 
 
 def _load_action() -> dict:

--- a/tests/test_cross_target_public_contract.py
+++ b/tests/test_cross_target_public_contract.py
@@ -35,7 +35,7 @@ def test_cross_target_action_description_has_only_blessed_contract() -> None:
 def test_readme_recommends_only_target_driven_cross_compilation() -> None:
     readme = README_PATH.read_text(encoding="utf-8")
 
-    assert "The default Soldr version is `0.9.4`." in readme
+    assert "The default Soldr version is `0.9.7`." in readme
     assert "### Legacy cross-compile auto-bootstrap" not in readme
     assert "soldr cargo zigbuild" not in readme
     assert "cross-tool:" not in readme
@@ -50,7 +50,7 @@ def test_default_soldr_version_is_one_public_constant() -> None:
     readme = README_PATH.read_text(encoding="utf-8")
     contract = CONTRACT_PATH.read_text(encoding="utf-8")
 
-    assert version == "0.9.4"
+    assert version == "0.9.7"
     assert f"The default Soldr version is `{version}`." in readme
     assert f'EXPECTED_SOLDR_DEFAULT_VERSION = "{version}"' in contract
 


### PR DESCRIPTION
## Summary
- update the setup-soldr default to published Soldr 0.9.7
- update the public documentation and contract expectations

Depends on the fully verified Soldr release from zackees/soldr#2851 and release run 32825875256.

## Validation
- release readiness: 6/6 supported combined archives
- 698 tests: 686 passed, 12 skipped, 0 failed
- live local installation resolved and verified Soldr 0.9.7