### PR TITLE
fix(cache): invalidate closures with yanked crates

### DIFF
--- a/__tests__/cache-eviction.test.ts
+++ b/__tests__/cache-eviction.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  deleteCacheEntriesByKeys,
   evictIfOverBudget,
   thresholdsForPolicy,
   ageFloorForOvershoot,
@@ -271,4 +272,60 @@ test("entries NOT matching foundation prefix are evictable", () => {
       `${key} should NOT be classified as foundation`,
     );
   }
+});
+
+test("targeted yank repair deletes exact poisoned keys and the retry misses", async () => {
+  const store = new Map<number, CacheEntry>([
+    [1, entry(1, "build-poisoned", 10, 1)],
+    [2, entry(2, "cook-poisoned", 20, 1)],
+    [3, entry(3, "healthy", 30, 1)],
+  ]);
+  const result = await deleteCacheEntriesByKeys({
+    owner: "owner",
+    repo: "repo",
+    token: "token",
+    keys: ["build-poisoned", "cook-poisoned"],
+    log: () => undefined,
+    listCachesForKey: async (key) => [...store.values()].filter((item) => item.key === key),
+    deleteCacheById: async (id) => { store.delete(id); },
+  });
+  assert.deepEqual(result, { found: 2, deleted: 2, failed: 0 });
+  assert.equal([...store.values()].some((item) => item.key === "build-poisoned"), false);
+  assert.equal([...store.values()].some((item) => item.key === "cook-poisoned"), false);
+  assert.equal([...store.values()].some((item) => item.key === "healthy"), true);
+});
+
+test("targeted yank repair reports permission failure and leaves the poisoned key", async () => {
+  const poisoned = entry(9, "poisoned", 10, 1);
+  const result = await deleteCacheEntriesByKeys({
+    owner: "owner",
+    repo: "repo",
+    token: "read-only-token",
+    keys: ["poisoned"],
+    log: () => undefined,
+    listCachesForKey: async () => [poisoned],
+    deleteCacheById: async () => {
+      const error = new Error("forbidden") as Error & { status: number };
+      error.status = 403;
+      throw error;
+    },
+  });
+  assert.deepEqual(result, { found: 1, deleted: 0, failed: 1 });
+});
+
+test("targeted yank repair treats a concurrent 404 deletion race as repaired", async () => {
+  const result = await deleteCacheEntriesByKeys({
+    owner: "owner",
+    repo: "repo",
+    token: "token",
+    keys: ["poisoned"],
+    log: () => undefined,
+    listCachesForKey: async () => [entry(9, "poisoned", 10, 1)],
+    deleteCacheById: async () => {
+      const error = new Error("gone") as Error & { status: number };
+      error.status = 404;
+      throw error;
+    },
+  });
+  assert.deepEqual(result, { found: 1, deleted: 1, failed: 0 });
 });

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,4 +1,5 @@
 import { test } from "node:test";
+import "./yank-audit.test.ts";
 import assert from "node:assert/strict";
 
 // Ensure main.ts does not auto-invoke its run() when imported under test.

--- a/__tests__/yank-audit.test.ts
+++ b/__tests__/yank-audit.test.ts
@@ -1,0 +1,151 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  auditDependencyYanks,
+  cratesIoSparsePath,
+  readRegistryDependencies,
+  waitForYankAuditResult,
+  writeYankAuditResult,
+  type YankAuditDependency,
+} from "../src/lib/yank-audit.js";
+
+const CRATES_IO = "registry+https://github.com/rust-lang/crates.io-index";
+
+function dependency(name: string, version: string): YankAuditDependency {
+  return { name, version, source: CRATES_IO };
+}
+
+function sparseFetch(records: Record<string, Array<{ vers: string; yanked: boolean }>>): typeof fetch {
+  return (async (input: string | URL | Request): Promise<Response> => {
+    const crateName = String(input).split("/").at(-1) ?? "";
+    const body = (records[crateName] ?? []).map((record) => JSON.stringify(record)).join("\n");
+    return new Response(body, { status: records[crateName] ? 200 : 404 });
+  }) as typeof fetch;
+}
+
+test("Cargo.lock parser selects registry packages and deduplicates the closure", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "setup-soldr-yank-lock-"));
+  try {
+    const lockfile = path.join(root, "Cargo.lock");
+    fs.writeFileSync(lockfile, `
+version = 4
+
+[[package]]
+name = "workspace"
+version = "0.1.0"
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+source = "${CRATES_IO}"
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+source = "${CRATES_IO}"
+
+[[package]]
+name = "git-dep"
+version = "2.0.0"
+source = "git+https://example.invalid/repo"
+`, "utf8");
+    assert.deepEqual(readRegistryDependencies(lockfile), [dependency("serde", "1.0.0")]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("sparse-index paths follow the crates.io name layout", () => {
+  assert.equal(cratesIoSparsePath("a"), "1/a");
+  assert.equal(cratesIoSparsePath("ab"), "2/ab");
+  assert.equal(cratesIoSparsePath("abc"), "3/a/abc");
+  assert.equal(cratesIoSparsePath("Serde_JSON"), "se/rd/serde_json");
+});
+
+test("audit reports the yanked crate and version", async () => {
+  const result = await auditDependencyYanks(
+    [dependency("serde", "1.0.0"), dependency("itoa", "1.0.0")],
+    {
+      fetchImpl: sparseFetch({
+        serde: [{ vers: "1.0.0", yanked: true }],
+        itoa: [{ vers: "1.0.0", yanked: false }],
+      }),
+    },
+  );
+  assert.equal(result.status, "yanked");
+  assert.deepEqual(result.yanked, [{ name: "serde", version: "1.0.0" }]);
+  assert.equal(result.checkedCount, 2);
+});
+
+test("audit reports clean only after every registry dependency is checked", async () => {
+  const result = await auditDependencyYanks([dependency("serde", "1.0.0")], {
+    fetchImpl: sparseFetch({ serde: [{ vers: "1.0.0", yanked: false }] }),
+  });
+  assert.equal(result.status, "clean");
+  assert.equal(result.checkedCount, 1);
+  assert.deepEqual(result.errors, []);
+});
+
+test("registry failure and unsupported registries are not checked, never clean", async () => {
+  const unreachable = await auditDependencyYanks([dependency("serde", "1.0.0")], {
+    fetchImpl: (async () => { throw new Error("network unreachable"); }) as typeof fetch,
+  });
+  assert.equal(unreachable.status, "not-checked");
+  assert.match(unreachable.errors?.[0] ?? "", /network unreachable/);
+
+  const unsupported = await auditDependencyYanks([
+    { name: "private", version: "1.2.3", source: "registry+https://registry.example/index" },
+  ]);
+  assert.equal(unsupported.status, "not-checked");
+  assert.match(unsupported.errors?.[0] ?? "", /not supported/);
+});
+
+test("one global deadline aborts every stalled request wave before post joins", async () => {
+  const stalledFetch = ((_input: string | URL | Request, init?: RequestInit): Promise<Response> =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+    })) as typeof fetch;
+  const dependencies = Array.from({ length: 40 }, (_, index) =>
+    dependency(`crate-${index}`, "1.0.0"));
+  const started = Date.now();
+  const result = await auditDependencyYanks(dependencies, {
+    fetchImpl: stalledFetch,
+    concurrency: 2,
+    requestTimeoutMs: 5_000,
+    overallTimeoutMs: 25,
+  });
+  assert.equal(result.status, "not-checked");
+  assert.ok(Date.now() - started < 1_000, "global deadline must not wait for successive waves");
+  assert.ok(result.errors?.some((error) => /aborted|deadline/.test(error)));
+});
+
+test("post join waits for a pending worker result", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "setup-soldr-yank-result-"));
+  try {
+    const resultPath = path.join(root, "result.json");
+    writeYankAuditResult(resultPath, { status: "pending" });
+    setTimeout(() => writeYankAuditResult(resultPath, {
+      status: "clean",
+      checkedAt: new Date().toISOString(),
+      dependencyCount: 1,
+      checkedCount: 1,
+    }), 20);
+    const result = await waitForYankAuditResult(resultPath, { timeoutMs: 1_000, pollMs: 5 });
+    assert.equal(result.status, "clean");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("post join timeout is reported as not checked", async () => {
+  const result = await waitForYankAuditResult("missing-result.json", {
+    timeoutMs: 10,
+    pollMs: 2,
+  });
+  assert.equal(result.status, "not-checked");
+  assert.equal(result.joinTimedOut, true);
+  assert.match(result.errors?.[0] ?? "", /did not finish/);
+});

--- a/dist/main.js
+++ b/dist/main.js
@@ -15,12 +15,12 @@
 //     -- this will require modifications to utils.parseParams
 
 const { Readable } = __nccwpck_require__(457)
-const { inherits } = __nccwpck_require__(398)
+const { inherits } = __nccwpck_require__(399)
 
 const Dicer = __nccwpck_require__(16)
 
-const parseParams = __nccwpck_require__(201)
-const decodeText = __nccwpck_require__(293)
+const parseParams = __nccwpck_require__(202)
+const decodeText = __nccwpck_require__(294)
 const basename = __nccwpck_require__(510)
 const getLimit = __nccwpck_require__(517)
 
@@ -340,7 +340,7 @@ __export(inspect_exports, {
   custom: () => custom
 });
 module.exports = __toCommonJS(inspect_exports);
-var import_node_util = __nccwpck_require__(398);
+var import_node_util = __nccwpck_require__(399);
 const custom = import_node_util.inspect.custom;
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -495,10 +495,10 @@ exports.buildMiniCacheKey = buildMiniCacheKey;
 exports.restoreMiniCache = restoreMiniCache;
 exports.saveMiniCache = saveMiniCache;
 exports.isEligibleForMiniCache = isEligibleForMiniCache;
-const fs = __importStar(__nccwpck_require__(265));
-const fsp = __importStar(__nccwpck_require__(118));
+const fs = __importStar(__nccwpck_require__(266));
+const fsp = __importStar(__nccwpck_require__(119));
 const path = __importStar(__nccwpck_require__(542));
-const cache = __importStar(__nccwpck_require__(222));
+const cache = __importStar(__nccwpck_require__(223));
 const cache_compress_js_1 = __nccwpck_require__(28);
 const ensure_soldr_js_1 = __nccwpck_require__(479);
 // Schema segment `v2` (still inside the `soldr-mini-` eviction namespace):
@@ -750,16 +750,16 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.downloadCacheStorageSDK = exports.downloadCacheHttpClientConcurrent = exports.downloadCacheHttpClient = exports.DownloadProgress = void 0;
 const core = __importStar(__nccwpck_require__(490));
-const http_client_1 = __nccwpck_require__(303);
+const http_client_1 = __nccwpck_require__(304);
 const storage_blob_1 = __nccwpck_require__(475);
-const buffer = __importStar(__nccwpck_require__(128));
-const fs = __importStar(__nccwpck_require__(567));
-const stream = __importStar(__nccwpck_require__(139));
-const util = __importStar(__nccwpck_require__(132));
+const buffer = __importStar(__nccwpck_require__(129));
+const fs = __importStar(__nccwpck_require__(568));
+const stream = __importStar(__nccwpck_require__(140));
+const util = __importStar(__nccwpck_require__(133));
 const utils = __importStar(__nccwpck_require__(83));
 const constants_1 = __nccwpck_require__(51);
-const requestUtils_1 = __nccwpck_require__(278);
-const abort_controller_1 = __nccwpck_require__(239);
+const requestUtils_1 = __nccwpck_require__(279);
+const abort_controller_1 = __nccwpck_require__(240);
 /**
  * Pipes the body of a HTTP response to a stream
  *
@@ -1120,13 +1120,13 @@ exports.SearchState = SearchState;
 
 
 const { InvalidArgumentError } = __nccwpck_require__(522)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(204)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(205)
 const DispatcherBase = __nccwpck_require__(69)
-const Pool = __nccwpck_require__(361)
+const Pool = __nccwpck_require__(362)
 const Client = __nccwpck_require__(98)
 const util = __nccwpck_require__(77)
-const createRedirectInterceptor = __nccwpck_require__(272)
-const { WeakRef, FinalizationRegistry } = __nccwpck_require__(440)()
+const createRedirectInterceptor = __nccwpck_require__(273)
+const { WeakRef, FinalizationRegistry } = __nccwpck_require__(441)()
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -1418,15 +1418,15 @@ exports.saveCookCache = saveCookCache;
 exports.saveLayeredCookCache = saveLayeredCookCache;
 exports.parseCookFlags = parseCookFlags;
 exports.canonicalizeCookFlags = canonicalizeCookFlags;
-const node_crypto_1 = __nccwpck_require__(292);
-const fs = __importStar(__nccwpck_require__(265));
-const fsp = __importStar(__nccwpck_require__(118));
+const node_crypto_1 = __nccwpck_require__(293);
+const fs = __importStar(__nccwpck_require__(266));
+const fsp = __importStar(__nccwpck_require__(119));
 const path = __importStar(__nccwpck_require__(542));
 const core = __importStar(__nccwpck_require__(490));
 const exec = __importStar(__nccwpck_require__(21));
-const cache = __importStar(__nccwpck_require__(222));
+const cache = __importStar(__nccwpck_require__(223));
 const cache_compress_js_1 = __nccwpck_require__(28);
-const log_utils_js_1 = __nccwpck_require__(200);
+const log_utils_js_1 = __nccwpck_require__(201);
 const two_phase_actions_cache_js_1 = __nccwpck_require__(40);
 function layeredCookBaseReady(restore, loaded) {
     return restore.base.hit && loaded.baseLoaded;
@@ -2335,7 +2335,7 @@ function canonicalizeCookFlags(flags) {
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(243)
+const { MockNotMatchedError } = __nccwpck_require__(244)
 const {
   kDispatches,
   kMockAgent,
@@ -2344,12 +2344,12 @@ const {
   kGetNetConnect
 } = __nccwpck_require__(504)
 const { buildURL, nop } = __nccwpck_require__(77)
-const { STATUS_CODES } = __nccwpck_require__(353)
+const { STATUS_CODES } = __nccwpck_require__(354)
 const {
   types: {
     isPromise
   }
-} = __nccwpck_require__(132)
+} = __nccwpck_require__(133)
 
 function matchValue (match, value) {
   if (typeof match === 'string') {
@@ -2916,10 +2916,10 @@ exports.decideBlessedPrepareCacheUse = decideBlessedPrepareCacheUse;
 exports.validateBlessedPrepareRestore = validateBlessedPrepareRestore;
 exports.assertMinimumSoldrVersion = assertMinimumSoldrVersion;
 exports.executeBlessedPrepare = executeBlessedPrepare;
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
 const exec = __importStar(__nccwpck_require__(21));
-const cache_keys_js_1 = __nccwpck_require__(332);
+const cache_keys_js_1 = __nccwpck_require__(333);
 const TRIPLE = /^[a-z0-9]+(?:_[a-z0-9]+)*-[a-z0-9]+(?:-[a-z0-9]+)+$/;
 function parseSingleCrossTarget(raw) {
     const values = [...new Set(raw.split(/[\s,]+/).map((v) => v.trim().toLowerCase()).filter(Boolean))].sort();
@@ -3100,18 +3100,18 @@ function formatDefaultJson(value) {
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(165)
+const { kConstruct } = __nccwpck_require__(166)
 const { urlEquals, fieldValues: getFieldValues } = __nccwpck_require__(86)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(77)
-const { kHeadersList } = __nccwpck_require__(204)
+const { kHeadersList } = __nccwpck_require__(205)
 const { webidl } = __nccwpck_require__(485)
 const { Response, cloneResponse } = __nccwpck_require__(46)
 const { Request } = __nccwpck_require__(90)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(18)
 const { fetching } = __nccwpck_require__(478)
 const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(552)
-const assert = __nccwpck_require__(562)
-const { getGlobalDispatcher } = __nccwpck_require__(399)
+const assert = __nccwpck_require__(563)
+const { getGlobalDispatcher } = __nccwpck_require__(400)
 
 /**
  * @see https://w3c.github.io/ServiceWorker/#dfn-cache-batch-operation
@@ -3947,12 +3947,12 @@ module.exports = {
 
 
 const WritableStream = (__nccwpck_require__(457).Writable)
-const inherits = (__nccwpck_require__(398).inherits)
+const inherits = (__nccwpck_require__(399).inherits)
 
-const StreamSearch = __nccwpck_require__(123)
+const StreamSearch = __nccwpck_require__(124)
 
 const PartStream = __nccwpck_require__(73)
-const HeaderParser = __nccwpck_require__(117)
+const HeaderParser = __nccwpck_require__(118)
 
 const DASH = 45
 const B_ONEDASH = Buffer.from('-')
@@ -4179,17 +4179,17 @@ exports.isObject = isObject;
 exports.randomUUID = randomUUID;
 exports.uint8ArrayToString = uint8ArrayToString;
 exports.stringToUint8Array = stringToUint8Array;
-const tslib_1 = __nccwpck_require__(225);
-const tspRuntime = tslib_1.__importStar(__nccwpck_require__(155));
+const tslib_1 = __nccwpck_require__(226);
+const tspRuntime = tslib_1.__importStar(__nccwpck_require__(156));
 var aborterUtils_js_1 = __nccwpck_require__(110);
 Object.defineProperty(exports, "cancelablePromiseRace", ({ enumerable: true, get: function () { return aborterUtils_js_1.cancelablePromiseRace; } }));
-var createAbortablePromise_js_1 = __nccwpck_require__(277);
+var createAbortablePromise_js_1 = __nccwpck_require__(278);
 Object.defineProperty(exports, "createAbortablePromise", ({ enumerable: true, get: function () { return createAbortablePromise_js_1.createAbortablePromise; } }));
-var delay_js_1 = __nccwpck_require__(122);
+var delay_js_1 = __nccwpck_require__(123);
 Object.defineProperty(exports, "delay", ({ enumerable: true, get: function () { return delay_js_1.delay; } }));
-var error_js_1 = __nccwpck_require__(221);
+var error_js_1 = __nccwpck_require__(222);
 Object.defineProperty(exports, "getErrorMessage", ({ enumerable: true, get: function () { return error_js_1.getErrorMessage; } }));
-var typeGuards_js_1 = __nccwpck_require__(120);
+var typeGuards_js_1 = __nccwpck_require__(121);
 Object.defineProperty(exports, "isDefined", ({ enumerable: true, get: function () { return typeGuards_js_1.isDefined; } }));
 Object.defineProperty(exports, "isObjectWithProperties", ({ enumerable: true, get: function () { return typeGuards_js_1.isObjectWithProperties; } }));
 Object.defineProperty(exports, "objectHasProperty", ({ enumerable: true, get: function () { return typeGuards_js_1.objectHasProperty; } }));
@@ -4365,7 +4365,7 @@ module.exports = __toCommonJS(retryPolicy_exports);
 var import_helpers = __nccwpck_require__(484);
 var import_restError = __nccwpck_require__(472);
 var import_AbortError = __nccwpck_require__(12);
-var import_logger = __nccwpck_require__(261);
+var import_logger = __nccwpck_require__(262);
 var import_constants = __nccwpck_require__(54);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("ts-http-runtime retryPolicy");
 const retryPolicyName = "retryPolicy";
@@ -4522,8 +4522,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
-const string_decoder_1 = __nccwpck_require__(158);
-const tr = __importStar(__nccwpck_require__(134));
+const string_decoder_1 = __nccwpck_require__(159);
+const tr = __importStar(__nccwpck_require__(135));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -4607,43 +4607,43 @@ exports.getExecOutput = getExecOutput;
 // webpack verbose output hints that this should be useful
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Convenience JSON typings and corresponding type guards
-var json_typings_1 = __nccwpck_require__(419);
+var json_typings_1 = __nccwpck_require__(420);
 Object.defineProperty(exports, "typeofJsonValue", ({ enumerable: true, get: function () { return json_typings_1.typeofJsonValue; } }));
 Object.defineProperty(exports, "isJsonObject", ({ enumerable: true, get: function () { return json_typings_1.isJsonObject; } }));
 // Base 64 encoding
-var base64_1 = __nccwpck_require__(324);
+var base64_1 = __nccwpck_require__(325);
 Object.defineProperty(exports, "base64decode", ({ enumerable: true, get: function () { return base64_1.base64decode; } }));
 Object.defineProperty(exports, "base64encode", ({ enumerable: true, get: function () { return base64_1.base64encode; } }));
 // UTF8 encoding
-var protobufjs_utf8_1 = __nccwpck_require__(370);
+var protobufjs_utf8_1 = __nccwpck_require__(371);
 Object.defineProperty(exports, "utf8read", ({ enumerable: true, get: function () { return protobufjs_utf8_1.utf8read; } }));
 // Binary format contracts, options for reading and writing, for example
-var binary_format_contract_1 = __nccwpck_require__(357);
+var binary_format_contract_1 = __nccwpck_require__(358);
 Object.defineProperty(exports, "WireType", ({ enumerable: true, get: function () { return binary_format_contract_1.WireType; } }));
 Object.defineProperty(exports, "mergeBinaryOptions", ({ enumerable: true, get: function () { return binary_format_contract_1.mergeBinaryOptions; } }));
 Object.defineProperty(exports, "UnknownFieldHandler", ({ enumerable: true, get: function () { return binary_format_contract_1.UnknownFieldHandler; } }));
 // Standard IBinaryReader implementation
-var binary_reader_1 = __nccwpck_require__(143);
+var binary_reader_1 = __nccwpck_require__(144);
 Object.defineProperty(exports, "BinaryReader", ({ enumerable: true, get: function () { return binary_reader_1.BinaryReader; } }));
 Object.defineProperty(exports, "binaryReadOptions", ({ enumerable: true, get: function () { return binary_reader_1.binaryReadOptions; } }));
 // Standard IBinaryWriter implementation
-var binary_writer_1 = __nccwpck_require__(267);
+var binary_writer_1 = __nccwpck_require__(268);
 Object.defineProperty(exports, "BinaryWriter", ({ enumerable: true, get: function () { return binary_writer_1.BinaryWriter; } }));
 Object.defineProperty(exports, "binaryWriteOptions", ({ enumerable: true, get: function () { return binary_writer_1.binaryWriteOptions; } }));
 // Int64 and UInt64 implementations required for the binary format
-var pb_long_1 = __nccwpck_require__(126);
+var pb_long_1 = __nccwpck_require__(127);
 Object.defineProperty(exports, "PbLong", ({ enumerable: true, get: function () { return pb_long_1.PbLong; } }));
 Object.defineProperty(exports, "PbULong", ({ enumerable: true, get: function () { return pb_long_1.PbULong; } }));
 // JSON format contracts, options for reading and writing, for example
-var json_format_contract_1 = __nccwpck_require__(254);
+var json_format_contract_1 = __nccwpck_require__(255);
 Object.defineProperty(exports, "jsonReadOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonReadOptions; } }));
 Object.defineProperty(exports, "jsonWriteOptions", ({ enumerable: true, get: function () { return json_format_contract_1.jsonWriteOptions; } }));
 Object.defineProperty(exports, "mergeJsonOptions", ({ enumerable: true, get: function () { return json_format_contract_1.mergeJsonOptions; } }));
 // Message type contract
-var message_type_contract_1 = __nccwpck_require__(432);
+var message_type_contract_1 = __nccwpck_require__(433);
 Object.defineProperty(exports, "MESSAGE_TYPE", ({ enumerable: true, get: function () { return message_type_contract_1.MESSAGE_TYPE; } }));
 // Message type implementation via reflection
-var message_type_1 = __nccwpck_require__(566);
+var message_type_1 = __nccwpck_require__(567);
 Object.defineProperty(exports, "MessageType", ({ enumerable: true, get: function () { return message_type_1.MessageType; } }));
 // Reflection info, generated by the plugin, exposed to the user, used by reflection ops
 var reflection_info_1 = __nccwpck_require__(481);
@@ -4655,35 +4655,35 @@ Object.defineProperty(exports, "readFieldOptions", ({ enumerable: true, get: fun
 Object.defineProperty(exports, "readFieldOption", ({ enumerable: true, get: function () { return reflection_info_1.readFieldOption; } }));
 Object.defineProperty(exports, "readMessageOption", ({ enumerable: true, get: function () { return reflection_info_1.readMessageOption; } }));
 // Message operations via reflection
-var reflection_type_check_1 = __nccwpck_require__(311);
+var reflection_type_check_1 = __nccwpck_require__(312);
 Object.defineProperty(exports, "ReflectionTypeCheck", ({ enumerable: true, get: function () { return reflection_type_check_1.ReflectionTypeCheck; } }));
-var reflection_create_1 = __nccwpck_require__(214);
+var reflection_create_1 = __nccwpck_require__(215);
 Object.defineProperty(exports, "reflectionCreate", ({ enumerable: true, get: function () { return reflection_create_1.reflectionCreate; } }));
 var reflection_scalar_default_1 = __nccwpck_require__(494);
 Object.defineProperty(exports, "reflectionScalarDefault", ({ enumerable: true, get: function () { return reflection_scalar_default_1.reflectionScalarDefault; } }));
-var reflection_merge_partial_1 = __nccwpck_require__(145);
+var reflection_merge_partial_1 = __nccwpck_require__(146);
 Object.defineProperty(exports, "reflectionMergePartial", ({ enumerable: true, get: function () { return reflection_merge_partial_1.reflectionMergePartial; } }));
 var reflection_equals_1 = __nccwpck_require__(492);
 Object.defineProperty(exports, "reflectionEquals", ({ enumerable: true, get: function () { return reflection_equals_1.reflectionEquals; } }));
-var reflection_binary_reader_1 = __nccwpck_require__(434);
+var reflection_binary_reader_1 = __nccwpck_require__(435);
 Object.defineProperty(exports, "ReflectionBinaryReader", ({ enumerable: true, get: function () { return reflection_binary_reader_1.ReflectionBinaryReader; } }));
-var reflection_binary_writer_1 = __nccwpck_require__(193);
+var reflection_binary_writer_1 = __nccwpck_require__(194);
 Object.defineProperty(exports, "ReflectionBinaryWriter", ({ enumerable: true, get: function () { return reflection_binary_writer_1.ReflectionBinaryWriter; } }));
-var reflection_json_reader_1 = __nccwpck_require__(367);
+var reflection_json_reader_1 = __nccwpck_require__(368);
 Object.defineProperty(exports, "ReflectionJsonReader", ({ enumerable: true, get: function () { return reflection_json_reader_1.ReflectionJsonReader; } }));
 var reflection_json_writer_1 = __nccwpck_require__(100);
 Object.defineProperty(exports, "ReflectionJsonWriter", ({ enumerable: true, get: function () { return reflection_json_writer_1.ReflectionJsonWriter; } }));
 var reflection_contains_message_type_1 = __nccwpck_require__(56);
 Object.defineProperty(exports, "containsMessageType", ({ enumerable: true, get: function () { return reflection_contains_message_type_1.containsMessageType; } }));
 // Oneof helpers
-var oneof_1 = __nccwpck_require__(198);
+var oneof_1 = __nccwpck_require__(199);
 Object.defineProperty(exports, "isOneofGroup", ({ enumerable: true, get: function () { return oneof_1.isOneofGroup; } }));
 Object.defineProperty(exports, "setOneofValue", ({ enumerable: true, get: function () { return oneof_1.setOneofValue; } }));
 Object.defineProperty(exports, "getOneofValue", ({ enumerable: true, get: function () { return oneof_1.getOneofValue; } }));
 Object.defineProperty(exports, "clearOneofValue", ({ enumerable: true, get: function () { return oneof_1.clearOneofValue; } }));
 Object.defineProperty(exports, "getSelectedOneofValue", ({ enumerable: true, get: function () { return oneof_1.getSelectedOneofValue; } }));
 // Enum object type guard and reflection util, may be interesting to the user.
-var enum_object_1 = __nccwpck_require__(290);
+var enum_object_1 = __nccwpck_require__(291);
 Object.defineProperty(exports, "listEnumValues", ({ enumerable: true, get: function () { return enum_object_1.listEnumValues; } }));
 Object.defineProperty(exports, "listEnumNames", ({ enumerable: true, get: function () { return enum_object_1.listEnumNames; } }));
 Object.defineProperty(exports, "listEnumNumbers", ({ enumerable: true, get: function () { return enum_object_1.listEnumNumbers; } }));
@@ -4775,7 +4775,7 @@ const XML_CHARKEY = "_";
 /***/ 25:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(204)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(205)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -4839,7 +4839,7 @@ __export(throttlingRetryPolicy_exports, {
   throttlingRetryPolicyName: () => throttlingRetryPolicyName
 });
 module.exports = __toCommonJS(throttlingRetryPolicy_exports);
-var import_policies = __nccwpck_require__(307);
+var import_policies = __nccwpck_require__(308);
 const throttlingRetryPolicyName = import_policies.throttlingRetryPolicyName;
 function throttlingRetryPolicy(options = {}) {
   return (0, import_policies.throttlingRetryPolicy)(options);
@@ -4856,7 +4856,7 @@ function throttlingRetryPolicy(options = {}) {
 "use strict";
 
 
-const Busboy = __nccwpck_require__(442)
+const Busboy = __nccwpck_require__(443)
 const util = __nccwpck_require__(77)
 const {
   ReadableStreamFrom,
@@ -4866,21 +4866,21 @@ const {
   createDeferredPromise,
   fullyReadBody
 } = __nccwpck_require__(552)
-const { FormData } = __nccwpck_require__(216)
+const { FormData } = __nccwpck_require__(217)
 const { kState } = __nccwpck_require__(18)
 const { webidl } = __nccwpck_require__(485)
 const { DOMException, structuredClone } = __nccwpck_require__(34)
-const { Blob, File: NativeFile } = __nccwpck_require__(128)
-const { kBodyUsed } = __nccwpck_require__(204)
-const assert = __nccwpck_require__(562)
+const { Blob, File: NativeFile } = __nccwpck_require__(129)
+const { kBodyUsed } = __nccwpck_require__(205)
+const assert = __nccwpck_require__(563)
 const { isErrored } = __nccwpck_require__(77)
-const { isUint8Array, isArrayBuffer } = __nccwpck_require__(207)
-const { File: UndiciFile } = __nccwpck_require__(388)
+const { isUint8Array, isArrayBuffer } = __nccwpck_require__(208)
+const { File: UndiciFile } = __nccwpck_require__(389)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(29)
 
 let random
 try {
-  const crypto = __nccwpck_require__(292)
+  const crypto = __nccwpck_require__(293)
   random = (max) => crypto.randomInt(0, max)
 } catch {
   random = (max) => Math.floor(Math.random(max))
@@ -4896,7 +4896,7 @@ const textDecoder = new TextDecoder()
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 function extractBody (object, keepalive = false) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(274).ReadableStream)
+    ReadableStream = (__nccwpck_require__(275).ReadableStream)
   }
 
   // 1. Let stream be null.
@@ -5117,7 +5117,7 @@ function extractBody (object, keepalive = false) {
 function safelyExtractBody (object, keepalive = false) {
   if (!ReadableStream) {
     // istanbul ignore next
-    ReadableStream = (__nccwpck_require__(274).ReadableStream)
+    ReadableStream = (__nccwpck_require__(275).ReadableStream)
   }
 
   // To safely extract a body and a `Content-Type` value from
@@ -5526,13 +5526,13 @@ exports.planTarPayload = planTarPayload;
 exports.paxTarCreateArgs = paxTarCreateArgs;
 exports.decompressCache = decompressCache;
 exports.compressCache = compressCache;
-const fs = __importStar(__nccwpck_require__(118));
-const os = __importStar(__nccwpck_require__(405));
+const fs = __importStar(__nccwpck_require__(119));
+const os = __importStar(__nccwpck_require__(406));
 const path = __importStar(__nccwpck_require__(542));
 const core = __importStar(__nccwpck_require__(490));
 const exec = __importStar(__nccwpck_require__(21));
-const io = __importStar(__nccwpck_require__(315));
-const cache_encrypt_js_1 = __nccwpck_require__(248);
+const io = __importStar(__nccwpck_require__(316));
+const cache_encrypt_js_1 = __nccwpck_require__(249);
 /**
  * Resolve the encryption config for a cache call. Callers pass `encryption`
  * explicitly for tests; in production they pass `cacheKey` and let the
@@ -6316,7 +6316,7 @@ function parseLevel(value) {
  * Bubbles non-zero exit codes from either side.
  */
 async function runPipe(producer, consumer) {
-    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 206, 23));
+    const { spawn } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 207, 23));
     const [pCmd, pArgs] = producer;
     const [cCmd, cArgs] = consumer;
     await new Promise((resolve, reject) => {
@@ -6359,8 +6359,8 @@ async function runPipe(producer, consumer) {
 /***/ 29:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const assert = __nccwpck_require__(562)
-const { atob } = __nccwpck_require__(128)
+const assert = __nccwpck_require__(563)
+const { atob } = __nccwpck_require__(129)
 const { isomorphicDecode } = __nccwpck_require__(552)
 
 const encoder = new TextEncoder()
@@ -7004,9 +7004,9 @@ module.exports = {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AppendBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(225);
+const tslib_1 = __nccwpck_require__(226);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(467));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(187));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(72));
 /** Class containing AppendBlob operations. */
 class AppendBlobImpl {
@@ -7339,7 +7339,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(420);
+var import_exponentialRetryStrategy = __nccwpck_require__(421);
 var import_retryPolicy = __nccwpck_require__(19);
 var import_constants = __nccwpck_require__(54);
 const systemErrorRetryPolicyName = "systemErrorRetryPolicy";
@@ -7413,7 +7413,7 @@ function rangeResponseFromModel(response) {
 "use strict";
 
 
-const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(341)
+const { MessageChannel, receiveMessageOnPort } = __nccwpck_require__(342)
 
 const corsSafeListedMethods = ['GET', 'HEAD', 'POST']
 const corsSafeListedMethodsSet = new Set(corsSafeListedMethods)
@@ -7576,7 +7576,7 @@ module.exports = {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tracingClient = void 0;
 const core_tracing_1 = __nccwpck_require__(88);
-const constants_js_1 = __nccwpck_require__(157);
+const constants_js_1 = __nccwpck_require__(158);
 /**
  * Creates a span using the global tracer.
  * @internal
@@ -7701,17 +7701,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.reserveCache = exports.downloadCache = exports.getCacheEntry = void 0;
 const core = __importStar(__nccwpck_require__(490));
-const http_client_1 = __nccwpck_require__(303);
+const http_client_1 = __nccwpck_require__(304);
 const auth_1 = __nccwpck_require__(31);
-const fs = __importStar(__nccwpck_require__(567));
+const fs = __importStar(__nccwpck_require__(568));
 const url_1 = __nccwpck_require__(95);
 const utils = __importStar(__nccwpck_require__(83));
-const uploadUtils_1 = __nccwpck_require__(168);
+const uploadUtils_1 = __nccwpck_require__(169);
 const downloadUtils_1 = __nccwpck_require__(4);
-const options_1 = __nccwpck_require__(282);
-const requestUtils_1 = __nccwpck_require__(278);
+const options_1 = __nccwpck_require__(283);
+const requestUtils_1 = __nccwpck_require__(279);
 const config_1 = __nccwpck_require__(42);
-const user_agent_1 = __nccwpck_require__(386);
+const user_agent_1 = __nccwpck_require__(387);
 function getCacheApiUrl(resource) {
     const baseUrl = (0, config_1.getCacheServiceURL)();
     if (!baseUrl) {
@@ -8038,7 +8038,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareActionsCacheArchive = prepareActionsCacheArchive;
 exports.saveReservedCache = saveReservedCache;
 exports.isReservationConflict = isReservationConflict;
-const fsp = __importStar(__nccwpck_require__(118));
+const fsp = __importStar(__nccwpck_require__(119));
 const path = __importStar(__nccwpck_require__(542));
 const config_js_1 = __nccwpck_require__(42);
 const cacheHttpClient = __importStar(__nccwpck_require__(38));
@@ -8344,9 +8344,9 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_https_proxy_agent = __nccwpck_require__(141);
-var import_http_proxy_agent = __nccwpck_require__(235);
-var import_log = __nccwpck_require__(160);
+var import_https_proxy_agent = __nccwpck_require__(142);
+var import_http_proxy_agent = __nccwpck_require__(236);
+var import_log = __nccwpck_require__(161);
 const HTTPS_PROXY = "HTTPS_PROXY";
 const HTTP_PROXY = "HTTP_PROXY";
 const ALL_PROXY = "ALL_PROXY";
@@ -8539,14 +8539,14 @@ const {
 } = __nccwpck_require__(34)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(18)
 const { webidl } = __nccwpck_require__(485)
-const { FormData } = __nccwpck_require__(216)
-const { getGlobalOrigin } = __nccwpck_require__(148)
+const { FormData } = __nccwpck_require__(217)
+const { getGlobalOrigin } = __nccwpck_require__(149)
 const { URLSerializer } = __nccwpck_require__(29)
-const { kHeadersList, kConstruct } = __nccwpck_require__(204)
-const assert = __nccwpck_require__(562)
-const { types } = __nccwpck_require__(132)
+const { kHeadersList, kConstruct } = __nccwpck_require__(205)
+const assert = __nccwpck_require__(563)
+const { types } = __nccwpck_require__(133)
 
-const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(274).ReadableStream)
+const ReadableStream = globalThis.ReadableStream || (__nccwpck_require__(275).ReadableStream)
 const textEncoder = new TextEncoder('utf-8')
 
 // https://fetch.spec.whatwg.org/#response-class
@@ -9180,8 +9180,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.partialMatch = exports.match = exports.getSearchPaths = void 0;
-const pathHelper = __importStar(__nccwpck_require__(231));
-const internal_match_kind_1 = __nccwpck_require__(565);
+const pathHelper = __importStar(__nccwpck_require__(232));
+const internal_match_kind_1 = __nccwpck_require__(566);
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Given an array of patterns, returns an array of paths to search.
@@ -9651,7 +9651,7 @@ exports.AzureLogger = void 0;
 exports.setLogLevel = setLogLevel;
 exports.getLogLevel = getLogLevel;
 exports.createClientLogger = createClientLogger;
-const logger_1 = __nccwpck_require__(156);
+const logger_1 = __nccwpck_require__(157);
 const context = (0, logger_1.createLoggerContext)({
     logLevelEnvVarName: "AZURE_LOG_LEVEL",
     namespace: "azure",
@@ -9803,9 +9803,9 @@ exports.BaseRequestPolicy = BaseRequestPolicy;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(225);
+const tslib_1 = __nccwpck_require__(226);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(467));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(187));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(72));
 /** Class containing Blob operations. */
 class BlobImpl {
@@ -10931,7 +10931,7 @@ exports.StorageBrowserPolicy = StorageBrowserPolicy;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.containsMessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(432);
+const message_type_contract_1 = __nccwpck_require__(433);
 /**
  * Check if the provided object is a proto message.
  *
@@ -10955,8 +10955,8 @@ exports.containsMessageType = containsMessageType;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollHttpOperation = exports.isOperationError = exports.getResourceLocation = exports.getOperationStatus = exports.getOperationLocation = exports.initHttpOperation = exports.getStatusFromInitialResponse = exports.getErrorFromResponse = exports.parseRetryAfter = exports.inferLroMode = void 0;
-const operation_js_1 = __nccwpck_require__(149);
-const logger_js_1 = __nccwpck_require__(199);
+const operation_js_1 = __nccwpck_require__(150);
+const logger_js_1 = __nccwpck_require__(200);
 function getOperationLocationPollingUrl(inputs) {
     const { azureAsyncOperation, operationLocation } = inputs;
     return operationLocation !== null && operationLocation !== void 0 ? operationLocation : azureAsyncOperation;
@@ -11359,9 +11359,9 @@ const { ProgressEvent } = __nccwpck_require__(470)
 const { getEncoding } = __nccwpck_require__(107)
 const { DOMException } = __nccwpck_require__(34)
 const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(29)
-const { types } = __nccwpck_require__(132)
-const { StringDecoder } = __nccwpck_require__(158)
-const { btoa } = __nccwpck_require__(128)
+const { types } = __nccwpck_require__(133)
+const { StringDecoder } = __nccwpck_require__(159)
+const { btoa } = __nccwpck_require__(129)
 
 /** @type {PropertyDescriptor} */
 const staticPropertyDescriptors = {
@@ -11747,7 +11747,7 @@ module.exports = {
 
 "use strict";
 
-const f = __nccwpck_require__(430)
+const f = __nccwpck_require__(431)
 const DateTime = global.Date
 
 class Date extends DateTime {
@@ -11799,7 +11799,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_policies = __nccwpck_require__(307);
+var import_policies = __nccwpck_require__(308);
 const defaultRetryPolicyName = import_policies.defaultRetryPolicyName;
 function defaultRetryPolicy(options = {}) {
   return (0, import_policies.defaultRetryPolicy)(options);
@@ -11875,7 +11875,7 @@ exports.UnaryCall = UnaryCall;
 
 const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(108)
 const { states, opcodes } = __nccwpck_require__(499)
-const { MessageEvent, ErrorEvent } = __nccwpck_require__(266)
+const { MessageEvent, ErrorEvent } = __nccwpck_require__(267)
 
 /* globals Blob */
 
@@ -12350,7 +12350,7 @@ __export(dist_src_exports, {
   RequestError: () => RequestError
 });
 module.exports = __toCommonJS(dist_src_exports);
-var import_deprecation = __nccwpck_require__(247);
+var import_deprecation = __nccwpck_require__(248);
 var import_once = __toESM(__nccwpck_require__(541));
 var logOnceCode = (0, import_once.default)((deprecation) => console.warn(deprecation));
 var logOnceHeaders = (0, import_once.default)((deprecation) => console.warn(deprecation));
@@ -12455,14 +12455,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.internalCacheTwirpClient = void 0;
 const core_1 = __nccwpck_require__(490);
-const user_agent_1 = __nccwpck_require__(386);
-const errors_1 = __nccwpck_require__(326);
+const user_agent_1 = __nccwpck_require__(387);
+const errors_1 = __nccwpck_require__(327);
 const config_1 = __nccwpck_require__(42);
 const cacheUtils_1 = __nccwpck_require__(83);
 const auth_1 = __nccwpck_require__(31);
-const http_client_1 = __nccwpck_require__(303);
+const http_client_1 = __nccwpck_require__(304);
 const cache_twirp_client_1 = __nccwpck_require__(463);
-const util_1 = __nccwpck_require__(316);
+const util_1 = __nccwpck_require__(317);
 /**
  * This class is a wrapper around the CacheServiceClientJSON class generated by Twirp.
  *
@@ -12619,7 +12619,7 @@ const {
   ClientClosedError,
   InvalidArgumentError
 } = __nccwpck_require__(522)
-const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(204)
+const { kDestroy, kClose, kDispatch, kInterceptors } = __nccwpck_require__(205)
 
 const kDestroyed = Symbol('destroyed')
 const kClosed = Symbol('closed')
@@ -12834,8 +12834,8 @@ __export(requestPolicyFactoryPolicy_exports, {
   requestPolicyFactoryPolicyName: () => requestPolicyFactoryPolicyName
 });
 module.exports = __toCommonJS(requestPolicyFactoryPolicy_exports);
-var import_util = __nccwpck_require__(119);
-var import_response = __nccwpck_require__(438);
+var import_util = __nccwpck_require__(120);
+var import_response = __nccwpck_require__(439);
 var HttpPipelineLogLevel = /* @__PURE__ */ ((HttpPipelineLogLevel2) => {
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["ERROR"] = 1] = "ERROR";
   HttpPipelineLogLevel2[HttpPipelineLogLevel2["INFO"] = 3] = "INFO";
@@ -12888,15 +12888,15 @@ exports.ContainerClient = void 0;
 const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_1 = __nccwpck_require__(17);
 const core_auth_1 = __nccwpck_require__(548);
-const storage_common_1 = __nccwpck_require__(294);
-const Pipeline_js_1 = __nccwpck_require__(190);
+const storage_common_1 = __nccwpck_require__(295);
+const Pipeline_js_1 = __nccwpck_require__(191);
 const StorageClient_js_1 = __nccwpck_require__(483);
 const tracing_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(163);
+const utils_common_js_1 = __nccwpck_require__(164);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(76);
-const BlobLeaseClient_js_1 = __nccwpck_require__(213);
-const Clients_js_1 = __nccwpck_require__(192);
-const BlobBatchClient_js_1 = __nccwpck_require__(428);
+const BlobLeaseClient_js_1 = __nccwpck_require__(214);
+const Clients_js_1 = __nccwpck_require__(193);
+const BlobBatchClient_js_1 = __nccwpck_require__(429);
 /**
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
  */
@@ -14198,7 +14198,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.action3 = exports.action2 = exports.leaseId1 = exports.action1 = exports.proposedLeaseId = exports.duration = exports.action = exports.comp10 = exports.sourceLeaseId = exports.sourceContainerName = exports.comp9 = exports.deletedContainerVersion = exports.deletedContainerName = exports.comp8 = exports.containerAcl = exports.comp7 = exports.comp6 = exports.ifUnmodifiedSince = exports.ifModifiedSince = exports.leaseId = exports.preventEncryptionScopeOverride = exports.defaultEncryptionScope = exports.access = exports.metadata = exports.restype2 = exports.where = exports.comp5 = exports.multipartContentType = exports.contentLength = exports.comp4 = exports.body = exports.restype1 = exports.comp3 = exports.keyInfo = exports.include = exports.maxPageSize = exports.marker = exports.prefix = exports.comp2 = exports.comp1 = exports.accept1 = exports.requestId = exports.version = exports.timeoutInSeconds = exports.comp = exports.restype = exports.url = exports.accept = exports.blobServiceProperties = exports.contentType = void 0;
 exports.copySourceTags = exports.copySourceAuthorization = exports.sourceContentMD5 = exports.xMsRequiresSync = exports.legalHold1 = exports.sealBlob = exports.blobTagsString = exports.copySource = exports.sourceIfTags = exports.sourceIfNoneMatch = exports.sourceIfMatch = exports.sourceIfUnmodifiedSince = exports.sourceIfModifiedSince = exports.rehydratePriority = exports.tier = exports.comp14 = exports.encryptionScope = exports.legalHold = exports.comp13 = exports.immutabilityPolicyMode = exports.immutabilityPolicyExpiry = exports.comp12 = exports.blobContentDisposition = exports.blobContentLanguage = exports.blobContentEncoding = exports.blobContentMD5 = exports.blobContentType = exports.blobCacheControl = exports.expiresOn = exports.expiryOptions = exports.comp11 = exports.blobDeleteType = exports.deleteSnapshots = exports.ifTags = exports.ifNoneMatch = exports.ifMatch = exports.encryptionAlgorithm = exports.encryptionKeySha256 = exports.encryptionKey = exports.rangeGetContentCRC64 = exports.rangeGetContentMD5 = exports.range = exports.versionId = exports.snapshot = exports.delimiter = exports.startFrom = exports.include1 = exports.proposedLeaseId1 = exports.action4 = exports.breakPeriod = void 0;
 exports.listType = exports.comp25 = exports.blocks = exports.blockId = exports.comp24 = exports.copySourceBlobProperties = exports.blobType2 = exports.comp23 = exports.sourceRange1 = exports.appendPosition = exports.maxSize = exports.comp22 = exports.blobType1 = exports.comp21 = exports.sequenceNumberAction = exports.prevSnapshotUrl = exports.prevsnapshot = exports.comp20 = exports.range1 = exports.sourceContentCrc64 = exports.sourceRange = exports.sourceUrl = exports.pageWrite1 = exports.ifSequenceNumberEqualTo = exports.ifSequenceNumberLessThan = exports.ifSequenceNumberLessThanOrEqualTo = exports.pageWrite = exports.comp19 = exports.accept2 = exports.body1 = exports.contentType1 = exports.blobSequenceNumber = exports.blobContentLength = exports.blobType = exports.transactionalContentCrc64 = exports.transactionalContentMD5 = exports.tags = exports.ifNoneMatch1 = exports.ifMatch1 = exports.ifUnmodifiedSince1 = exports.ifModifiedSince1 = exports.comp18 = exports.comp17 = exports.queryRequest = exports.tier1 = exports.comp16 = exports.copyId = exports.copyActionAbortConstant = exports.comp15 = exports.fileRequestIntent = void 0;
-const mappers_js_1 = __nccwpck_require__(187);
+const mappers_js_1 = __nccwpck_require__(188);
 exports.contentType = {
     parameterPath: ["options", "contentType"],
     mapper: {
@@ -15874,7 +15874,7 @@ exports.listType = {
 "use strict";
 
 
-const inherits = (__nccwpck_require__(398).inherits)
+const inherits = (__nccwpck_require__(399).inherits)
 const ReadableStream = (__nccwpck_require__(457).Readable)
 
 function PartStream (opts) {
@@ -16138,13 +16138,13 @@ exports.generateBlobSASQueryParametersInternal = generateBlobSASQueryParametersI
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const BlobSASPermissions_js_1 = __nccwpck_require__(537);
-const ContainerSASPermissions_js_1 = __nccwpck_require__(298);
-const storage_common_1 = __nccwpck_require__(294);
-const SasIPRange_js_1 = __nccwpck_require__(384);
-const SASQueryParameters_js_1 = __nccwpck_require__(561);
-const constants_js_1 = __nccwpck_require__(157);
-const utils_common_js_1 = __nccwpck_require__(163);
-const storage_common_2 = __nccwpck_require__(294);
+const ContainerSASPermissions_js_1 = __nccwpck_require__(299);
+const storage_common_1 = __nccwpck_require__(295);
+const SasIPRange_js_1 = __nccwpck_require__(385);
+const SASQueryParameters_js_1 = __nccwpck_require__(562);
+const constants_js_1 = __nccwpck_require__(158);
+const utils_common_js_1 = __nccwpck_require__(164);
+const storage_common_2 = __nccwpck_require__(295);
 function generateBlobSASQueryParameters(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName) {
     return generateBlobSASQueryParametersInternal(blobSASSignatureValues, sharedKeyCredentialOrUserDelegationKey, accountName).sasQueryParameters;
 }
@@ -16810,15 +16810,15 @@ function SASSignatureValuesSanityCheckAndAutofill(blobSASSignatureValues) {
 "use strict";
 
 
-const assert = __nccwpck_require__(562)
-const { kDestroyed, kBodyUsed } = __nccwpck_require__(204)
-const { IncomingMessage } = __nccwpck_require__(353)
-const stream = __nccwpck_require__(139)
+const assert = __nccwpck_require__(563)
+const { kDestroyed, kBodyUsed } = __nccwpck_require__(205)
+const { IncomingMessage } = __nccwpck_require__(354)
+const stream = __nccwpck_require__(140)
 const net = __nccwpck_require__(543)
 const { InvalidArgumentError } = __nccwpck_require__(522)
-const { Blob } = __nccwpck_require__(128)
-const nodeUtil = __nccwpck_require__(132)
-const { stringify } = __nccwpck_require__(138)
+const { Blob } = __nccwpck_require__(129)
+const nodeUtil = __nccwpck_require__(133)
+const { stringify } = __nccwpck_require__(139)
 const { headerNameLowerCasedRecord } = __nccwpck_require__(81)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
@@ -17188,7 +17188,7 @@ async function * convertIterableToBuffer (iterable) {
 let ReadableStream
 function ReadableStreamFrom (iterable) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(274).ReadableStream)
+    ReadableStream = (__nccwpck_require__(275).ReadableStream)
   }
 
   if (ReadableStream.from) {
@@ -17368,8 +17368,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(191);
-var import_policies = __nccwpck_require__(307);
+var import_log = __nccwpck_require__(192);
+var import_policies = __nccwpck_require__(308);
 const logPolicyName = import_policies.logPolicyName;
 function logPolicy(options = {}) {
   return (0, import_policies.logPolicy)({
@@ -17415,12 +17415,12 @@ __export(src_exports, {
   toHttpHeadersLike: () => import_util.toHttpHeadersLike
 });
 module.exports = __toCommonJS(src_exports);
-var import_extendedClient = __nccwpck_require__(223);
-var import_response = __nccwpck_require__(438);
+var import_extendedClient = __nccwpck_require__(224);
+var import_response = __nccwpck_require__(439);
 var import_requestPolicyFactoryPolicy = __nccwpck_require__(70);
 var import_disableKeepAlivePolicy = __nccwpck_require__(10);
-var import_httpClientAdapter = __nccwpck_require__(219);
-var import_util = __nccwpck_require__(119);
+var import_httpClientAdapter = __nccwpck_require__(220);
+var import_util = __nccwpck_require__(120);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -18012,13 +18012,13 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRuntimeToken = exports.getCacheVersion = exports.assertDefined = exports.getGnuTarPathOnWindows = exports.getCacheFileName = exports.getCompressionMethod = exports.unlinkFile = exports.resolvePaths = exports.getArchiveFileSizeInBytes = exports.createTempDirectory = void 0;
 const core = __importStar(__nccwpck_require__(490));
 const exec = __importStar(__nccwpck_require__(21));
-const glob = __importStar(__nccwpck_require__(175));
-const io = __importStar(__nccwpck_require__(315));
-const crypto = __importStar(__nccwpck_require__(312));
-const fs = __importStar(__nccwpck_require__(567));
-const path = __importStar(__nccwpck_require__(264));
-const semver = __importStar(__nccwpck_require__(186));
-const util = __importStar(__nccwpck_require__(132));
+const glob = __importStar(__nccwpck_require__(176));
+const io = __importStar(__nccwpck_require__(316));
+const crypto = __importStar(__nccwpck_require__(313));
+const fs = __importStar(__nccwpck_require__(568));
+const path = __importStar(__nccwpck_require__(265));
+const semver = __importStar(__nccwpck_require__(187));
+const util = __importStar(__nccwpck_require__(133));
 const constants_1 = __nccwpck_require__(51);
 const versionSalt = '1.0';
 // From https://github.com/actions/toolkit/blob/main/packages/tool-cache/src/tool-cache.ts#L23
@@ -18205,10 +18205,10 @@ module.exports = 'AGFzbQEAAAABMAhgAX8Bf2ADf39/AX9gBH9/f38Bf2AAAGADf39/AGABfwBgAn
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.storageSharedKeyCredentialPolicyName = void 0;
 exports.storageSharedKeyCredentialPolicy = storageSharedKeyCredentialPolicy;
-const node_crypto_1 = __nccwpck_require__(292);
+const node_crypto_1 = __nccwpck_require__(293);
 const constants_js_1 = __nccwpck_require__(41);
 const utils_common_js_1 = __nccwpck_require__(507);
-const SharedKeyComparator_js_1 = __nccwpck_require__(184);
+const SharedKeyComparator_js_1 = __nccwpck_require__(185);
 /**
  * The programmatic identifier of the storageSharedKeyCredentialPolicy.
  */
@@ -18344,7 +18344,7 @@ function storageSharedKeyCredentialPolicy(options) {
 "use strict";
 
 
-const assert = __nccwpck_require__(562)
+const assert = __nccwpck_require__(563)
 const { URLSerializer } = __nccwpck_require__(29)
 const { isValidHeaderName } = __nccwpck_require__(552)
 
@@ -18410,7 +18410,7 @@ const RequestPolicy_js_1 = __nccwpck_require__(52);
 const constants_js_1 = __nccwpck_require__(41);
 const utils_common_js_1 = __nccwpck_require__(507);
 const log_js_1 = __nccwpck_require__(20);
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(443);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(444);
 /**
  * A factory method used to generated a RetryPolicy factory.
  *
@@ -18635,9 +18635,9 @@ exports.StorageRetryPolicy = StorageRetryPolicy;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = exports.useInstrumenter = void 0;
-var instrumenter_js_1 = __nccwpck_require__(433);
+var instrumenter_js_1 = __nccwpck_require__(434);
 Object.defineProperty(exports, "useInstrumenter", ({ enumerable: true, get: function () { return instrumenter_js_1.useInstrumenter; } }));
-var tracingClient_js_1 = __nccwpck_require__(372);
+var tracingClient_js_1 = __nccwpck_require__(373);
 Object.defineProperty(exports, "createTracingClient", ({ enumerable: true, get: function () { return tracingClient_js_1.createTracingClient; } }));
 //# sourceMappingURL=index.js.map
 
@@ -18665,7 +18665,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 const { extractBody, mixinBody, cloneBody } = __nccwpck_require__(27)
 const { Headers, fill: fillHeaders, HeadersList } = __nccwpck_require__(550)
-const { FinalizationRegistry } = __nccwpck_require__(440)()
+const { FinalizationRegistry } = __nccwpck_require__(441)()
 const util = __nccwpck_require__(77)
 const {
   isValidHTTPToken,
@@ -18687,10 +18687,10 @@ const {
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(18)
 const { webidl } = __nccwpck_require__(485)
-const { getGlobalOrigin } = __nccwpck_require__(148)
+const { getGlobalOrigin } = __nccwpck_require__(149)
 const { URLSerializer } = __nccwpck_require__(29)
-const { kHeadersList, kConstruct } = __nccwpck_require__(204)
-const assert = __nccwpck_require__(562)
+const { kHeadersList, kConstruct } = __nccwpck_require__(205)
+const assert = __nccwpck_require__(563)
 const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(503)
 
 let TransformStream = globalThis.TransformStream
@@ -19178,7 +19178,7 @@ class Request {
 
       // 2. Set finalBody to the result of creating a proxy for inputBody.
       if (!TransformStream) {
-        TransformStream = (__nccwpck_require__(274).TransformStream)
+        TransformStream = (__nccwpck_require__(275).TransformStream)
       }
 
       // https://streams.spec.whatwg.org/#readablestream-create-a-proxy
@@ -19665,8 +19665,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokit = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(224));
-const utils_1 = __nccwpck_require__(296);
+const Context = __importStar(__nccwpck_require__(225));
+const utils_1 = __nccwpck_require__(297);
 exports.context = new Context.Context();
 /**
  * Returns a hydrated octokit ready to use for GitHub Actions
@@ -19842,12 +19842,12 @@ exports.findBundledZccacheDir = findBundledZccacheDir;
 exports.managedReleaseUrl = managedReleaseUrl;
 exports.downloadManagedRelease = downloadManagedRelease;
 exports.seedZccache = seedZccache;
-const fs = __importStar(__nccwpck_require__(265));
-const os = __importStar(__nccwpck_require__(405));
+const fs = __importStar(__nccwpck_require__(266));
+const os = __importStar(__nccwpck_require__(406));
 const path = __importStar(__nccwpck_require__(542));
 const core = __importStar(__nccwpck_require__(490));
 const exec = __importStar(__nccwpck_require__(21));
-const tc = __importStar(__nccwpck_require__(557));
+const tc = __importStar(__nccwpck_require__(558));
 const LOCAL_DIR_ENV = "SOLDR_ZCCACHE_LOCAL_DIR";
 const VENDOR_DIR_ENV = "SETUP_SOLDR_ZCCACHE_VENDOR_DIR";
 const SEED_ENV = "SETUP_SOLDR_ZCCACHE_SEEDED";
@@ -20463,13 +20463,13 @@ function apiKeyAuthenticationPolicy(options) {
 
 /* global WebAssembly */
 
-const assert = __nccwpck_require__(562)
+const assert = __nccwpck_require__(563)
 const net = __nccwpck_require__(543)
-const http = __nccwpck_require__(353)
-const { pipeline } = __nccwpck_require__(139)
+const http = __nccwpck_require__(354)
+const { pipeline } = __nccwpck_require__(140)
 const util = __nccwpck_require__(77)
-const timers = __nccwpck_require__(352)
-const Request = __nccwpck_require__(319)
+const timers = __nccwpck_require__(353)
+const Request = __nccwpck_require__(320)
 const DispatcherBase = __nccwpck_require__(69)
 const {
   RequestContentLengthMismatchError,
@@ -20485,7 +20485,7 @@ const {
   ResponseExceededMaxSizeError,
   ClientDestroyedError
 } = __nccwpck_require__(522)
-const buildConnector = __nccwpck_require__(283)
+const buildConnector = __nccwpck_require__(284)
 const {
   kUrl,
   kReset,
@@ -20537,7 +20537,7 @@ const {
   kHTTP2BuildRequest,
   kHTTP2CopyHeaders,
   kHTTP1BuildRequest
-} = __nccwpck_require__(204)
+} = __nccwpck_require__(205)
 
 /** @type {import('http2')} */
 let http2
@@ -20570,7 +20570,7 @@ const kClosedResolve = Symbol('kClosedResolve')
 const channels = {}
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(150)
+  const diagnosticsChannel = __nccwpck_require__(151)
   channels.sendHeaders = diagnosticsChannel.channel('undici:client:sendHeaders')
   channels.beforeConnect = diagnosticsChannel.channel('undici:client:beforeConnect')
   channels.connectError = diagnosticsChannel.channel('undici:client:connectError')
@@ -20944,7 +20944,7 @@ function onHTTP2GoAway (code) {
 }
 
 const constants = __nccwpck_require__(476)
-const createRedirectInterceptor = __nccwpck_require__(272)
+const createRedirectInterceptor = __nccwpck_require__(273)
 const EMPTY_BUF = Buffer.alloc(0)
 
 async function lazyllhttp () {
@@ -22785,16 +22785,16 @@ __export(src_exports, {
 });
 module.exports = __toCommonJS(src_exports);
 var import_AbortError = __nccwpck_require__(12);
-var import_logger = __nccwpck_require__(261);
+var import_logger = __nccwpck_require__(262);
 var import_httpHeaders = __nccwpck_require__(519);
-var import_pipelineRequest = __nccwpck_require__(124);
-var import_pipeline = __nccwpck_require__(559);
+var import_pipelineRequest = __nccwpck_require__(125);
+var import_pipeline = __nccwpck_require__(560);
 var import_restError = __nccwpck_require__(472);
-var import_bytesEncoding = __nccwpck_require__(308);
-var import_defaultHttpClient = __nccwpck_require__(395);
-var import_getClient = __nccwpck_require__(218);
-var import_operationOptionHelpers = __nccwpck_require__(406);
-var import_restError2 = __nccwpck_require__(391);
+var import_bytesEncoding = __nccwpck_require__(309);
+var import_defaultHttpClient = __nccwpck_require__(396);
+var import_getClient = __nccwpck_require__(219);
+var import_operationOptionHelpers = __nccwpck_require__(407);
+var import_restError2 = __nccwpck_require__(392);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=index.js.map
@@ -22809,8 +22809,8 @@ var import_restError2 = __nccwpck_require__(391);
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonWriter = void 0;
-const base64_1 = __nccwpck_require__(324);
-const pb_long_1 = __nccwpck_require__(126);
+const base64_1 = __nccwpck_require__(325);
+const pb_long_1 = __nccwpck_require__(127);
 const reflection_info_1 = __nccwpck_require__(481);
 const assert_1 = __nccwpck_require__(518);
 /**
@@ -23198,7 +23198,7 @@ module.exports = require("os");
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AnonymousCredentialPolicy = void 0;
-const CredentialPolicy_js_1 = __nccwpck_require__(330);
+const CredentialPolicy_js_1 = __nccwpck_require__(331);
 /**
  * AnonymousCredentialPolicy is used with HTTP(S) requests that read public resources
  * or for use with Shared Access Signatures (SAS).
@@ -24061,32 +24061,32 @@ __export(src_exports, {
   userAgentPolicyName: () => import_userAgentPolicy.userAgentPolicyName
 });
 module.exports = __toCommonJS(src_exports);
-var import_pipeline = __nccwpck_require__(258);
-var import_createPipelineFromOptions = __nccwpck_require__(299);
-var import_defaultHttpClient = __nccwpck_require__(246);
-var import_httpHeaders = __nccwpck_require__(255);
+var import_pipeline = __nccwpck_require__(259);
+var import_createPipelineFromOptions = __nccwpck_require__(300);
+var import_defaultHttpClient = __nccwpck_require__(247);
+var import_httpHeaders = __nccwpck_require__(256);
 var import_pipelineRequest = __nccwpck_require__(23);
-var import_restError = __nccwpck_require__(378);
-var import_decompressResponsePolicy = __nccwpck_require__(251);
-var import_exponentialRetryPolicy = __nccwpck_require__(417);
-var import_setClientRequestIdPolicy = __nccwpck_require__(159);
+var import_restError = __nccwpck_require__(379);
+var import_decompressResponsePolicy = __nccwpck_require__(252);
+var import_exponentialRetryPolicy = __nccwpck_require__(418);
+var import_setClientRequestIdPolicy = __nccwpck_require__(160);
 var import_logPolicy = __nccwpck_require__(79);
-var import_multipartPolicy = __nccwpck_require__(289);
+var import_multipartPolicy = __nccwpck_require__(290);
 var import_proxyPolicy = __nccwpck_require__(506);
-var import_redirectPolicy = __nccwpck_require__(365);
-var import_systemErrorRetryPolicy = __nccwpck_require__(227);
+var import_redirectPolicy = __nccwpck_require__(366);
+var import_systemErrorRetryPolicy = __nccwpck_require__(228);
 var import_throttlingRetryPolicy = __nccwpck_require__(26);
-var import_retryPolicy = __nccwpck_require__(220);
-var import_tracingPolicy = __nccwpck_require__(360);
+var import_retryPolicy = __nccwpck_require__(221);
+var import_tracingPolicy = __nccwpck_require__(361);
 var import_defaultRetryPolicy = __nccwpck_require__(61);
-var import_userAgentPolicy = __nccwpck_require__(412);
-var import_tlsPolicy = __nccwpck_require__(401);
-var import_formDataPolicy = __nccwpck_require__(286);
-var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(226);
-var import_ndJsonPolicy = __nccwpck_require__(252);
-var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(202);
-var import_agentPolicy = __nccwpck_require__(242);
-var import_file = __nccwpck_require__(350);
+var import_userAgentPolicy = __nccwpck_require__(413);
+var import_tlsPolicy = __nccwpck_require__(402);
+var import_formDataPolicy = __nccwpck_require__(287);
+var import_bearerTokenAuthenticationPolicy = __nccwpck_require__(227);
+var import_ndJsonPolicy = __nccwpck_require__(253);
+var import_auxiliaryAuthenticationHeaderPolicy = __nccwpck_require__(203);
+var import_agentPolicy = __nccwpck_require__(243);
+var import_file = __nccwpck_require__(351);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 
@@ -24119,8 +24119,8 @@ __export(logPolicy_exports, {
   logPolicyName: () => logPolicyName
 });
 module.exports = __toCommonJS(logPolicy_exports);
-var import_log = __nccwpck_require__(160);
-var import_sanitizer = __nccwpck_require__(130);
+var import_log = __nccwpck_require__(161);
+var import_sanitizer = __nccwpck_require__(131);
 const logPolicyName = "logPolicy";
 function logPolicy(options = {}) {
   const logger = options.logger ?? import_log.logger.info;
@@ -24211,6 +24211,256 @@ module.exports = {
 /***/ }),
 
 /***/ 114:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.YANK_AUDIT_WORKER_ARG = void 0;
+exports.readRegistryDependencies = readRegistryDependencies;
+exports.cratesIoSparsePath = cratesIoSparsePath;
+exports.auditDependencyYanks = auditDependencyYanks;
+exports.writeYankAuditResult = writeYankAuditResult;
+exports.readYankAuditResult = readYankAuditResult;
+exports.waitForYankAuditResult = waitForYankAuditResult;
+exports.runYankAuditWorker = runYankAuditWorker;
+const fs = __importStar(__nccwpck_require__(266));
+const path = __importStar(__nccwpck_require__(542));
+const toml = __importStar(__nccwpck_require__(427));
+exports.YANK_AUDIT_WORKER_ARG = "--setup-soldr-yank-audit-worker";
+const CRATES_IO_GIT_INDEX = "registry+https://github.com/rust-lang/crates.io-index";
+const CRATES_IO_SPARSE_INDEX = "sparse+https://index.crates.io/";
+function isCratesIoSource(source) {
+    return source === CRATES_IO_GIT_INDEX || source === CRATES_IO_SPARSE_INDEX;
+}
+function readRegistryDependencies(lockfilePath) {
+    const parsed = toml.parse(fs.readFileSync(lockfilePath, "utf8"));
+    const seen = new Set();
+    const dependencies = [];
+    for (const pkg of Array.isArray(parsed.package) ? parsed.package : []) {
+        if (typeof pkg.name !== "string" || typeof pkg.version !== "string")
+            continue;
+        if (typeof pkg.source !== "string" ||
+            (!pkg.source.startsWith("registry+") && !pkg.source.startsWith("sparse+")))
+            continue;
+        const key = `${pkg.source}\0${pkg.name}\0${pkg.version}`;
+        if (seen.has(key))
+            continue;
+        seen.add(key);
+        dependencies.push({ name: pkg.name, version: pkg.version, source: pkg.source });
+    }
+    return dependencies;
+}
+function cratesIoSparsePath(crateName) {
+    const name = crateName.toLowerCase();
+    if (name.length === 1)
+        return `1/${name}`;
+    if (name.length === 2)
+        return `2/${name}`;
+    if (name.length === 3)
+        return `3/${name[0]}/${name}`;
+    return `${name.slice(0, 2)}/${name.slice(2, 4)}/${name}`;
+}
+async function fetchCrateYanks(crateName, versions, fetchImpl, timeoutMs, overallSignal) {
+    const controller = new AbortController();
+    const abortForOverallDeadline = () => controller.abort();
+    overallSignal.addEventListener("abort", abortForOverallDeadline, { once: true });
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const response = await fetchImpl(`https://index.crates.io/${cratesIoSparsePath(crateName)}`, {
+            headers: {
+                "Accept": "text/plain",
+                "User-Agent": "setup-soldr-yank-audit/1",
+            },
+            signal: controller.signal,
+        });
+        if (!response.ok)
+            throw new Error(`HTTP ${response.status}`);
+        const records = new Map();
+        for (const line of (await response.text()).split(/\r?\n/)) {
+            if (!line.trim())
+                continue;
+            const record = JSON.parse(line);
+            if (typeof record.vers === "string" && typeof record.yanked === "boolean") {
+                records.set(record.vers, record.yanked);
+            }
+        }
+        const checked = [];
+        const yanked = [];
+        for (const version of versions) {
+            if (!records.has(version)) {
+                throw new Error(`version ${crateName} ${version} absent from sparse index`);
+            }
+            const dependency = { name: crateName, version };
+            checked.push(dependency);
+            if (records.get(version))
+                yanked.push(dependency);
+        }
+        return { checked, yanked };
+    }
+    finally {
+        clearTimeout(timeout);
+        overallSignal.removeEventListener("abort", abortForOverallDeadline);
+    }
+}
+async function auditDependencyYanks(dependencies, options = {}) {
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const timeoutMs = options.requestTimeoutMs ?? 30_000;
+    const concurrency = Math.max(1, options.concurrency ?? 12);
+    const overallTimeoutMs = Math.max(1, options.overallTimeoutMs ?? 45_000);
+    const overallController = new AbortController();
+    const overallTimeout = setTimeout(() => overallController.abort(), overallTimeoutMs);
+    const errors = [];
+    const yanked = [];
+    let checkedCount = 0;
+    const byCrate = new Map();
+    for (const dependency of dependencies) {
+        if (!isCratesIoSource(dependency.source)) {
+            errors.push(`${dependency.name} ${dependency.version}: registry ${dependency.source} is not supported`);
+            continue;
+        }
+        const versions = byCrate.get(dependency.name) ?? new Set();
+        versions.add(dependency.version);
+        byCrate.set(dependency.name, versions);
+    }
+    const work = [...byCrate.entries()];
+    let index = 0;
+    let omittedErrors = 0;
+    const recordError = (message) => {
+        if (errors.length < 20)
+            errors.push(message);
+        else
+            omittedErrors += 1;
+    };
+    const worker = async () => {
+        while (true) {
+            const item = work[index++];
+            if (!item)
+                return;
+            const [crateName, versions] = item;
+            try {
+                if (overallController.signal.aborted) {
+                    throw new Error(`audit deadline exceeded after ${overallTimeoutMs}ms`);
+                }
+                const result = await fetchCrateYanks(crateName, [...versions], fetchImpl, timeoutMs, overallController.signal);
+                checkedCount += result.checked.length;
+                yanked.push(...result.yanked);
+            }
+            catch (err) {
+                recordError(`${crateName}: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    };
+    try {
+        await Promise.all(Array.from({ length: Math.min(concurrency, work.length) }, () => worker()));
+    }
+    finally {
+        clearTimeout(overallTimeout);
+    }
+    if (omittedErrors > 0)
+        errors.push(`${omittedErrors} additional registry errors omitted`);
+    const base = {
+        checkedAt: new Date().toISOString(),
+        dependencyCount: dependencies.length,
+        checkedCount,
+    };
+    if (yanked.length > 0) {
+        return { ...base, status: "yanked", yanked, errors };
+    }
+    if (errors.length > 0) {
+        return { ...base, status: "not-checked", yanked: [], errors };
+    }
+    return { ...base, status: "clean", yanked: [], errors: [] };
+}
+function writeYankAuditResult(resultPath, result) {
+    fs.mkdirSync(path.dirname(resultPath), { recursive: true });
+    const temporaryPath = `${resultPath}.${process.pid}.tmp`;
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(result)}\n`, "utf8");
+    fs.renameSync(temporaryPath, resultPath);
+}
+function readYankAuditResult(resultPath) {
+    try {
+        const result = JSON.parse(fs.readFileSync(resultPath, "utf8"));
+        if (!["pending", "clean", "yanked", "not-checked"].includes(result.status))
+            return null;
+        return result;
+    }
+    catch {
+        return null;
+    }
+}
+async function waitForYankAuditResult(resultPath, options = {}) {
+    const timeoutMs = options.timeoutMs ?? 60_000;
+    const pollMs = options.pollMs ?? 250;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const result = readYankAuditResult(resultPath);
+        if (result && result.status !== "pending")
+            return result;
+        await new Promise((resolve) => setTimeout(resolve, pollMs));
+    }
+    return {
+        status: "not-checked",
+        checkedAt: new Date().toISOString(),
+        errors: [`audit did not finish within ${timeoutMs}ms`],
+        joinTimedOut: true,
+    };
+}
+async function runYankAuditWorker(configPath, resultPath) {
+    try {
+        const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+        const result = await auditDependencyYanks(config.dependencies, {
+            requestTimeoutMs: config.requestTimeoutMs,
+            overallTimeoutMs: config.overallTimeoutMs,
+        });
+        writeYankAuditResult(resultPath, result);
+    }
+    catch (err) {
+        writeYankAuditResult(resultPath, {
+            status: "not-checked",
+            checkedAt: new Date().toISOString(),
+            errors: [err instanceof Error ? err.message : String(err)],
+        });
+    }
+}
+
+
+/***/ }),
+
+/***/ 115:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -24241,7 +24491,7 @@ function rangeToString(iRange) {
 
 /***/ }),
 
-/***/ 115:
+/***/ 116:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24251,7 +24501,7 @@ const {
   Readable,
   Duplex,
   PassThrough
-} = __nccwpck_require__(139)
+} = __nccwpck_require__(140)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
@@ -24260,7 +24510,7 @@ const {
 const util = __nccwpck_require__(77)
 const { AsyncResource } = __nccwpck_require__(456)
 const { addSignal, removeSignal } = __nccwpck_require__(113)
-const assert = __nccwpck_require__(562)
+const assert = __nccwpck_require__(563)
 
 const kResume = Symbol('resume')
 
@@ -24498,7 +24748,7 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 116:
+/***/ 117:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24516,17 +24766,17 @@ exports.logger = (0, logger_1.createClientLogger)("storage-blob");
 
 /***/ }),
 
-/***/ 117:
+/***/ 118:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const EventEmitter = (__nccwpck_require__(152).EventEmitter)
-const inherits = (__nccwpck_require__(398).inherits)
+const EventEmitter = (__nccwpck_require__(153).EventEmitter)
+const inherits = (__nccwpck_require__(399).inherits)
 const getLimit = __nccwpck_require__(517)
 
-const StreamSearch = __nccwpck_require__(123)
+const StreamSearch = __nccwpck_require__(124)
 
 const B_DCRLF = Buffer.from('\r\n\r\n')
 const RE_CRLF = /\r\n/g
@@ -24624,7 +24874,7 @@ module.exports = HeaderParser
 
 /***/ }),
 
-/***/ 118:
+/***/ 119:
 /***/ ((module) => {
 
 "use strict";
@@ -24632,7 +24882,7 @@ module.exports = require("node:fs/promises");
 
 /***/ }),
 
-/***/ 119:
+/***/ 120:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -24902,7 +25152,7 @@ class HttpHeaders {
 
 /***/ }),
 
-/***/ 120:
+/***/ 121:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -24948,7 +25198,7 @@ function objectHasProperty(thing, property) {
 
 /***/ }),
 
-/***/ 121:
+/***/ 122:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25031,7 +25281,7 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 
 /***/ }),
 
-/***/ 122:
+/***/ 123:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25041,8 +25291,8 @@ async function authorizeRequestOnClaimChallenge(onChallengeOptions) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.delay = delay;
 exports.calculateRetryDelay = calculateRetryDelay;
-const createAbortablePromise_js_1 = __nccwpck_require__(277);
-const util_1 = __nccwpck_require__(155);
+const createAbortablePromise_js_1 = __nccwpck_require__(278);
+const util_1 = __nccwpck_require__(156);
 const StandardAbortMessage = "The delay was aborted.";
 /**
  * A wrapper for setTimeout that resolves a promise after timeInMs milliseconds.
@@ -25081,7 +25331,7 @@ function calculateRetryDelay(retryAttempt, config) {
 
 /***/ }),
 
-/***/ 123:
+/***/ 124:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25113,8 +25363,8 @@ function calculateRetryDelay(retryAttempt, config) {
  * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
-const EventEmitter = (__nccwpck_require__(152).EventEmitter)
-const inherits = (__nccwpck_require__(398).inherits)
+const EventEmitter = (__nccwpck_require__(153).EventEmitter)
+const inherits = (__nccwpck_require__(399).inherits)
 
 function SBMH (needle) {
   if (typeof needle === 'string') {
@@ -25317,7 +25567,7 @@ module.exports = SBMH
 
 /***/ }),
 
-/***/ 124:
+/***/ 125:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -25343,7 +25593,7 @@ __export(pipelineRequest_exports, {
 });
 module.exports = __toCommonJS(pipelineRequest_exports);
 var import_httpHeaders = __nccwpck_require__(519);
-var import_uuidUtils = __nccwpck_require__(418);
+var import_uuidUtils = __nccwpck_require__(419);
 class PipelineRequestImpl {
   url;
   method;
@@ -25396,7 +25646,7 @@ function createPipelineRequest(options) {
 
 /***/ }),
 
-/***/ 125:
+/***/ 126:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -25432,8 +25682,8 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(405));
-var import_node_process = __toESM(__nccwpck_require__(249));
+var import_node_os = __toESM(__nccwpck_require__(406));
+var import_node_process = __toESM(__nccwpck_require__(250));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -25456,14 +25706,14 @@ async function setPlatformSpecificData(map) {
 
 /***/ }),
 
-/***/ 126:
+/***/ 127:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PbLong = exports.PbULong = exports.detectBi = void 0;
-const goog_varint_1 = __nccwpck_require__(212);
+const goog_varint_1 = __nccwpck_require__(213);
 let BI;
 function detectBi() {
     const dv = new DataView(new ArrayBuffer(8));
@@ -25702,7 +25952,7 @@ PbLong.ZERO = new PbLong(0, 0);
 
 /***/ }),
 
-/***/ 127:
+/***/ 128:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -25719,7 +25969,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 128:
+/***/ 129:
 /***/ ((module) => {
 
 "use strict";
@@ -25727,7 +25977,7 @@ module.exports = require("buffer");
 
 /***/ }),
 
-/***/ 129:
+/***/ 130:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -25756,9 +26006,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Path = void 0;
-const path = __importStar(__nccwpck_require__(264));
-const pathHelper = __importStar(__nccwpck_require__(231));
-const assert_1 = __importDefault(__nccwpck_require__(562));
+const path = __importStar(__nccwpck_require__(265));
+const pathHelper = __importStar(__nccwpck_require__(232));
+const assert_1 = __importDefault(__nccwpck_require__(563));
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Helper class for parsing paths into segments
@@ -25847,7 +26097,7 @@ exports.Path = Path;
 
 /***/ }),
 
-/***/ 130:
+/***/ 131:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -25872,7 +26122,7 @@ __export(sanitizer_exports, {
   Sanitizer: () => Sanitizer
 });
 module.exports = __toCommonJS(sanitizer_exports);
-var import_object = __nccwpck_require__(153);
+var import_object = __nccwpck_require__(154);
 const RedactedString = "REDACTED";
 const defaultAllowedHeaderNames = [
   "x-ms-client-request-id",
@@ -26021,7 +26271,7 @@ class Sanitizer {
 
 /***/ }),
 
-/***/ 131:
+/***/ 132:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -26038,7 +26288,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 132:
+/***/ 133:
 /***/ ((module) => {
 
 "use strict";
@@ -26046,13 +26296,13 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 133:
+/***/ 134:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
-var path = (function () { try { return __nccwpck_require__(264) } catch (e) {}}()) || {
+var path = (function () { try { return __nccwpck_require__(265) } catch (e) {}}()) || {
   sep: '/'
 }
 minimatch.sep = path.sep
@@ -27058,7 +27308,7 @@ function regExpEscape (s) {
 
 /***/ }),
 
-/***/ 134:
+/***/ 135:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -27095,10 +27345,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.argStringToArray = exports.ToolRunner = void 0;
 const os = __importStar(__nccwpck_require__(102));
 const events = __importStar(__nccwpck_require__(503));
-const child = __importStar(__nccwpck_require__(172));
-const path = __importStar(__nccwpck_require__(264));
-const io = __importStar(__nccwpck_require__(315));
-const ioUtil = __importStar(__nccwpck_require__(236));
+const child = __importStar(__nccwpck_require__(173));
+const path = __importStar(__nccwpck_require__(265));
+const io = __importStar(__nccwpck_require__(316));
+const ioUtil = __importStar(__nccwpck_require__(237));
 const timers_1 = __nccwpck_require__(544);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
@@ -27683,7 +27933,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 135:
+/***/ 136:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -27694,8 +27944,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredentialPolicy = void 0;
 const constants_js_1 = __nccwpck_require__(41);
 const utils_common_js_1 = __nccwpck_require__(507);
-const CredentialPolicy_js_1 = __nccwpck_require__(330);
-const SharedKeyComparator_js_1 = __nccwpck_require__(184);
+const CredentialPolicy_js_1 = __nccwpck_require__(331);
+const SharedKeyComparator_js_1 = __nccwpck_require__(185);
 /**
  * StorageSharedKeyCredentialPolicy is a policy used to sign HTTP request with a shared key.
  */
@@ -27839,7 +28089,7 @@ exports.StorageSharedKeyCredentialPolicy = StorageSharedKeyCredentialPolicy;
 
 /***/ }),
 
-/***/ 136:
+/***/ 137:
 /***/ ((module) => {
 
 "use strict";
@@ -27859,7 +28109,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 137:
+/***/ 138:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -27867,8 +28117,8 @@ module.exports = {
 
 
 
-const assert = __nccwpck_require__(562)
-const { Readable } = __nccwpck_require__(139)
+const assert = __nccwpck_require__(563)
+const { Readable } = __nccwpck_require__(140)
 const { RequestAbortedError, NotSupportedError, InvalidArgumentError } = __nccwpck_require__(522)
 const util = __nccwpck_require__(77)
 const { ReadableStreamFrom, toUSVString } = __nccwpck_require__(77)
@@ -28151,7 +28401,7 @@ function consumeEnd (consume) {
       resolve(dst.buffer)
     } else if (type === 'blob') {
       if (!Blob) {
-        Blob = (__nccwpck_require__(128).Blob)
+        Blob = (__nccwpck_require__(129).Blob)
       }
       resolve(new Blob(body, { type: stream[kContentType] }))
     }
@@ -28189,7 +28439,7 @@ function consumeFinish (consume, err) {
 
 /***/ }),
 
-/***/ 138:
+/***/ 139:
 /***/ ((module) => {
 
 "use strict";
@@ -28197,7 +28447,7 @@ module.exports = require("querystring");
 
 /***/ }),
 
-/***/ 139:
+/***/ 140:
 /***/ ((module) => {
 
 "use strict";
@@ -28205,7 +28455,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 140:
+/***/ 141:
 /***/ ((module) => {
 
 "use strict";
@@ -28275,7 +28525,7 @@ function range(a, b, str) {
 
 /***/ }),
 
-/***/ 141:
+/***/ 142:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28310,11 +28560,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpsProxyAgent = void 0;
 const net = __importStar(__nccwpck_require__(543));
 const tls = __importStar(__nccwpck_require__(539));
-const assert_1 = __importDefault(__nccwpck_require__(562));
+const assert_1 = __importDefault(__nccwpck_require__(563));
 const debug_1 = __importDefault(__nccwpck_require__(549));
-const agent_base_1 = __nccwpck_require__(253);
+const agent_base_1 = __nccwpck_require__(254);
 const url_1 = __nccwpck_require__(95);
-const parse_proxy_response_1 = __nccwpck_require__(445);
+const parse_proxy_response_1 = __nccwpck_require__(446);
 const debug = (0, debug_1.default)('https-proxy-agent');
 const setServernameFromNonIpHost = (options) => {
     if (options.servername === undefined &&
@@ -28462,7 +28712,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 142:
+/***/ 143:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28478,7 +28728,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(303);
+const http_client_1 = __nccwpck_require__(304);
 const auth_1 = __nccwpck_require__(31);
 const core_1 = __nccwpck_require__(490);
 class OidcClient {
@@ -28546,16 +28796,16 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 143:
+/***/ 144:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryReader = exports.binaryReadOptions = void 0;
-const binary_format_contract_1 = __nccwpck_require__(357);
-const pb_long_1 = __nccwpck_require__(126);
-const goog_varint_1 = __nccwpck_require__(212);
+const binary_format_contract_1 = __nccwpck_require__(358);
+const pb_long_1 = __nccwpck_require__(127);
+const goog_varint_1 = __nccwpck_require__(213);
 const defaultsRead = {
     readUnknownField: true,
     readerFactory: bytes => new BinaryReader(bytes),
@@ -28737,7 +28987,7 @@ exports.BinaryReader = BinaryReader;
 
 /***/ }),
 
-/***/ 144:
+/***/ 145:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28951,7 +29201,7 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 145:
+/***/ 146:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -29049,7 +29299,7 @@ exports.reflectionMergePartial = reflectionMergePartial;
 
 /***/ }),
 
-/***/ 146:
+/***/ 147:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -29075,7 +29325,7 @@ __export(xml_exports, {
   stringifyXML: () => stringifyXML
 });
 module.exports = __toCommonJS(xml_exports);
-var import_fast_xml_parser = __nccwpck_require__(344);
+var import_fast_xml_parser = __nccwpck_require__(345);
 var import_xml_common = __nccwpck_require__(24);
 function getCommonOptions(options) {
   return {
@@ -29142,22 +29392,22 @@ async function parseXML(str, opts = {}) {
 
 /***/ }),
 
-/***/ 147:
+/***/ 148:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports.request = __nccwpck_require__(545)
-module.exports.stream = __nccwpck_require__(380)
-module.exports.pipeline = __nccwpck_require__(115)
+module.exports.stream = __nccwpck_require__(381)
+module.exports.pipeline = __nccwpck_require__(116)
 module.exports.upgrade = __nccwpck_require__(460)
-module.exports.connect = __nccwpck_require__(396)
+module.exports.connect = __nccwpck_require__(397)
 
 
 /***/ }),
 
-/***/ 148:
+/***/ 149:
 /***/ ((module) => {
 
 "use strict";
@@ -29205,7 +29455,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 149:
+/***/ 150:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -29214,7 +29464,7 @@ module.exports = {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pollOperation = exports.initOperation = exports.deserializeState = void 0;
-const logger_js_1 = __nccwpck_require__(199);
+const logger_js_1 = __nccwpck_require__(200);
 const constants_js_1 = __nccwpck_require__(67);
 /**
  * Deserializes the state
@@ -29384,7 +29634,7 @@ exports.pollOperation = pollOperation;
 
 /***/ }),
 
-/***/ 150:
+/***/ 151:
 /***/ ((module) => {
 
 "use strict";
@@ -29392,7 +29642,7 @@ module.exports = require("diagnostics_channel");
 
 /***/ }),
 
-/***/ 151:
+/***/ 152:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -29408,7 +29658,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(397);
+	createDebug.humanize = __nccwpck_require__(398);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -29691,7 +29941,7 @@ module.exports = setup;
 
 /***/ }),
 
-/***/ 152:
+/***/ 153:
 /***/ ((module) => {
 
 "use strict";
@@ -29699,7 +29949,7 @@ module.exports = require("node:events");
 
 /***/ }),
 
-/***/ 153:
+/***/ 154:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -29734,7 +29984,7 @@ function isObject(input) {
 
 /***/ }),
 
-/***/ 154:
+/***/ 155:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -29802,7 +30052,7 @@ async function resolveSoldrReleaseVersion(repo, version, ref, env, deps) {
 
 /***/ }),
 
-/***/ 155:
+/***/ 156:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -29845,13 +30095,13 @@ __export(internal_exports, {
 module.exports = __toCommonJS(internal_exports);
 var import_delay = __nccwpck_require__(508);
 var import_random = __nccwpck_require__(540);
-var import_object = __nccwpck_require__(153);
-var import_error = __nccwpck_require__(162);
-var import_sha256 = __nccwpck_require__(209);
-var import_uuidUtils = __nccwpck_require__(418);
+var import_object = __nccwpck_require__(154);
+var import_error = __nccwpck_require__(163);
+var import_sha256 = __nccwpck_require__(210);
+var import_uuidUtils = __nccwpck_require__(419);
 var import_checkEnvironment = __nccwpck_require__(466);
-var import_bytesEncoding = __nccwpck_require__(308);
-var import_sanitizer = __nccwpck_require__(130);
+var import_bytesEncoding = __nccwpck_require__(309);
+var import_sanitizer = __nccwpck_require__(131);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -29859,7 +30109,7 @@ var import_sanitizer = __nccwpck_require__(130);
 
 /***/ }),
 
-/***/ 156:
+/***/ 157:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -29884,7 +30134,7 @@ __export(internal_exports, {
   createLoggerContext: () => import_logger.createLoggerContext
 });
 module.exports = __toCommonJS(internal_exports);
-var import_logger = __nccwpck_require__(261);
+var import_logger = __nccwpck_require__(262);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -29892,7 +30142,7 @@ var import_logger = __nccwpck_require__(261);
 
 /***/ }),
 
-/***/ 157:
+/***/ 158:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30128,7 +30378,7 @@ exports.PathStylePorts = [
 
 /***/ }),
 
-/***/ 158:
+/***/ 159:
 /***/ ((module) => {
 
 "use strict";
@@ -30136,7 +30386,7 @@ module.exports = require("string_decoder");
 
 /***/ }),
 
-/***/ 159:
+/***/ 160:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -30180,7 +30430,7 @@ function setClientRequestIdPolicy(requestIdHeaderName = "x-ms-client-request-id"
 
 /***/ }),
 
-/***/ 160:
+/***/ 161:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30205,7 +30455,7 @@ __export(log_exports, {
   logger: () => logger
 });
 module.exports = __toCommonJS(log_exports);
-var import_logger = __nccwpck_require__(261);
+var import_logger = __nccwpck_require__(262);
 const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -30214,7 +30464,7 @@ const logger = (0, import_logger.createClientLogger)("ts-http-runtime");
 
 /***/ }),
 
-/***/ 161:
+/***/ 162:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30240,7 +30490,7 @@ __export(basicAuthenticationPolicy_exports, {
   basicAuthenticationPolicyName: () => basicAuthenticationPolicyName
 });
 module.exports = __toCommonJS(basicAuthenticationPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(308);
+var import_bytesEncoding = __nccwpck_require__(309);
 var import_checkInsecureConnection = __nccwpck_require__(462);
 const basicAuthenticationPolicyName = "bearerAuthenticationPolicy";
 function basicAuthenticationPolicy(options) {
@@ -30271,7 +30521,7 @@ function basicAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 162:
+/***/ 163:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -30296,7 +30546,7 @@ __export(error_exports, {
   isError: () => isError
 });
 module.exports = __toCommonJS(error_exports);
-var import_object = __nccwpck_require__(153);
+var import_object = __nccwpck_require__(154);
 function isError(e) {
   if ((0, import_object.isObject)(e)) {
     const hasName = typeof e.name === "string";
@@ -30312,7 +30562,7 @@ function isError(e) {
 
 /***/ }),
 
-/***/ 163:
+/***/ 164:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -30358,7 +30608,7 @@ exports.EscapePath = EscapePath;
 exports.assertResponse = assertResponse;
 const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_1 = __nccwpck_require__(17);
-const constants_js_1 = __nccwpck_require__(157);
+const constants_js_1 = __nccwpck_require__(158);
 /**
  * Reserved URL characters must be properly escaped for Storage services like Blob or File.
  *
@@ -31126,7 +31376,7 @@ function assertResponse(response) {
 
 /***/ }),
 
-/***/ 164:
+/***/ 165:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31156,20 +31406,20 @@ exports.StorageBrowserPolicyFactory = StorageBrowserPolicyFactory;
 
 /***/ }),
 
-/***/ 165:
+/***/ 166:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(204).kConstruct)
+  kConstruct: (__nccwpck_require__(205).kConstruct)
 }
 
 
 /***/ }),
 
-/***/ 166:
+/***/ 167:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31201,7 +31451,7 @@ exports.reflectionLongConvert = reflectionLongConvert;
 
 /***/ }),
 
-/***/ 167:
+/***/ 168:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -31235,7 +31485,7 @@ const DEFAULT_RETRY_POLICY_COUNT = 3;
 
 /***/ }),
 
-/***/ 168:
+/***/ 169:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -31276,7 +31526,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.uploadCacheArchiveSDK = exports.UploadProgress = void 0;
 const core = __importStar(__nccwpck_require__(490));
 const storage_blob_1 = __nccwpck_require__(475);
-const errors_1 = __nccwpck_require__(326);
+const errors_1 = __nccwpck_require__(327);
 /**
  * Class for tracking the upload state and displaying stats.
  */
@@ -31409,7 +31659,7 @@ exports.uploadCacheArchiveSDK = uploadCacheArchiveSDK;
 
 /***/ }),
 
-/***/ 169:
+/***/ 170:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -31439,7 +31689,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.req = exports.json = exports.toBuffer = void 0;
-const http = __importStar(__nccwpck_require__(353));
+const http = __importStar(__nccwpck_require__(354));
 const https = __importStar(__nccwpck_require__(78));
 async function toBuffer(stream) {
     let length = 0;
@@ -31482,7 +31732,7 @@ exports.req = req;
 
 /***/ }),
 
-/***/ 170:
+/***/ 171:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -31620,7 +31870,7 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 
 /***/ }),
 
-/***/ 171:
+/***/ 172:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31629,27 +31879,27 @@ function createTokenCycler(credential, tokenCyclerOptions) {
 const Client = __nccwpck_require__(98)
 const Dispatcher = __nccwpck_require__(511)
 const errors = __nccwpck_require__(522)
-const Pool = __nccwpck_require__(361)
-const BalancedPool = __nccwpck_require__(404)
+const Pool = __nccwpck_require__(362)
+const BalancedPool = __nccwpck_require__(405)
 const Agent = __nccwpck_require__(6)
 const util = __nccwpck_require__(77)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(147)
-const buildConnector = __nccwpck_require__(283)
-const MockClient = __nccwpck_require__(208)
-const MockAgent = __nccwpck_require__(400)
-const MockPool = __nccwpck_require__(374)
-const mockErrors = __nccwpck_require__(243)
-const ProxyAgent = __nccwpck_require__(366)
-const RetryHandler = __nccwpck_require__(291)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(399)
+const api = __nccwpck_require__(148)
+const buildConnector = __nccwpck_require__(284)
+const MockClient = __nccwpck_require__(209)
+const MockAgent = __nccwpck_require__(401)
+const MockPool = __nccwpck_require__(375)
+const mockErrors = __nccwpck_require__(244)
+const ProxyAgent = __nccwpck_require__(367)
+const RetryHandler = __nccwpck_require__(292)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(400)
 const DecoratorHandler = __nccwpck_require__(509)
-const RedirectHandler = __nccwpck_require__(414)
-const createRedirectInterceptor = __nccwpck_require__(272)
+const RedirectHandler = __nccwpck_require__(415)
+const createRedirectInterceptor = __nccwpck_require__(273)
 
 let hasCrypto
 try {
-  __nccwpck_require__(312)
+  __nccwpck_require__(313)
   hasCrypto = true
 } catch {
   hasCrypto = false
@@ -31744,17 +31994,17 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
   module.exports.Headers = __nccwpck_require__(550).Headers
   module.exports.Response = __nccwpck_require__(46).Response
   module.exports.Request = __nccwpck_require__(90).Request
-  module.exports.FormData = __nccwpck_require__(216).FormData
-  module.exports.File = __nccwpck_require__(388).File
+  module.exports.FormData = __nccwpck_require__(217).FormData
+  module.exports.File = __nccwpck_require__(389).File
   module.exports.FileReader = __nccwpck_require__(104).FileReader
 
-  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(148)
+  const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(149)
 
   module.exports.setGlobalOrigin = setGlobalOrigin
   module.exports.getGlobalOrigin = getGlobalOrigin
 
-  const { CacheStorage } = __nccwpck_require__(301)
-  const { kConstruct } = __nccwpck_require__(165)
+  const { CacheStorage } = __nccwpck_require__(302)
+  const { kConstruct } = __nccwpck_require__(166)
 
   // Cache & CacheStorage are tightly coupled with fetch. Even if it may run
   // in an older version of Node, it doesn't have any use without fetch.
@@ -31762,7 +32012,7 @@ if (util.nodeMajor > 16 || (util.nodeMajor === 16 && util.nodeMinor >= 8)) {
 }
 
 if (util.nodeMajor >= 16) {
-  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(409)
+  const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(410)
 
   module.exports.deleteCookie = deleteCookie
   module.exports.getCookies = getCookies
@@ -31776,7 +32026,7 @@ if (util.nodeMajor >= 16) {
 }
 
 if (util.nodeMajor >= 18 && hasCrypto) {
-  const { WebSocket } = __nccwpck_require__(321)
+  const { WebSocket } = __nccwpck_require__(322)
 
   module.exports.WebSocket = WebSocket
 }
@@ -31795,7 +32045,7 @@ module.exports.mockErrors = mockErrors
 
 /***/ }),
 
-/***/ 172:
+/***/ 173:
 /***/ ((module) => {
 
 "use strict";
@@ -31803,7 +32053,7 @@ module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 173:
+/***/ 174:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31816,18 +32066,18 @@ module.exports = require("child_process");
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(225);
-tslib_1.__exportStar(__nccwpck_require__(127), exports);
-tslib_1.__exportStar(__nccwpck_require__(188), exports);
-tslib_1.__exportStar(__nccwpck_require__(131), exports);
-tslib_1.__exportStar(__nccwpck_require__(339), exports);
-tslib_1.__exportStar(__nccwpck_require__(217), exports);
-tslib_1.__exportStar(__nccwpck_require__(288), exports);
+const tslib_1 = __nccwpck_require__(226);
+tslib_1.__exportStar(__nccwpck_require__(128), exports);
+tslib_1.__exportStar(__nccwpck_require__(189), exports);
+tslib_1.__exportStar(__nccwpck_require__(132), exports);
+tslib_1.__exportStar(__nccwpck_require__(340), exports);
+tslib_1.__exportStar(__nccwpck_require__(218), exports);
+tslib_1.__exportStar(__nccwpck_require__(289), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 174:
+/***/ 175:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -31840,7 +32090,7 @@ exports.storageRetryPolicy = storageRetryPolicy;
 const abort_controller_1 = __nccwpck_require__(529);
 const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_1 = __nccwpck_require__(17);
-const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(349);
+const StorageRetryPolicyFactory_js_1 = __nccwpck_require__(350);
 const constants_js_1 = __nccwpck_require__(41);
 const utils_common_js_1 = __nccwpck_require__(507);
 const log_js_1 = __nccwpck_require__(20);
@@ -32002,7 +32252,7 @@ function storageRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 175:
+/***/ 176:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -32035,7 +32285,7 @@ exports.create = create;
 
 /***/ }),
 
-/***/ 176:
+/***/ 177:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -32044,7 +32294,7 @@ exports.create = create;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.UserDelegationKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(292);
+const node_crypto_1 = __nccwpck_require__(293);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -32089,7 +32339,7 @@ exports.UserDelegationKeyCredential = UserDelegationKeyCredential;
 
 /***/ }),
 
-/***/ 177:
+/***/ 178:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -32115,10 +32365,10 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(308);
+var import_bytesEncoding = __nccwpck_require__(309);
 var import_typeGuards = __nccwpck_require__(531);
-var import_uuidUtils = __nccwpck_require__(418);
-var import_concat = __nccwpck_require__(325);
+var import_uuidUtils = __nccwpck_require__(419);
+var import_concat = __nccwpck_require__(326);
 function generateBoundary() {
   return `----AzSDKFormBoundary${(0, import_uuidUtils.randomUUID)()}`;
 }
@@ -32227,12 +32477,12 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 178:
+/***/ 179:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(430)
+const f = __nccwpck_require__(431)
 
 class FloatingDateTime extends Date {
   constructor (value) {
@@ -32259,7 +32509,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 179:
+/***/ 180:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -32386,7 +32636,7 @@ function requestToOptions(request) {
 
 /***/ }),
 
-/***/ 180:
+/***/ 181:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -32398,7 +32648,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 181:
+/***/ 182:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -32409,30 +32659,30 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 var service_type_1 = __nccwpck_require__(512);
 Object.defineProperty(exports, "ServiceType", ({ enumerable: true, get: function () { return service_type_1.ServiceType; } }));
-var reflection_info_1 = __nccwpck_require__(564);
+var reflection_info_1 = __nccwpck_require__(565);
 Object.defineProperty(exports, "readMethodOptions", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOptions; } }));
 Object.defineProperty(exports, "readMethodOption", ({ enumerable: true, get: function () { return reflection_info_1.readMethodOption; } }));
 Object.defineProperty(exports, "readServiceOption", ({ enumerable: true, get: function () { return reflection_info_1.readServiceOption; } }));
-var rpc_error_1 = __nccwpck_require__(183);
+var rpc_error_1 = __nccwpck_require__(184);
 Object.defineProperty(exports, "RpcError", ({ enumerable: true, get: function () { return rpc_error_1.RpcError; } }));
-var rpc_options_1 = __nccwpck_require__(314);
+var rpc_options_1 = __nccwpck_require__(315);
 Object.defineProperty(exports, "mergeRpcOptions", ({ enumerable: true, get: function () { return rpc_options_1.mergeRpcOptions; } }));
-var rpc_output_stream_1 = __nccwpck_require__(328);
+var rpc_output_stream_1 = __nccwpck_require__(329);
 Object.defineProperty(exports, "RpcOutputStreamController", ({ enumerable: true, get: function () { return rpc_output_stream_1.RpcOutputStreamController; } }));
 var test_transport_1 = __nccwpck_require__(546);
 Object.defineProperty(exports, "TestTransport", ({ enumerable: true, get: function () { return test_transport_1.TestTransport; } }));
 var deferred_1 = __nccwpck_require__(58);
 Object.defineProperty(exports, "Deferred", ({ enumerable: true, get: function () { return deferred_1.Deferred; } }));
 Object.defineProperty(exports, "DeferredState", ({ enumerable: true, get: function () { return deferred_1.DeferredState; } }));
-var duplex_streaming_call_1 = __nccwpck_require__(327);
+var duplex_streaming_call_1 = __nccwpck_require__(328);
 Object.defineProperty(exports, "DuplexStreamingCall", ({ enumerable: true, get: function () { return duplex_streaming_call_1.DuplexStreamingCall; } }));
-var client_streaming_call_1 = __nccwpck_require__(375);
+var client_streaming_call_1 = __nccwpck_require__(376);
 Object.defineProperty(exports, "ClientStreamingCall", ({ enumerable: true, get: function () { return client_streaming_call_1.ClientStreamingCall; } }));
 var server_streaming_call_1 = __nccwpck_require__(480);
 Object.defineProperty(exports, "ServerStreamingCall", ({ enumerable: true, get: function () { return server_streaming_call_1.ServerStreamingCall; } }));
 var unary_call_1 = __nccwpck_require__(62);
 Object.defineProperty(exports, "UnaryCall", ({ enumerable: true, get: function () { return unary_call_1.UnaryCall; } }));
-var rpc_interceptor_1 = __nccwpck_require__(568);
+var rpc_interceptor_1 = __nccwpck_require__(569);
 Object.defineProperty(exports, "stackIntercept", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackIntercept; } }));
 Object.defineProperty(exports, "stackDuplexStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackDuplexStreamingInterceptors; } }));
 Object.defineProperty(exports, "stackClientStreamingInterceptors", ({ enumerable: true, get: function () { return rpc_interceptor_1.stackClientStreamingInterceptors; } }));
@@ -32444,7 +32694,7 @@ Object.defineProperty(exports, "ServerCallContextController", ({ enumerable: tru
 
 /***/ }),
 
-/***/ 182:
+/***/ 183:
 /***/ ((module) => {
 
 // Returns a wrapper function that returns a wrapped callback
@@ -32484,7 +32734,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 183:
+/***/ 184:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -32528,7 +32778,7 @@ exports.RpcError = RpcError;
 
 /***/ }),
 
-/***/ 184:
+/***/ 185:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -32611,7 +32861,7 @@ function isLessThan(lhs, rhs) {
 
 /***/ }),
 
-/***/ 185:
+/***/ 186:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -32620,10 +32870,10 @@ function isLessThan(lhs, rhs) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-const operation_js_1 = __nccwpck_require__(383);
+const operation_js_1 = __nccwpck_require__(384);
 const constants_js_1 = __nccwpck_require__(67);
 const poller_js_1 = __nccwpck_require__(82);
-const operation_js_2 = __nccwpck_require__(149);
+const operation_js_2 = __nccwpck_require__(150);
 /**
  * The LRO Engine, a class that performs polling.
  */
@@ -32651,7 +32901,7 @@ exports.LroEngine = LroEngine;
 
 /***/ }),
 
-/***/ 186:
+/***/ 187:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -34301,7 +34551,7 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 187:
+/***/ 188:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -42644,7 +42894,7 @@ exports.BlockBlobGetBlockListExceptionHeaders = {
 
 /***/ }),
 
-/***/ 188:
+/***/ 189:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -42661,7 +42911,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 189:
+/***/ 190:
 /***/ ((module) => {
 
 "use strict";
@@ -42669,7 +42919,7 @@ module.exports = require("tty");
 
 /***/ }),
 
-/***/ 190:
+/***/ 191:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -42685,11 +42935,11 @@ exports.getCredentialFromPipeline = getCredentialFromPipeline;
 const core_http_compat_1 = __nccwpck_require__(80);
 const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_client_1 = __nccwpck_require__(467);
-const core_xml_1 = __nccwpck_require__(203);
+const core_xml_1 = __nccwpck_require__(204);
 const core_auth_1 = __nccwpck_require__(548);
-const log_js_1 = __nccwpck_require__(116);
-const storage_common_1 = __nccwpck_require__(294);
-const constants_js_1 = __nccwpck_require__(157);
+const log_js_1 = __nccwpck_require__(117);
+const storage_common_1 = __nccwpck_require__(295);
+const constants_js_1 = __nccwpck_require__(158);
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return constants_js_1.StorageOAuthScopes; } }));
 /**
  * A helper to decide if a given argument satisfies the Pipeline contract
@@ -42953,7 +43203,7 @@ function isCoreHttpPolicyFactory(factory) {
 
 /***/ }),
 
-/***/ 191:
+/***/ 192:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -42986,7 +43236,7 @@ const logger = (0, import_logger.createClientLogger)("core-rest-pipeline");
 
 /***/ }),
 
-/***/ 192:
+/***/ 193:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -43000,22 +43250,22 @@ const core_auth_1 = __nccwpck_require__(548);
 const core_util_1 = __nccwpck_require__(17);
 const core_util_2 = __nccwpck_require__(17);
 const BlobDownloadResponse_js_1 = __nccwpck_require__(453);
-const BlobQueryResponse_js_1 = __nccwpck_require__(210);
-const storage_common_1 = __nccwpck_require__(294);
-const models_js_1 = __nccwpck_require__(441);
+const BlobQueryResponse_js_1 = __nccwpck_require__(211);
+const storage_common_1 = __nccwpck_require__(295);
+const models_js_1 = __nccwpck_require__(442);
 const PageBlobRangeResponse_js_1 = __nccwpck_require__(33);
-const Pipeline_js_1 = __nccwpck_require__(190);
-const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(570);
-const Range_js_1 = __nccwpck_require__(114);
+const Pipeline_js_1 = __nccwpck_require__(191);
+const BlobStartCopyFromUrlPoller_js_1 = __nccwpck_require__(571);
+const Range_js_1 = __nccwpck_require__(115);
 const StorageClient_js_1 = __nccwpck_require__(483);
 const Batch_js_1 = __nccwpck_require__(101);
-const storage_common_2 = __nccwpck_require__(294);
-const constants_js_1 = __nccwpck_require__(157);
+const storage_common_2 = __nccwpck_require__(295);
+const constants_js_1 = __nccwpck_require__(158);
 const tracing_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(163);
-const utils_js_1 = __nccwpck_require__(211);
+const utils_common_js_1 = __nccwpck_require__(164);
+const utils_js_1 = __nccwpck_require__(212);
 const BlobSASSignatureValues_js_1 = __nccwpck_require__(76);
-const BlobLeaseClient_js_1 = __nccwpck_require__(213);
+const BlobLeaseClient_js_1 = __nccwpck_require__(214);
 /**
  * A BlobClient represents a URL to an Azure Storage blob; the blob may be a block blob,
  * append blob, or page blob.
@@ -45845,17 +46095,17 @@ exports.PageBlobClient = PageBlobClient;
 
 /***/ }),
 
-/***/ 193:
+/***/ 194:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryWriter = void 0;
-const binary_format_contract_1 = __nccwpck_require__(357);
+const binary_format_contract_1 = __nccwpck_require__(358);
 const reflection_info_1 = __nccwpck_require__(481);
 const assert_1 = __nccwpck_require__(518);
-const pb_long_1 = __nccwpck_require__(126);
+const pb_long_1 = __nccwpck_require__(127);
 /**
  * Writes proto3 messages in binary format using reflection information.
  *
@@ -46086,7 +46336,7 @@ exports.ReflectionBinaryWriter = ReflectionBinaryWriter;
 
 /***/ }),
 
-/***/ 194:
+/***/ 195:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46097,7 +46347,7 @@ const { maxUnsigned16Bit } = __nccwpck_require__(499)
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(312)
+  crypto = __nccwpck_require__(313)
 } catch {
 
 }
@@ -46167,7 +46417,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 195:
+/***/ 196:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -46230,12 +46480,12 @@ exports.applyStagedToLiveRoots = applyStagedToLiveRoots;
 exports.saveSoloCache = saveSoloCache;
 exports.restoreSoloCache = restoreSoloCache;
 exports.verifyRestoredToolchain = verifyRestoredToolchain;
-const node_crypto_1 = __nccwpck_require__(292);
-const fs = __importStar(__nccwpck_require__(265));
-const fsp = __importStar(__nccwpck_require__(118));
-const os = __importStar(__nccwpck_require__(405));
+const node_crypto_1 = __nccwpck_require__(293);
+const fs = __importStar(__nccwpck_require__(266));
+const fsp = __importStar(__nccwpck_require__(119));
+const os = __importStar(__nccwpck_require__(406));
 const path = __importStar(__nccwpck_require__(542));
-const cache = __importStar(__nccwpck_require__(222));
+const cache = __importStar(__nccwpck_require__(223));
 const exec = __importStar(__nccwpck_require__(21));
 const github = __importStar(__nccwpck_require__(92));
 const cache_compress_js_1 = __nccwpck_require__(28);
@@ -46908,7 +47158,7 @@ async function verifyRestoredToolchain(opts) {
 
 /***/ }),
 
-/***/ 196:
+/***/ 197:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -46955,10 +47205,10 @@ function isApiKeyCredential(credential) {
 
 /***/ }),
 
-/***/ 197:
+/***/ 198:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const assert = __nccwpck_require__(562)
+const assert = __nccwpck_require__(563)
 const {
   ResponseStatusCodeError
 } = __nccwpck_require__(522)
@@ -47008,7 +47258,7 @@ module.exports = { getResolveErrorBodyCallback }
 
 /***/ }),
 
-/***/ 198:
+/***/ 199:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -47130,7 +47380,7 @@ exports.getSelectedOneofValue = getSelectedOneofValue;
 
 /***/ }),
 
-/***/ 199:
+/***/ 200:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -47149,7 +47399,7 @@ exports.logger = (0, logger_1.createClientLogger)("core-lro");
 
 /***/ }),
 
-/***/ 200:
+/***/ 201:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -47203,7 +47453,7 @@ exports.isTimestampsEnabled = isTimestampsEnabled;
 exports.getTimestampFormat = getTimestampFormat;
 exports.streamExec = streamExec;
 const core = __importStar(__nccwpck_require__(490));
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 function makeFileLogger(env) {
     const logPath = (env["SETUP_SOLDR_LOG"] ?? "").trim();
     if (!logPath)
@@ -47414,14 +47664,14 @@ async function streamExec(command, args, opts = {}) {
 
 /***/ }),
 
-/***/ 201:
+/***/ 202:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 /* eslint-disable object-property-newline */
 
 
-const decodeText = __nccwpck_require__(293)
+const decodeText = __nccwpck_require__(294)
 
 const RE_ENCODED = /%[a-fA-F0-9][a-fA-F0-9]/g
 
@@ -47618,7 +47868,7 @@ module.exports = parseParams
 
 /***/ }),
 
-/***/ 202:
+/***/ 203:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47644,8 +47894,8 @@ __export(auxiliaryAuthenticationHeaderPolicy_exports, {
   auxiliaryAuthenticationHeaderPolicyName: () => auxiliaryAuthenticationHeaderPolicyName
 });
 module.exports = __toCommonJS(auxiliaryAuthenticationHeaderPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(170);
-var import_log = __nccwpck_require__(191);
+var import_tokenCycler = __nccwpck_require__(171);
+var import_log = __nccwpck_require__(192);
 const auxiliaryAuthenticationHeaderPolicyName = "auxiliaryAuthenticationHeaderPolicy";
 const AUTHORIZATION_AUXILIARY_HEADER = "x-ms-authorization-auxiliary";
 async function sendAuthorizeRequest(options) {
@@ -47711,7 +47961,7 @@ function auxiliaryAuthenticationHeaderPolicy(options) {
 
 /***/ }),
 
-/***/ 203:
+/***/ 204:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -47739,7 +47989,7 @@ __export(src_exports, {
   stringifyXML: () => import_xml.stringifyXML
 });
 module.exports = __toCommonJS(src_exports);
-var import_xml = __nccwpck_require__(146);
+var import_xml = __nccwpck_require__(147);
 var import_xml_common = __nccwpck_require__(24);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -47748,7 +47998,7 @@ var import_xml_common = __nccwpck_require__(24);
 
 /***/ }),
 
-/***/ 204:
+/***/ 205:
 /***/ ((module) => {
 
 module.exports = {
@@ -47818,7 +48068,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 205:
+/***/ 206:
 /***/ ((module) => {
 
 "use strict";
@@ -47943,7 +48193,7 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 206:
+/***/ 207:
 /***/ ((module) => {
 
 "use strict";
@@ -47951,7 +48201,7 @@ module.exports = require("node:child_process");
 
 /***/ }),
 
-/***/ 207:
+/***/ 208:
 /***/ ((module) => {
 
 "use strict";
@@ -47959,13 +48209,13 @@ module.exports = require("util/types");
 
 /***/ }),
 
-/***/ 208:
+/***/ 209:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(132)
+const { promisify } = __nccwpck_require__(133)
 const Client = __nccwpck_require__(98)
 const { buildMockDispatch } = __nccwpck_require__(9)
 const {
@@ -47977,8 +48227,8 @@ const {
   kOriginalDispatch,
   kConnected
 } = __nccwpck_require__(504)
-const { MockInterceptor } = __nccwpck_require__(144)
-const Symbols = __nccwpck_require__(204)
+const { MockInterceptor } = __nccwpck_require__(145)
+const Symbols = __nccwpck_require__(205)
 const { InvalidArgumentError } = __nccwpck_require__(522)
 
 /**
@@ -48026,7 +48276,7 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 209:
+/***/ 210:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -48052,7 +48302,7 @@ __export(sha256_exports, {
   computeSha256Hmac: () => computeSha256Hmac
 });
 module.exports = __toCommonJS(sha256_exports);
-var import_node_crypto = __nccwpck_require__(292);
+var import_node_crypto = __nccwpck_require__(293);
 async function computeSha256Hmac(key, stringToSign, encoding) {
   const decodedKey = Buffer.from(key, "base64");
   return (0, import_node_crypto.createHmac)("sha256", decodedKey).update(stringToSign).digest(encoding);
@@ -48067,7 +48317,7 @@ async function computeSha256Hash(content, encoding) {
 
 /***/ }),
 
-/***/ 210:
+/***/ 211:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -48447,7 +48697,7 @@ exports.BlobQueryResponse = BlobQueryResponse;
 
 /***/ }),
 
-/***/ 211:
+/***/ 212:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -48460,10 +48710,10 @@ exports.streamToBuffer = streamToBuffer;
 exports.streamToBuffer2 = streamToBuffer2;
 exports.streamToBuffer3 = streamToBuffer3;
 exports.readStreamToLocalFile = readStreamToLocalFile;
-const tslib_1 = __nccwpck_require__(225);
-const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(265));
-const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(398));
-const constants_js_1 = __nccwpck_require__(157);
+const tslib_1 = __nccwpck_require__(226);
+const node_fs_1 = tslib_1.__importDefault(__nccwpck_require__(266));
+const node_util_1 = tslib_1.__importDefault(__nccwpck_require__(399));
+const constants_js_1 = __nccwpck_require__(158);
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
  *
@@ -48594,7 +48844,7 @@ exports.fsCreateReadStream = node_fs_1.default.createReadStream;
 
 /***/ }),
 
-/***/ 212:
+/***/ 213:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -48876,7 +49126,7 @@ exports.varint32read = varint32read;
 
 /***/ }),
 
-/***/ 213:
+/***/ 214:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -48886,9 +49136,9 @@ exports.varint32read = varint32read;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobLeaseClient = void 0;
 const core_util_1 = __nccwpck_require__(17);
-const constants_js_1 = __nccwpck_require__(157);
+const constants_js_1 = __nccwpck_require__(158);
 const tracing_js_1 = __nccwpck_require__(35);
-const utils_common_js_1 = __nccwpck_require__(163);
+const utils_common_js_1 = __nccwpck_require__(164);
 /**
  * A client that manages leases for a {@link ContainerClient} or a {@link BlobClient}.
  */
@@ -49088,7 +49338,7 @@ exports.BlobLeaseClient = BlobLeaseClient;
 
 /***/ }),
 
-/***/ 214:
+/***/ 215:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49096,7 +49346,7 @@ exports.BlobLeaseClient = BlobLeaseClient;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionCreate = void 0;
 const reflection_scalar_default_1 = __nccwpck_require__(494);
-const message_type_contract_1 = __nccwpck_require__(432);
+const message_type_contract_1 = __nccwpck_require__(433);
 /**
  * Creates an instance of the generic message, using the field
  * information.
@@ -49144,7 +49394,7 @@ exports.reflectionCreate = reflectionCreate;
 
 /***/ }),
 
-/***/ 215:
+/***/ 216:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49186,7 +49436,7 @@ function storageBrowserPolicy() {
 
 /***/ }),
 
-/***/ 216:
+/***/ 217:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49194,9 +49444,9 @@ function storageBrowserPolicy() {
 
 const { isBlobLike, toUSVString, makeIterator } = __nccwpck_require__(552)
 const { kState } = __nccwpck_require__(18)
-const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(388)
+const { File: UndiciFile, FileLike, isFileLike } = __nccwpck_require__(389)
 const { webidl } = __nccwpck_require__(485)
-const { Blob, File: NativeFile } = __nccwpck_require__(128)
+const { Blob, File: NativeFile } = __nccwpck_require__(129)
 
 /** @type {globalThis['File']} */
 const File = NativeFile ?? UndiciFile
@@ -49459,7 +49709,7 @@ module.exports = { FormData }
 
 /***/ }),
 
-/***/ 217:
+/***/ 218:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -49476,7 +49726,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 218:
+/***/ 219:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49503,7 +49753,7 @@ __export(getClient_exports, {
 module.exports = __toCommonJS(getClient_exports);
 var import_clientHelpers = __nccwpck_require__(525);
 var import_sendRequest = __nccwpck_require__(477);
-var import_urlHelpers = __nccwpck_require__(346);
+var import_urlHelpers = __nccwpck_require__(347);
 var import_checkEnvironment = __nccwpck_require__(466);
 function getClient(endpoint, clientOptions = {}) {
   const pipeline = clientOptions.pipeline ?? (0, import_clientHelpers.createDefaultPipeline)(clientOptions);
@@ -49659,7 +49909,7 @@ function buildOperation(method, url, pipeline, options, allowInsecureConnection,
 
 /***/ }),
 
-/***/ 219:
+/***/ 220:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49684,8 +49934,8 @@ __export(httpClientAdapter_exports, {
   convertHttpClient: () => convertHttpClient
 });
 module.exports = __toCommonJS(httpClientAdapter_exports);
-var import_response = __nccwpck_require__(438);
-var import_util = __nccwpck_require__(119);
+var import_response = __nccwpck_require__(439);
+var import_util = __nccwpck_require__(120);
 function convertHttpClient(requestPolicyClient) {
   return {
     sendRequest: async (request) => {
@@ -49703,7 +49953,7 @@ function convertHttpClient(requestPolicyClient) {
 
 /***/ }),
 
-/***/ 220:
+/***/ 221:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -49729,8 +49979,8 @@ __export(retryPolicy_exports, {
 });
 module.exports = __toCommonJS(retryPolicy_exports);
 var import_logger = __nccwpck_require__(50);
-var import_constants = __nccwpck_require__(167);
-var import_policies = __nccwpck_require__(307);
+var import_constants = __nccwpck_require__(168);
+var import_policies = __nccwpck_require__(308);
 const retryPolicyLogger = (0, import_logger.createClientLogger)("core-rest-pipeline retryPolicy");
 function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAULT_RETRY_POLICY_COUNT }) {
   return (0, import_policies.retryPolicy)(strategies, {
@@ -49744,7 +49994,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 
 /***/ }),
 
-/***/ 221:
+/***/ 222:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -49753,7 +50003,7 @@ function retryPolicy(strategies, options = { maxRetries: import_constants.DEFAUL
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getErrorMessage = getErrorMessage;
-const util_1 = __nccwpck_require__(155);
+const util_1 = __nccwpck_require__(156);
 /**
  * Given what is thought to be an error object, return the message if possible.
  * If the message is missing, returns a stringified version of the input.
@@ -49784,7 +50034,7 @@ function getErrorMessage(e) {
 
 /***/ }),
 
-/***/ 222:
+/***/ 223:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -49824,13 +50074,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveCache = exports.restoreCache = exports.isFeatureAvailable = exports.FinalizeCacheError = exports.ReserveCacheError = exports.ValidationError = void 0;
 const core = __importStar(__nccwpck_require__(490));
-const path = __importStar(__nccwpck_require__(264));
+const path = __importStar(__nccwpck_require__(265));
 const utils = __importStar(__nccwpck_require__(83));
 const cacheHttpClient = __importStar(__nccwpck_require__(38));
 const cacheTwirpClient = __importStar(__nccwpck_require__(68));
 const config_1 = __nccwpck_require__(42);
 const tar_1 = __nccwpck_require__(468);
-const http_client_1 = __nccwpck_require__(303);
+const http_client_1 = __nccwpck_require__(304);
 class ValidationError extends Error {
     constructor(message) {
         super(message);
@@ -50310,7 +50560,7 @@ function saveCacheV2(paths, key, options, enableCrossOsArchive = false) {
 
 /***/ }),
 
-/***/ 223:
+/***/ 224:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -50338,7 +50588,7 @@ module.exports = __toCommonJS(extendedClient_exports);
 var import_disableKeepAlivePolicy = __nccwpck_require__(10);
 var import_core_rest_pipeline = __nccwpck_require__(111);
 var import_core_client = __nccwpck_require__(467);
-var import_response = __nccwpck_require__(438);
+var import_response = __nccwpck_require__(439);
 class ExtendedServiceClient extends import_core_client.ServiceClient {
   constructor(options) {
     super(options);
@@ -50387,14 +50637,14 @@ class ExtendedServiceClient extends import_core_client.ServiceClient {
 
 /***/ }),
 
-/***/ 224:
+/***/ 225:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Context = void 0;
-const fs_1 = __nccwpck_require__(567);
+const fs_1 = __nccwpck_require__(568);
 const os_1 = __nccwpck_require__(102);
 class Context {
     /**
@@ -50450,7 +50700,7 @@ exports.Context = Context;
 
 /***/ }),
 
-/***/ 225:
+/***/ 226:
 /***/ ((module) => {
 
 /******************************************************************************
@@ -50908,7 +51158,7 @@ var __rewriteRelativeImportExtension;
 
 /***/ }),
 
-/***/ 226:
+/***/ 227:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -50935,9 +51185,9 @@ __export(bearerTokenAuthenticationPolicy_exports, {
   parseChallenges: () => parseChallenges
 });
 module.exports = __toCommonJS(bearerTokenAuthenticationPolicy_exports);
-var import_tokenCycler = __nccwpck_require__(170);
-var import_log = __nccwpck_require__(191);
-var import_restError = __nccwpck_require__(378);
+var import_tokenCycler = __nccwpck_require__(171);
+var import_log = __nccwpck_require__(192);
+var import_restError = __nccwpck_require__(379);
 const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPolicy";
 async function trySendRequest(request, next) {
   try {
@@ -51127,7 +51377,7 @@ function getCaeChallengeClaims(challenges) {
 
 /***/ }),
 
-/***/ 227:
+/***/ 228:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -51153,7 +51403,7 @@ __export(systemErrorRetryPolicy_exports, {
   systemErrorRetryPolicyName: () => systemErrorRetryPolicyName
 });
 module.exports = __toCommonJS(systemErrorRetryPolicy_exports);
-var import_policies = __nccwpck_require__(307);
+var import_policies = __nccwpck_require__(308);
 const systemErrorRetryPolicyName = import_policies.systemErrorRetryPolicyName;
 function systemErrorRetryPolicy(options = {}) {
   return (0, import_policies.systemErrorRetryPolicy)(options);
@@ -51164,7 +51414,7 @@ function systemErrorRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 228:
+/***/ 229:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -51178,9 +51428,9 @@ function systemErrorRetryPolicy(options = {}) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ContainerImpl = void 0;
-const tslib_1 = __nccwpck_require__(225);
+const tslib_1 = __nccwpck_require__(226);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(467));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(187));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(72));
 /** Class containing Container operations. */
 class ContainerImpl {
@@ -51892,7 +52142,7 @@ const getAccountInfoOperationSpec = {
 
 /***/ }),
 
-/***/ 229:
+/***/ 230:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -51937,7 +52187,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 230:
+/***/ 231:
 /***/ ((module) => {
 
 module.exports = removeHook;
@@ -51963,7 +52213,7 @@ function removeHook(state, name, method) {
 
 /***/ }),
 
-/***/ 231:
+/***/ 232:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -51992,8 +52242,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.safeTrimTrailingSeparator = exports.normalizeSeparators = exports.hasRoot = exports.hasAbsoluteRoot = exports.ensureAbsoluteRoot = exports.dirname = void 0;
-const path = __importStar(__nccwpck_require__(264));
-const assert_1 = __importDefault(__nccwpck_require__(562));
+const path = __importStar(__nccwpck_require__(265));
+const assert_1 = __importDefault(__nccwpck_require__(563));
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Similar to path.dirname except normalizes the path separators and slightly better handling for Windows UNC paths.
@@ -52168,20 +52418,20 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 
 /***/ }),
 
-/***/ 232:
+/***/ 233:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-module.exports = __nccwpck_require__(309)
-module.exports.async = __nccwpck_require__(437)
-module.exports.stream = __nccwpck_require__(446)
-module.exports.prettyError = __nccwpck_require__(297)
+module.exports = __nccwpck_require__(310)
+module.exports.async = __nccwpck_require__(438)
+module.exports.stream = __nccwpck_require__(447)
+module.exports.prettyError = __nccwpck_require__(298)
 
 
 /***/ }),
 
-/***/ 233:
+/***/ 234:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52232,11 +52482,11 @@ exports.targetDirHasCompiledArtifacts = targetDirHasCompiledArtifacts;
 exports.shouldEmitSharedTargetWarning = shouldEmitSharedTargetWarning;
 exports.tryDelegateToSoldrDoctorSharedTargetWarning = tryDelegateToSoldrDoctorSharedTargetWarning;
 exports.detectSharedTargetWarning = detectSharedTargetWarning;
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
 const core = __importStar(__nccwpck_require__(490));
-const log_utils_js_1 = __nccwpck_require__(200);
-const soldr_toolchain_client_js_1 = __nccwpck_require__(364);
+const log_utils_js_1 = __nccwpck_require__(201);
+const soldr_toolchain_client_js_1 = __nccwpck_require__(365);
 const WARNING_MESSAGE = "setup-soldr detected a pre-populated shared target directory; a " +
     "subsequent `soldr cargo build` using the same `--target-dir` may fail " +
     "with a missing .rmeta error - see README 'Known limitations'.";
@@ -52425,7 +52675,7 @@ async function detectSharedTargetWarning(opts) {
 
 /***/ }),
 
-/***/ 234:
+/***/ 235:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -52521,7 +52771,7 @@ function readRawInputs(env) {
 
 /***/ }),
 
-/***/ 235:
+/***/ 236:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52558,7 +52808,7 @@ const net = __importStar(__nccwpck_require__(543));
 const tls = __importStar(__nccwpck_require__(539));
 const debug_1 = __importDefault(__nccwpck_require__(549));
 const events_1 = __nccwpck_require__(503);
-const agent_base_1 = __nccwpck_require__(253);
+const agent_base_1 = __nccwpck_require__(254);
 const url_1 = __nccwpck_require__(95);
 const debug = (0, debug_1.default)('http-proxy-agent');
 /**
@@ -52676,7 +52926,7 @@ function omit(obj, ...keys) {
 
 /***/ }),
 
-/***/ 236:
+/***/ 237:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -52712,8 +52962,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
-const fs = __importStar(__nccwpck_require__(567));
-const path = __importStar(__nccwpck_require__(264));
+const fs = __importStar(__nccwpck_require__(568));
+const path = __importStar(__nccwpck_require__(265));
 _a = fs.promises
 // export const {open} = 'fs'
 , exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
@@ -52866,7 +53116,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 237:
+/***/ 238:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -52875,8 +53125,8 @@ exports.getCmdPath = getCmdPath;
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
-const tslib_1 = __nccwpck_require__(225);
-var poller_js_1 = __nccwpck_require__(342);
+const tslib_1 = __nccwpck_require__(226);
+var poller_js_1 = __nccwpck_require__(343);
 Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: function () { return poller_js_1.createHttpPoller; } }));
 /**
  * This can be uncommented to expose the protocol-agnostic poller
@@ -52890,14 +53140,14 @@ Object.defineProperty(exports, "createHttpPoller", ({ enumerable: true, get: fun
 // } from "./poller/models";
 // export { buildCreatePoller } from "./poller/poller";
 /** legacy */
-tslib_1.__exportStar(__nccwpck_require__(257), exports);
+tslib_1.__exportStar(__nccwpck_require__(258), exports);
 tslib_1.__exportStar(__nccwpck_require__(82), exports);
 tslib_1.__exportStar(__nccwpck_require__(45), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 238:
+/***/ 239:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -52943,7 +53193,7 @@ function apiVersionPolicy(options) {
 
 /***/ }),
 
-/***/ 239:
+/***/ 240:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -53190,7 +53440,7 @@ exports.AbortSignal = AbortSignal;
 
 /***/ }),
 
-/***/ 240:
+/***/ 241:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -53207,7 +53457,7 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
 
 /***/ }),
 
-/***/ 241:
+/***/ 242:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53221,9 +53471,9 @@ exports.AVRO_SCHEMA_KEY = "avro.schema";
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceImpl = void 0;
-const tslib_1 = __nccwpck_require__(225);
+const tslib_1 = __nccwpck_require__(226);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(467));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(187));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(72));
 /** Class containing Service operations. */
 class ServiceImpl {
@@ -53543,7 +53793,7 @@ const filterBlobsOperationSpec = {
 
 /***/ }),
 
-/***/ 242:
+/***/ 243:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53569,7 +53819,7 @@ __export(agentPolicy_exports, {
   agentPolicyName: () => agentPolicyName
 });
 module.exports = __toCommonJS(agentPolicy_exports);
-var import_policies = __nccwpck_require__(307);
+var import_policies = __nccwpck_require__(308);
 const agentPolicyName = import_policies.agentPolicyName;
 function agentPolicy(agent) {
   return (0, import_policies.agentPolicy)(agent);
@@ -53580,7 +53830,7 @@ function agentPolicy(agent) {
 
 /***/ }),
 
-/***/ 243:
+/***/ 244:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53605,13 +53855,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 244:
+/***/ 245:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Transform } = __nccwpck_require__(139)
+const { Transform } = __nccwpck_require__(140)
 const { Console } = __nccwpck_require__(36)
 
 /**
@@ -53653,7 +53903,7 @@ module.exports = class PendingInterceptorsFormatter {
 
 /***/ }),
 
-/***/ 245:
+/***/ 246:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53665,7 +53915,7 @@ const runtime_2 = __nccwpck_require__(22);
 const runtime_3 = __nccwpck_require__(22);
 const runtime_4 = __nccwpck_require__(22);
 const runtime_5 = __nccwpck_require__(22);
-const cachescope_1 = __nccwpck_require__(421);
+const cachescope_1 = __nccwpck_require__(422);
 // @generated message type with reflection information, may provide speed optimized methods
 class CacheMetadata$Type extends runtime_5.MessageType {
     constructor() {
@@ -53724,7 +53974,7 @@ exports.CacheMetadata = new CacheMetadata$Type();
 
 /***/ }),
 
-/***/ 246:
+/***/ 247:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -53771,7 +54021,7 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 247:
+/***/ 248:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -53799,7 +54049,7 @@ exports.Deprecation = Deprecation;
 
 /***/ }),
 
-/***/ 248:
+/***/ 249:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -53874,12 +54124,12 @@ exports.isEncryptedArchive = isEncryptedArchive;
 exports.getEncryptionConfig = getEncryptionConfig;
 exports.decryptedTempPathFor = decryptedTempPathFor;
 exports._testInMemoryRoundTrip = _testInMemoryRoundTrip;
-const crypto = __importStar(__nccwpck_require__(292));
-const fs = __importStar(__nccwpck_require__(265));
-const fsp = __importStar(__nccwpck_require__(118));
+const crypto = __importStar(__nccwpck_require__(293));
+const fs = __importStar(__nccwpck_require__(266));
+const fsp = __importStar(__nccwpck_require__(119));
 const path = __importStar(__nccwpck_require__(542));
-const os = __importStar(__nccwpck_require__(405));
-const promises_1 = __nccwpck_require__(415);
+const os = __importStar(__nccwpck_require__(406));
+const promises_1 = __nccwpck_require__(416);
 exports.ENCRYPT_MAGIC = Buffer.from("SOLDRENC", "ascii");
 exports.ENCRYPT_VERSION = 0x01;
 exports.IV_BYTES = 12;
@@ -54103,7 +54353,7 @@ exports.tmpdir = os.tmpdir;
 
 /***/ }),
 
-/***/ 249:
+/***/ 250:
 /***/ ((module) => {
 
 "use strict";
@@ -54111,7 +54361,7 @@ module.exports = require("node:process");
 
 /***/ }),
 
-/***/ 250:
+/***/ 251:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -54122,7 +54372,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getRequestUrl = getRequestUrl;
 exports.appendQueryParams = appendQueryParams;
 const operationHelpers_js_1 = __nccwpck_require__(459);
-const interfaceHelpers_js_1 = __nccwpck_require__(425);
+const interfaceHelpers_js_1 = __nccwpck_require__(426);
 const CollectionFormatToDelimiterMap = {
     CSV: ",",
     SSV: " ",
@@ -54355,7 +54605,7 @@ function appendQueryParams(url, queryParams, sequenceParams, noOverwrite = false
 
 /***/ }),
 
-/***/ 251:
+/***/ 252:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -54381,7 +54631,7 @@ __export(decompressResponsePolicy_exports, {
   decompressResponsePolicyName: () => decompressResponsePolicyName
 });
 module.exports = __toCommonJS(decompressResponsePolicy_exports);
-var import_policies = __nccwpck_require__(307);
+var import_policies = __nccwpck_require__(308);
 const decompressResponsePolicyName = import_policies.decompressResponsePolicyName;
 function decompressResponsePolicy() {
   return (0, import_policies.decompressResponsePolicy)();
@@ -54392,7 +54642,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 252:
+/***/ 253:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -54439,7 +54689,7 @@ function ndJsonPolicy() {
 
 /***/ }),
 
-/***/ 253:
+/***/ 254:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -54473,9 +54723,9 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Agent = void 0;
 const net = __importStar(__nccwpck_require__(543));
-const http = __importStar(__nccwpck_require__(353));
+const http = __importStar(__nccwpck_require__(354));
 const https_1 = __nccwpck_require__(78);
-__exportStar(__nccwpck_require__(169), exports);
+__exportStar(__nccwpck_require__(170), exports);
 const INTERNAL = Symbol('AgentBaseInternalState');
 class Agent extends http.Agent {
     constructor(opts) {
@@ -54624,7 +54874,7 @@ exports.Agent = Agent;
 
 /***/ }),
 
-/***/ 254:
+/***/ 255:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -54667,7 +54917,7 @@ exports.mergeJsonOptions = mergeJsonOptions;
 
 /***/ }),
 
-/***/ 255:
+/***/ 256:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -54702,7 +54952,7 @@ function createHttpHeaders(rawHeaders) {
 
 /***/ }),
 
-/***/ 256:
+/***/ 257:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -54877,7 +55127,7 @@ function targetArtifactDirectory(workspace, target) {
 
 /***/ }),
 
-/***/ 257:
+/***/ 258:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -54886,13 +55136,13 @@ function targetArtifactDirectory(workspace, target) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.LroEngine = void 0;
-var lroEngine_js_1 = __nccwpck_require__(185);
+var lroEngine_js_1 = __nccwpck_require__(186);
 Object.defineProperty(exports, "LroEngine", ({ enumerable: true, get: function () { return lroEngine_js_1.LroEngine; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 258:
+/***/ 259:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -54927,7 +55177,7 @@ function createEmptyPipeline() {
 
 /***/ }),
 
-/***/ 259:
+/***/ 260:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -54976,13 +55226,13 @@ exports.extractCargoRegistryExtrasArchive = extractCargoRegistryExtrasArchive;
 exports.cargoRegistryPayloadCensus = cargoRegistryPayloadCensus;
 exports.saveCargoRegistryArchive = saveCargoRegistryArchive;
 exports.restoreCargoRegistryArchive = restoreCargoRegistryArchive;
-const fs = __importStar(__nccwpck_require__(118));
-const os = __importStar(__nccwpck_require__(405));
+const fs = __importStar(__nccwpck_require__(119));
+const os = __importStar(__nccwpck_require__(406));
 const path = __importStar(__nccwpck_require__(542));
-const node_crypto_1 = __nccwpck_require__(292);
-const node_child_process_1 = __nccwpck_require__(206);
-const io = __importStar(__nccwpck_require__(315));
-const tc = __importStar(__nccwpck_require__(557));
+const node_crypto_1 = __nccwpck_require__(293);
+const node_child_process_1 = __nccwpck_require__(207);
+const io = __importStar(__nccwpck_require__(316));
+const tc = __importStar(__nccwpck_require__(558));
 const cache_compress_js_1 = __nccwpck_require__(28);
 const soldr_load_shim_js_1 = __nccwpck_require__(526);
 const OPTIONAL_EXTRA_BASENAMES = [".global-cache", "git"];
@@ -55331,7 +55581,7 @@ async function restoreCargoRegistryArchive(input) {
 
 /***/ }),
 
-/***/ 260:
+/***/ 261:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -55382,10 +55632,10 @@ exports.isGitRepo = isGitRepo;
 exports.listTrackedFiles = listTrackedFiles;
 exports.normalizeWorkspace = normalizeWorkspace;
 exports.normalizeSourceMtime = normalizeSourceMtime;
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
 const exec = __importStar(__nccwpck_require__(21));
-const log_utils_js_1 = __nccwpck_require__(200);
+const log_utils_js_1 = __nccwpck_require__(201);
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 // Globs evaluated against the repo-relative POSIX path of each tracked file.
 const INCLUDE_GLOBS = [
@@ -55617,7 +55867,7 @@ exports._internal = {
 
 /***/ }),
 
-/***/ 261:
+/***/ 262:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __create = Object.create;
@@ -55762,7 +56012,7 @@ function createClientLogger(namespace) {
 
 /***/ }),
 
-/***/ 262:
+/***/ 263:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -55810,15 +56060,15 @@ exports.shouldRefreshToolchain = shouldRefreshToolchain;
 exports.shouldSkipRefreshForExactHit = shouldSkipRefreshForExactHit;
 exports.tryDelegateToSoldrToolchainEnsure = tryDelegateToSoldrToolchainEnsure;
 exports.ensureRustToolchain = ensureRustToolchain;
-const fs = __importStar(__nccwpck_require__(265));
-const os = __importStar(__nccwpck_require__(405));
+const fs = __importStar(__nccwpck_require__(266));
+const os = __importStar(__nccwpck_require__(406));
 const path = __importStar(__nccwpck_require__(542));
 const core = __importStar(__nccwpck_require__(490));
 const exec = __importStar(__nccwpck_require__(21));
-const io = __importStar(__nccwpck_require__(315));
-const tc = __importStar(__nccwpck_require__(557));
-const log_utils_js_1 = __nccwpck_require__(200);
-const soldr_toolchain_client_js_1 = __nccwpck_require__(364);
+const io = __importStar(__nccwpck_require__(316));
+const tc = __importStar(__nccwpck_require__(558));
+const log_utils_js_1 = __nccwpck_require__(201);
+const soldr_toolchain_client_js_1 = __nccwpck_require__(365);
 function rustupInitTargetTriple() {
     const system = process.platform;
     const arch = process.arch;
@@ -56168,7 +56418,7 @@ async function ensureRustToolchain(opts) {
 
 /***/ }),
 
-/***/ 263:
+/***/ 264:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -56215,7 +56465,7 @@ function isTokenCredential(credential) {
 
 /***/ }),
 
-/***/ 264:
+/***/ 265:
 /***/ ((module) => {
 
 "use strict";
@@ -56223,7 +56473,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 265:
+/***/ 266:
 /***/ ((module) => {
 
 "use strict";
@@ -56231,7 +56481,7 @@ module.exports = require("node:fs");
 
 /***/ }),
 
-/***/ 266:
+/***/ 267:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56239,7 +56489,7 @@ module.exports = require("node:fs");
 
 const { webidl } = __nccwpck_require__(485)
 const { kEnumerableProperty } = __nccwpck_require__(77)
-const { MessagePort } = __nccwpck_require__(341)
+const { MessagePort } = __nccwpck_require__(342)
 
 /**
  * @see https://html.spec.whatwg.org/multipage/comms.html#messageevent
@@ -56542,15 +56792,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 267:
+/***/ 268:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BinaryWriter = exports.binaryWriteOptions = void 0;
-const pb_long_1 = __nccwpck_require__(126);
-const goog_varint_1 = __nccwpck_require__(212);
+const pb_long_1 = __nccwpck_require__(127);
+const goog_varint_1 = __nccwpck_require__(213);
 const assert_1 = __nccwpck_require__(518);
 const defaultsWrite = {
     writeUnknownFields: true,
@@ -56782,7 +57032,7 @@ exports.BinaryWriter = BinaryWriter;
 
 /***/ }),
 
-/***/ 268:
+/***/ 269:
 /***/ ((module) => {
 
 module.exports = register;
@@ -56816,7 +57066,7 @@ function register(state, name, method, options) {
 
 /***/ }),
 
-/***/ 269:
+/***/ 270:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56825,9 +57075,9 @@ function register(state, name, method, options) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = void 0;
-const AvroReadable_js_1 = __nccwpck_require__(410);
+const AvroReadable_js_1 = __nccwpck_require__(411);
 const abort_controller_1 = __nccwpck_require__(530);
-const buffer_1 = __nccwpck_require__(128);
+const buffer_1 = __nccwpck_require__(129);
 const ABORT_ERROR = new abort_controller_1.AbortError("Reading from the avro stream was aborted.");
 class AvroReadableFromStream extends AvroReadable_js_1.AvroReadable {
     _position;
@@ -56913,7 +57163,7 @@ exports.AvroReadableFromStream = AvroReadableFromStream;
 
 /***/ }),
 
-/***/ 270:
+/***/ 271:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -56934,7 +57184,7 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 271:
+/***/ 272:
 /***/ ((module) => {
 
 "use strict";
@@ -56971,13 +57221,13 @@ module.exports = class Pluralizer {
 
 /***/ }),
 
-/***/ 272:
+/***/ 273:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const RedirectHandler = __nccwpck_require__(414)
+const RedirectHandler = __nccwpck_require__(415)
 
 function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections }) {
   return (dispatch) => {
@@ -57000,7 +57250,7 @@ module.exports = createRedirectInterceptor
 
 /***/ }),
 
-/***/ 273:
+/***/ 274:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -57054,7 +57304,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 274:
+/***/ 275:
 /***/ ((module) => {
 
 "use strict";
@@ -57062,7 +57312,7 @@ module.exports = require("stream/web");
 
 /***/ }),
 
-/***/ 275:
+/***/ 276:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57072,8 +57322,8 @@ module.exports = require("stream/web");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getBodyAsText = getBodyAsText;
 exports.utf8ByteLength = utf8ByteLength;
-const utils_js_1 = __nccwpck_require__(211);
-const constants_js_1 = __nccwpck_require__(157);
+const utils_js_1 = __nccwpck_require__(212);
+const constants_js_1 = __nccwpck_require__(158);
 async function getBodyAsText(batchResponse) {
     let buffer = Buffer.alloc(constants_js_1.BATCH_MAX_PAYLOAD_IN_BYTES);
     const responseLength = await (0, utils_js_1.streamToBuffer2)(batchResponse.readableStreamBody, buffer);
@@ -57088,7 +57338,7 @@ function utf8ByteLength(str) {
 
 /***/ }),
 
-/***/ 276:
+/***/ 277:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -57139,7 +57389,7 @@ function wrapAbortSignalLikePolicy() {
 
 /***/ }),
 
-/***/ 277:
+/***/ 278:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57191,7 +57441,7 @@ function createAbortablePromise(buildPromise, options) {
 
 /***/ }),
 
-/***/ 278:
+/***/ 279:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -57231,7 +57481,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.retryHttpClientResponse = exports.retryTypedResponse = exports.retry = exports.isRetryableStatusCode = exports.isServerErrorStatusCode = exports.isSuccessStatusCode = void 0;
 const core = __importStar(__nccwpck_require__(490));
-const http_client_1 = __nccwpck_require__(303);
+const http_client_1 = __nccwpck_require__(304);
 const constants_1 = __nccwpck_require__(51);
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
@@ -57335,7 +57585,7 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 
 /***/ }),
 
-/***/ 279:
+/***/ 280:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57344,8 +57594,8 @@ exports.retryHttpClientResponse = retryHttpClientResponse;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageSharedKeyCredential = void 0;
-const node_crypto_1 = __nccwpck_require__(292);
-const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(135);
+const node_crypto_1 = __nccwpck_require__(293);
+const StorageSharedKeyCredentialPolicy_js_1 = __nccwpck_require__(136);
 const Credential_js_1 = __nccwpck_require__(105);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -57394,7 +57644,7 @@ exports.StorageSharedKeyCredential = StorageSharedKeyCredential;
 
 /***/ }),
 
-/***/ 280:
+/***/ 281:
 /***/ ((module) => {
 
 "use strict";
@@ -57402,7 +57652,7 @@ module.exports = require("node:http");
 
 /***/ }),
 
-/***/ 281:
+/***/ 282:
 /***/ ((module) => {
 
 "use strict";
@@ -57410,7 +57660,7 @@ module.exports = require("node:buffer");
 
 /***/ }),
 
-/***/ 282:
+/***/ 283:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -57534,14 +57784,14 @@ exports.getDownloadOptions = getDownloadOptions;
 
 /***/ }),
 
-/***/ 283:
+/***/ 284:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const net = __nccwpck_require__(543)
-const assert = __nccwpck_require__(562)
+const assert = __nccwpck_require__(563)
 const util = __nccwpck_require__(77)
 const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(522)
 
@@ -57731,7 +57981,7 @@ module.exports = buildConnector
 
 /***/ }),
 
-/***/ 284:
+/***/ 285:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57740,7 +57990,7 @@ module.exports = buildConnector
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageContextClient = void 0;
-const index_js_1 = __nccwpck_require__(317);
+const index_js_1 = __nccwpck_require__(318);
 /**
  * @internal
  */
@@ -57759,7 +58009,7 @@ exports.StorageContextClient = StorageContextClient;
 
 /***/ }),
 
-/***/ 285:
+/***/ 286:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -57789,10 +58039,10 @@ __export(index_exports, {
 });
 module.exports = __toCommonJS(index_exports);
 var import_universal_user_agent = __nccwpck_require__(91);
-var import_before_after_hook = __nccwpck_require__(424);
+var import_before_after_hook = __nccwpck_require__(425);
 var import_request = __nccwpck_require__(75);
-var import_graphql = __nccwpck_require__(571);
-var import_auth_token = __nccwpck_require__(429);
+var import_graphql = __nccwpck_require__(572);
+var import_auth_token = __nccwpck_require__(430);
 
 // pkg/dist-src/version.js
 var VERSION = "5.2.2";
@@ -57935,7 +58185,7 @@ var Octokit = class {
 
 /***/ }),
 
-/***/ 286:
+/***/ 287:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -57961,7 +58211,7 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_policies = __nccwpck_require__(307);
+var import_policies = __nccwpck_require__(308);
 const formDataPolicyName = import_policies.formDataPolicyName;
 function formDataPolicy() {
   return (0, import_policies.formDataPolicy)();
@@ -57972,7 +58222,7 @@ function formDataPolicy() {
 
 /***/ }),
 
-/***/ 287:
+/***/ 288:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -58000,7 +58250,7 @@ __export(multipart_exports, {
 module.exports = __toCommonJS(multipart_exports);
 var import_restError = __nccwpck_require__(472);
 var import_httpHeaders = __nccwpck_require__(519);
-var import_bytesEncoding = __nccwpck_require__(308);
+var import_bytesEncoding = __nccwpck_require__(309);
 var import_typeGuards = __nccwpck_require__(531);
 function getHeaderValue(descriptor, headerName) {
   if (descriptor.headers) {
@@ -58110,7 +58360,7 @@ function buildMultipartBody(parts) {
 
 /***/ }),
 
-/***/ 288:
+/***/ 289:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58127,7 +58377,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 289:
+/***/ 290:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -58153,8 +58403,8 @@ __export(multipartPolicy_exports, {
   multipartPolicyName: () => multipartPolicyName
 });
 module.exports = __toCommonJS(multipartPolicy_exports);
-var import_policies = __nccwpck_require__(307);
-var import_file = __nccwpck_require__(350);
+var import_policies = __nccwpck_require__(308);
+var import_file = __nccwpck_require__(351);
 const multipartPolicyName = import_policies.multipartPolicyName;
 function multipartPolicy() {
   const tspPolicy = (0, import_policies.multipartPolicy)();
@@ -58178,7 +58428,7 @@ function multipartPolicy() {
 
 /***/ }),
 
-/***/ 290:
+/***/ 291:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58273,12 +58523,12 @@ exports.listEnumNumbers = listEnumNumbers;
 
 /***/ }),
 
-/***/ 291:
+/***/ 292:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const assert = __nccwpck_require__(562)
+const assert = __nccwpck_require__(563)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(204)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(205)
 const { RequestRetryError } = __nccwpck_require__(522)
 const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(77)
 
@@ -58616,7 +58866,7 @@ module.exports = RetryHandler
 
 /***/ }),
 
-/***/ 292:
+/***/ 293:
 /***/ ((module) => {
 
 "use strict";
@@ -58624,7 +58874,7 @@ module.exports = require("node:crypto");
 
 /***/ }),
 
-/***/ 293:
+/***/ 294:
 /***/ (function(module) {
 
 "use strict";
@@ -58746,7 +58996,7 @@ module.exports = decodeText
 
 /***/ }),
 
-/***/ 294:
+/***/ 295:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -58755,32 +59005,32 @@ module.exports = decodeText
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BaseRequestPolicy = exports.getCachedDefaultHttpClient = void 0;
-const tslib_1 = __nccwpck_require__(225);
-tslib_1.__exportStar(__nccwpck_require__(387), exports);
-var cache_js_1 = __nccwpck_require__(270);
+const tslib_1 = __nccwpck_require__(226);
+tslib_1.__exportStar(__nccwpck_require__(388), exports);
+var cache_js_1 = __nccwpck_require__(271);
 Object.defineProperty(exports, "getCachedDefaultHttpClient", ({ enumerable: true, get: function () { return cache_js_1.getCachedDefaultHttpClient; } }));
 tslib_1.__exportStar(__nccwpck_require__(89), exports);
-tslib_1.__exportStar(__nccwpck_require__(164), exports);
-tslib_1.__exportStar(__nccwpck_require__(422), exports);
+tslib_1.__exportStar(__nccwpck_require__(165), exports);
+tslib_1.__exportStar(__nccwpck_require__(423), exports);
 tslib_1.__exportStar(__nccwpck_require__(105), exports);
-tslib_1.__exportStar(__nccwpck_require__(279), exports);
-tslib_1.__exportStar(__nccwpck_require__(349), exports);
+tslib_1.__exportStar(__nccwpck_require__(280), exports);
+tslib_1.__exportStar(__nccwpck_require__(350), exports);
 var RequestPolicy_js_1 = __nccwpck_require__(52);
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return RequestPolicy_js_1.BaseRequestPolicy; } }));
 tslib_1.__exportStar(__nccwpck_require__(103), exports);
-tslib_1.__exportStar(__nccwpck_require__(330), exports);
-tslib_1.__exportStar(__nccwpck_require__(215), exports);
+tslib_1.__exportStar(__nccwpck_require__(331), exports);
+tslib_1.__exportStar(__nccwpck_require__(216), exports);
 tslib_1.__exportStar(__nccwpck_require__(495), exports);
-tslib_1.__exportStar(__nccwpck_require__(174), exports);
-tslib_1.__exportStar(__nccwpck_require__(135), exports);
+tslib_1.__exportStar(__nccwpck_require__(175), exports);
+tslib_1.__exportStar(__nccwpck_require__(136), exports);
 tslib_1.__exportStar(__nccwpck_require__(85), exports);
 tslib_1.__exportStar(__nccwpck_require__(454), exports);
-tslib_1.__exportStar(__nccwpck_require__(176), exports);
+tslib_1.__exportStar(__nccwpck_require__(177), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 295:
+/***/ 296:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -58793,18 +59043,18 @@ tslib_1.__exportStar(__nccwpck_require__(176), exports);
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tslib_1 = __nccwpck_require__(225);
-tslib_1.__exportStar(__nccwpck_require__(241), exports);
-tslib_1.__exportStar(__nccwpck_require__(228), exports);
+const tslib_1 = __nccwpck_require__(226);
+tslib_1.__exportStar(__nccwpck_require__(242), exports);
+tslib_1.__exportStar(__nccwpck_require__(229), exports);
 tslib_1.__exportStar(__nccwpck_require__(53), exports);
-tslib_1.__exportStar(__nccwpck_require__(300), exports);
+tslib_1.__exportStar(__nccwpck_require__(301), exports);
 tslib_1.__exportStar(__nccwpck_require__(30), exports);
-tslib_1.__exportStar(__nccwpck_require__(381), exports);
+tslib_1.__exportStar(__nccwpck_require__(382), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 296:
+/***/ 297:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -58834,10 +59084,10 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokitOptions = exports.GitHub = exports.defaults = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(224));
-const Utils = __importStar(__nccwpck_require__(305));
+const Context = __importStar(__nccwpck_require__(225));
+const Utils = __importStar(__nccwpck_require__(306));
 // octokit + plugins
-const core_1 = __nccwpck_require__(285);
+const core_1 = __nccwpck_require__(286);
 const plugin_rest_endpoint_methods_1 = __nccwpck_require__(496);
 const plugin_paginate_rest_1 = __nccwpck_require__(488);
 exports.context = new Context.Context();
@@ -58870,7 +59120,7 @@ exports.getOctokitOptions = getOctokitOptions;
 
 /***/ }),
 
-/***/ 297:
+/***/ 298:
 /***/ ((module) => {
 
 "use strict";
@@ -58911,7 +59161,7 @@ function prettyError (err, buf) {
 
 /***/ }),
 
-/***/ 298:
+/***/ 299:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -59141,7 +59391,7 @@ exports.ContainerSASPermissions = ContainerSASPermissions;
 
 /***/ }),
 
-/***/ 299:
+/***/ 300:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -59167,20 +59417,20 @@ __export(createPipelineFromOptions_exports, {
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(79);
-var import_pipeline = __nccwpck_require__(258);
-var import_redirectPolicy = __nccwpck_require__(365);
-var import_userAgentPolicy = __nccwpck_require__(412);
-var import_multipartPolicy = __nccwpck_require__(289);
-var import_decompressResponsePolicy = __nccwpck_require__(251);
+var import_pipeline = __nccwpck_require__(259);
+var import_redirectPolicy = __nccwpck_require__(366);
+var import_userAgentPolicy = __nccwpck_require__(413);
+var import_multipartPolicy = __nccwpck_require__(290);
+var import_decompressResponsePolicy = __nccwpck_require__(252);
 var import_defaultRetryPolicy = __nccwpck_require__(61);
-var import_formDataPolicy = __nccwpck_require__(286);
+var import_formDataPolicy = __nccwpck_require__(287);
 var import_core_util = __nccwpck_require__(17);
 var import_proxyPolicy = __nccwpck_require__(506);
-var import_setClientRequestIdPolicy = __nccwpck_require__(159);
-var import_agentPolicy = __nccwpck_require__(242);
-var import_tlsPolicy = __nccwpck_require__(401);
-var import_tracingPolicy = __nccwpck_require__(360);
-var import_wrapAbortSignalLikePolicy = __nccwpck_require__(276);
+var import_setClientRequestIdPolicy = __nccwpck_require__(160);
+var import_agentPolicy = __nccwpck_require__(243);
+var import_tlsPolicy = __nccwpck_require__(402);
+var import_tracingPolicy = __nccwpck_require__(361);
+var import_wrapAbortSignalLikePolicy = __nccwpck_require__(277);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_core_util.isNodeLike) {
@@ -59214,7 +59464,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 300:
+/***/ 301:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59228,9 +59478,9 @@ function createPipelineFromOptions(options) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PageBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(225);
+const tslib_1 = __nccwpck_require__(226);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(467));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(187));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(72));
 /** Class containing PageBlob operations. */
 class PageBlobImpl {
@@ -59684,13 +59934,13 @@ const copyIncrementalOperationSpec = {
 
 /***/ }),
 
-/***/ 301:
+/***/ 302:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(165)
+const { kConstruct } = __nccwpck_require__(166)
 const { Cache } = __nccwpck_require__(15)
 const { webidl } = __nccwpck_require__(485)
 const { kEnumerableProperty } = __nccwpck_require__(77)
@@ -59836,7 +60086,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 302:
+/***/ 303:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -59872,7 +60122,7 @@ function createClientPipeline(options = {}) {
 
 /***/ }),
 
-/***/ 303:
+/***/ 304:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -59912,11 +60162,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
-const http = __importStar(__nccwpck_require__(353));
+const http = __importStar(__nccwpck_require__(354));
 const https = __importStar(__nccwpck_require__(78));
-const pm = __importStar(__nccwpck_require__(333));
+const pm = __importStar(__nccwpck_require__(334));
 const tunnel = __importStar(__nccwpck_require__(555));
-const undici_1 = __nccwpck_require__(171);
+const undici_1 = __nccwpck_require__(172);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -60531,7 +60781,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 304:
+/***/ 305:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -60583,34 +60833,34 @@ exports.resolveLocalSourceVersion = resolveLocalSourceVersion;
 exports.resolveManifestWorkspace = resolveManifestWorkspace;
 exports.resolveSetup = resolveSetup;
 exports.applyResolveResult = applyResolveResult;
-const os = __importStar(__nccwpck_require__(405));
+const os = __importStar(__nccwpck_require__(406));
 const path = __importStar(__nccwpck_require__(542));
-const fs = __importStar(__nccwpck_require__(265));
-const node_child_process_1 = __nccwpck_require__(206);
+const fs = __importStar(__nccwpck_require__(266));
+const node_child_process_1 = __nccwpck_require__(207);
 const core = __importStar(__nccwpck_require__(490));
-const toml = __importStar(__nccwpck_require__(426));
-const cache_keys_js_1 = __nccwpck_require__(332);
+const toml = __importStar(__nccwpck_require__(427));
+const cache_keys_js_1 = __nccwpck_require__(333);
 const blessed_cross_prepare_js_1 = __nccwpck_require__(13);
-const log_utils_js_1 = __nccwpck_require__(200);
-const cache_encrypt_js_1 = __nccwpck_require__(248);
-const dylint_nightly_js_1 = __nccwpck_require__(368);
+const log_utils_js_1 = __nccwpck_require__(201);
+const cache_encrypt_js_1 = __nccwpck_require__(249);
+const dylint_nightly_js_1 = __nccwpck_require__(369);
 const detect_musl_cc_js_1 = __nccwpck_require__(493);
 Object.defineProperty(exports, "detectMuslCcEnv", ({ enumerable: true, get: function () { return detect_musl_cc_js_1.detectMuslCcEnv; } }));
-const build_outputs_js_1 = __nccwpck_require__(413);
+const build_outputs_js_1 = __nccwpck_require__(414);
 Object.defineProperty(exports, "buildOutputs", ({ enumerable: true, get: function () { return build_outputs_js_1.buildOutputs; } }));
-const raw_inputs_js_1 = __nccwpck_require__(234);
+const raw_inputs_js_1 = __nccwpck_require__(235);
 Object.defineProperty(exports, "readRawInputs", ({ enumerable: true, get: function () { return raw_inputs_js_1.readRawInputs; } }));
 const phase_timing_js_1 = __nccwpck_require__(551);
 const input_parsers_js_1 = __nccwpck_require__(93);
 Object.defineProperty(exports, "detectUserLinkerEnv", ({ enumerable: true, get: function () { return input_parsers_js_1.detectUserLinkerEnv; } }));
 Object.defineProperty(exports, "parseCacheShutdownOnIdleSeconds", ({ enumerable: true, get: function () { return input_parsers_js_1.parseCacheShutdownOnIdleSeconds; } }));
 Object.defineProperty(exports, "parseRustBacktrace", ({ enumerable: true, get: function () { return input_parsers_js_1.parseRustBacktrace; } }));
-const fetch_release_js_1 = __nccwpck_require__(154);
-const cargo_registry_archive_js_1 = __nccwpck_require__(259);
+const fetch_release_js_1 = __nccwpck_require__(155);
+const cargo_registry_archive_js_1 = __nccwpck_require__(260);
 const soldr_load_shim_js_1 = __nccwpck_require__(526);
 const python_json_js_1 = __nccwpck_require__(14);
 Object.defineProperty(exports, "pythonDefaultJson", ({ enumerable: true, get: function () { return python_json_js_1.pythonDefaultJson; } }));
-const toolchain_js_1 = __nccwpck_require__(322);
+const toolchain_js_1 = __nccwpck_require__(323);
 const FALSY_VALUES = new Set(["0", "false", "no", "off"]);
 const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
 const ALLOWED_LINKER_VALUES = [
@@ -61099,7 +61349,7 @@ async function resolveSetup(ctx, inputs, deps) {
     // so canonical_json_stringify is wrong; mirror Python's default separators
     // (", " and ": ") to match byte-for-byte.
     const signatureString = (0, python_json_js_1.pythonDefaultJson)(toolchainSignature);
-    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 292, 23));
+    const { createHash } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 293, 23));
     const digest = createHash("sha256").update(signatureString, "utf8").digest("hex").slice(0, 16);
     const runnerOs = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform).toLowerCase());
     const runnerArch = (0, cache_keys_js_1.sanitizeFragment)((env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch).toLowerCase());
@@ -61767,7 +62017,7 @@ async function applyResolveResult(result) {
 
 /***/ }),
 
-/***/ 305:
+/***/ 306:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61806,8 +62056,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getApiBaseUrl = exports.getProxyFetch = exports.getProxyAgentDispatcher = exports.getProxyAgent = exports.getAuthString = void 0;
-const httpClient = __importStar(__nccwpck_require__(303));
-const undici_1 = __nccwpck_require__(171);
+const httpClient = __importStar(__nccwpck_require__(304));
+const undici_1 = __nccwpck_require__(172);
 function getAuthString(token, options) {
     if (!token && !options.auth) {
         throw new Error('Parameter token or opts.auth is required');
@@ -61844,7 +62094,7 @@ exports.getApiBaseUrl = getApiBaseUrl;
 
 /***/ }),
 
-/***/ 306:
+/***/ 307:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -61900,7 +62150,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseIsolatedSeedTargets = parseIsolatedSeedTargets;
 exports.shouldSeedBuildCacheEntry = shouldSeedBuildCacheEntry;
 exports.seedIsolatedBuildCache = seedIsolatedBuildCache;
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
 const cache_compress_js_1 = __nccwpck_require__(28);
 const TRANSIENT_SEED_SUFFIXES = [".lock", ".lck", ".sock", ".pid", ".tmp", ".temp", ".part", ".partial"];
@@ -62049,7 +62299,7 @@ function seedIsolatedBuildCache(opts) {
 
 /***/ }),
 
-/***/ 307:
+/***/ 308:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62102,19 +62352,19 @@ __export(internal_exports, {
 });
 module.exports = __toCommonJS(internal_exports);
 var import_agentPolicy = __nccwpck_require__(497);
-var import_decompressResponsePolicy = __nccwpck_require__(382);
-var import_defaultRetryPolicy = __nccwpck_require__(347);
-var import_exponentialRetryPolicy = __nccwpck_require__(558);
+var import_decompressResponsePolicy = __nccwpck_require__(383);
+var import_defaultRetryPolicy = __nccwpck_require__(348);
+var import_exponentialRetryPolicy = __nccwpck_require__(559);
 var import_retryPolicy = __nccwpck_require__(19);
 var import_systemErrorRetryPolicy = __nccwpck_require__(32);
-var import_throttlingRetryPolicy = __nccwpck_require__(556);
-var import_formDataPolicy = __nccwpck_require__(363);
+var import_throttlingRetryPolicy = __nccwpck_require__(557);
+var import_formDataPolicy = __nccwpck_require__(364);
 var import_logPolicy = __nccwpck_require__(112);
-var import_multipartPolicy = __nccwpck_require__(177);
+var import_multipartPolicy = __nccwpck_require__(178);
 var import_proxyPolicy = __nccwpck_require__(44);
-var import_redirectPolicy = __nccwpck_require__(340);
-var import_tlsPolicy = __nccwpck_require__(229);
-var import_userAgentPolicy = __nccwpck_require__(385);
+var import_redirectPolicy = __nccwpck_require__(341);
+var import_tlsPolicy = __nccwpck_require__(230);
+var import_userAgentPolicy = __nccwpck_require__(386);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=internal.js.map
@@ -62122,7 +62372,7 @@ var import_userAgentPolicy = __nccwpck_require__(385);
 
 /***/ }),
 
-/***/ 308:
+/***/ 309:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -62161,15 +62411,15 @@ function stringToUint8Array(value, format) {
 
 /***/ }),
 
-/***/ 309:
+/***/ 310:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseString
 
-const TOMLParser = __nccwpck_require__(371)
-const prettyError = __nccwpck_require__(297)
+const TOMLParser = __nccwpck_require__(372)
+const prettyError = __nccwpck_require__(298)
 
 function parseString (str) {
   if (global.Buffer && global.Buffer.isBuffer(str)) {
@@ -62187,7 +62437,7 @@ function parseString (str) {
 
 /***/ }),
 
-/***/ 310:
+/***/ 311:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62199,11 +62449,11 @@ exports.generateAccountSASQueryParameters = generateAccountSASQueryParameters;
 exports.generateAccountSASQueryParametersInternal = generateAccountSASQueryParametersInternal;
 const AccountSASPermissions_js_1 = __nccwpck_require__(64);
 const AccountSASResourceTypes_js_1 = __nccwpck_require__(2);
-const AccountSASServices_js_1 = __nccwpck_require__(402);
-const SasIPRange_js_1 = __nccwpck_require__(384);
-const SASQueryParameters_js_1 = __nccwpck_require__(561);
-const constants_js_1 = __nccwpck_require__(157);
-const utils_common_js_1 = __nccwpck_require__(163);
+const AccountSASServices_js_1 = __nccwpck_require__(403);
+const SasIPRange_js_1 = __nccwpck_require__(385);
+const SASQueryParameters_js_1 = __nccwpck_require__(562);
+const constants_js_1 = __nccwpck_require__(158);
+const utils_common_js_1 = __nccwpck_require__(164);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -62298,7 +62548,7 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 
 /***/ }),
 
-/***/ 311:
+/***/ 312:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62306,7 +62556,7 @@ function generateAccountSASQueryParametersInternal(accountSASSignatureValues, sh
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionTypeCheck = void 0;
 const reflection_info_1 = __nccwpck_require__(481);
-const oneof_1 = __nccwpck_require__(198);
+const oneof_1 = __nccwpck_require__(199);
 // noinspection JSMethodCanBeStatic
 class ReflectionTypeCheck {
     constructor(info) {
@@ -62536,7 +62786,7 @@ exports.ReflectionTypeCheck = ReflectionTypeCheck;
 
 /***/ }),
 
-/***/ 312:
+/***/ 313:
 /***/ ((module) => {
 
 "use strict";
@@ -62544,7 +62794,7 @@ module.exports = require("crypto");
 
 /***/ }),
 
-/***/ 313:
+/***/ 314:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -62570,8 +62820,8 @@ __export(userAgent_exports, {
   getUserAgentValue: () => getUserAgentValue
 });
 module.exports = __toCommonJS(userAgent_exports);
-var import_userAgentPlatform = __nccwpck_require__(125);
-var import_constants = __nccwpck_require__(167);
+var import_userAgentPlatform = __nccwpck_require__(126);
+var import_constants = __nccwpck_require__(168);
 function getUserAgentString(telemetryInfo) {
   const parts = [];
   for (const [key, value] of telemetryInfo) {
@@ -62597,7 +62847,7 @@ async function getUserAgentValue(prefix) {
 
 /***/ }),
 
-/***/ 314:
+/***/ 315:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -62671,7 +62921,7 @@ function copy(a, into) {
 
 /***/ }),
 
-/***/ 315:
+/***/ 316:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -62706,9 +62956,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
-const assert_1 = __nccwpck_require__(562);
-const path = __importStar(__nccwpck_require__(264));
-const ioUtil = __importStar(__nccwpck_require__(236));
+const assert_1 = __nccwpck_require__(563);
+const path = __importStar(__nccwpck_require__(265));
+const ioUtil = __importStar(__nccwpck_require__(237));
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -62977,7 +63227,7 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 316:
+/***/ 317:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -63058,7 +63308,7 @@ exports.maskSecretUrls = maskSecretUrls;
 
 /***/ }),
 
-/***/ 317:
+/***/ 318:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -63072,16 +63322,16 @@ exports.maskSecretUrls = maskSecretUrls;
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(225);
+const tslib_1 = __nccwpck_require__(226);
 tslib_1.__exportStar(__nccwpck_require__(505), exports);
 var storageClient_js_1 = __nccwpck_require__(474);
 Object.defineProperty(exports, "StorageClient", ({ enumerable: true, get: function () { return storageClient_js_1.StorageClient; } }));
-tslib_1.__exportStar(__nccwpck_require__(173), exports);
+tslib_1.__exportStar(__nccwpck_require__(174), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 318:
+/***/ 319:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -63131,7 +63381,7 @@ exports.AzureKeyCredential = AzureKeyCredential;
 
 /***/ }),
 
-/***/ 319:
+/***/ 320:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -63141,8 +63391,8 @@ const {
   InvalidArgumentError,
   NotSupportedError
 } = __nccwpck_require__(522)
-const assert = __nccwpck_require__(562)
-const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(204)
+const assert = __nccwpck_require__(563)
+const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = __nccwpck_require__(205)
 const util = __nccwpck_require__(77)
 
 // tokenRegExp and headerCharRegex have been lifted from
@@ -63173,7 +63423,7 @@ const channels = {}
 let extractBody
 
 try {
-  const diagnosticsChannel = __nccwpck_require__(150)
+  const diagnosticsChannel = __nccwpck_require__(151)
   channels.create = diagnosticsChannel.channel('undici:request:create')
   channels.bodySent = diagnosticsChannel.channel('undici:request:bodySent')
   channels.headers = diagnosticsChannel.channel('undici:request:headers')
@@ -63638,7 +63888,7 @@ module.exports = Request
 
 /***/ }),
 
-/***/ 320:
+/***/ 321:
 /***/ ((module) => {
 
 "use strict";
@@ -63942,7 +64192,7 @@ function stringifyComplexTable (prefix, indent, key, value) {
 
 /***/ }),
 
-/***/ 321:
+/***/ 322:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -63951,7 +64201,7 @@ function stringifyComplexTable (prefix, indent, key, value) {
 const { webidl } = __nccwpck_require__(485)
 const { DOMException } = __nccwpck_require__(34)
 const { URLSerializer } = __nccwpck_require__(29)
-const { getGlobalOrigin } = __nccwpck_require__(148)
+const { getGlobalOrigin } = __nccwpck_require__(149)
 const { staticPropertyDescriptors, states, opcodes, emptyBuffer } = __nccwpck_require__(499)
 const {
   kWebSocketURL,
@@ -63963,12 +64213,12 @@ const {
   kByteParser
 } = __nccwpck_require__(108)
 const { isEstablished, isClosing, isValidSubprotocol, failWebsocketConnection, fireEvent } = __nccwpck_require__(63)
-const { establishWebSocketConnection } = __nccwpck_require__(389)
-const { WebsocketFrameSend } = __nccwpck_require__(194)
+const { establishWebSocketConnection } = __nccwpck_require__(390)
+const { WebsocketFrameSend } = __nccwpck_require__(195)
 const { ByteParser } = __nccwpck_require__(515)
 const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(77)
-const { getGlobalDispatcher } = __nccwpck_require__(399)
-const { types } = __nccwpck_require__(132)
+const { getGlobalDispatcher } = __nccwpck_require__(400)
+const { types } = __nccwpck_require__(133)
 
 let experimentalWarned = false
 
@@ -64591,7 +64841,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 322:
+/***/ 323:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -64643,11 +64893,11 @@ exports.rustChannelManifestRelease = rustChannelManifestRelease;
 exports.resolveToolchainCacheChannel = resolveToolchainCacheChannel;
 exports.loadToolchainSpec = loadToolchainSpec;
 exports.systemRustupSatisfiesRequest = systemRustupSatisfiesRequest;
-const node_crypto_1 = __nccwpck_require__(292);
-const fs = __importStar(__nccwpck_require__(265));
+const node_crypto_1 = __nccwpck_require__(293);
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
-const toml = __importStar(__nccwpck_require__(426));
-const io = __importStar(__nccwpck_require__(315));
+const toml = __importStar(__nccwpck_require__(427));
+const io = __importStar(__nccwpck_require__(316));
 const exec = __importStar(__nccwpck_require__(21));
 const ROLLING_TOOLCHAIN_ALIASES = ["stable", "beta", "nightly"];
 /**
@@ -64979,7 +65229,7 @@ async function defaultWhich(cmd) {
 
 /***/ }),
 
-/***/ 323:
+/***/ 324:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65314,7 +65564,7 @@ class AvroRecordType extends AvroType {
 
 /***/ }),
 
-/***/ 324:
+/***/ 325:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65440,7 +65690,7 @@ exports.base64encode = base64encode;
 
 /***/ }),
 
-/***/ 325:
+/***/ 326:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -65465,7 +65715,7 @@ __export(concat_exports, {
   concat: () => concat
 });
 module.exports = __toCommonJS(concat_exports);
-var import_stream = __nccwpck_require__(139);
+var import_stream = __nccwpck_require__(140);
 var import_typeGuards = __nccwpck_require__(531);
 async function* streamAsyncIterator() {
   const reader = this.getReader();
@@ -65527,7 +65777,7 @@ async function concat(sources) {
 
 /***/ }),
 
-/***/ 326:
+/***/ 327:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65604,7 +65854,7 @@ UsageError.isUsageErrorMessage = (msg) => {
 
 /***/ }),
 
-/***/ 327:
+/***/ 328:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -65661,7 +65911,7 @@ exports.DuplexStreamingCall = DuplexStreamingCall;
 
 /***/ }),
 
-/***/ 328:
+/***/ 329:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65839,7 +66089,7 @@ exports.RpcOutputStreamController = RpcOutputStreamController;
 
 /***/ }),
 
-/***/ 329:
+/***/ 330:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -65861,7 +66111,7 @@ exports.enumToMap = enumToMap;
 
 /***/ }),
 
-/***/ 330:
+/***/ 331:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65901,7 +66151,7 @@ exports.CredentialPolicy = CredentialPolicy;
 
 /***/ }),
 
-/***/ 331:
+/***/ 332:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -65912,9 +66162,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BatchResponseParser = void 0;
 const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_http_compat_1 = __nccwpck_require__(80);
-const constants_js_1 = __nccwpck_require__(157);
-const BatchUtils_js_1 = __nccwpck_require__(275);
-const log_js_1 = __nccwpck_require__(116);
+const constants_js_1 = __nccwpck_require__(158);
+const BatchUtils_js_1 = __nccwpck_require__(276);
+const log_js_1 = __nccwpck_require__(117);
 const HTTP_HEADER_DELIMITER = ": ";
 const SPACE_DELIMITER = " ";
 const NOT_FOUND = -1;
@@ -66054,7 +66304,7 @@ exports.BatchResponseParser = BatchResponseParser;
 
 /***/ }),
 
-/***/ 332:
+/***/ 333:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -66133,8 +66383,8 @@ exports.setupCachePaths = setupCachePaths;
 exports.setupCacheLayout = setupCacheLayout;
 exports.crossToolCacheKeyFor = crossToolCacheKeyFor;
 exports.pathForOutput = pathForOutput;
-const node_crypto_1 = __nccwpck_require__(292);
-const fs = __importStar(__nccwpck_require__(265));
+const node_crypto_1 = __nccwpck_require__(293);
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
 const TARGET_CACHE_PROFILES = ["thin-v1", "thin-v2", "thin-v3"];
 const TARGET_CACHE_BOOL_TRUE = new Set(["true", "1", "yes", "on"]);
@@ -66550,7 +66800,7 @@ function pathForOutput(workspace, p) {
 
 /***/ }),
 
-/***/ 333:
+/***/ 334:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -66652,7 +66902,7 @@ class DecodedURL extends URL {
 
 /***/ }),
 
-/***/ 334:
+/***/ 335:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -66878,7 +67128,7 @@ function diagnoseShimBypass(input) {
 
 /***/ }),
 
-/***/ 335:
+/***/ 336:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67019,7 +67269,7 @@ function flattenResponse(fullResponse, responseSpec) {
 
 /***/ }),
 
-/***/ 336:
+/***/ 337:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67028,7 +67278,7 @@ function flattenResponse(fullResponse, responseSpec) {
 // Licensed under the MIT license.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.buildCreatePoller = void 0;
-const operation_js_1 = __nccwpck_require__(149);
+const operation_js_1 = __nccwpck_require__(150);
 const constants_js_1 = __nccwpck_require__(67);
 const core_util_1 = __nccwpck_require__(17);
 const createStateProxy = () => ({
@@ -67200,7 +67450,7 @@ exports.buildCreatePoller = buildCreatePoller;
 
 /***/ }),
 
-/***/ 337:
+/***/ 338:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67210,12 +67460,12 @@ exports.buildCreatePoller = buildCreatePoller;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceClient = void 0;
 const core_rest_pipeline_1 = __nccwpck_require__(111);
-const pipeline_js_1 = __nccwpck_require__(302);
-const utils_js_1 = __nccwpck_require__(335);
-const httpClientCache_js_1 = __nccwpck_require__(423);
+const pipeline_js_1 = __nccwpck_require__(303);
+const utils_js_1 = __nccwpck_require__(336);
+const httpClientCache_js_1 = __nccwpck_require__(424);
 const operationHelpers_js_1 = __nccwpck_require__(459);
-const urlHelpers_js_1 = __nccwpck_require__(250);
-const interfaceHelpers_js_1 = __nccwpck_require__(425);
+const urlHelpers_js_1 = __nccwpck_require__(251);
+const interfaceHelpers_js_1 = __nccwpck_require__(426);
 const log_js_1 = __nccwpck_require__(514);
 /**
  * Initializes a new instance of the ServiceClient.
@@ -67383,7 +67633,7 @@ function getCredentialScopes(options) {
 
 /***/ }),
 
-/***/ 338:
+/***/ 339:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67409,17 +67659,17 @@ __export(createPipelineFromOptions_exports, {
 });
 module.exports = __toCommonJS(createPipelineFromOptions_exports);
 var import_logPolicy = __nccwpck_require__(112);
-var import_pipeline = __nccwpck_require__(559);
-var import_redirectPolicy = __nccwpck_require__(340);
-var import_userAgentPolicy = __nccwpck_require__(385);
-var import_decompressResponsePolicy = __nccwpck_require__(382);
-var import_defaultRetryPolicy = __nccwpck_require__(347);
-var import_formDataPolicy = __nccwpck_require__(363);
+var import_pipeline = __nccwpck_require__(560);
+var import_redirectPolicy = __nccwpck_require__(341);
+var import_userAgentPolicy = __nccwpck_require__(386);
+var import_decompressResponsePolicy = __nccwpck_require__(383);
+var import_defaultRetryPolicy = __nccwpck_require__(348);
+var import_formDataPolicy = __nccwpck_require__(364);
 var import_checkEnvironment = __nccwpck_require__(466);
 var import_proxyPolicy = __nccwpck_require__(44);
 var import_agentPolicy = __nccwpck_require__(497);
-var import_tlsPolicy = __nccwpck_require__(229);
-var import_multipartPolicy = __nccwpck_require__(177);
+var import_tlsPolicy = __nccwpck_require__(230);
+var import_multipartPolicy = __nccwpck_require__(178);
 function createPipelineFromOptions(options) {
   const pipeline = (0, import_pipeline.createEmptyPipeline)();
   if (import_checkEnvironment.isNodeLike) {
@@ -67449,7 +67699,7 @@ function createPipelineFromOptions(options) {
 
 /***/ }),
 
-/***/ 339:
+/***/ 340:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67466,7 +67716,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 340:
+/***/ 341:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67492,7 +67742,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_log = __nccwpck_require__(160);
+var import_log = __nccwpck_require__(161);
 const redirectPolicyName = "redirectPolicy";
 const allowedRedirect = ["GET", "HEAD"];
 function redirectPolicy(options = {}) {
@@ -67538,7 +67788,7 @@ async function handleRedirect(next, response, maxRetries, allowCrossOriginRedire
 
 /***/ }),
 
-/***/ 341:
+/***/ 342:
 /***/ ((module) => {
 
 "use strict";
@@ -67546,7 +67796,7 @@ module.exports = require("worker_threads");
 
 /***/ }),
 
-/***/ 342:
+/***/ 343:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -67556,7 +67806,7 @@ module.exports = require("worker_threads");
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createHttpPoller = void 0;
 const operation_js_1 = __nccwpck_require__(57);
-const poller_js_1 = __nccwpck_require__(336);
+const poller_js_1 = __nccwpck_require__(337);
 /**
  * Creates a poller that can be used to poll a long-running operation.
  * @param lro - Description of the long-running operation
@@ -67601,7 +67851,7 @@ exports.createHttpPoller = createHttpPoller;
 
 /***/ }),
 
-/***/ 343:
+/***/ 344:
 /***/ ((module) => {
 
 "use strict";
@@ -67609,14 +67859,14 @@ module.exports = require("perf_hooks");
 
 /***/ }),
 
-/***/ 344:
+/***/ 345:
 /***/ ((module) => {
 
 (()=>{"use strict";var t={d:(e,n)=>{for(var i in n)t.o(n,i)&&!t.o(e,i)&&Object.defineProperty(e,i,{enumerable:!0,get:n[i]})},o:(t,e)=>Object.prototype.hasOwnProperty.call(t,e),r:t=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(t,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(t,"__esModule",{value:!0})}},e={};t.r(e),t.d(e,{XMLBuilder:()=>ie,XMLParser:()=>Lt,XMLValidator:()=>se});const n=":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD",i=new RegExp("^["+n+"]["+n+"\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$");function s(t,e){const n=[];let i=e.exec(t);for(;i;){const s=[];s.startIndex=e.lastIndex-i[0].length;const r=i.length;for(let t=0;t<r;t++)s.push(i[t]);n.push(s),i=e.exec(t)}return n}const r=function(t){return!(null==i.exec(t))},o=["hasOwnProperty","toString","valueOf","__defineGetter__","__defineSetter__","__lookupGetter__","__lookupSetter__"],a=["__proto__","constructor","prototype"],h={allowBooleanAttributes:!1,unpairedTags:[]};function l(t,e){e=Object.assign({},h,e);const n=[];let i=!1,s=!1;"\ufeff"===t[0]&&(t=t.substr(1));for(let r=0;r<t.length;r++)if("<"===t[r]&&"?"===t[r+1]){if(r+=2,r=p(t,r),r.err)return r}else{if("<"!==t[r]){if(u(t[r]))continue;return b("InvalidChar","char '"+t[r]+"' is not expected.",w(t,r))}{let o=r;if(r++,"!"===t[r]){r=c(t,r);continue}{let a=!1;"/"===t[r]&&(a=!0,r++);let h="";for(;r<t.length&&">"!==t[r]&&" "!==t[r]&&"\t"!==t[r]&&"\n"!==t[r]&&"\r"!==t[r];r++)h+=t[r];if(h=h.trim(),"/"===h[h.length-1]&&(h=h.substring(0,h.length-1),r--),!E(h)){let e;return e=0===h.trim().length?"Invalid space after '<'.":"Tag '"+h+"' is an invalid name.",b("InvalidTag",e,w(t,r))}const l=g(t,r);if(!1===l)return b("InvalidAttr","Attributes for '"+h+"' have open quote.",w(t,r));let d=l.value;if(r=l.index,"/"===d[d.length-1]){const n=r-d.length;d=d.substring(0,d.length-1);const s=x(d,e);if(!0!==s)return b(s.err.code,s.err.msg,w(t,n+s.err.line));i=!0}else if(a){if(!l.tagClosed)return b("InvalidTag","Closing tag '"+h+"' doesn't have proper closing.",w(t,r));if(d.trim().length>0)return b("InvalidTag","Closing tag '"+h+"' can't have attributes or invalid starting.",w(t,o));if(0===n.length)return b("InvalidTag","Closing tag '"+h+"' has not been opened.",w(t,o));{const e=n.pop();if(h!==e.tagName){let n=w(t,e.tagStartPos);return b("InvalidTag","Expected closing tag '"+e.tagName+"' (opened in line "+n.line+", col "+n.col+") instead of closing tag '"+h+"'.",w(t,o))}0==n.length&&(s=!0)}}else{const a=x(d,e);if(!0!==a)return b(a.err.code,a.err.msg,w(t,r-d.length+a.err.line));if(!0===s)return b("InvalidXml","Multiple possible root nodes found.",w(t,r));-1!==e.unpairedTags.indexOf(h)||n.push({tagName:h,tagStartPos:o}),i=!0}for(r++;r<t.length;r++)if("<"===t[r]){if("!"===t[r+1]){r++,r=c(t,r);continue}if("?"!==t[r+1])break;if(r=p(t,++r),r.err)return r}else if("&"===t[r]){const e=N(t,r);if(-1==e)return b("InvalidChar","char '&' is not expected.",w(t,r));r=e}else if(!0===s&&!u(t[r]))return b("InvalidXml","Extra text at the end",w(t,r));"<"===t[r]&&r--}}}return i?1==n.length?b("InvalidTag","Unclosed tag '"+n[0].tagName+"'.",w(t,n[0].tagStartPos)):!(n.length>0)||b("InvalidXml","Invalid '"+JSON.stringify(n.map(t=>t.tagName),null,4).replace(/\r?\n/g,"")+"' found.",{line:1,col:1}):b("InvalidXml","Start tag expected.",1)}function u(t){return" "===t||"\t"===t||"\n"===t||"\r"===t}function p(t,e){const n=e;for(;e<t.length;e++)if("?"==t[e]||" "==t[e]){const i=t.substr(n,e-n);if(e>5&&"xml"===i)return b("InvalidXml","XML declaration allowed only at the start of the document.",w(t,e));if("?"==t[e]&&">"==t[e+1]){e++;break}continue}return e}function c(t,e){if(t.length>e+5&&"-"===t[e+1]&&"-"===t[e+2]){for(e+=3;e<t.length;e++)if("-"===t[e]&&"-"===t[e+1]&&">"===t[e+2]){e+=2;break}}else if(t.length>e+8&&"D"===t[e+1]&&"O"===t[e+2]&&"C"===t[e+3]&&"T"===t[e+4]&&"Y"===t[e+5]&&"P"===t[e+6]&&"E"===t[e+7]){let n=1;for(e+=8;e<t.length;e++)if("<"===t[e])n++;else if(">"===t[e]&&(n--,0===n))break}else if(t.length>e+9&&"["===t[e+1]&&"C"===t[e+2]&&"D"===t[e+3]&&"A"===t[e+4]&&"T"===t[e+5]&&"A"===t[e+6]&&"["===t[e+7])for(e+=8;e<t.length;e++)if("]"===t[e]&&"]"===t[e+1]&&">"===t[e+2]){e+=2;break}return e}const d='"',f="'";function g(t,e){let n="",i="",s=!1;for(;e<t.length;e++){if(t[e]===d||t[e]===f)""===i?i=t[e]:i!==t[e]||(i="");else if(">"===t[e]&&""===i){s=!0;break}n+=t[e]}return""===i&&{value:n,index:e,tagClosed:s}}const m=new RegExp("(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['\"])(([\\s\\S])*?)\\5)?","g");function x(t,e){const n=s(t,m),i={};for(let t=0;t<n.length;t++){if(0===n[t][1].length)return b("InvalidAttr","Attribute '"+n[t][2]+"' has no space in starting.",v(n[t]));if(void 0!==n[t][3]&&void 0===n[t][4])return b("InvalidAttr","Attribute '"+n[t][2]+"' is without value.",v(n[t]));if(void 0===n[t][3]&&!e.allowBooleanAttributes)return b("InvalidAttr","boolean attribute '"+n[t][2]+"' is not allowed.",v(n[t]));const s=n[t][2];if(!y(s))return b("InvalidAttr","Attribute '"+s+"' is an invalid name.",v(n[t]));if(Object.prototype.hasOwnProperty.call(i,s))return b("InvalidAttr","Attribute '"+s+"' is repeated.",v(n[t]));i[s]=1}return!0}function N(t,e){if(";"===t[++e])return-1;if("#"===t[e])return function(t,e){let n=/\d/;for("x"===t[e]&&(e++,n=/[\da-fA-F]/);e<t.length;e++){if(";"===t[e])return e;if(!t[e].match(n))break}return-1}(t,++e);let n=0;for(;e<t.length;e++,n++)if(!(t[e].match(/\w/)&&n<20)){if(";"===t[e])break;return-1}return e}function b(t,e,n){return{err:{code:t,msg:e,line:n.line||n,col:n.col}}}function y(t){return r(t)}function E(t){return r(t)}function w(t,e){const n=t.substring(0,e).split(/\r?\n/);return{line:n.length,col:n[n.length-1].length+1}}function v(t){return t.startIndex+t[1].length}const S=t=>o.includes(t)?"__"+t:t,_={preserveOrder:!1,attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,removeNSPrefix:!1,allowBooleanAttributes:!1,parseTagValue:!0,parseAttributeValue:!1,trimValues:!0,cdataPropName:!1,numberParseOptions:{hex:!0,leadingZeros:!0,eNotation:!0},tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},stopNodes:[],alwaysCreateTextNode:!1,isArray:()=>!1,commentPropName:!1,unpairedTags:[],processEntities:!0,htmlEntities:!1,entityDecoder:null,ignoreDeclaration:!1,ignorePiTags:!1,transformTagName:!1,transformAttributeName:!1,updateTag:function(t,e,n){return t},captureMetaData:!1,maxNestedTags:100,strictReservedNames:!0,jPath:!0,onDangerousProperty:S};function A(t,e){if("string"!=typeof t)return;const n=t.toLowerCase();if(o.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);if(a.some(t=>n===t.toLowerCase()))throw new Error(`[SECURITY] Invalid ${e}: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`)}function T(t,e){return"boolean"==typeof t?{enabled:t,maxEntitySize:1e4,maxExpansionDepth:1e4,maxTotalExpansions:1/0,maxExpandedLength:1e5,maxEntityCount:1e3,allowedTags:null,tagFilter:null,appliesTo:"all"}:"object"==typeof t&&null!==t?{enabled:!1!==t.enabled,maxEntitySize:Math.max(1,t.maxEntitySize??1e4),maxExpansionDepth:Math.max(1,t.maxExpansionDepth??1e4),maxTotalExpansions:Math.max(1,t.maxTotalExpansions??1/0),maxExpandedLength:Math.max(1,t.maxExpandedLength??1e5),maxEntityCount:Math.max(1,t.maxEntityCount??1e3),allowedTags:t.allowedTags??null,tagFilter:t.tagFilter??null,appliesTo:t.appliesTo??"all"}:T(!0)}const C=function(t){const e=Object.assign({},_,t),n=[{value:e.attributeNamePrefix,name:"attributeNamePrefix"},{value:e.attributesGroupName,name:"attributesGroupName"},{value:e.textNodeName,name:"textNodeName"},{value:e.cdataPropName,name:"cdataPropName"},{value:e.commentPropName,name:"commentPropName"}];for(const{value:t,name:e}of n)t&&A(t,e);return null===e.onDangerousProperty&&(e.onDangerousProperty=S),e.processEntities=T(e.processEntities,e.htmlEntities),e.unpairedTagsSet=new Set(e.unpairedTags),e.stopNodes&&Array.isArray(e.stopNodes)&&(e.stopNodes=e.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),e};let P;P="function"!=typeof Symbol?"@@xmlMetadata":Symbol("XML Node Metadata");class ${constructor(t){this.tagname=t,this.child=[],this[":@"]=Object.create(null)}add(t,e){"__proto__"===t&&(t="#__proto__"),this.child.push({[t]:e})}addChild(t,e){"__proto__"===t.tagname&&(t.tagname="#__proto__"),t[":@"]&&Object.keys(t[":@"]).length>0?this.child.push({[t.tagname]:t.child,":@":t[":@"]}):this.child.push({[t.tagname]:t.child}),void 0!==e&&(this.child[this.child.length-1][P]={startIndex:e})}static getMetaDataSymbol(){return P}}const O=":A-Za-z_À-ÖØ-öø-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�",I=":A-Za-z_À-˿Ͱ-ͽͿ-҆҈-῿‌-‍⁰-↏Ⰰ-⿯、-퟿豈-﷏ﷰ-�𐀀-󯿿",V=I+"\\-\\.\\d·̀-ͯ҇‿-⁀",D=(t,e,n="")=>{const i=`[${t.replace(":","")}][${e.replace(":","")}]*`;return{name:new RegExp(`^[${t}][${e}]*$`,n),ncName:new RegExp(`^${i}$`,n),qName:new RegExp(`^${i}(?::${i})?$`,n),nmToken:new RegExp(`^[${e}]+$`,n),nmTokens:new RegExp(`^[${e}]+(?:\\s+[${e}]+)*$`,n)}},M=D(O,O+"\\-\\.\\d·̀-ͯ‿-⁀"),j=D(I,V,"u"),L=(t,{xmlVersion:e="1.0"}={})=>((t="1.0")=>"1.1"===t?j:M)(e).qName.test(t);class k{constructor(t,e){this.suppressValidationErr=!t,this.options=t,this.xmlVersion=e||1}setXmlVersion(t=1){this.xmlVersion=t}readDocType(t,e){const n=Object.create(null);let i=0;if("O"!==t[e+3]||"C"!==t[e+4]||"T"!==t[e+5]||"Y"!==t[e+6]||"P"!==t[e+7]||"E"!==t[e+8])throw new Error("Invalid Tag instead of DOCTYPE");{e+=9;let s=1,r=!1,o=!1,a="";for(;e<t.length;e++)if("<"!==t[e]||o)if(">"===t[e]){if(o?"-"===t[e-1]&&"-"===t[e-2]&&(o=!1,s--):s--,0===s)break}else"["===t[e]?r=!0:a+=t[e];else{if(r&&F(t,"!ENTITY",e)){let s,r;if(e+=7,[s,r,e]=this.readEntityExp(t,e+1,this.suppressValidationErr),-1===r.indexOf("&")){if(!1!==this.options.enabled&&null!=this.options.maxEntityCount&&i>=this.options.maxEntityCount)throw new Error(`Entity count (${i+1}) exceeds maximum allowed (${this.options.maxEntityCount})`);n[s]=r,i++}}else if(r&&F(t,"!ELEMENT",e)){e+=8;const{index:n}=this.readElementExp(t,e+1);e=n}else if(r&&F(t,"!ATTLIST",e))e+=8;else if(r&&F(t,"!NOTATION",e)){e+=9;const{index:n}=this.readNotationExp(t,e+1,this.suppressValidationErr);e=n}else{if(!F(t,"!--",e))throw new Error("Invalid DOCTYPE");o=!0}s++,a=""}if(0!==s)throw new Error("Unclosed DOCTYPE")}return{entities:n,i:e}}readEntityExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e])&&'"'!==t[e]&&"'"!==t[e];)e++;let i=t.substring(n,e);if(G(i,{xmlVersion:this.xmlVersion}),e=R(t,e),!this.suppressValidationErr){if("SYSTEM"===t.substring(e,e+6).toUpperCase())throw new Error("External entities are not supported");if("%"===t[e])throw new Error("Parameter entities are not supported")}let s="";if([e,s]=this.readIdentifierVal(t,e,"entity"),!1!==this.options.enabled&&null!=this.options.maxEntitySize&&s.length>this.options.maxEntitySize)throw new Error(`Entity "${i}" size (${s.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`);return[i,s,--e]}readNotationExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);!this.suppressValidationErr&&G(i,{xmlVersion:this.xmlVersion}),e=R(t,e);const s=t.substring(e,e+6).toUpperCase();if(!this.suppressValidationErr&&"SYSTEM"!==s&&"PUBLIC"!==s)throw new Error(`Expected SYSTEM or PUBLIC, found "${s}"`);e+=s.length,e=R(t,e);let r=null,o=null;if("PUBLIC"===s)[e,r]=this.readIdentifierVal(t,e,"publicIdentifier"),'"'!==t[e=R(t,e)]&&"'"!==t[e]||([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"));else if("SYSTEM"===s&&([e,o]=this.readIdentifierVal(t,e,"systemIdentifier"),!this.suppressValidationErr&&!o))throw new Error("Missing mandatory system identifier for SYSTEM notation");return{notationName:i,publicIdentifier:r,systemIdentifier:o,index:--e}}readIdentifierVal(t,e,n){let i="";const s=t[e];if('"'!==s&&"'"!==s)throw new Error(`Expected quoted string, found "${s}"`);const r=++e;for(;e<t.length&&t[e]!==s;)e++;if(i=t.substring(r,e),t[e]!==s)throw new Error(`Unterminated ${n} value`);return[++e,i]}readElementExp(t,e){const n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);if(!this.suppressValidationErr&&!L(i,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid element name: "${i}"`);let s="";if("E"===t[e=R(t,e)]&&F(t,"MPTY",e))e+=4;else if("A"===t[e]&&F(t,"NY",e))e+=2;else if("("===t[e]){const n=++e;for(;e<t.length&&")"!==t[e];)e++;if(s=t.substring(n,e),")"!==t[e])throw new Error("Unterminated content model")}else if(!this.suppressValidationErr)throw new Error(`Invalid Element Expression, found "${t[e]}"`);return{elementName:i,contentModel:s.trim(),index:e}}readAttlistExp(t,e){let n=e=R(t,e);for(;e<t.length&&!/\s/.test(t[e]);)e++;let i=t.substring(n,e);for(G(i,{xmlVersion:this.xmlVersion}),n=e=R(t,e);e<t.length&&!/\s/.test(t[e]);)e++;let s=t.substring(n,e);if(!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid attribute name: "${s}"`);e=R(t,e);let r="";if("NOTATION"===t.substring(e,e+8).toUpperCase()){if(r="NOTATION","("!==t[e=R(t,e+=8)])throw new Error(`Expected '(', found "${t[e]}"`);e++;let n=[];for(;e<t.length&&")"!==t[e];){const i=e;for(;e<t.length&&"|"!==t[e]&&")"!==t[e];)e++;let s=t.substring(i,e);if(s=s.trim(),!G(s,{xmlVersion:this.xmlVersion}))throw new Error(`Invalid notation name: "${s}"`);n.push(s),"|"===t[e]&&(e++,e=R(t,e))}if(")"!==t[e])throw new Error("Unterminated list of notations");e++,r+=" ("+n.join("|")+")"}else{const n=e;for(;e<t.length&&!/\s/.test(t[e]);)e++;r+=t.substring(n,e);const i=["CDATA","ID","IDREF","IDREFS","ENTITY","ENTITIES","NMTOKEN","NMTOKENS"];if(!this.suppressValidationErr&&!i.includes(r.toUpperCase()))throw new Error(`Invalid attribute type: "${r}"`)}e=R(t,e);let o="";return"#REQUIRED"===t.substring(e,e+8).toUpperCase()?(o="#REQUIRED",e+=8):"#IMPLIED"===t.substring(e,e+7).toUpperCase()?(o="#IMPLIED",e+=7):[e,o]=this.readIdentifierVal(t,e,"ATTLIST"),{elementName:i,attributeName:s,attributeType:r,defaultValue:o,index:e}}}const R=(t,e)=>{for(;e<t.length&&/\s/.test(t[e]);)e++;return e};function F(t,e,n){for(let i=0;i<e.length;i++)if(e[i]!==t[n+i+1])return!1;return!0}function G(t,e){if(L(t,{xmlVersion:e}))return t;throw new Error(`Invalid entity name ${t}`)}const U=/^[-+]?0x[a-fA-F0-9]+$/,B=/^0b[01]+$/,W=/^0o[0-7]+$/,z=/^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/,X={hex:!0,binary:!1,octal:!1,leadingZeros:!0,decimalPoint:".",eNotation:!0,infinity:"original"};const Y=/^([-+])?(0*)(\d*(\.\d*)?[eE][-\+]?\d+)$/;function q(t,e){const n=t.trim();if(2!==e&&8!==e||(t=n.substring(2)),parseInt)return parseInt(t,e);if(Number.parseInt)return Number.parseInt(t,e);if(window&&window.parseInt)return window.parseInt(t,e);throw new Error("parseInt, Number.parseInt, window.parseInt are not supported")}class Z{constructor(t){this._matcher=t}get separator(){return this._matcher.separator}getCurrentTag(){const t=this._matcher.path;return t.length>0?t[t.length-1].tag:void 0}getCurrentNamespace(){const t=this._matcher.path;return t.length>0?t[t.length-1].namespace:void 0}getAttrValue(t){const e=this._matcher.path;if(0!==e.length)return e[e.length-1].values?.[t]}hasAttr(t){const e=this._matcher.path;if(0===e.length)return!1;const n=e[e.length-1];return void 0!==n.values&&t in n.values}getPosition(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].position??0}getCounter(){const t=this._matcher.path;return 0===t.length?-1:t[t.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this._matcher.path.length}toString(t,e=!0){return this._matcher.toString(t,e)}toArray(){return this._matcher.path.map(t=>t.tag)}matches(t){return this._matcher.matches(t)}matchesAny(t){return t.matchesAny(this._matcher)}}class J{constructor(t={}){this.separator=t.separator||".",this.path=[],this.siblingStacks=[],this._pathStringCache=null,this._view=new Z(this)}push(t,e=null,n=null){this._pathStringCache=null,this.path.length>0&&(this.path[this.path.length-1].values=void 0);const i=this.path.length;this.siblingStacks[i]||(this.siblingStacks[i]=new Map);const s=this.siblingStacks[i],r=n?`${n}:${t}`:t,o=s.get(r)||0;let a=0;for(const t of s.values())a+=t;s.set(r,o+1);const h={tag:t,position:a,counter:o};null!=n&&(h.namespace=n),null!=e&&(h.values=e),this.path.push(h)}pop(){if(0===this.path.length)return;this._pathStringCache=null;const t=this.path.pop();return this.siblingStacks.length>this.path.length+1&&(this.siblingStacks.length=this.path.length+1),t}updateCurrent(t){if(this.path.length>0){const e=this.path[this.path.length-1];null!=t&&(e.values=t)}}getCurrentTag(){return this.path.length>0?this.path[this.path.length-1].tag:void 0}getCurrentNamespace(){return this.path.length>0?this.path[this.path.length-1].namespace:void 0}getAttrValue(t){if(0!==this.path.length)return this.path[this.path.length-1].values?.[t]}hasAttr(t){if(0===this.path.length)return!1;const e=this.path[this.path.length-1];return void 0!==e.values&&t in e.values}getPosition(){return 0===this.path.length?-1:this.path[this.path.length-1].position??0}getCounter(){return 0===this.path.length?-1:this.path[this.path.length-1].counter??0}getIndex(){return this.getPosition()}getDepth(){return this.path.length}toString(t,e=!0){const n=t||this.separator;if(n===this.separator&&!0===e){if(null!==this._pathStringCache)return this._pathStringCache;const t=this.path.map(t=>t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n);return this._pathStringCache=t,t}return this.path.map(t=>e&&t.namespace?`${t.namespace}:${t.tag}`:t.tag).join(n)}toArray(){return this.path.map(t=>t.tag)}reset(){this._pathStringCache=null,this.path=[],this.siblingStacks=[]}matches(t){const e=t.segments;return 0!==e.length&&(t.hasDeepWildcard()?this._matchWithDeepWildcard(e):this._matchSimple(e))}_matchSimple(t){if(this.path.length!==t.length)return!1;for(let e=0;e<t.length;e++)if(!this._matchSegment(t[e],this.path[e],e===this.path.length-1))return!1;return!0}_matchWithDeepWildcard(t){let e=this.path.length-1,n=t.length-1;for(;n>=0&&e>=0;){const i=t[n];if("deep-wildcard"===i.type){if(n--,n<0)return!0;const i=t[n];let s=!1;for(let t=e;t>=0;t--)if(this._matchSegment(i,this.path[t],t===this.path.length-1)){e=t-1,n--,s=!0;break}if(!s)return!1}else{if(!this._matchSegment(i,this.path[e],e===this.path.length-1))return!1;e--,n--}}return n<0}_matchSegment(t,e,n){if("*"!==t.tag&&t.tag!==e.tag)return!1;if(void 0!==t.namespace&&"*"!==t.namespace&&t.namespace!==e.namespace)return!1;if(void 0!==t.attrName){if(!n)return!1;if(!e.values||!(t.attrName in e.values))return!1;if(void 0!==t.attrValue&&String(e.values[t.attrName])!==String(t.attrValue))return!1}if(void 0!==t.position){if(!n)return!1;const i=e.counter??0;if("first"===t.position&&0!==i)return!1;if("odd"===t.position&&i%2!=1)return!1;if("even"===t.position&&i%2!=0)return!1;if("nth"===t.position&&i!==t.positionValue)return!1}return!0}matchesAny(t){return t.matchesAny(this)}snapshot(){return{path:this.path.map(t=>({...t})),siblingStacks:this.siblingStacks.map(t=>new Map(t))}}restore(t){this._pathStringCache=null,this.path=t.path.map(t=>({...t})),this.siblingStacks=t.siblingStacks.map(t=>new Map(t))}readOnly(){return this._view}}class K{constructor(t,e={},n){this.pattern=t,this.separator=e.separator||".",this.segments=this._parse(t),this.data=n,this._hasDeepWildcard=this.segments.some(t=>"deep-wildcard"===t.type),this._hasAttributeCondition=this.segments.some(t=>void 0!==t.attrName),this._hasPositionSelector=this.segments.some(t=>void 0!==t.position)}_parse(t){const e=[];let n=0,i="";for(;n<t.length;)t[n]===this.separator?n+1<t.length&&t[n+1]===this.separator?(i.trim()&&(e.push(this._parseSegment(i.trim())),i=""),e.push({type:"deep-wildcard"}),n+=2):(i.trim()&&e.push(this._parseSegment(i.trim())),i="",n++):(i+=t[n],n++);return i.trim()&&e.push(this._parseSegment(i.trim())),e}_parseSegment(t){const e={type:"tag"};let n=null,i=t;const s=t.match(/^([^\[]+)(\[[^\]]*\])(.*)$/);if(s&&(i=s[1]+s[3],s[2])){const t=s[2].slice(1,-1);t&&(n=t)}let r,o,a=i;if(i.includes("::")){const e=i.indexOf("::");if(r=i.substring(0,e).trim(),a=i.substring(e+2).trim(),!r)throw new Error(`Invalid namespace in pattern: ${t}`)}let h=null;if(a.includes(":")){const t=a.lastIndexOf(":"),e=a.substring(0,t).trim(),n=a.substring(t+1).trim();["first","last","odd","even"].includes(n)||/^nth\(\d+\)$/.test(n)?(o=e,h=n):o=a}else o=a;if(!o)throw new Error(`Invalid segment pattern: ${t}`);if(e.tag=o,r&&(e.namespace=r),n)if(n.includes("=")){const t=n.indexOf("=");e.attrName=n.substring(0,t).trim(),e.attrValue=n.substring(t+1).trim()}else e.attrName=n.trim();if(h){const t=h.match(/^nth\((\d+)\)$/);t?(e.position="nth",e.positionValue=parseInt(t[1],10)):e.position=h}return e}get length(){return this.segments.length}hasDeepWildcard(){return this._hasDeepWildcard}hasAttributeCondition(){return this._hasAttributeCondition}hasPositionSelector(){return this._hasPositionSelector}toString(){return this.pattern}}class Q{constructor(){this._byDepthAndTag=new Map,this._wildcardByDepth=new Map,this._deepWildcards=[],this._patterns=new Set,this._sealed=!1}add(t){if(this._sealed)throw new TypeError("ExpressionSet is sealed. Create a new ExpressionSet to add more expressions.");if(this._patterns.has(t.pattern))return this;if(this._patterns.add(t.pattern),t.hasDeepWildcard())return this._deepWildcards.push(t),this;const e=t.length,n=t.segments[t.segments.length-1],i=n?.tag;if(i&&"*"!==i){const n=`${e}:${i}`;this._byDepthAndTag.has(n)||this._byDepthAndTag.set(n,[]),this._byDepthAndTag.get(n).push(t)}else this._wildcardByDepth.has(e)||this._wildcardByDepth.set(e,[]),this._wildcardByDepth.get(e).push(t);return this}addAll(t){for(const e of t)this.add(e);return this}has(t){return this._patterns.has(t.pattern)}get size(){return this._patterns.size}seal(){return this._sealed=!0,this}get isSealed(){return this._sealed}matchesAny(t){return null!==this.findMatch(t)}findMatch(t){const e=t.getDepth(),n=`${e}:${t.getCurrentTag()}`,i=this._byDepthAndTag.get(n);if(i)for(let e=0;e<i.length;e++)if(t.matches(i[e]))return i[e];const s=this._wildcardByDepth.get(e);if(s)for(let e=0;e<s.length;e++)if(t.matches(s[e]))return s[e];for(let e=0;e<this._deepWildcards.length;e++)if(t.matches(this._deepWildcards[e]))return this._deepWildcards[e];return null}}const H={cent:"¢",pound:"£",curren:"¤",yen:"¥",euro:"€",dollar:"$",euro:"€",fnof:"ƒ",inr:"₹",af:"؋",birr:"ብር",peso:"₱",rub:"₽",won:"₩",yuan:"¥",cedil:"¸"},tt={amp:"&",apos:"'",gt:">",lt:"<",quot:'"'},et={nbsp:" ",copy:"©",reg:"®",trade:"™",mdash:"—",ndash:"–",hellip:"…",laquo:"«",raquo:"»",lsquo:"‘",rsquo:"’",ldquo:"“",rdquo:"”",bull:"•",para:"¶",sect:"§",deg:"°",frac12:"½",frac14:"¼",frac34:"¾"},nt=new Set("!?\\\\/[]$%{}^&*()<>|+");function it(t){if("#"===t[0])throw new Error(`[EntityReplacer] Invalid character '#' in entity name: "${t}"`);for(const e of t)if(nt.has(e))throw new Error(`[EntityReplacer] Invalid character '${e}' in entity name: "${t}"`);return t}function st(...t){const e=Object.create(null);for(const n of t)if(n)for(const t of Object.keys(n)){const i=n[t];if("string"==typeof i)e[t]=i;else if(i&&"object"==typeof i&&void 0!==i.val){const n=i.val;"string"==typeof n&&(e[t]=n)}}return e}const rt="external",ot="base",at="all",ht=Object.freeze({allow:0,leave:1,remove:2,throw:3}),lt=new Set([9,10,13]);class ut{constructor(t={}){var e;this._limit=t.limit||{},this._maxTotalExpansions=this._limit.maxTotalExpansions||0,this._maxExpandedLength=this._limit.maxExpandedLength||0,this._postCheck="function"==typeof t.postCheck?t.postCheck:t=>t,this._limitTiers=(e=this._limit.applyLimitsTo??rt)&&e!==rt?e===at?new Set([at]):e===ot?new Set([ot]):Array.isArray(e)?new Set(e):new Set([rt]):new Set([rt]),this._numericAllowed=t.numericAllowed??!0,this._baseMap=st(tt,t.namedEntities||null),this._externalMap=Object.create(null),this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this._removeSet=new Set(t.remove&&Array.isArray(t.remove)?t.remove:[]),this._leaveSet=new Set(t.leave&&Array.isArray(t.leave)?t.leave:[]);const n=function(t){if(!t)return{xmlVersion:1,onLevel:ht.allow,nullLevel:ht.remove};const e=1.1===t.xmlVersion?1.1:1,n=ht[t.onNCR]??ht.allow,i=ht[t.nullNCR]??ht.remove;return{xmlVersion:e,onLevel:n,nullLevel:Math.max(i,ht.remove)}}(t.ncr);this._ncrXmlVersion=n.xmlVersion,this._ncrOnLevel=n.onLevel,this._ncrNullLevel=n.nullLevel}setExternalEntities(t){if(t)for(const e of Object.keys(t))it(e);this._externalMap=st(t)}addExternalEntity(t,e){it(t),"string"==typeof e&&-1===e.indexOf("&")&&(this._externalMap[t]=e)}addInputEntities(t){this._totalExpansions=0,this._expandedLength=0,this._inputMap=st(t)}reset(){return this._inputMap=Object.create(null),this._totalExpansions=0,this._expandedLength=0,this}setXmlVersion(t){this._ncrXmlVersion=1.1===t?1.1:1}decode(t){if("string"!=typeof t||0===t.length)return t;const e=t,n=[],i=t.length;let s=0,r=0;const o=this._maxTotalExpansions>0,a=this._maxExpandedLength>0,h=o||a;for(;r<i;){if(38!==t.charCodeAt(r)){r++;continue}let e=r+1;for(;e<i&&59!==t.charCodeAt(e)&&e-r<=32;)e++;if(e>=i||59!==t.charCodeAt(e)){r++;continue}const l=t.slice(r+1,e);if(0===l.length){r++;continue}let u,p;if(this._removeSet.has(l))u="",void 0===p&&(p=rt);else{if(this._leaveSet.has(l)){r++;continue}if(35===l.charCodeAt(0)){const t=this._resolveNCR(l);if(void 0===t){r++;continue}u=t,p=ot}else{const t=this._resolveName(l);u=t?.value,p=t?.tier}}if(void 0!==u){if(r>s&&n.push(t.slice(s,r)),n.push(u),s=e+1,r=s,h&&this._tierCounts(p)){if(o&&(this._totalExpansions++,this._totalExpansions>this._maxTotalExpansions))throw new Error(`[EntityReplacer] Entity expansion count limit exceeded: ${this._totalExpansions} > ${this._maxTotalExpansions}`);if(a){const t=u.length-(l.length+2);if(t>0&&(this._expandedLength+=t,this._expandedLength>this._maxExpandedLength))throw new Error(`[EntityReplacer] Expanded content length limit exceeded: ${this._expandedLength} > ${this._maxExpandedLength}`)}}}else r++}s<i&&n.push(t.slice(s));const l=0===n.length?t:n.join("");return this._postCheck(l,e)}_tierCounts(t){return!!this._limitTiers.has(at)||this._limitTiers.has(t)}_resolveName(t){return t in this._inputMap?{value:this._inputMap[t],tier:rt}:t in this._externalMap?{value:this._externalMap[t],tier:rt}:t in this._baseMap?{value:this._baseMap[t],tier:ot}:void 0}_classifyNCR(t){return 0===t?this._ncrNullLevel:t>=55296&&t<=57343||1===this._ncrXmlVersion&&t>=1&&t<=31&&!lt.has(t)?ht.remove:-1}_applyNCRAction(t,e,n){switch(t){case ht.allow:return String.fromCodePoint(n);case ht.remove:return"";case ht.leave:return;case ht.throw:throw new Error(`[EntityDecoder] Prohibited numeric character reference &${e}; (U+${n.toString(16).toUpperCase().padStart(4,"0")})`);default:return String.fromCodePoint(n)}}_resolveNCR(t){const e=t.charCodeAt(1);let n;if(n=120===e||88===e?parseInt(t.slice(2),16):parseInt(t.slice(1),10),Number.isNaN(n)||n<0||n>1114111)return;const i=this._classifyNCR(n);if(!this._numericAllowed&&i<ht.remove)return;const s=-1===i?this._ncrOnLevel:Math.max(this._ncrOnLevel,i);return this._applyNCRAction(s,t,n)}}function pt(t,e){if(!t)return{};const n=e.attributesGroupName?t[e.attributesGroupName]:t;if(!n)return{};const i={};for(const t in n)t.startsWith(e.attributeNamePrefix)?i[t.substring(e.attributeNamePrefix.length)]=n[t]:i[t]=n[t];return i}function ct(t){if(!t||"string"!=typeof t)return;const e=t.indexOf(":");if(-1!==e&&e>0){const n=t.substring(0,e);if("xmlns"!==n)return n}}class dt{constructor(t,e){var n;this.options=t,this.currentNode=null,this.tagsNodeStack=[],this.parseXml=Nt,this.parseTextData=ft,this.resolveNameSpace=gt,this.buildAttributesMap=xt,this.isItStopNode=wt,this.replaceEntitiesValue=yt,this.readStopNodeData=At,this.saveTextToParentTag=Et,this.addChild=bt,this.ignoreAttributesFn="function"==typeof(n=this.options.ignoreAttributes)?n:Array.isArray(n)?t=>{for(const e of n){if("string"==typeof e&&t===e)return!0;if(e instanceof RegExp&&e.test(t))return!0}}:()=>!1,this.entityExpansionCount=0,this.currentExpandedLength=0;let i={...tt};this.options.entityDecoder?this.entityDecoder=this.options.entityDecoder:("object"==typeof this.options.htmlEntities?i=this.options.htmlEntities:!0===this.options.htmlEntities&&(i={...et,...H}),this.entityDecoder=new ut({namedEntities:{...i,...e},numericAllowed:this.options.htmlEntities,limit:{maxTotalExpansions:this.options.processEntities.maxTotalExpansions,maxExpandedLength:this.options.processEntities.maxExpandedLength,applyLimitsTo:this.options.processEntities.appliesTo}})),this.matcher=new J,this.readonlyMatcher=this.matcher.readOnly(),this.isCurrentNodeStopNode=!1,this.stopNodeExpressionsSet=new Q;const s=this.options.stopNodes;if(s&&s.length>0){for(let t=0;t<s.length;t++){const e=s[t];"string"==typeof e?this.stopNodeExpressionsSet.add(new K(e)):e instanceof K&&this.stopNodeExpressionsSet.add(e)}this.stopNodeExpressionsSet.seal()}}}function ft(t,e,n,i,s,r,o){const a=this.options;if(void 0!==t&&(a.trimValues&&!i&&(t=t.trim()),t.length>0)){o||(t=this.replaceEntitiesValue(t,e,n));const i=a.jPath?n.toString():n,h=a.tagValueProcessor(e,t,i,s,r);return null==h?t:typeof h!=typeof t||h!==t?h:a.trimValues||t.trim()===t?Tt(t,a.parseTagValue,a.numberParseOptions):t}}function gt(t){if(this.options.removeNSPrefix){const e=t.split(":"),n="/"===t.charAt(0)?"/":"";if("xmlns"===e[0])return"";2===e.length&&(t=n+e[1])}return t}const mt=new RegExp("([^\\s=]+)\\s*(=\\s*(['\"])([\\s\\S]*?)\\3)?","gm");function xt(t,e,n,i=!1){const r=this.options;if(!0===i||!0!==r.ignoreAttributes&&"string"==typeof t){const i=s(t,mt),o=i.length,a={},h=new Array(o);let l=!1;const u={};for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]),s=i[t][4];if(e.length&&void 0!==s){let i=s;r.trimValues&&(i=i.trim()),i=this.replaceEntitiesValue(i,n,this.readonlyMatcher),h[t]=i,u[e]=i,l=!0}}l&&"object"==typeof e&&e.updateCurrent&&e.updateCurrent(u);const p=r.jPath?e.toString():this.readonlyMatcher;let c=!1;for(let t=0;t<o;t++){const e=this.resolveNameSpace(i[t][1]);if(this.ignoreAttributesFn(e,p))continue;let n=r.attributeNamePrefix+e;if(e.length)if(r.transformAttributeName&&(n=r.transformAttributeName(n)),n=Pt(n,r),void 0!==i[t][4]){const i=h[t],s=r.attributeValueProcessor(e,i,p);a[n]=null==s?i:typeof s!=typeof i||s!==i?s:Tt(i,r.parseAttributeValue,r.numberParseOptions),c=!0}else r.allowBooleanAttributes&&(a[n]=!0,c=!0)}if(!c)return;if(r.attributesGroupName&&!r.preserveOrder){const t={};return t[r.attributesGroupName]=a,t}return a}}const Nt=function(t){t=t.replace(/\r\n?/g,"\n");const e=new $("!xml");let n=e,i="";this.matcher.reset(),this.entityDecoder.reset(),this.entityExpansionCount=0,this.currentExpandedLength=0;const s=this.options,r=new k(s.processEntities),o=t.length;for(let a=0;a<o;a++)if("<"===t[a]){const h=t.charCodeAt(a+1);if(47===h){const e=vt(t,">",a,"Closing Tag is not closed.");let r=t.substring(a+2,e).trim();if(s.removeNSPrefix){const t=r.indexOf(":");-1!==t&&(r=r.substr(t+1))}r=Ct(s.transformTagName,r,"",s).tagName,n&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher));const o=this.matcher.getCurrentTag();if(r&&s.unpairedTagsSet.has(r))throw new Error(`Unpaired tag can not be used as closing tag: </${r}>`);o&&s.unpairedTagsSet.has(o)&&(this.matcher.pop(),this.tagsNodeStack.pop()),this.matcher.pop(),this.isCurrentNodeStopNode=!1,n=this.tagsNodeStack.pop(),i="",a=e}else if(63===h){let e=_t(t,a,!1,"?>");if(!e)throw new Error("Pi Tag is not closed.");i=this.saveTextToParentTag(i,n,this.readonlyMatcher);const o=this.buildAttributesMap(e.tagExp,this.matcher,e.tagName,!0);if(o){const t=o[this.options.attributeNamePrefix+"version"];this.entityDecoder.setXmlVersion(Number(t)||1),r.setXmlVersion(Number(t)||1)}if(s.ignoreDeclaration&&"?xml"===e.tagName||s.ignorePiTags);else{const t=new $(e.tagName);t.add(s.textNodeName,""),e.tagName!==e.tagExp&&e.attrExpPresent&&!0!==s.ignoreAttributes&&(t[":@"]=o),this.addChild(n,t,this.readonlyMatcher,a)}a=e.closeIndex+1}else if(33===h&&45===t.charCodeAt(a+2)&&45===t.charCodeAt(a+3)){const e=vt(t,"--\x3e",a+4,"Comment is not closed.");if(s.commentPropName){const r=t.substring(a+4,e-2);i=this.saveTextToParentTag(i,n,this.readonlyMatcher),n.add(s.commentPropName,[{[s.textNodeName]:r}])}a=e}else if(33===h&&68===t.charCodeAt(a+2)){const e=r.readDocType(t,a);this.entityDecoder.addInputEntities(e.entities),a=e.i}else if(33===h&&91===t.charCodeAt(a+2)){const e=vt(t,"]]>",a,"CDATA is not closed.")-2,r=t.substring(a+9,e);i=this.saveTextToParentTag(i,n,this.readonlyMatcher);let o=this.parseTextData(r,n.tagname,this.readonlyMatcher,!0,!1,!0,!0);null==o&&(o=""),s.cdataPropName?n.add(s.cdataPropName,[{[s.textNodeName]:r}]):n.add(s.textNodeName,o),a=e+2}else{let r=_t(t,a,s.removeNSPrefix);if(!r){const e=t.substring(Math.max(0,a-50),Math.min(o,a+50));throw new Error(`readTagExp returned undefined at position ${a}. Context: "${e}"`)}let h=r.tagName;const l=r.rawTagName;let u=r.tagExp,p=r.attrExpPresent,c=r.closeIndex;if(({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s)),s.strictReservedNames&&(h===s.commentPropName||h===s.cdataPropName||h===s.textNodeName||h===s.attributesGroupName))throw new Error(`Invalid tag name: ${h}`);n&&i&&"!xml"!==n.tagname&&(i=this.saveTextToParentTag(i,n,this.readonlyMatcher,!1));const d=n;d&&s.unpairedTagsSet.has(d.tagname)&&(n=this.tagsNodeStack.pop(),this.matcher.pop());let f=!1;u.length>0&&u.lastIndexOf("/")===u.length-1&&(f=!0,"/"===h[h.length-1]?(h=h.substr(0,h.length-1),u=h):u=u.substr(0,u.length-1),p=h!==u);let g,m=null,x={};g=ct(l),h!==e.tagname&&this.matcher.push(h,{},g),h!==u&&p&&(m=this.buildAttributesMap(u,this.matcher,h),m&&(x=pt(m,s))),h!==e.tagname&&(this.isCurrentNodeStopNode=this.isItStopNode());const N=a;if(this.isCurrentNodeStopNode){let e="";if(f)a=r.closeIndex;else if(s.unpairedTagsSet.has(h))a=r.closeIndex;else{const n=this.readStopNodeData(t,l,c+1);if(!n)throw new Error(`Unexpected end of ${l}`);a=n.i,e=n.tagContent}const i=new $(h);m&&(i[":@"]=m),i.add(s.textNodeName,e),this.matcher.pop(),this.isCurrentNodeStopNode=!1,this.addChild(n,i,this.readonlyMatcher,N)}else{if(f){({tagName:h,tagExp:u}=Ct(s.transformTagName,h,u,s));const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1}else{if(s.unpairedTagsSet.has(h)){const t=new $(h);m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),this.matcher.pop(),this.isCurrentNodeStopNode=!1,a=r.closeIndex;continue}{const t=new $(h);if(this.tagsNodeStack.length>s.maxNestedTags)throw new Error("Maximum nested tags exceeded");this.tagsNodeStack.push(n),m&&(t[":@"]=m),this.addChild(n,t,this.readonlyMatcher,N),n=t}}i="",a=c}}}else i+=t[a];return e.child};function bt(t,e,n,i){this.options.captureMetaData||(i=void 0);const s=this.options.jPath?n.toString():n,r=this.options.updateTag(e.tagname,s,e[":@"]);!1===r||("string"==typeof r?(e.tagname=r,t.addChild(e,i)):t.addChild(e,i))}function yt(t,e,n){const i=this.options.processEntities;if(!i||!i.enabled)return t;if(i.allowedTags){const s=this.options.jPath?n.toString():n;if(!(Array.isArray(i.allowedTags)?i.allowedTags.includes(e):i.allowedTags(e,s)))return t}if(i.tagFilter){const s=this.options.jPath?n.toString():n;if(!i.tagFilter(e,s))return t}return this.entityDecoder.decode(t)}function Et(t,e,n,i){return t&&(void 0===i&&(i=0===e.child.length),void 0!==(t=this.parseTextData(t,e.tagname,n,!1,!!e[":@"]&&0!==Object.keys(e[":@"]).length,i))&&""!==t&&e.add(this.options.textNodeName,t),t=""),t}function wt(){return 0!==this.stopNodeExpressionsSet.size&&this.matcher.matchesAny(this.stopNodeExpressionsSet)}function vt(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s+e.length-1}function St(t,e,n,i){const s=t.indexOf(e,n);if(-1===s)throw new Error(i);return s}function _t(t,e,n,i=">"){const s=function(t,e,n=">"){let i=0;const s=t.length,r=n.charCodeAt(0),o=n.length>1?n.charCodeAt(1):-1;let a="",h=e;for(let n=e;n<s;n++){const e=t.charCodeAt(n);if(i)e===i&&(i=0);else if(34===e||39===e)i=e;else if(e===r){if(-1===o)return a+=t.substring(h,n),{data:a,index:n};if(t.charCodeAt(n+1)===o)return a+=t.substring(h,n),{data:a,index:n}}else 9!==e||i||(a+=t.substring(h,n)+" ",h=n+1)}}(t,e+1,i);if(!s)return;let r=s.data;const o=s.index,a=r.search(/\s/);let h=r,l=!0;-1!==a&&(h=r.substring(0,a),r=r.substring(a+1).trimStart());const u=h;if(n){const t=h.indexOf(":");-1!==t&&(h=h.substr(t+1),l=h!==s.data.substr(t+1))}return{tagName:h,tagExp:r,closeIndex:o,attrExpPresent:l,rawTagName:u}}function At(t,e,n){const i=n;let s=1;const r=t.length;for(;n<r;n++)if("<"===t[n]){const r=t.charCodeAt(n+1);if(47===r){const r=St(t,">",n,`${e} is not closed`);if(t.substring(n+2,r).trim()===e&&(s--,0===s))return{tagContent:t.substring(i,n),i:r};n=r}else if(63===r)n=vt(t,"?>",n+1,"StopNode is not closed.");else if(33===r&&45===t.charCodeAt(n+2)&&45===t.charCodeAt(n+3))n=vt(t,"--\x3e",n+3,"StopNode is not closed.");else if(33===r&&91===t.charCodeAt(n+2))n=vt(t,"]]>",n,"StopNode is not closed.")-2;else{const i=_t(t,n,!1);i&&((i&&i.tagName)===e&&"/"!==i.tagExp[i.tagExp.length-1]&&s++,n=i.closeIndex)}}}function Tt(t,e,n){if(e&&"string"==typeof t){const e=t.trim();return"true"===e||"false"!==e&&function(t,e={}){if(e=Object.assign({},X,e),!t||"string"!=typeof t)return t;let n=t.trim();if(0===n.length)return t;if(void 0!==e.skipLike&&e.skipLike.test(n))return t;if("0"===n)return 0;if(e.hex&&U.test(n))return q(n,16);if(e.binary&&B.test(n))return q(n,2);if(e.octal&&W.test(n))return q(n,8);if(isFinite(n)){if(n.includes("e")||n.includes("E"))return function(t,e,n){if(!n.eNotation)return t;const i=e.match(Y);if(i){let s=i[1]||"";const r=-1===i[3].indexOf("e")?"E":"e",o=i[2],a=s?t[o.length+1]===r:t[o.length]===r;return o.length>1&&a?t:(1!==o.length||!i[3].startsWith(`.${r}`)&&i[3][0]!==r)&&o.length>0?n.leadingZeros&&!a?(e=(i[1]||"")+i[3],Number(e)):t:Number(e)}return t}(t,n,e);{const s=z.exec(n);if(s){const r=s[1]||"",o=s[2];let a=(i=s[3])&&-1!==i.indexOf(".")?("."===(i=i.replace(/0+$/,""))?i="0":"."===i[0]?i="0"+i:"."===i[i.length-1]&&(i=i.substring(0,i.length-1)),i):i;const h=r?"."===t[o.length+1]:"."===t[o.length];if(!e.leadingZeros&&(o.length>1||1===o.length&&!h))return t;{const i=Number(n),s=String(i);if(0===i)return i;if(-1!==s.search(/[eE]/))return e.eNotation?i:t;if(-1!==n.indexOf("."))return"0"===s||s===a||s===`${r}${a}`?i:t;let h=o?a:n;return o?h===s||r+h===s?i:t:h===s||h===r+s?i:t}}return t}}var i;return function(t,e,n){const i=e===1/0;switch(n.infinity.toLowerCase()){case"null":return null;case"infinity":return e;case"string":return i?"Infinity":"-Infinity";default:return t}}(t,Number(n),e)}(t,n)}return void 0!==t?t:""}function Ct(t,e,n,i){if(t){const i=t(e);n===e&&(n=i),e=i}return{tagName:e=Pt(e,i),tagExp:n}}function Pt(t,e){if(a.includes(t))throw new Error(`[SECURITY] Invalid name: "${t}" is a reserved JavaScript keyword that could cause prototype pollution`);return o.includes(t)?e.onDangerousProperty(t):t}const $t=$.getMetaDataSymbol();function Ot(t,e){if(!t||"object"!=typeof t)return{};if(!e)return t;const n={};for(const i in t)i.startsWith(e)?n[i.substring(e.length)]=t[i]:n[i]=t[i];return n}function It(t,e,n,i){return Vt(t,e,n,i)}function Vt(t,e,n,i){let s;const r={};for(let o=0;o<t.length;o++){const a=t[o],h=Dt(a);if(void 0!==h&&h!==e.textNodeName){const t=Ot(a[":@"]||{},e.attributeNamePrefix);n.push(h,t)}if(h===e.textNodeName)void 0===s?s=a[h]:s+=""+a[h];else{if(void 0===h)continue;if(a[h]){let t=Vt(a[h],e,n,i);const s=jt(t,e);if(0===Object.keys(t).length&&e.alwaysCreateTextNode&&(t[e.textNodeName]=""),a[":@"]?Mt(t,a[":@"],i,e):1!==Object.keys(t).length||void 0===t[e.textNodeName]||e.alwaysCreateTextNode?0===Object.keys(t).length&&(e.alwaysCreateTextNode?t[e.textNodeName]="":t=""):t=t[e.textNodeName],void 0!==a[$t]&&"object"==typeof t&&null!==t&&(t[$t]=a[$t]),void 0!==r[h]&&Object.prototype.hasOwnProperty.call(r,h))Array.isArray(r[h])||(r[h]=[r[h]]),r[h].push(t);else{const n=e.jPath?i.toString():i;e.isArray(h,n,s)?r[h]=[t]:r[h]=t}void 0!==h&&h!==e.textNodeName&&n.pop()}}}return"string"==typeof s?s.length>0&&(r[e.textNodeName]=s):void 0!==s&&(r[e.textNodeName]=s),r}function Dt(t){const e=Object.keys(t);for(let t=0;t<e.length;t++){const n=e[t];if(":@"!==n)return n}}function Mt(t,e,n,i){if(e){const s=Object.keys(e),r=s.length;for(let o=0;o<r;o++){const r=s[o],a=r.startsWith(i.attributeNamePrefix)?r.substring(i.attributeNamePrefix.length):r,h=i.jPath?n.toString()+"."+a:n;i.isArray(r,h,!0,!0)?t[r]=[e[r]]:t[r]=e[r]}}}function jt(t,e){const{textNodeName:n}=e,i=Object.keys(t).length;return 0===i||!(1!==i||!t[n]&&"boolean"!=typeof t[n]&&0!==t[n])}class Lt{constructor(t){this.externalEntities={},this.options=C(t)}parse(t,e){if("string"!=typeof t&&t.toString)t=t.toString();else if("string"!=typeof t)throw new Error("XML data is accepted in String or Bytes[] form.");if(e){!0===e&&(e={});const n=l(t,e);if(!0!==n)throw Error(`${n.err.msg}:${n.err.line}:${n.err.col}`)}const n=new dt(this.options,this.externalEntities),i=n.parseXml(t);return this.options.preserveOrder||void 0===i?i:It(i,this.options,n.matcher,n.readonlyMatcher)}addEntity(t,e){if(-1!==e.indexOf("&"))throw new Error("Entity value can't have '&'");if(-1!==t.indexOf("&")||-1!==t.indexOf(";"))throw new Error("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");if("&"===e)throw new Error("An entity with value '&' is not permitted");this.externalEntities[t]=e}static getMetaDataSymbol(){return $.getMetaDataSymbol()}}function kt(t){return String(t).replace(/--/g,"- -").replace(/--/g,"- -").replace(/-$/,"- ")}function Rt(t){return String(t).replace(/\]\]>/g,"]]]]><![CDATA[>")}function Ft(t){return String(t).replace(/"/g,"&quot;").replace(/'/g,"&apos;")}function Gt(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function Ut(t,e){let n="";e.format&&(n="\n");const i=[];if(e.stopNodes&&Array.isArray(e.stopNodes))for(let t=0;t<e.stopNodes.length;t++){const n=e.stopNodes[t];"string"==typeof n?i.push(new K(n)):n instanceof K&&i.push(n)}const s=function(t,e){if(!Array.isArray(t)||0===t.length)return"1.0";const n=t[0];if("?xml"===Yt(n)){const t=n[":@"];if(t){const n=e.attributeNamePrefix+"version";if(t[n])return t[n]}}return"1.0"}(t,e);return Bt(t,e,n,new J,i,s)}function Bt(t,e,n,i,s,r){let o="",a=!1;if(e.maxNestedTags&&i.getDepth()>e.maxNestedTags)throw new Error("Maximum nested tags exceeded");if(!Array.isArray(t)){if(null!=t){let n=t.toString();return n=Jt(n,e),n}return""}for(let h=0;h<t.length;h++){const l=t[h],u=Yt(l);if(void 0===u)continue;const p=u===e.textNodeName||u===e.cdataPropName||u===e.commentPropName||"?"===u[0]?u:Gt(u,!1,e,i,r),c=Wt(l[":@"],e);i.push(p,c);const d=Zt(i,s);if(p===e.textNodeName){let t=l[u];d||(t=e.tagValueProcessor(p,t),t=Jt(t,e)),a&&(o+=n),o+=t,a=!1,i.pop();continue}if(p===e.cdataPropName){a&&(o+=n),o+=`<![CDATA[${Rt(l[u][0][e.textNodeName])}]]>`,a=!1,i.pop();continue}if(p===e.commentPropName){o+=n+`\x3c!--${kt(l[u][0][e.textNodeName])}--\x3e`,a=!0,i.pop();continue}if("?"===p[0]){o+=("?xml"===p?"":n)+`<${p}${qt(l[":@"],e,d,i,r)}?>`,a=!0,i.pop();continue}let f=n;""!==f&&(f+=e.indentBy);const g=n+`<${p}${qt(l[":@"],e,d,i,r)}`;let m;m=d?zt(l[u],e):Bt(l[u],e,f,i,s,r),-1!==e.unpairedTags.indexOf(p)?e.suppressUnpairedNode?o+=g+">":o+=g+"/>":m&&0!==m.length||!e.suppressEmptyNode?m&&m.endsWith(">")?o+=g+`>${m}${n}</${p}>`:(o+=g+">",m&&""!==n&&(m.includes("/>")||m.includes("</"))?o+=n+e.indentBy+m+n:o+=m,o+=`</${p}>`):o+=g+"/>",a=!0,i.pop()}return o}function Wt(t,e){if(!t||e.ignoreAttributes)return null;const n={};let i=!1;for(let s in t)Object.prototype.hasOwnProperty.call(t,s)&&(n[s.startsWith(e.attributeNamePrefix)?s.substr(e.attributeNamePrefix.length):s]=Ft(t[s]),i=!0);return i?n:null}function zt(t,e){if(!Array.isArray(t))return null!=t?t.toString():"";let n="";for(let i=0;i<t.length;i++){const s=t[i],r=Yt(s);if(r===e.textNodeName)n+=s[r];else if(r===e.cdataPropName)n+=s[r][0][e.textNodeName];else if(r===e.commentPropName)n+=s[r][0][e.textNodeName];else{if(r&&"?"===r[0])continue;if(r){const t=Xt(s[":@"],e),i=zt(s[r],e);i&&0!==i.length?n+=`<${r}${t}>${i}</${r}>`:n+=`<${r}${t}/>`}}}return n}function Xt(t,e){let n="";if(t&&!e.ignoreAttributes)for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;let s=t[i];!0===s&&e.suppressBooleanAttributes?n+=` ${i.substr(e.attributeNamePrefix.length)}`:n+=` ${i.substr(e.attributeNamePrefix.length)}="${Ft(s)}"`}return n}function Yt(t){const e=Object.keys(t);for(let n=0;n<e.length;n++){const i=e[n];if(Object.prototype.hasOwnProperty.call(t,i)&&":@"!==i)return i}}function qt(t,e,n,i,s){let r="";if(t&&!e.ignoreAttributes)for(let o in t){if(!Object.prototype.hasOwnProperty.call(t,o))continue;const a=o.substr(e.attributeNamePrefix.length),h=n?a:Gt(a,!0,e,i,s);let l;n?l=t[o]:(l=e.attributeValueProcessor(o,t[o]),l=Jt(l,e)),!0===l&&e.suppressBooleanAttributes?r+=` ${h}`:r+=` ${h}="${Ft(l)}"`}return r}function Zt(t,e){if(!e||0===e.length)return!1;for(let n=0;n<e.length;n++)if(t.matches(e[n]))return!0;return!1}function Jt(t,e){if(t&&t.length>0&&e.processEntities)for(let n=0;n<e.entities.length;n++){const i=e.entities[n];t=t.replace(i.regex,i.val)}return t}const Kt={attributeNamePrefix:"@_",attributesGroupName:!1,textNodeName:"#text",ignoreAttributes:!0,cdataPropName:!1,format:!1,indentBy:"  ",suppressEmptyNode:!1,suppressUnpairedNode:!0,suppressBooleanAttributes:!0,tagValueProcessor:function(t,e){return e},attributeValueProcessor:function(t,e){return e},preserveOrder:!1,commentPropName:!1,unpairedTags:[],entities:[{regex:new RegExp("&","g"),val:"&amp;"},{regex:new RegExp(">","g"),val:"&gt;"},{regex:new RegExp("<","g"),val:"&lt;"},{regex:new RegExp("'","g"),val:"&apos;"},{regex:new RegExp('"',"g"),val:"&quot;"}],processEntities:!0,stopNodes:[],oneListGroup:!1,maxNestedTags:100,jPath:!0,sanitizeName:!1};function Qt(t){if(this.options=Object.assign({},Kt,t),this.options.stopNodes&&Array.isArray(this.options.stopNodes)&&(this.options.stopNodes=this.options.stopNodes.map(t=>"string"==typeof t&&t.startsWith("*.")?".."+t.substring(2):t)),this.stopNodeExpressions=[],this.options.stopNodes&&Array.isArray(this.options.stopNodes))for(let t=0;t<this.options.stopNodes.length;t++){const e=this.options.stopNodes[t];"string"==typeof e?this.stopNodeExpressions.push(new K(e)):e instanceof K&&this.stopNodeExpressions.push(e)}var e;!0===this.options.ignoreAttributes||this.options.attributesGroupName?this.isAttribute=function(){return!1}:(this.ignoreAttributesFn="function"==typeof(e=this.options.ignoreAttributes)?e:Array.isArray(e)?t=>{for(const n of e){if("string"==typeof n&&t===n)return!0;if(n instanceof RegExp&&n.test(t))return!0}}:()=>!1,this.attrPrefixLen=this.options.attributeNamePrefix.length,this.isAttribute=ne),this.processTextOrObjNode=te,this.options.format?(this.indentate=ee,this.tagEndChar=">\n",this.newLine="\n"):(this.indentate=function(){return""},this.tagEndChar=">",this.newLine="")}function Ht(t,e,n,i,s){return n.sanitizeName?L(t,{xmlVersion:s})?t:n.sanitizeName(t,{isAttribute:e,matcher:i.readOnly()}):t}function te(t,e,n,i,s){const r=this.extractAttributes(t);if(i.push(e,r),this.checkStopNode(i)){const s=this.buildRawContent(t),r=this.buildAttributesForStopNode(t);return i.pop(),this.buildObjectNode(s,e,r,n)}const o=this.j2x(t,n+1,i,s);return i.pop(),"?"===e[0]?this.buildTextValNode("",e,o.attrStr,n,i):void 0!==t[this.options.textNodeName]&&1===Object.keys(t).length?this.buildTextValNode(t[this.options.textNodeName],e,o.attrStr,n,i):this.buildObjectNode(o.val,e,o.attrStr,n)}function ee(t){return this.options.indentBy.repeat(t)}function ne(t){return!(!t.startsWith(this.options.attributeNamePrefix)||t===this.options.textNodeName)&&t.substr(this.attrPrefixLen)}Qt.prototype.build=function(t){if(this.options.preserveOrder)return Ut(t,this.options);{Array.isArray(t)&&this.options.arrayNodeName&&this.options.arrayNodeName.length>1&&(t={[this.options.arrayNodeName]:t});const e=new J,n=function(t,e){const n=t["?xml"];if(n&&"object"==typeof n){if(e.attributesGroupName&&n[e.attributesGroupName]){const t=n[e.attributesGroupName][e.attributeNamePrefix+"version"];if(t)return t}const t=n[e.attributeNamePrefix+"version"];if(t)return t}return"1.0"}(t,this.options);return this.j2x(t,0,e,n).val}},Qt.prototype.j2x=function(t,e,n,i){let s="",r="";if(this.options.maxNestedTags&&n.getDepth()>=this.options.maxNestedTags)throw new Error("Maximum nested tags exceeded");const o=this.options.jPath?n.toString():n,a=this.checkStopNode(n);for(let h in t){if(!Object.prototype.hasOwnProperty.call(t,h))continue;const l=h===this.options.textNodeName||h===this.options.cdataPropName||h===this.options.commentPropName||this.options.attributesGroupName&&h===this.options.attributesGroupName||this.isAttribute(h)||"?"===h[0]?h:Ht(h,!1,this.options,n,i);if(void 0===t[h])this.isAttribute(h)&&(r+="");else if(null===t[h])this.isAttribute(h)||l===this.options.cdataPropName||l===this.options.commentPropName?r+="":"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if(t[h]instanceof Date)r+=this.buildTextValNode(t[h],l,"",e,n);else if("object"!=typeof t[h]){const u=this.isAttribute(h);if(u&&!this.ignoreAttributesFn(u,o)){const e=Ht(u,!0,this.options,n,i);s+=this.buildAttrPairStr(e,""+t[h],a)}else if(!u)if(h===this.options.textNodeName){let e=this.options.tagValueProcessor(h,""+t[h]);r+=this.replaceEntitiesValue(e)}else{n.push(l);const i=this.checkStopNode(n);if(n.pop(),i){const n=""+t[h];r+=""===n?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+n+"</"+l+this.tagEndChar}else r+=this.buildTextValNode(t[h],l,"",e,n)}}else if(Array.isArray(t[h])){const s=t[h].length;let o="",a="";for(let u=0;u<s;u++){const s=t[h][u];if(void 0===s);else if(null===s)"?"===l[0]?r+=this.indentate(e)+"<"+l+"?"+this.tagEndChar:r+=this.indentate(e)+"<"+l+"/"+this.tagEndChar;else if("object"==typeof s)if(this.options.oneListGroup){n.push(l);const t=this.j2x(s,e+1,n,i);n.pop(),o+=t.val,this.options.attributesGroupName&&s.hasOwnProperty(this.options.attributesGroupName)&&(a+=t.attrStr)}else o+=this.processTextOrObjNode(s,l,e,n,i);else if(this.options.oneListGroup){let t=this.options.tagValueProcessor(l,s);t=this.replaceEntitiesValue(t),o+=t}else{n.push(l);const t=this.checkStopNode(n);if(n.pop(),t){const t=""+s;o+=""===t?this.indentate(e)+"<"+l+this.closeTag(l)+this.tagEndChar:this.indentate(e)+"<"+l+">"+t+"</"+l+this.tagEndChar}else o+=this.buildTextValNode(s,l,"",e,n)}}this.options.oneListGroup&&(o=this.buildObjectNode(o,l,a,e)),r+=o}else if(this.options.attributesGroupName&&h===this.options.attributesGroupName){const e=Object.keys(t[h]),r=e.length;for(let o=0;o<r;o++){const r=Ht(e[o],!0,this.options,n,i);s+=this.buildAttrPairStr(r,""+t[h][e[o]],a)}}else r+=this.processTextOrObjNode(t[h],l,e,n,i)}return{attrStr:s,val:r}},Qt.prototype.buildAttrPairStr=function(t,e,n){return n||(e=this.options.attributeValueProcessor(t,""+e),e=this.replaceEntitiesValue(e)),this.options.suppressBooleanAttributes&&"true"===e?" "+t:" "+t+'="'+Ft(e)+'"'},Qt.prototype.extractAttributes=function(t){if(!t||"object"!=typeof t)return null;const e={};let n=!1;if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const i=t[this.options.attributesGroupName];for(let t in i)Object.prototype.hasOwnProperty.call(i,t)&&(e[t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t]=Ft(i[t]),n=!0)}else for(let i in t){if(!Object.prototype.hasOwnProperty.call(t,i))continue;const s=this.isAttribute(i);s&&(e[s]=Ft(t[i]),n=!0)}return n?e:null},Qt.prototype.buildRawContent=function(t){if("string"==typeof t)return t;if("object"!=typeof t||null===t)return String(t);if(void 0!==t[this.options.textNodeName])return t[this.options.textNodeName];let e="";for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;if(this.isAttribute(n))continue;if(this.options.attributesGroupName&&n===this.options.attributesGroupName)continue;const i=t[n];if(n===this.options.textNodeName)e+=i;else if(Array.isArray(i)){for(let t of i)if("string"==typeof t||"number"==typeof t)e+=`<${n}>${t}</${n}>`;else if("object"==typeof t&&null!==t){const i=this.buildRawContent(t),s=this.buildAttributesForStopNode(t);e+=""===i?`<${n}${s}/>`:`<${n}${s}>${i}</${n}>`}}else if("object"==typeof i&&null!==i){const t=this.buildRawContent(i),s=this.buildAttributesForStopNode(i);e+=""===t?`<${n}${s}/>`:`<${n}${s}>${t}</${n}>`}else e+=`<${n}>${i}</${n}>`}return e},Qt.prototype.buildAttributesForStopNode=function(t){if(!t||"object"!=typeof t)return"";let e="";if(this.options.attributesGroupName&&t[this.options.attributesGroupName]){const n=t[this.options.attributesGroupName];for(let t in n){if(!Object.prototype.hasOwnProperty.call(n,t))continue;const i=t.startsWith(this.options.attributeNamePrefix)?t.substring(this.options.attributeNamePrefix.length):t,s=n[t];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}else for(let n in t){if(!Object.prototype.hasOwnProperty.call(t,n))continue;const i=this.isAttribute(n);if(i){const s=t[n];!0===s&&this.options.suppressBooleanAttributes?e+=" "+i:e+=" "+i+'="'+s+'"'}}return e},Qt.prototype.buildObjectNode=function(t,e,n,i){if(""===t)return"?"===e[0]?this.indentate(i)+"<"+e+n+"?"+this.tagEndChar:this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar;if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s="</"+e+this.tagEndChar,r="";return"?"===e[0]&&(r="?",s=""),!n&&""!==n||-1!==t.indexOf("<")?!1!==this.options.commentPropName&&e===this.options.commentPropName&&0===r.length?this.indentate(i)+`\x3c!--${t}--\x3e`+this.newLine:this.indentate(i)+"<"+e+n+r+this.tagEndChar+t+this.indentate(i)+s:this.indentate(i)+"<"+e+n+r+">"+t+s}},Qt.prototype.closeTag=function(t){let e="";return-1!==this.options.unpairedTags.indexOf(t)?this.options.suppressUnpairedNode||(e="/"):e=this.options.suppressEmptyNode?"/":`></${t}`,e},Qt.prototype.checkStopNode=function(t){if(!this.stopNodeExpressions||0===this.stopNodeExpressions.length)return!1;for(let e=0;e<this.stopNodeExpressions.length;e++)if(t.matches(this.stopNodeExpressions[e]))return!0;return!1},Qt.prototype.buildTextValNode=function(t,e,n,i,s){if(!1!==this.options.cdataPropName&&e===this.options.cdataPropName){const e=Rt(t);return this.indentate(i)+`<![CDATA[${e}]]>`+this.newLine}if(!1!==this.options.commentPropName&&e===this.options.commentPropName){const e=kt(t);return this.indentate(i)+`\x3c!--${e}--\x3e`+this.newLine}if("?"===e[0])return this.indentate(i)+"<"+e+n+"?"+this.tagEndChar;{let s=this.options.tagValueProcessor(e,t);return s=this.replaceEntitiesValue(s),""===s?this.indentate(i)+"<"+e+n+this.closeTag(e)+this.tagEndChar:this.indentate(i)+"<"+e+n+">"+s+"</"+e+this.tagEndChar}},Qt.prototype.replaceEntitiesValue=function(t){if(t&&t.length>0&&this.options.processEntities)for(let e=0;e<this.options.entities.length;e++){const n=this.options.entities[e];t=t.replace(n.regex,n.val)}return t};const ie=Qt,se={validate:l};module.exports=e})();
 
 /***/ }),
 
-/***/ 345:
+/***/ 346:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -67634,7 +67884,7 @@ var KnownEncryptionAlgorithmType;
 
 /***/ }),
 
-/***/ 346:
+/***/ 347:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -67863,7 +68113,7 @@ function replaceAll(value, searchValue, replaceValue) {
 
 /***/ }),
 
-/***/ 347:
+/***/ 348:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -67889,7 +68139,7 @@ __export(defaultRetryPolicy_exports, {
   defaultRetryPolicyName: () => defaultRetryPolicyName
 });
 module.exports = __toCommonJS(defaultRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(420);
+var import_exponentialRetryStrategy = __nccwpck_require__(421);
 var import_throttlingRetryStrategy = __nccwpck_require__(39);
 var import_retryPolicy = __nccwpck_require__(19);
 var import_constants = __nccwpck_require__(54);
@@ -67909,7 +68159,7 @@ function defaultRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 348:
+/***/ 349:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -67949,7 +68199,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareDylint = prepareDylint;
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
 const exec = __importStar(__nccwpck_require__(21));
 function processEnvironment() {
@@ -68005,7 +68255,7 @@ async function prepareDylint(options) {
 
 /***/ }),
 
-/***/ 349:
+/***/ 350:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68017,7 +68267,7 @@ exports.StorageRetryPolicyFactory = exports.NewRetryPolicyFactory = exports.Stor
 const StorageRetryPolicy_js_1 = __nccwpck_require__(87);
 Object.defineProperty(exports, "StorageRetryPolicy", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.StorageRetryPolicy; } }));
 Object.defineProperty(exports, "NewRetryPolicyFactory", ({ enumerable: true, get: function () { return StorageRetryPolicy_js_1.NewRetryPolicyFactory; } }));
-const StorageRetryPolicyType_js_1 = __nccwpck_require__(443);
+const StorageRetryPolicyType_js_1 = __nccwpck_require__(444);
 Object.defineProperty(exports, "StorageRetryPolicyType", ({ enumerable: true, get: function () { return StorageRetryPolicyType_js_1.StorageRetryPolicyType; } }));
 /**
  * StorageRetryPolicyFactory is a factory class helping generating {@link StorageRetryPolicy} objects.
@@ -68046,7 +68296,7 @@ exports.StorageRetryPolicyFactory = StorageRetryPolicyFactory;
 
 /***/ }),
 
-/***/ 350:
+/***/ 351:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -68152,7 +68402,7 @@ function toArrayBuffer(source) {
 
 /***/ }),
 
-/***/ 351:
+/***/ 352:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -68209,7 +68459,7 @@ exports.readJournal = readJournal;
 exports.summarize = summarize;
 exports.formatJournalSection = formatJournalSection;
 exports.formatRollupsSection = formatRollupsSection;
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 const diagnostics_js_1 = __nccwpck_require__(498);
 const SLOWEST_TOP_N = 20;
 /**
@@ -68503,7 +68753,7 @@ function formatRollupsSection(report) {
 
 /***/ }),
 
-/***/ 352:
+/***/ 353:
 /***/ ((module) => {
 
 "use strict";
@@ -68608,7 +68858,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 353:
+/***/ 354:
 /***/ ((module) => {
 
 "use strict";
@@ -68616,7 +68866,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 354:
+/***/ 355:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -68635,7 +68885,7 @@ exports.state = {
 
 /***/ }),
 
-/***/ 355:
+/***/ 356:
 /***/ (function(module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -68674,13 +68924,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._readLinuxVersionFile = exports._getOsVersion = exports._findMatch = void 0;
-const semver = __importStar(__nccwpck_require__(186));
+const semver = __importStar(__nccwpck_require__(187));
 const core_1 = __nccwpck_require__(490);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
 const os = __nccwpck_require__(102);
-const cp = __nccwpck_require__(172);
-const fs = __nccwpck_require__(567);
+const cp = __nccwpck_require__(173);
+const fs = __nccwpck_require__(568);
 function _findMatch(versionSpec, stable, candidates, archFilter) {
     return __awaiter(this, void 0, void 0, function* () {
         const platFilter = os.platform();
@@ -68771,7 +69021,7 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
-/***/ 356:
+/***/ 357:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -68801,7 +69051,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-const path = __importStar(__nccwpck_require__(264));
+const path = __importStar(__nccwpck_require__(265));
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
  * replaced with /.
@@ -68840,7 +69090,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 357:
+/***/ 358:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -68948,7 +69198,7 @@ var WireType;
 
 /***/ }),
 
-/***/ 358:
+/***/ 359:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -68961,13 +69211,13 @@ const core_util_1 = __nccwpck_require__(17);
 const core_auth_1 = __nccwpck_require__(548);
 const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_2 = __nccwpck_require__(17);
-const storage_common_1 = __nccwpck_require__(294);
-const Clients_js_1 = __nccwpck_require__(192);
+const storage_common_1 = __nccwpck_require__(295);
+const Clients_js_1 = __nccwpck_require__(193);
 const Mutex_js_1 = __nccwpck_require__(553);
-const Pipeline_js_1 = __nccwpck_require__(190);
-const utils_common_js_1 = __nccwpck_require__(163);
-const core_xml_1 = __nccwpck_require__(203);
-const constants_js_1 = __nccwpck_require__(157);
+const Pipeline_js_1 = __nccwpck_require__(191);
+const utils_common_js_1 = __nccwpck_require__(164);
+const core_xml_1 = __nccwpck_require__(204);
+const constants_js_1 = __nccwpck_require__(158);
 const tracing_js_1 = __nccwpck_require__(35);
 const core_client_1 = __nccwpck_require__(467);
 /**
@@ -69233,7 +69483,7 @@ function batchHeaderFilterPolicy() {
 
 /***/ }),
 
-/***/ 359:
+/***/ 360:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69242,17 +69492,17 @@ function batchHeaderFilterPolicy() {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReadableFromStream = exports.AvroReadable = exports.AvroReader = void 0;
-var AvroReader_js_1 = __nccwpck_require__(447);
+var AvroReader_js_1 = __nccwpck_require__(448);
 Object.defineProperty(exports, "AvroReader", ({ enumerable: true, get: function () { return AvroReader_js_1.AvroReader; } }));
-var AvroReadable_js_1 = __nccwpck_require__(410);
+var AvroReadable_js_1 = __nccwpck_require__(411);
 Object.defineProperty(exports, "AvroReadable", ({ enumerable: true, get: function () { return AvroReadable_js_1.AvroReadable; } }));
-var AvroReadableFromStream_js_1 = __nccwpck_require__(269);
+var AvroReadableFromStream_js_1 = __nccwpck_require__(270);
 Object.defineProperty(exports, "AvroReadableFromStream", ({ enumerable: true, get: function () { return AvroReadableFromStream_js_1.AvroReadableFromStream; } }));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 360:
+/***/ 361:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69279,12 +69529,12 @@ __export(tracingPolicy_exports, {
 });
 module.exports = __toCommonJS(tracingPolicy_exports);
 var import_core_tracing = __nccwpck_require__(88);
-var import_constants = __nccwpck_require__(167);
-var import_userAgent = __nccwpck_require__(313);
-var import_log = __nccwpck_require__(191);
+var import_constants = __nccwpck_require__(168);
+var import_userAgent = __nccwpck_require__(314);
+var import_log = __nccwpck_require__(192);
 var import_core_util = __nccwpck_require__(17);
-var import_restError = __nccwpck_require__(378);
-var import_util = __nccwpck_require__(155);
+var import_restError = __nccwpck_require__(379);
+var import_util = __nccwpck_require__(156);
 const tracingPolicyName = "tracingPolicy";
 function tracingPolicy(options = {}) {
   const userAgentPromise = (0, import_userAgent.getUserAgentValue)(options.userAgentPrefix);
@@ -69398,7 +69648,7 @@ function tryProcessResponse(span, response) {
 
 /***/ }),
 
-/***/ 361:
+/***/ 362:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -69410,14 +69660,14 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher
-} = __nccwpck_require__(392)
+} = __nccwpck_require__(393)
 const Client = __nccwpck_require__(98)
 const {
   InvalidArgumentError
 } = __nccwpck_require__(522)
 const util = __nccwpck_require__(77)
-const { kUrl, kInterceptors } = __nccwpck_require__(204)
-const buildConnector = __nccwpck_require__(283)
+const { kUrl, kInterceptors } = __nccwpck_require__(205)
+const buildConnector = __nccwpck_require__(284)
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -69514,7 +69764,7 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 362:
+/***/ 363:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69566,7 +69816,7 @@ function oauth2AuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 363:
+/***/ 364:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -69592,7 +69842,7 @@ __export(formDataPolicy_exports, {
   formDataPolicyName: () => formDataPolicyName
 });
 module.exports = __toCommonJS(formDataPolicy_exports);
-var import_bytesEncoding = __nccwpck_require__(308);
+var import_bytesEncoding = __nccwpck_require__(309);
 var import_checkEnvironment = __nccwpck_require__(466);
 var import_httpHeaders = __nccwpck_require__(519);
 const formDataPolicyName = "formDataPolicy";
@@ -69682,7 +69932,7 @@ async function prepareFormData(formData, request) {
 
 /***/ }),
 
-/***/ 364:
+/***/ 365:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -69741,7 +69991,7 @@ exports.soldrToolchainEnsure = soldrToolchainEnsure;
 exports.soldrToolchainLink = soldrToolchainLink;
 exports.soldrToolchainDoctor = soldrToolchainDoctor;
 const exec = __importStar(__nccwpck_require__(21));
-const verify_soldr_js_1 = __nccwpck_require__(379);
+const verify_soldr_js_1 = __nccwpck_require__(380);
 /**
  * Minimum soldr version that exposes the `toolchain ensure/link/doctor`
  * JSON subcommands. Set by Wave 3.4 of zackees/soldr#514.
@@ -69996,7 +70246,7 @@ async function soldrToolchainDoctor(soldrPath, deps) {
 
 /***/ }),
 
-/***/ 365:
+/***/ 366:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -70022,7 +70272,7 @@ __export(redirectPolicy_exports, {
   redirectPolicyName: () => redirectPolicyName
 });
 module.exports = __toCommonJS(redirectPolicy_exports);
-var import_policies = __nccwpck_require__(307);
+var import_policies = __nccwpck_require__(308);
 const redirectPolicyName = import_policies.redirectPolicyName;
 function redirectPolicy(options = {}) {
   return (0, import_policies.redirectPolicy)(options);
@@ -70033,19 +70283,19 @@ function redirectPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 366:
+/***/ 367:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(204)
+const { kProxy, kClose, kDestroy, kInterceptors } = __nccwpck_require__(205)
 const { URL } = __nccwpck_require__(95)
 const Agent = __nccwpck_require__(6)
-const Pool = __nccwpck_require__(361)
+const Pool = __nccwpck_require__(362)
 const DispatcherBase = __nccwpck_require__(69)
 const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(522)
-const buildConnector = __nccwpck_require__(283)
+const buildConnector = __nccwpck_require__(284)
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -70230,19 +70480,19 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 367:
+/***/ 368:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionJsonReader = void 0;
-const json_typings_1 = __nccwpck_require__(419);
-const base64_1 = __nccwpck_require__(324);
+const json_typings_1 = __nccwpck_require__(420);
+const base64_1 = __nccwpck_require__(325);
 const reflection_info_1 = __nccwpck_require__(481);
-const pb_long_1 = __nccwpck_require__(126);
+const pb_long_1 = __nccwpck_require__(127);
 const assert_1 = __nccwpck_require__(518);
-const reflection_long_convert_1 = __nccwpck_require__(166);
+const reflection_long_convert_1 = __nccwpck_require__(167);
 /**
  * Reads proto3 messages in canonical JSON format using reflection information.
  *
@@ -70555,7 +70805,7 @@ exports.ReflectionJsonReader = ReflectionJsonReader;
 
 /***/ }),
 
-/***/ 368:
+/***/ 369:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -70563,7 +70813,7 @@ exports.ReflectionJsonReader = ReflectionJsonReader;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DEFAULT_DYLINT_CATALOGUE_ORIGIN = void 0;
 exports.resolveDylintNightly = resolveDylintNightly;
-const node_crypto_1 = __nccwpck_require__(292);
+const node_crypto_1 = __nccwpck_require__(293);
 async function defaultFetchBytes(url) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 30_000);
@@ -70675,7 +70925,7 @@ exports.DEFAULT_DYLINT_CATALOGUE_ORIGIN = "https://raw.githubusercontent.com/zac
 
 /***/ }),
 
-/***/ 369:
+/***/ 370:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -70692,7 +70942,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
 const os_1 = __nccwpck_require__(102);
-const fs_1 = __nccwpck_require__(567);
+const fs_1 = __nccwpck_require__(568);
 const { access, appendFile, writeFile } = fs_1.promises;
 exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
 exports.SUMMARY_DOCS_URL = 'https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary';
@@ -70965,7 +71215,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 370:
+/***/ 371:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -71048,7 +71298,7 @@ exports.utf8read = utf8read;
 
 /***/ }),
 
-/***/ 371:
+/***/ 372:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -71075,10 +71325,10 @@ TomlError.wrap = err => {
 }
 module.exports.TomlError = TomlError
 
-const createDateTime = __nccwpck_require__(407)
-const createDateTimeFloat = __nccwpck_require__(178)
+const createDateTime = __nccwpck_require__(408)
+const createDateTimeFloat = __nccwpck_require__(179)
 const createDate = __nccwpck_require__(60)
-const createTime = __nccwpck_require__(373)
+const createTime = __nccwpck_require__(374)
 
 const CTRL_I = 0x09
 const CTRL_J = 0x0A
@@ -72435,7 +72685,7 @@ function makeParserClass (Parser) {
 
 /***/ }),
 
-/***/ 372:
+/***/ 373:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -72444,8 +72694,8 @@ function makeParserClass (Parser) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTracingClient = createTracingClient;
-const instrumenter_js_1 = __nccwpck_require__(433);
-const tracingContext_js_1 = __nccwpck_require__(393);
+const instrumenter_js_1 = __nccwpck_require__(434);
+const tracingContext_js_1 = __nccwpck_require__(394);
 /**
  * Creates a new tracing client.
  *
@@ -72523,12 +72773,12 @@ function createTracingClient(options) {
 
 /***/ }),
 
-/***/ 373:
+/***/ 374:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const f = __nccwpck_require__(430)
+const f = __nccwpck_require__(431)
 
 class Time extends Date {
   constructor (value) {
@@ -72553,14 +72803,14 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 374:
+/***/ 375:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { promisify } = __nccwpck_require__(132)
-const Pool = __nccwpck_require__(361)
+const { promisify } = __nccwpck_require__(133)
+const Pool = __nccwpck_require__(362)
 const { buildMockDispatch } = __nccwpck_require__(9)
 const {
   kDispatches,
@@ -72571,8 +72821,8 @@ const {
   kOriginalDispatch,
   kConnected
 } = __nccwpck_require__(504)
-const { MockInterceptor } = __nccwpck_require__(144)
-const Symbols = __nccwpck_require__(204)
+const { MockInterceptor } = __nccwpck_require__(145)
+const Symbols = __nccwpck_require__(205)
 const { InvalidArgumentError } = __nccwpck_require__(522)
 
 /**
@@ -72620,7 +72870,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 375:
+/***/ 376:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -72678,7 +72928,7 @@ exports.ClientStreamingCall = ClientStreamingCall;
 
 /***/ }),
 
-/***/ 376:
+/***/ 377:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -73441,7 +73691,7 @@ exports.Decompress = Decompress;
 
 /***/ }),
 
-/***/ 377:
+/***/ 378:
 /***/ ((module) => {
 
 module.exports = function (xs, fn) {
@@ -73461,7 +73711,7 @@ var isArray = Array.isArray || function (xs) {
 
 /***/ }),
 
-/***/ 378:
+/***/ 379:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -73498,7 +73748,7 @@ function isRestError(e) {
 
 /***/ }),
 
-/***/ 379:
+/***/ 380:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -73546,7 +73796,7 @@ exports.versionTuple = versionTuple;
 exports.parseVersionJsonOutput = parseVersionJsonOutput;
 exports.verifySoldr = verifySoldr;
 const exec = __importStar(__nccwpck_require__(21));
-const log_utils_js_1 = __nccwpck_require__(200);
+const log_utils_js_1 = __nccwpck_require__(201);
 function versionTuple(value) {
     const cleaned = value.trim().replace(/^v/, "");
     const parts = cleaned.split(".");
@@ -73696,20 +73946,20 @@ async function verifySoldr(opts) {
 
 /***/ }),
 
-/***/ 380:
+/***/ 381:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { finished, PassThrough } = __nccwpck_require__(139)
+const { finished, PassThrough } = __nccwpck_require__(140)
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
 } = __nccwpck_require__(522)
 const util = __nccwpck_require__(77)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(197)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(198)
 const { AsyncResource } = __nccwpck_require__(456)
 const { addSignal, removeSignal } = __nccwpck_require__(113)
 
@@ -73924,7 +74174,7 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 381:
+/***/ 382:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -73938,9 +74188,9 @@ module.exports = stream
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlockBlobImpl = void 0;
-const tslib_1 = __nccwpck_require__(225);
+const tslib_1 = __nccwpck_require__(226);
 const coreClient = tslib_1.__importStar(__nccwpck_require__(467));
-const Mappers = tslib_1.__importStar(__nccwpck_require__(187));
+const Mappers = tslib_1.__importStar(__nccwpck_require__(188));
 const Parameters = tslib_1.__importStar(__nccwpck_require__(72));
 /** Class containing BlockBlob operations. */
 class BlockBlobImpl {
@@ -74304,7 +74554,7 @@ const getBlockListOperationSpec = {
 
 /***/ }),
 
-/***/ 382:
+/***/ 383:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -74349,7 +74599,7 @@ function decompressResponsePolicy() {
 
 /***/ }),
 
-/***/ 383:
+/***/ 384:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74359,7 +74609,7 @@ function decompressResponsePolicy() {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GenericPollOperation = void 0;
 const operation_js_1 = __nccwpck_require__(57);
-const logger_js_1 = __nccwpck_require__(199);
+const logger_js_1 = __nccwpck_require__(200);
 const createStateProxy = () => ({
     initState: (config) => ({ config, isStarted: true }),
     setCanceled: (state) => (state.isCancelled = true),
@@ -74444,7 +74694,7 @@ exports.GenericPollOperation = GenericPollOperation;
 
 /***/ }),
 
-/***/ 384:
+/***/ 385:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -74467,7 +74717,7 @@ function ipRangeToString(ipRange) {
 
 /***/ }),
 
-/***/ 385:
+/***/ 386:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -74493,7 +74743,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(273);
+var import_userAgent = __nccwpck_require__(274);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -74515,7 +74765,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 386:
+/***/ 387:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74535,7 +74785,7 @@ exports.getUserAgentString = getUserAgentString;
 
 /***/ }),
 
-/***/ 387:
+/***/ 388:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -74545,7 +74795,7 @@ exports.getUserAgentString = getUserAgentString;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BufferScheduler = void 0;
 const events_1 = __nccwpck_require__(503);
-const PooledBuffer_js_1 = __nccwpck_require__(394);
+const PooledBuffer_js_1 = __nccwpck_require__(395);
 /**
  * This class accepts a Node.js Readable stream as input, and keeps reading data
  * from the stream into the internal buffer structure, until it reaches maxBuffers.
@@ -74824,14 +75074,14 @@ exports.BufferScheduler = BufferScheduler;
 
 /***/ }),
 
-/***/ 388:
+/***/ 389:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Blob, File: NativeFile } = __nccwpck_require__(128)
-const { types } = __nccwpck_require__(132)
+const { Blob, File: NativeFile } = __nccwpck_require__(129)
+const { types } = __nccwpck_require__(133)
 const { kState } = __nccwpck_require__(18)
 const { isBlobLike } = __nccwpck_require__(552)
 const { webidl } = __nccwpck_require__(485)
@@ -75176,13 +75426,13 @@ module.exports = { File, FileLike, isFileLike }
 
 /***/ }),
 
-/***/ 389:
+/***/ 390:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const diagnosticsChannel = __nccwpck_require__(150)
+const diagnosticsChannel = __nccwpck_require__(151)
 const { uid, states } = __nccwpck_require__(499)
 const {
   kReadyState,
@@ -75191,12 +75441,12 @@ const {
   kReceivedClose
 } = __nccwpck_require__(108)
 const { fireEvent, failWebsocketConnection } = __nccwpck_require__(63)
-const { CloseEvent } = __nccwpck_require__(266)
+const { CloseEvent } = __nccwpck_require__(267)
 const { makeRequest } = __nccwpck_require__(90)
 const { fetching } = __nccwpck_require__(478)
 const { Headers } = __nccwpck_require__(550)
-const { getGlobalDispatcher } = __nccwpck_require__(399)
-const { kHeadersList } = __nccwpck_require__(204)
+const { getGlobalDispatcher } = __nccwpck_require__(400)
+const { kHeadersList } = __nccwpck_require__(205)
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -75206,7 +75456,7 @@ channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error
 /** @type {import('crypto')} */
 let crypto
 try {
-  crypto = __nccwpck_require__(312)
+  crypto = __nccwpck_require__(313)
 } catch {
 
 }
@@ -75475,7 +75725,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 390:
+/***/ 391:
 /***/ ((module) => {
 
 "use strict";
@@ -75491,7 +75741,7 @@ module.exports = (flag, argv = process.argv) => {
 
 /***/ }),
 
-/***/ 391:
+/***/ 392:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -75547,15 +75797,15 @@ function statusCodeToNumber(statusCode) {
 
 /***/ }),
 
-/***/ 392:
+/***/ 393:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const DispatcherBase = __nccwpck_require__(69)
-const FixedQueue = __nccwpck_require__(205)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(204)
+const FixedQueue = __nccwpck_require__(206)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(205)
 const PoolStats = __nccwpck_require__(25)
 
 const kClients = Symbol('clients')
@@ -75749,7 +75999,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 393:
+/***/ 394:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -75809,7 +76059,7 @@ exports.TracingContextImpl = TracingContextImpl;
 
 /***/ }),
 
-/***/ 394:
+/***/ 395:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -75818,9 +76068,9 @@ exports.TracingContextImpl = TracingContextImpl;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PooledBuffer = void 0;
-const tslib_1 = __nccwpck_require__(225);
-const BuffersStream_js_1 = __nccwpck_require__(408);
-const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(281));
+const tslib_1 = __nccwpck_require__(226);
+const BuffersStream_js_1 = __nccwpck_require__(409);
+const node_buffer_1 = tslib_1.__importDefault(__nccwpck_require__(282));
 /**
  * maxBufferLength is max size of each buffer in the pooled buffers.
  */
@@ -75916,7 +76166,7 @@ exports.PooledBuffer = PooledBuffer;
 
 /***/ }),
 
-/***/ 395:
+/***/ 396:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -75952,7 +76202,7 @@ function createDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 396:
+/***/ 397:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76064,7 +76314,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 397:
+/***/ 398:
 /***/ ((module) => {
 
 /**
@@ -76233,7 +76483,7 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 398:
+/***/ 399:
 /***/ ((module) => {
 
 "use strict";
@@ -76241,7 +76491,7 @@ module.exports = require("node:util");
 
 /***/ }),
 
-/***/ 399:
+/***/ 400:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76281,13 +76531,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 400:
+/***/ 401:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(204)
+const { kClients } = __nccwpck_require__(205)
 const Agent = __nccwpck_require__(6)
 const {
   kAgent,
@@ -76300,13 +76550,13 @@ const {
   kOptions,
   kFactory
 } = __nccwpck_require__(504)
-const MockClient = __nccwpck_require__(208)
-const MockPool = __nccwpck_require__(374)
+const MockClient = __nccwpck_require__(209)
+const MockPool = __nccwpck_require__(375)
 const { matchValue, buildMockOptions } = __nccwpck_require__(9)
 const { InvalidArgumentError, UndiciError } = __nccwpck_require__(522)
 const Dispatcher = __nccwpck_require__(511)
-const Pluralizer = __nccwpck_require__(271)
-const PendingInterceptorsFormatter = __nccwpck_require__(244)
+const Pluralizer = __nccwpck_require__(272)
+const PendingInterceptorsFormatter = __nccwpck_require__(245)
 
 class FakeWeakRef {
   constructor (value) {
@@ -76460,7 +76710,7 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 401:
+/***/ 402:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76486,7 +76736,7 @@ __export(tlsPolicy_exports, {
   tlsPolicyName: () => tlsPolicyName
 });
 module.exports = __toCommonJS(tlsPolicy_exports);
-var import_policies = __nccwpck_require__(307);
+var import_policies = __nccwpck_require__(308);
 const tlsPolicyName = import_policies.tlsPolicyName;
 function tlsPolicy(tlsSettings) {
   return (0, import_policies.tlsPolicy)(tlsSettings);
@@ -76497,7 +76747,7 @@ function tlsPolicy(tlsSettings) {
 
 /***/ }),
 
-/***/ 402:
+/***/ 403:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -76586,7 +76836,7 @@ exports.AccountSASServices = AccountSASServices;
 
 /***/ }),
 
-/***/ 403:
+/***/ 404:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -76640,7 +76890,7 @@ function bearerAuthenticationPolicy(options) {
 
 /***/ }),
 
-/***/ 404:
+/***/ 405:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -76657,9 +76907,9 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(392)
-const Pool = __nccwpck_require__(361)
-const { kUrl, kInterceptors } = __nccwpck_require__(204)
+} = __nccwpck_require__(393)
+const Pool = __nccwpck_require__(362)
+const { kUrl, kInterceptors } = __nccwpck_require__(205)
 const { parseOrigin } = __nccwpck_require__(77)
 const kFactory = Symbol('factory')
 
@@ -76838,7 +77088,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 405:
+/***/ 406:
 /***/ ((module) => {
 
 "use strict";
@@ -76846,7 +77096,7 @@ module.exports = require("node:os");
 
 /***/ }),
 
-/***/ 406:
+/***/ 407:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -76890,7 +77140,7 @@ function operationOptionsToRequestParameters(options) {
 
 /***/ }),
 
-/***/ 407:
+/***/ 408:
 /***/ ((module) => {
 
 "use strict";
@@ -76908,7 +77158,7 @@ module.exports = value => {
 
 /***/ }),
 
-/***/ 408:
+/***/ 409:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77016,14 +77266,14 @@ exports.BuffersStream = BuffersStream;
 
 /***/ }),
 
-/***/ 409:
+/***/ 410:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { parseSetCookie } = __nccwpck_require__(449)
-const { stringify } = __nccwpck_require__(435)
+const { parseSetCookie } = __nccwpck_require__(450)
+const { stringify } = __nccwpck_require__(436)
 const { webidl } = __nccwpck_require__(485)
 const { Headers } = __nccwpck_require__(550)
 
@@ -77207,7 +77457,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 410:
+/***/ 411:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -77223,7 +77473,7 @@ exports.AvroReadable = AvroReadable;
 
 /***/ }),
 
-/***/ 411:
+/***/ 412:
 /***/ ((module) => {
 
 "use strict";
@@ -77231,7 +77481,7 @@ module.exports = require("node:https");
 
 /***/ }),
 
-/***/ 412:
+/***/ 413:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -77257,7 +77507,7 @@ __export(userAgentPolicy_exports, {
   userAgentPolicyName: () => userAgentPolicyName
 });
 module.exports = __toCommonJS(userAgentPolicy_exports);
-var import_userAgent = __nccwpck_require__(313);
+var import_userAgent = __nccwpck_require__(314);
 const UserAgentHeaderName = (0, import_userAgent.getUserAgentHeaderName)();
 const userAgentPolicyName = "userAgentPolicy";
 function userAgentPolicy(options = {}) {
@@ -77278,7 +77528,7 @@ function userAgentPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 413:
+/***/ 414:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77290,7 +77540,7 @@ function userAgentPolicy(options = {}) {
 // assert byte-for-byte.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.buildOutputs = buildOutputs;
-const target_lifecycle_js_1 = __nccwpck_require__(256);
+const target_lifecycle_js_1 = __nccwpck_require__(257);
 /**
  * Build the $GITHUB_OUTPUT key/value map. Exposed for tests so they
  * can assert byte-for-byte parity with the legacy Python action's
@@ -77437,15 +77687,15 @@ function buildOutputs(result) {
 
 /***/ }),
 
-/***/ 414:
+/***/ 415:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const util = __nccwpck_require__(77)
-const { kBodyUsed } = __nccwpck_require__(204)
-const assert = __nccwpck_require__(562)
+const { kBodyUsed } = __nccwpck_require__(205)
+const assert = __nccwpck_require__(563)
 const { InvalidArgumentError } = __nccwpck_require__(522)
 const EE = __nccwpck_require__(503)
 
@@ -77666,7 +77916,7 @@ module.exports = RedirectHandler
 
 /***/ }),
 
-/***/ 415:
+/***/ 416:
 /***/ ((module) => {
 
 "use strict";
@@ -77674,7 +77924,7 @@ module.exports = require("node:stream/promises");
 
 /***/ }),
 
-/***/ 416:
+/***/ 417:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -77700,7 +77950,7 @@ function arraysEqual(a, b) {
 
 /***/ }),
 
-/***/ 417:
+/***/ 418:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -77726,7 +77976,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_policies = __nccwpck_require__(307);
+var import_policies = __nccwpck_require__(308);
 const exponentialRetryPolicyName = import_policies.exponentialRetryPolicyName;
 function exponentialRetryPolicy(options = {}) {
   return (0, import_policies.exponentialRetryPolicy)(options);
@@ -77737,7 +77987,7 @@ function exponentialRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 418:
+/***/ 419:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -77772,7 +78022,7 @@ function randomUUID() {
 
 /***/ }),
 
-/***/ 419:
+/***/ 420:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -77805,7 +78055,7 @@ exports.isJsonObject = isJsonObject;
 
 /***/ }),
 
-/***/ 420:
+/***/ 421:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -77878,7 +78128,7 @@ function isSystemError(err) {
 
 /***/ }),
 
-/***/ 421:
+/***/ 422:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77948,7 +78198,7 @@ exports.CacheScope = new CacheScope$Type();
 
 /***/ }),
 
-/***/ 422:
+/***/ 423:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -77981,7 +78231,7 @@ exports.AnonymousCredential = AnonymousCredential;
 
 /***/ }),
 
-/***/ 423:
+/***/ 424:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -78002,12 +78252,12 @@ function getCachedDefaultHttpClient() {
 
 /***/ }),
 
-/***/ 424:
+/***/ 425:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var register = __nccwpck_require__(268);
+var register = __nccwpck_require__(269);
 var addHook = __nccwpck_require__(516);
-var removeHook = __nccwpck_require__(230);
+var removeHook = __nccwpck_require__(231);
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind;
@@ -78070,7 +78320,7 @@ module.exports.Collection = Hook.Collection;
 
 /***/ }),
 
-/***/ 425:
+/***/ 426:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -78120,18 +78370,18 @@ function getPathStringFromParameter(parameter) {
 
 /***/ }),
 
-/***/ 426:
+/***/ 427:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-exports.parse = __nccwpck_require__(232)
-exports.stringify = __nccwpck_require__(320)
+exports.parse = __nccwpck_require__(233)
+exports.stringify = __nccwpck_require__(321)
 
 
 /***/ }),
 
-/***/ 427:
+/***/ 428:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -78141,17 +78391,17 @@ exports.BlobServiceClient = void 0;
 const core_auth_1 = __nccwpck_require__(548);
 const core_rest_pipeline_1 = __nccwpck_require__(111);
 const core_util_1 = __nccwpck_require__(17);
-const Pipeline_js_1 = __nccwpck_require__(190);
+const Pipeline_js_1 = __nccwpck_require__(191);
 const ContainerClient_js_1 = __nccwpck_require__(71);
-const utils_common_js_1 = __nccwpck_require__(163);
-const storage_common_1 = __nccwpck_require__(294);
-const utils_common_js_2 = __nccwpck_require__(163);
+const utils_common_js_1 = __nccwpck_require__(164);
+const storage_common_1 = __nccwpck_require__(295);
+const utils_common_js_2 = __nccwpck_require__(164);
 const tracing_js_1 = __nccwpck_require__(35);
-const BlobBatchClient_js_1 = __nccwpck_require__(428);
+const BlobBatchClient_js_1 = __nccwpck_require__(429);
 const StorageClient_js_1 = __nccwpck_require__(483);
 const AccountSASPermissions_js_1 = __nccwpck_require__(64);
-const AccountSASSignatureValues_js_1 = __nccwpck_require__(310);
-const AccountSASServices_js_1 = __nccwpck_require__(402);
+const AccountSASSignatureValues_js_1 = __nccwpck_require__(311);
+const AccountSASServices_js_1 = __nccwpck_require__(403);
 /**
  * A BlobServiceClient represents a Client to the Azure Storage Blob service allowing you
  * to manipulate blob containers.
@@ -78844,7 +79094,7 @@ exports.BlobServiceClient = BlobServiceClient;
 
 /***/ }),
 
-/***/ 428:
+/***/ 429:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -78853,14 +79103,14 @@ exports.BlobServiceClient = BlobServiceClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBatchClient = void 0;
-const BatchResponseParser_js_1 = __nccwpck_require__(331);
-const BatchUtils_js_1 = __nccwpck_require__(275);
-const BlobBatch_js_1 = __nccwpck_require__(358);
+const BatchResponseParser_js_1 = __nccwpck_require__(332);
+const BatchUtils_js_1 = __nccwpck_require__(276);
+const BlobBatch_js_1 = __nccwpck_require__(359);
 const tracing_js_1 = __nccwpck_require__(35);
-const storage_common_1 = __nccwpck_require__(294);
-const StorageContextClient_js_1 = __nccwpck_require__(284);
-const Pipeline_js_1 = __nccwpck_require__(190);
-const utils_common_js_1 = __nccwpck_require__(163);
+const storage_common_1 = __nccwpck_require__(295);
+const StorageContextClient_js_1 = __nccwpck_require__(285);
+const Pipeline_js_1 = __nccwpck_require__(191);
+const utils_common_js_1 = __nccwpck_require__(164);
 /**
  * A BlobBatchClient allows you to make batched requests to the Azure Storage Blob service.
  *
@@ -79027,7 +79277,7 @@ exports.BlobBatchClient = BlobBatchClient;
 
 /***/ }),
 
-/***/ 429:
+/***/ 430:
 /***/ ((module) => {
 
 "use strict";
@@ -79112,7 +79362,7 @@ var createTokenAuth = function createTokenAuth2(token) {
 
 /***/ }),
 
-/***/ 430:
+/***/ 431:
 /***/ ((module) => {
 
 "use strict";
@@ -79126,14 +79376,14 @@ module.exports = (d, num) => {
 
 /***/ }),
 
-/***/ 431:
+/***/ 432:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const Decoder = __nccwpck_require__(47)
-const decodeText = __nccwpck_require__(293)
+const decodeText = __nccwpck_require__(294)
 const getLimit = __nccwpck_require__(517)
 
 const RE_CHARSET = /^charset$/i
@@ -79324,7 +79574,7 @@ module.exports = UrlEncoded
 
 /***/ }),
 
-/***/ 432:
+/***/ 433:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -79342,7 +79592,7 @@ exports.MESSAGE_TYPE = Symbol.for("protobuf-ts/message-type");
 
 /***/ }),
 
-/***/ 433:
+/***/ 434:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -79354,7 +79604,7 @@ exports.createDefaultTracingSpan = createDefaultTracingSpan;
 exports.createDefaultInstrumenter = createDefaultInstrumenter;
 exports.useInstrumenter = useInstrumenter;
 exports.getInstrumenter = getInstrumenter;
-const tracingContext_js_1 = __nccwpck_require__(393);
+const tracingContext_js_1 = __nccwpck_require__(394);
 const state_js_1 = __nccwpck_require__(106);
 function createDefaultTracingSpan() {
     return {
@@ -79418,16 +79668,16 @@ function getInstrumenter() {
 
 /***/ }),
 
-/***/ 434:
+/***/ 435:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ReflectionBinaryReader = void 0;
-const binary_format_contract_1 = __nccwpck_require__(357);
+const binary_format_contract_1 = __nccwpck_require__(358);
 const reflection_info_1 = __nccwpck_require__(481);
-const reflection_long_convert_1 = __nccwpck_require__(166);
+const reflection_long_convert_1 = __nccwpck_require__(167);
 const reflection_scalar_default_1 = __nccwpck_require__(494);
 /**
  * Reads proto3 messages in binary format using reflection information.
@@ -79609,7 +79859,7 @@ exports.ReflectionBinaryReader = ReflectionBinaryReader;
 
 /***/ }),
 
-/***/ 435:
+/***/ 436:
 /***/ ((module) => {
 
 "use strict";
@@ -79891,7 +80141,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 436:
+/***/ 437:
 /***/ ((module) => {
 
 "use strict";
@@ -79899,15 +80149,15 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 437:
+/***/ 438:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseAsync
 
-const TOMLParser = __nccwpck_require__(371)
-const prettyError = __nccwpck_require__(297)
+const TOMLParser = __nccwpck_require__(372)
+const prettyError = __nccwpck_require__(298)
 
 function parseAsync (str, opts) {
   if (!opts) opts = {}
@@ -79937,7 +80187,7 @@ function parseAsync (str, opts) {
 
 /***/ }),
 
-/***/ 438:
+/***/ 439:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -79964,7 +80214,7 @@ __export(response_exports, {
 });
 module.exports = __toCommonJS(response_exports);
 var import_core_rest_pipeline = __nccwpck_require__(111);
-var import_util = __nccwpck_require__(119);
+var import_util = __nccwpck_require__(120);
 const originalResponse = /* @__PURE__ */ Symbol("Original FullOperationResponse");
 function toCompatResponse(response, options) {
   let request = (0, import_util.toWebResourceLike)(response.request);
@@ -80020,7 +80270,7 @@ function toPipelineResponse(compatResponse) {
 
 /***/ }),
 
-/***/ 439:
+/***/ 440:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -80077,7 +80327,7 @@ exports.getOptions = getOptions;
 
 /***/ }),
 
-/***/ 440:
+/***/ 441:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80085,7 +80335,7 @@ exports.getOptions = getOptions;
 
 /* istanbul ignore file: only for Node 12 */
 
-const { kConnected, kSize } = __nccwpck_require__(204)
+const { kConnected, kSize } = __nccwpck_require__(205)
 
 class CompatWeakRef {
   constructor (value) {
@@ -80133,7 +80383,7 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 441:
+/***/ 442:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80145,7 +80395,7 @@ exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTie
 exports.toAccessTier = toAccessTier;
 exports.ensureCpkIfSpecified = ensureCpkIfSpecified;
 exports.getBlobServiceAccountAudience = getBlobServiceAccountAudience;
-const constants_js_1 = __nccwpck_require__(157);
+const constants_js_1 = __nccwpck_require__(158);
 /**
  * Represents the access tier on a blob.
  * For detailed information about block blob level tiering see {@link https://learn.microsoft.com/azure/storage/blobs/storage-blob-storage-tiers|Hot, cool and archive storage tiers.}
@@ -80261,19 +80511,19 @@ function getBlobServiceAccountAudience(storageAccountName) {
 
 /***/ }),
 
-/***/ 442:
+/***/ 443:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const WritableStream = (__nccwpck_require__(457).Writable)
-const { inherits } = __nccwpck_require__(398)
+const { inherits } = __nccwpck_require__(399)
 const Dicer = __nccwpck_require__(16)
 
 const MultipartParser = __nccwpck_require__(0)
-const UrlencodedParser = __nccwpck_require__(431)
-const parseParams = __nccwpck_require__(201)
+const UrlencodedParser = __nccwpck_require__(432)
+const parseParams = __nccwpck_require__(202)
 
 function Busboy (opts) {
   if (!(this instanceof Busboy)) { return new Busboy(opts) }
@@ -80354,7 +80604,7 @@ module.exports.Dicer = Dicer
 
 /***/ }),
 
-/***/ 443:
+/***/ 444:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -80381,7 +80631,7 @@ var StorageRetryPolicyType;
 
 /***/ }),
 
-/***/ 444:
+/***/ 445:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -80482,7 +80732,7 @@ exports.getDetails = getDetails;
 
 /***/ }),
 
-/***/ 445:
+/***/ 446:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -80590,15 +80840,15 @@ exports.parseProxyResponse = parseProxyResponse;
 
 /***/ }),
 
-/***/ 446:
+/***/ 447:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = parseStream
 
-const stream = __nccwpck_require__(139)
-const TOMLParser = __nccwpck_require__(371)
+const stream = __nccwpck_require__(140)
+const TOMLParser = __nccwpck_require__(372)
 
 function parseStream (stm) {
   if (stm) {
@@ -80678,7 +80928,7 @@ function parseTransform () {
 
 /***/ }),
 
-/***/ 447:
+/***/ 448:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80689,9 +80939,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.AvroReader = void 0;
 // TODO: Do a review of non-interfaces
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
-const AvroConstants_js_1 = __nccwpck_require__(240);
-const AvroParser_js_1 = __nccwpck_require__(323);
-const utils_common_js_1 = __nccwpck_require__(416);
+const AvroConstants_js_1 = __nccwpck_require__(241);
+const AvroParser_js_1 = __nccwpck_require__(324);
+const utils_common_js_1 = __nccwpck_require__(417);
 class AvroReader {
     _dataStream;
     _headerStream;
@@ -80805,7 +81055,7 @@ exports.AvroReader = AvroReader;
 
 /***/ }),
 
-/***/ 448:
+/***/ 449:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -80815,13 +81065,13 @@ exports.CacheService = exports.GetCacheEntryDownloadURLResponse = exports.GetCac
 // @generated by protobuf-ts 2.9.1 with parameter long_type_string,client_none,generate_dependencies
 // @generated from protobuf file "results/api/v1/cache.proto" (package "github.actions.results.api.v1", syntax proto3)
 // tslint:disable
-const runtime_rpc_1 = __nccwpck_require__(181);
+const runtime_rpc_1 = __nccwpck_require__(182);
 const runtime_1 = __nccwpck_require__(22);
 const runtime_2 = __nccwpck_require__(22);
 const runtime_3 = __nccwpck_require__(22);
 const runtime_4 = __nccwpck_require__(22);
 const runtime_5 = __nccwpck_require__(22);
-const cachemetadata_1 = __nccwpck_require__(245);
+const cachemetadata_1 = __nccwpck_require__(246);
 // @generated message type with reflection information, may provide speed optimized methods
 class CreateCacheEntryRequest$Type extends runtime_5.MessageType {
     constructor() {
@@ -81214,16 +81464,16 @@ exports.CacheService = new runtime_rpc_1.ServiceType("github.actions.results.api
 
 /***/ }),
 
-/***/ 449:
+/***/ 450:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(136)
-const { isCTLExcludingHtab } = __nccwpck_require__(435)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(137)
+const { isCTLExcludingHtab } = __nccwpck_require__(436)
 const { collectASequenceOfCodePointsFast } = __nccwpck_require__(29)
-const assert = __nccwpck_require__(562)
+const assert = __nccwpck_require__(563)
 
 /**
  * @description Parses the field-value attributes of a set-cookie header string.
@@ -81534,1597 +81784,6 @@ function parseUnparsedAttributes (unparsedAttributes, cookieAttributeList = {}) 
 module.exports = {
   parseSetCookie,
   parseUnparsedAttributes
-}
-
-
-/***/ }),
-
-/***/ 450:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-// setup-soldr entry point. Owned by Agent 2.
-//
-// Replaces the composite action's main-phase steps with a single JS
-// orchestrator. Calls the helpers in src/lib/* in the same order the
-// composite's steps fire.
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.shouldSkipCargoRegistryExtractionError = shouldSkipCargoRegistryExtractionError;
-exports.run = run;
-const fs = __importStar(__nccwpck_require__(265));
-const os = __importStar(__nccwpck_require__(405));
-const path = __importStar(__nccwpck_require__(542));
-const core = __importStar(__nccwpck_require__(490));
-const cache = __importStar(__nccwpck_require__(222));
-const exec = __importStar(__nccwpck_require__(21));
-const log_utils_js_1 = __nccwpck_require__(200);
-const resolve_setup_js_1 = __nccwpck_require__(304);
-const phase_timing_js_1 = __nccwpck_require__(551);
-const ensure_rust_toolchain_js_1 = __nccwpck_require__(262);
-const ensure_soldr_js_1 = __nccwpck_require__(479);
-const verify_soldr_js_1 = __nccwpck_require__(379);
-const prepare_dylint_js_1 = __nccwpck_require__(348);
-const install_passthrough_js_1 = __nccwpck_require__(547);
-const normalize_source_mtime_js_1 = __nccwpck_require__(260);
-const detect_shared_target_warning_js_1 = __nccwpck_require__(233);
-const ensure_shims_js_1 = __nccwpck_require__(560);
-const zccache_seed_js_1 = __nccwpck_require__(94);
-const cache_compress_js_1 = __nccwpck_require__(28);
-const cargo_registry_archive_js_1 = __nccwpck_require__(259);
-const seed_isolated_cache_js_1 = __nccwpck_require__(306);
-const stats_collector_js_1 = __nccwpck_require__(464);
-const toolchain_snapshot_js_1 = __nccwpck_require__(489);
-const solo_toolchain_cache_js_1 = __nccwpck_require__(195);
-const cook_cache_js_1 = __nccwpck_require__(8);
-const soldr_mini_cache_js_1 = __nccwpck_require__(3);
-const diagnostics_js_1 = __nccwpck_require__(498);
-const shim_bypass_check_js_1 = __nccwpck_require__(334);
-const blessed_cross_prepare_js_1 = __nccwpck_require__(13);
-const target_lifecycle_js_1 = __nccwpck_require__(256);
-const source_mtime_snapshot_js_1 = __nccwpck_require__(487);
-/**
- * Map (hit, matchedKey) → workflow-visible restore-status string.
- * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
- * for the `<layer>-cache-restore-status` outputs declared in action.yml.
- */
-function deriveRestoreStatus(hit, matchedKey) {
-    if (hit)
-        return "exact-hit";
-    if (matchedKey.trim())
-        return "restore-key-hit";
-    return "miss";
-}
-function shouldSkipCargoRegistryExtractionError(err, format, onFailure) {
-    if (format !== "legacy-v1" || onFailure?.trim().toLowerCase() !== "skip")
-        return false;
-    const code = err?.code;
-    return code === "EAUTHFAIL" || code === "EENCNOKEY";
-}
-function writeCacheKeysManifest(result, runnerTemp, log) {
-    if (!runnerTemp)
-        return;
-    const keys = [
-        result.setupCache.key,
-        result.buildCache.key,
-        result.targetCache.key,
-        result.cargoRegistryCache.key,
-    ].filter((k) => Boolean(k));
-    if (keys.length === 0)
-        return;
-    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
-    try {
-        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
-        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
-    }
-    catch (err) {
-        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-}
-const TRUTHY = new Set(["1", "true", "yes", "on"]);
-const FALSY = new Set(["0", "false", "no", "off"]);
-function isTruthy(value) {
-    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
-}
-function isFalsy(value) {
-    return FALSY.has(((value ?? "").trim().toLowerCase()));
-}
-function fileExists(p) {
-    try {
-        return fs.statSync(p).isFile();
-    }
-    catch {
-        return false;
-    }
-}
-async function queryTargetPlan(soldrPath, target, log) {
-    const output = await exec.getExecOutput(soldrPath, ["env", "--target", target, "--json"], {
-        silent: true,
-        ignoreReturnCode: true,
-    });
-    if (output.exitCode !== 0) {
-        log(`target-plan: soldr env failed with exit ${output.exitCode}`);
-        return null;
-    }
-    const line = output.stdout.split(/\r?\n/).map((value) => value.trim()).filter(Boolean).at(-1);
-    if (!line)
-        return null;
-    try {
-        return JSON.parse(line);
-    }
-    catch {
-        log("target-plan: soldr env returned non-JSON output");
-        return null;
-    }
-}
-function publishTargetContract(result, contract, logger) {
-    const target = result.blessedPrepareCache.target;
-    if (!target)
-        return;
-    if (!contract.cacheIdentity)
-        throw new Error(`Soldr target plan for ${target} has no cache identity`);
-    (0, target_lifecycle_js_1.assertTargetOperationSupported)(contract, "prepare");
-    result.targetContract = contract;
-    const mergedEnvironment = (0, target_lifecycle_js_1.mergeTargetEnvironment)(process.env, contract.environment);
-    for (const key of Object.keys(contract.environment)) {
-        core.exportVariable(key, mergedEnvironment[key] ?? contract.environment[key]);
-    }
-    const outputs = (0, target_lifecycle_js_1.buildTargetOperationOutputs)(result.workspace, contract);
-    core.setOutput("target-plan-json", JSON.stringify(contract));
-    core.setOutput("target-capabilities-json", JSON.stringify({
-        schemaVersion: contract.schemaVersion,
-        canonicalTarget: contract.canonicalTarget,
-        cacheIdentity: contract.cacheIdentity,
-        supportedOperations: contract.supportedOperations,
-        toolchain: contract.toolchain,
-        platform: contract.platform,
-    }));
-    core.setOutput("target-env-json", JSON.stringify(contract.environment));
-    core.setOutput("target-cache-identity", contract.cacheIdentity);
-    core.setOutput("target-artifact-dir", outputs.artifactDirectory);
-    core.setOutput("target-build-hook", outputs.build);
-    core.setOutput("target-clippy-hook", outputs.clippy);
-    core.setOutput("target-test-hook", outputs.testNoRun);
-    core.setOutput("target-wheel-hook", outputs.pep517Wheel);
-    core.setOutput("target-sdist-hook", outputs.pep517Sdist);
-    core.saveState("targetPlanJson", JSON.stringify(contract));
-    logger.log(`target-plan: canonical=${contract.canonicalTarget} cache=${contract.cacheIdentity} operations=${contract.supportedOperations.join(",")}`);
-}
-function dirHasContent(p) {
-    try {
-        return fs.readdirSync(p).length > 0;
-    }
-    catch {
-        return false;
-    }
-}
-async function runGitCapture(workspace, args) {
-    let stdout = "";
-    let stderr = "";
-    const code = await exec.exec("git", ["-C", workspace, ...args], {
-        silent: true,
-        ignoreReturnCode: true,
-        listeners: {
-            stdout: (data) => { stdout += data.toString("utf8"); },
-            stderr: (data) => { stderr += data.toString("utf8"); },
-        },
-    });
-    return { code, stdout, stderr };
-}
-async function deriveParentSha(workspace, githubSha, logger) {
-    // #365: derive parent SHA so cook-cache-delta + target-cache +
-    // cargo-registry can fall back to the prior commit's saved
-    // entry. Returns "" on any error (no regression from prior
-    // behavior — caller treats "" as "no fallback").
-    //
-    // Strategy: try `git log -1 --format=%P HEAD` first. On a
-    // shallow clone (actions/checkout default fetch-depth=1) this
-    // returns empty for grafted root commits — fall back to
-    // `git cat-file -p HEAD` and parse the `parent` header lines
-    // from the raw commit object, which are preserved even when
-    // the parent commit object isn't present in the local repo.
-    // Pass 1: git log %P (works on full-depth checkouts).
-    try {
-        const { code, stdout, stderr } = await runGitCapture(workspace, [
-            "log", "-1", "--format=%P", "HEAD",
-        ]);
-        if (code === 0) {
-            const first = stdout.trim().split(/\s+/)[0] ?? "";
-            if (/^[0-9a-f]{7,40}$/i.test(first)) {
-                if (first === githubSha)
-                    return "";
-                logger.log(`parent-sha: derived ${first.slice(0, 12)} from git log (#365)`);
-                return first;
-            }
-            // empty / unparseable → fall through to cat-file
-        }
-        else {
-            logger.log(`parent-sha: git log exit=${code} stderr=${stderr.trim().slice(0, 120)}; trying cat-file`);
-        }
-    }
-    catch (err) {
-        logger.log(`parent-sha: git log threw (${err instanceof Error ? err.message : String(err)}); trying cat-file`);
-    }
-    // Pass 2: git cat-file -p HEAD (works on shallow clones — the
-    // commit object's `parent` header is preserved even when the
-    // parent commit isn't fetched).
-    try {
-        const { code, stdout, stderr } = await runGitCapture(workspace, [
-            "cat-file", "-p", "HEAD",
-        ]);
-        if (code !== 0) {
-            logger.log(`parent-sha: cat-file exit=${code} stderr=${stderr.trim().slice(0, 120)}; leaving empty`);
-            return "";
-        }
-        // Raw commit object format:
-        //   tree <sha>
-        //   parent <sha>      ← first parent (mainline)
-        //   parent <sha>      ← second parent (only for merges)
-        //   author ...
-        //   committer ...
-        //
-        //   <message>
-        for (const line of stdout.split("\n")) {
-            if (line.startsWith("parent ")) {
-                const sha = line.slice("parent ".length).trim();
-                if (/^[0-9a-f]{7,40}$/i.test(sha) && sha !== githubSha) {
-                    logger.log(`parent-sha: derived ${sha.slice(0, 12)} from cat-file (#365, shallow-safe)`);
-                    return sha;
-                }
-            }
-            if (line === "")
-                break; // header section ended
-        }
-        logger.log(`parent-sha: cat-file produced no usable parent (root commit?); leaving empty`);
-        return "";
-    }
-    catch (err) {
-        logger.log(`parent-sha: cat-file threw (${err instanceof Error ? err.message : String(err)}); leaving empty`);
-        return "";
-    }
-}
-async function buildActionContext() {
-    const env = process.env;
-    const logger = (0, log_utils_js_1.createLogger)(env);
-    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
-    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
-    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
-    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
-    const githubSha = env["GITHUB_SHA"]?.trim() || "";
-    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
-    // #365: parentSha enables cook-cache-delta + target-cache + cargo-
-    // registry to share entries across consecutive commits. The env
-    // override (ACTION_PARENT_SHA) lets a workflow set it explicitly;
-    // otherwise we derive it from `git log -1 --format=%P HEAD` so the
-    // fallback works out of the box for any repo with non-shallow
-    // checkout. Without this, every push-event run had the delta key
-    // mismatch the prior save (0% hit rate observed on zccache).
-    let parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
-    if (!parentSha && githubSha) {
-        parentSha = await deriveParentSha(workspace, githubSha, logger);
-    }
-    return {
-        env: { ...env },
-        workspace,
-        runnerTemp,
-        runnerOs,
-        runnerArch,
-        githubSha,
-        githubToken,
-        parentSha,
-        logger,
-    };
-}
-function actionRoot() {
-    const explicit = process.env["GITHUB_ACTION_PATH"]?.trim() || process.env["SETUP_SOLDR_ACTION_ROOT"]?.trim();
-    if (explicit)
-        return path.resolve(explicit);
-    const moduleDir = typeof __dirname === "string" ? __dirname : process.cwd();
-    return path.resolve(moduleDir, "..");
-}
-async function restoreCacheSafe(paths, key, restoreKeys, logger) {
-    if (paths.length === 0 || !key) {
-        return { hit: false, matchedKey: "" };
-    }
-    try {
-        const matched = await cache.restoreCache(paths, key, restoreKeys);
-        return { hit: matched === key, matchedKey: matched ?? "" };
-    }
-    catch (err) {
-        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
-        return { hit: false, matchedKey: "" };
-    }
-}
-async function run() {
-    const ctx = await buildActionContext();
-    const logger = ctx.logger;
-    await (0, phase_timing_js_1.markPhase)("action");
-    // ---- resolve ----
-    await (0, phase_timing_js_1.markPhase)("resolve");
-    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
-    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
-    await (0, resolve_setup_js_1.applyResolveResult)(result);
-    await (0, phase_timing_js_1.finishPhase)("resolve");
-    // Always emit the cache-keys manifest right after resolve so workflow
-    // steps that run between main and post (e.g. actions/upload-artifact)
-    // can read it. The four keys are fully determined by resolveSetup and
-    // never change later in the run.
-    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
-    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            logger,
-            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
-        });
-    }
-    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
-    if (dryRun) {
-        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
-        await (0, phase_timing_js_1.finishPhase)("action");
-        return;
-    }
-    // Persist resolve state for the post-job step.
-    core.saveState("resolveResult", JSON.stringify(result));
-    core.saveState("buildCacheMode", result.buildCache.mode);
-    core.saveState("logging", logging ? "true" : "false");
-    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
-    const statsMode = result.stats;
-    const debugMode = result.debugMode;
-    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
-    const statsCollector = new stats_collector_js_1.StatsCollector();
-    // ---- source-mtime-normalize ----
-    if (isTruthy(inputs.sourceMtimeNormalize)) {
-        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
-    }
-    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
-    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
-    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
-    core.saveState("setupCacheExactHit", "false");
-    core.saveState("setupCacheMatchedKey", "");
-    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
-    core.saveState("targetCacheExactHit", "false");
-    core.saveState("targetCacheMatchedKey", "");
-    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
-    core.saveState("buildCacheExactHit", "false");
-    core.saveState("buildCacheMatchedKey", "");
-    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
-    core.saveState("cargoRegistryCacheExactHit", "false");
-    core.saveState("cargoRegistryCacheMatchedKey", "");
-    core.saveState("dylintCacheEnabled", result.dylintCache.enabled ? "true" : "false");
-    core.saveState("dylintCacheExactHit", "false");
-    core.saveState("dylintCacheMatchedKey", "");
-    core.saveState("dylintOutputCacheEnabled", result.dylintCache.outputCacheEnabled ? "true" : "false");
-    core.saveState("dylintOutputCacheExactHit", "false");
-    core.saveState("dylintOutputCacheMatchedKey", "");
-    core.saveState("blessedPrepareCacheEnabled", result.blessedPrepareCache.enabled ? "true" : "false");
-    core.saveState("blessedPrepareCacheExactHit", "false");
-    core.saveState("blessedPrepareCacheMatchedKey", "");
-    core.saveState("blessedPrepareComplete", "false");
-    // ---- parallel restores ----
-    // setup-cache, target-cache, build-cache, and cargo-registry write to
-    // disjoint paths and have no inter-dependencies, so they run concurrently.
-    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
-    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
-    //
-    // Layers that must stay sequential (wired below): solo-toolchain (writes
-    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
-    // install dir, must precede ensureSoldr), cook (writes target/ and needs
-    // the soldr binary). Cargo-registry was previously after-cook — it's been
-    // moved into this parallel block because nothing the soldr install path
-    // touches depends on its hydrated cargo registry state.
-    await (0, phase_timing_js_1.markPhase)("parallel-restore");
-    let setupCacheExactHit = false;
-    // Capture target-cache match status so we can skip the redundant cook restore.
-    // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
-    // (~2.5 GB inflated) also contains compiled deps. When target-cache matched
-    // at the lockfile/shape/toolchain level (exact OR parent-SHA OR lock-prefix
-    // fallback), we have target/deps/ already populated with identical content —
-    // cook restore would just overwrite. Skipping saves ~5–10 s per warm run.
-    // A looser restoreKeyLockfile-only match (different shape) is NOT enough to
-    // skip cook, since cook output may differ across shapes.
-    let targetCacheMatchedKey = "";
-    const setupRestorePromise = (async () => {
-        if (!(cacheEnabled && result.setupCache.paths.length > 0))
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
-        setupCacheExactHit = restore.hit;
-        core.setOutput("cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("setup_cache_matched_key", restore.matchedKey);
-        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("setupCacheMatchedKey", restore.matchedKey);
-        // Expose for ensure_rust_toolchain to read via env. Must be visible by
-        // the time toolchain phase runs — guaranteed by the Promise.all below.
-        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
-        statsCollector.record({
-            label: "setup-cache", operation: "restore", hit: restore.hit,
-            key: result.setupCache.key, matchedKey: restore.matchedKey,
-            restoreKeys: [result.setupCache.restorePrefix],
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const targetRestorePromise = (async () => {
-        if (!result.targetCache.enabled)
-            return;
-        const targetPaths = result.targetCache.paths
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        if (targetPaths.length === 0)
-            return;
-        const restoreKeys = [];
-        if (result.targetCache.restoreKeyParent)
-            restoreKeys.push(result.targetCache.restoreKeyParent);
-        if (result.targetCache.restoreKeyLock)
-            restoreKeys.push(result.targetCache.restoreKeyLock);
-        if (result.targetCache.restoreKeyLockfile)
-            restoreKeys.push(result.targetCache.restoreKeyLockfile);
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
-        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("target_cache_matched_key", restore.matchedKey);
-        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("targetCacheMatchedKey", restore.matchedKey);
-        targetCacheMatchedKey = restore.matchedKey;
-        statsCollector.record({
-            label: "target-cache", operation: "restore", hit: restore.hit,
-            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: null, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        if (debugMode)
-            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const buildRestorePromise = (async () => {
-        if (!buildCacheEnabled)
-            return;
-        const buildCachePath = result.buildCache.path;
-        const archivePath = `${buildCachePath}.tar.zst`;
-        const restoreKeys = [];
-        if (result.buildCache.restoreKeyParent)
-            restoreKeys.push(result.buildCache.restoreKeyParent);
-        if (result.buildCache.restoreKeyToolchain)
-            restoreKeys.push(result.buildCache.restoreKeyToolchain);
-        if (result.buildCache.restoreKeyOsArch)
-            restoreKeys.push(result.buildCache.restoreKeyOsArch);
-        const t0 = Date.now();
-        // @actions/cache hashes the `paths` array into a "version" key — save and
-        // restore MUST pass the same array or the lookup misses even when the
-        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
-        // restore must use the same single-path array. The decompression below
-        // unpacks archivePath → buildCachePath afterwards.
-        let restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
-        let buildArchiveBytes = null;
-        let buildInflatedBytes = null;
-        let buildFileCount = null;
-        if (restore.matchedKey) {
-            try {
-                buildArchiveBytes = fs.statSync(archivePath).size;
-            }
-            catch {
-                buildArchiveBytes = 0;
-            }
-            if (buildArchiveBytes === 0) {
-                logger.warning(`build-cache: matched key ${restore.matchedKey} produced an unusable payload: ` +
-                    `archive=0B; treating as miss`);
-                restore = { hit: false, matchedKey: "" };
-            }
-        }
-        if (restore.matchedKey && fileExists(archivePath)) {
-            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
-            const haveEncryptKey = (process.env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] ?? "").trim().length > 0;
-            if (magic === "zstd" || magic === "gzip" || haveEncryptKey) {
-                try {
-                    const dr = await (0, cache_compress_js_1.decompressCache)({
-                        archivePath,
-                        targetDir: buildCachePath,
-                        debug: debugMode,
-                        log: debugLog,
-                        cacheKey: restore.matchedKey || result.buildCache.key,
-                    });
-                    buildArchiveBytes = dr.archiveBytes;
-                    buildInflatedBytes = dr.inflatedBytes;
-                    buildFileCount = dr.fileCount;
-                    if (dr.fileCount === 0) {
-                        logger.warning(`build-cache: matched key ${restore.matchedKey} produced an unusable payload: ` +
-                            `archive=${dr.archiveBytes}B extracted_files=0 extracted_bytes=${dr.inflatedBytes}; treating as miss`);
-                        restore = { hit: false, matchedKey: "" };
-                    }
-                }
-                catch (err) {
-                    logger.warning(`build-cache: matched key ${restore.matchedKey} produced an unusable payload: ` +
-                        `archive=${buildArchiveBytes ?? 0}B decompress failed: ${err instanceof Error ? err.message : String(err)}; treating as miss`);
-                    restore = { hit: false, matchedKey: "" };
-                }
-            }
-            else {
-                logger.warning(`build-cache: matched key ${restore.matchedKey} produced an unusable payload: ` +
-                    `archive=${buildArchiveBytes ?? 0}B codec=unknown; treating as miss`);
-                restore = { hit: false, matchedKey: "" };
-            }
-        }
-        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("build_cache_matched_key", restore.matchedKey);
-        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("buildCacheMatchedKey", restore.matchedKey);
-        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
-        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
-        // dir on the cold side; if it's present after decompress, walk it and
-        // set each matching source file's mtime to what cold saw. The replay
-        // is gated by (size, content-hash) match so we never overwrite a
-        // genuinely modified file's mtime — that would underbuild.
-        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
-            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
-            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
-            if (snapshot) {
-                const rt0 = Date.now();
-                try {
-                    // Match the project-root selection that post.ts uses when
-                    // writing the snapshot — the parent of the resolved target-dir,
-                    // not the (outer) GITHUB_WORKSPACE.
-                    const projectRoot = path.dirname(result.targetCache.targetPath);
-                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
-                        workspace: projectRoot,
-                        snapshot,
-                        log: (msg) => logger.log(msg),
-                    });
-                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
-                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
-                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
-                }
-                catch (err) {
-                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-            else {
-                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
-            }
-        }
-        statsCollector.record({
-            label: "build-cache", operation: "restore", hit: restore.hit,
-            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
-            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-        // Seed an isolated SOLDR_CACHE_DIR from the just-restored build-cache
-        // artifact store (issue #240). Opt-in: only fires when the consumer
-        // declares the isolated root(s) it switches its self-test phase to, so a
-        // daemon-isolated coverage/integration phase starts warm instead of cold.
-        const seedTargets = (0, seed_isolated_cache_js_1.parseIsolatedSeedTargets)(inputs.seedIsolatedBuildCache);
-        if (seedTargets.length > 0) {
-            try {
-                (0, seed_isolated_cache_js_1.seedIsolatedBuildCache)({
-                    sourceZccacheDir: buildCachePath,
-                    targetSoldrRoots: seedTargets,
-                    log: (msg) => logger.log(msg),
-                });
-            }
-            catch (err) {
-                logger.log(`seed-isolated-build-cache: failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        }
-    })();
-    let cargoRegistryDownload = null;
-    // Download only. Archive extraction is deliberately deferred until after
-    // ensureSoldr() + runtime verification because soldr-v2 needs the installed
-    // binary and must never race its setup-cache/mini-cache restore.
-    const cargoRegistryRestorePromise = (async () => {
-        if (!result.cargoRegistryCache.enabled)
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.cargoRegistryCache.archive.restorePaths, result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
-        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
-        cargoRegistryDownload = { hit: restore.hit, matchedKey: restore.matchedKey, startedMs: t0 };
-    })();
-    const blessedPrepareRestorePromise = (async () => {
-        const plan = result.blessedPrepareCache;
-        if (!plan.enabled)
-            return;
-        const t0 = Date.now();
-        const restored = await restoreCacheSafe(plan.archivePaths, plan.key, plan.restoreKeys, logger);
-        const restore = (0, blessed_cross_prepare_js_1.validateBlessedPrepareRestore)({
-            ...restored,
-            archivePaths: plan.archivePaths,
-            warn: (message) => logger.warning(message),
-        });
-        core.saveState("blessedPrepareCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("blessedPrepareCacheMatchedKey", restore.matchedKey);
-        core.setOutput("blessed-prepare-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("blessed-prepare-cache-key", plan.key);
-        statsCollector.record({
-            label: "blessed-prepare-cache", operation: "restore", hit: restore.hit,
-            key: plan.key, matchedKey: restore.matchedKey, restoreKeys: plan.restoreKeys,
-            archiveBytes: restore.archiveBytes, inflatedBytes: null, fileCount: null,
-            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
-        });
-    })();
-    const dylintRestorePromise = (async () => {
-        if (!result.dylintCache.enabled)
-            return;
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.dylintCache.paths, result.dylintCache.key, [], logger);
-        core.setOutput("dylint-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("dylint-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.setOutput("dylint_cache_hit", restore.hit ? "true" : "false");
-        core.setOutput("dylint_cache_matched_key", restore.matchedKey);
-        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_HIT", restore.hit ? "true" : "false");
-        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_MATCHED_KEY", restore.matchedKey);
-        core.saveState("dylintCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("dylintCacheMatchedKey", restore.matchedKey);
-        statsCollector.record({
-            label: "dylint-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: result.dylintCache.key,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - t0,
-            timestamp: new Date().toISOString(),
-        });
-        logger.log(`dylint-cache: key=${result.dylintCache.key} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    const dylintOutputRestorePromise = (async () => {
-        if (!result.dylintCache.outputCacheEnabled || result.dylintCache.outputPaths.length === 0) {
-            return;
-        }
-        const t0 = Date.now();
-        const restore = await restoreCacheSafe(result.dylintCache.outputPaths, result.dylintCache.outputKey, [], logger);
-        core.setOutput("dylint-output-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("dylint-output-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
-        core.saveState("dylintOutputCacheExactHit", restore.hit ? "true" : "false");
-        core.saveState("dylintOutputCacheMatchedKey", restore.matchedKey);
-        statsCollector.record({
-            label: "dylint-output-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: result.dylintCache.outputKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - t0,
-            timestamp: new Date().toISOString(),
-        });
-        logger.log(`dylint-output-cache: key=${result.dylintCache.outputKey} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
-    })();
-    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
-    // try/catches, so this should only see rejections for genuine programming
-    // bugs.
-    await Promise.all([
-        setupRestorePromise,
-        targetRestorePromise,
-        buildRestorePromise,
-        cargoRegistryRestorePromise,
-        blessedPrepareRestorePromise,
-        dylintRestorePromise,
-        dylintOutputRestorePromise,
-    ]);
-    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
-    // ---- target-tree-cache (full mode) ----
-    // The bundle path is included in target-cache restore paths above when full
-    // mode is requested, so there's no separate restore here. We keep the phase
-    // marker for parity with the composite step ordering.
-    await (0, phase_timing_js_1.markPhase)("target-tree");
-    await (0, phase_timing_js_1.finishPhase)("target-tree");
-    // Plan soldr-mini-cache restore now, but perform the extract inside the
-    // install phase. Restoring this layer in the background can rewrite the
-    // install dir while later phases spawn PATH tools, which surfaced as Linux
-    // ETXTBSY on the warm demo after soldr-cook started invoking soldr earlier.
-    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
-    const miniInstallDir = path.dirname(result.soldrPath);
-    const miniArchive = `${miniInstallDir}.tar.zst`;
-    let miniHit = false;
-    let miniKey = "";
-    let miniSkipReason = "";
-    let miniRestoreEligible = false;
-    if (miniEnabled) {
-        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
-            hasRef: Boolean(result.soldrRef.trim()),
-            enable: result.enabled,
-            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
-        });
-        if (eligibility.eligible) {
-            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
-            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
-                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-                soldrVersion: version,
-            });
-            miniRestoreEligible = true;
-            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir}`);
-        }
-        else {
-            miniSkipReason = eligibility.reason;
-        }
-    }
-    // Kick off cook restore in the background. It overlaps with the
-    // sequential toolchain + soldr install + shims + verify steps that
-    // follow. By the time the cook phase runs, the restore is done — we
-    // just await the promise. Saves ~5–7 s of warm-build wall clock.
-    //
-    // Why this is safe (vs the disastrous PR #145 which added cook to the
-    // BIG parallel block): cook now races with SMALL ops (rust install
-    // ~1–2 s, soldr install ~2–3 s, shims/verify ~1–2 s). Those don't
-    // contend on disk write bandwidth the way target/build/cargo-registry
-    // restores did. Cook's 2.5 GB tar write becomes the long pole and
-    // hides behind the small ops.
-    //
-    // SAFETY: when target-cache writes to target/ (build-cache-mode: full),
-    // cook restore would race with target-cache restore on the same dir.
-    // The parallel-restore block above already finished target-cache, but
-    // we still want a runtime gate just in case the mode changes.
-    const cookGate = (0, cook_cache_js_1.decideCookGate)({
-        prebuildDeps: inputs.prebuildDeps,
-        cacheUmbrella: cacheEnabled,
-        lockfilePath: result.targetCache.lockfilePath,
-    });
-    const cookActive = cookGate.enabled && result.enabled;
-    let cookFlags = [];
-    let cookKey = "";
-    let cookBaseKey = "";
-    let cookDeltaKey = "";
-    let cookDeltaParentKey = "";
-    let cookDeltaRestoreKeys = [];
-    let cookProjectRoot = "";
-    let cookTargetDir = "";
-    let cookArchive = "";
-    let cookBaseArchive = "";
-    let cookDeltaArchive = "";
-    let cookBaseManifest = "";
-    let cookLayered = false;
-    core.setOutput("cook-cache-hit", "false");
-    core.setOutput("cook-cache-base-hit", "false");
-    core.setOutput("cook-cache-delta-hit", "false");
-    core.setOutput("cook-cache-status", cookActive ? "miss" : "disabled");
-    core.setOutput("cook-cache-load-report-json", "{}");
-    let cookRestoreT0 = Date.now();
-    let cookRestorePromise = null;
-    let cookLayeredRestorePromise = null;
-    // Skip cook restore when target-cache matched at the lockfile/shape level.
-    // restoreKeyLock = `${prefix}-${targetInputsHash}-${suffix}-` where
-    // targetInputsHash = sha256(toolchain, lockfile, manifest, shape). A
-    // matchedKey starting with restoreKeyLock means the cached entry was built
-    // with the same toolchain + lockfile + shape — its target/deps/ matches
-    // what cook would restore. Covers:
-    //   - exact hit  (matchedKey === current key, also startsWith restoreKeyLock)
-    //   - parent-SHA hit (matchedKey === restoreKeyParent, also startsWith)
-    //   - lock-prefix fallback (any saved entry with same lockfile+shape)
-    // Does NOT cover restoreKeyLockfile fallback (shorter prefix that drops
-    // shape) — different shape may mean different cook output, so cook still
-    // runs there as the safety net.
-    const targetCacheLockMatch = !!targetCacheMatchedKey &&
-        !!result.targetCache.restoreKeyLock &&
-        targetCacheMatchedKey.startsWith(result.targetCache.restoreKeyLock);
-    const cookSkippedDueToTargetHit = cookActive && targetCacheLockMatch;
-    if (cookActive && !cookSkippedDueToTargetHit) {
-        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
-        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
-        const lockHash = result.targetCache.lockfileHash || "no-lock";
-        const cookKeyParts = {
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            flagsHash,
-            lockHash,
-            soldrVersion: result.soldrSourceIdentity.trim() ||
-                result.soldrVersionResolved.trim() ||
-                result.soldrVersionRequested.trim() ||
-                "unset",
-            keySuffix: inputs.cacheKeySuffix.trim(),
-        };
-        cookProjectRoot = path.dirname(result.targetCache.targetPath);
-        cookTargetDir = result.targetCache.targetPath;
-        cookRestoreT0 = Date.now();
-        const deltaInput = inputs.prebuildDepsDeltaCache.trim() || "true";
-        const deltaRequested = !isFalsy(deltaInput);
-        const soldrVersionForCook = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
-        cookLayered = deltaRequested && (0, cook_cache_js_1.supportsLayeredCookCache)(soldrVersionForCook);
-        if (cookLayered) {
-            const shapeHash = (0, cook_cache_js_1.hashCookBuildShape)(result.targetCache.restoreKeyLock || result.targetCache.key);
-            cookBaseKey = (0, cook_cache_js_1.buildCookBaseCacheKey)(cookKeyParts);
-            cookDeltaKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
-                ...cookKeyParts,
-                buildShapeHash: shapeHash,
-                githubSha: ctx.githubSha || "nosha",
-            });
-            if (ctx.parentSha && ctx.parentSha !== ctx.githubSha) {
-                cookDeltaParentKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
-                    ...cookKeyParts,
-                    buildShapeHash: shapeHash,
-                    githubSha: ctx.parentSha,
-                });
-            }
-            cookDeltaRestoreKeys = cookDeltaParentKey ? [cookDeltaParentKey] : [];
-            cookDeltaRestoreKeys.push((0, cook_cache_js_1.buildCookDeltaCacheRestorePrefix)({
-                ...cookKeyParts,
-                buildShapeHash: shapeHash,
-            }));
-            cookBaseArchive = `${cookTargetDir}.soldr-base.tar.zst`;
-            cookDeltaArchive = `${cookTargetDir}.soldr-delta.tar.zst`;
-            cookBaseManifest = `${cookTargetDir}.soldr-base-manifest.pb`;
-            logger.log(`cook: layered keys base=${cookBaseKey} delta=${cookDeltaKey}` +
-                (cookDeltaParentKey ? ` delta-fallback=${cookDeltaParentKey}` : ` (no parent-fallback — parentSha unavailable, #365)`) +
-                ` delta-prefix=${cookDeltaRestoreKeys.at(-1)}` +
-                ` starting archive restore concurrent with install`);
-            cookLayeredRestorePromise = (0, cook_cache_js_1.restoreLayeredCookCacheArchives)({
-                baseKey: cookBaseKey,
-                deltaKey: cookDeltaKey,
-                deltaRestoreKeys: cookDeltaRestoreKeys,
-                baseArchivePath: cookBaseArchive,
-                deltaArchivePath: cookDeltaArchive,
-                log: (msg) => logger.log(msg),
-                warn: (msg) => logger.warning(msg),
-            });
-        }
-        else {
-            if (deltaRequested) {
-                logger.log(`cook: layered cache requires soldr >=0.7.38; ` +
-                    `version=${soldrVersionForCook || "unknown"} falling back to legacy cook cache`);
-            }
-            else {
-                logger.log("cook: layered cache disabled via prebuild-deps-delta-cache=false");
-            }
-            cookKey = (0, cook_cache_js_1.buildCookCacheKey)(cookKeyParts);
-            cookArchive = `${cookTargetDir}.tar.zst`;
-            logger.log(`cook: key=${cookKey} starting background restore concurrent with install`);
-            cookRestorePromise = (0, cook_cache_js_1.restoreCookCache)({
-                exactKey: cookKey,
-                archivePath: cookArchive,
-                targetDir: cookTargetDir,
-                longWindow: 27,
-                debug: debugMode,
-                log: (msg) => logger.log(msg),
-                warn: (msg) => logger.warning(msg),
-            });
-        }
-    }
-    // ---- toolchain ----
-    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
-    // toolchain install so we can see which inodes setup-soldr added on
-    // top of the runner image. When solo-toolchain-cache is opted in, a
-    // third snapshot is taken *before* the cache restore so the saved
-    // tarball captures the full above-runner state — not just the
-    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
-    // lifetime axis".
-    await (0, phase_timing_js_1.markPhase)("toolchain");
-    const snapshotRoots = [
-        path.join(result.rustupHome, "toolchains"),
-        path.join(result.cargoHome, "bin"),
-    ];
-    const soloRootMap = {
-        "rustup-toolchains": snapshotRoots[0],
-        "cargo-bin": snapshotRoots[1],
-    };
-    const soloEnabled = isTruthy(inputs.soloToolchainCache);
-    // #310: default-changed from "19" → "9". Measured first-save cost
-    // dropped from ~104s → ~12s on 140 MB toolchain delta; restore stays
-    // bandwidth-bound either way.
-    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "9");
-    let soloKeys = null;
-    let soloMatchedKey = "";
-    let soloExactHit = false;
-    let forceToolchainRepair = false;
-    let soloRestoreInvalid = false;
-    let soloRestoredBytes = 0;
-    // Pre-restore snapshot — only needed when solo cache is enabled, so
-    // we can compute the full save-diff (post-install vs runner-image,
-    // not vs post-restore baseline). (#302: timed as sub-phase.)
-    const preRestoreSnapshot = soloEnabled
-        ? await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-pre", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots))
-        : null;
-    if (soloEnabled) {
-        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
-            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
-            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
-            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
-            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
-            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
-            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
-            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
-        });
-        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
-        const restoreT0 = Date.now();
-        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
-        const restored = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "solo-restore", () => (0, solo_toolchain_cache_js_1.restoreSoloCache)({
-            keys: soloKeys,
-            rootMap: soloRootMap,
-            stagingDir,
-            log: (msg) => logger.log(msg),
-            // #316 follow-up: pass canonical archive path explicitly so
-            // save and restore agree regardless of stagingDir layout.
-            cacheArchivePath: (0, solo_toolchain_cache_js_1.soloCacheArchivePath)(ctx.runnerTemp),
-        }));
-        soloMatchedKey = restored.matchedKey;
-        soloRestoredBytes = restored.restoredBytes;
-        let verifiedMatch = true;
-        if (restored.verified && restored.matchedKey) {
-            const expected = result.toolchain.cacheChannel.trim();
-            // The rustup home is set up so `rustc` will resolve through the
-            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
-            // the cargo bin one.
-            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
-            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
-                expectedRelease: expected,
-                expectedTargets: result.toolchain.targets,
-                expectedComponents: result.toolchain.components,
-                channel: result.toolchain.channel,
-                rustupCommand: process.platform === "win32" ? "rustup.exe" : "rustup",
-                log: (msg) => logger.log(msg),
-            });
-            verifiedMatch = verify.match;
-        }
-        soloRestoreInvalid = Boolean(restored.matchedKey) && (!restored.verified || !verifiedMatch);
-        forceToolchainRepair = soloRestoreInvalid;
-        if (soloRestoreInvalid) {
-            core.warning(`solo-toolchain-cache: restored entry failed validation; key=${restored.matchedKey} ` +
-                `archive=${restored.restoredBytes}B. The requested toolchain and targets will be repaired, ` +
-                `then the poisoned cache entry will be deleted and replaced (#473).`);
-        }
-        soloExactHit = restored.hit && restored.verified && verifiedMatch;
-        core.saveState("soloToolchainEnabled", "true");
-        core.saveState("soloToolchainExactKey", soloKeys.exact);
-        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
-        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
-        core.saveState("soloToolchainRestoreInvalid", soloRestoreInvalid ? "true" : "false");
-        core.saveState("soloToolchainInvalidMatchedKey", soloRestoreInvalid ? soloMatchedKey : "");
-        core.saveState("soloToolchainRestoredBytes", String(soloRestoredBytes));
-        core.saveState("soloToolchainLevel", soloLevel);
-        statsCollector.record({
-            label: "solo-toolchain-cache",
-            operation: "restore",
-            hit: soloExactHit,
-            key: soloKeys.exact,
-            matchedKey: soloMatchedKey,
-            restoreKeys: soloKeys.fallbacks,
-            archiveBytes: restored.restoredBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - restoreT0,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else {
-        core.saveState("soloToolchainEnabled", "false");
-        core.saveState("soloToolchainRestoreInvalid", "false");
-    }
-    const baselineSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-base", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
-    // #323: when solo-cache exact-hit AND verifyRestoredToolchain
-    // passed, the requested toolchain is already on disk from the
-    // restore. `rustup toolchain install` would be a no-op but still
-    // costs ~8s on hosted runners (self-update check, metadata fetch,
-    // profile diff). Skip the install entirely on the verified
-    // exact-hit path. The snapshot still runs so cache-save logic
-    // downstream sees an unchanged tree (install-delta empty).
-    if (soloExactHit) {
-        logger.log("toolchain: solo-cache exact-hit + verified — skipping rustup install (#323)");
-        // The restored tree is already valid, but the skipped installer is also
-        // where ensureRustToolchain normally exports the selected channel. Keep
-        // cache-hit jobs explicit so rustup proxies used by later probes never
-        // depend on a runner-global default toolchain.
-        core.exportVariable("RUSTUP_TOOLCHAIN", result.toolchain.channel);
-        process.env["RUSTUP_TOOLCHAIN"] = result.toolchain.channel;
-    }
-    else {
-        await (0, phase_timing_js_1.timeSubPhase)("toolchain", "rustup-install", () => (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({
-            resolveResult: result,
-            setupCacheExactHit,
-            forceRepair: forceToolchainRepair,
-        }));
-        if (forceToolchainRepair) {
-            const repaired = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
-                expectedRelease: result.toolchain.cacheChannel.trim(),
-                expectedTargets: result.toolchain.targets,
-                expectedComponents: result.toolchain.components,
-                channel: result.toolchain.channel,
-                rustupCommand: process.platform === "win32" ? "rustup.exe" : "rustup",
-                log: (msg) => logger.log(msg),
-            });
-            if (!repaired.match) {
-                throw new Error(`solo-toolchain-cache: repair did not restore the requested toolchain and targets for key=${soloMatchedKey}`);
-            }
-            logger.log(`solo-toolchain-cache: repaired toolchain and requested targets verified for key=${soloMatchedKey}`);
-        }
-    }
-    const postInstallSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-post", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
-    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
-    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
-    // When solo cache is enabled, also compute the save-diff (post-install
-    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
-    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
-        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
-        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
-        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
-        try {
-            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
-            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
-            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
-            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
-                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
-                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
-                `incremental-empty=${toolchainDiff.added.length === 0}`);
-        }
-        catch (err) {
-            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
-    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
-        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
-    if (ctx.runnerTemp) {
-        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
-        try {
-            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
-            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
-        }
-        catch (err) {
-            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    await (0, phase_timing_js_1.finishPhase)("toolchain");
-    // ---- install soldr ----
-    // Restore soldr-mini-cache synchronously so the install dir is quiescent
-    // before ensureSoldr's installedVersion() check or any later soldr spawn.
-    await (0, phase_timing_js_1.markPhase)("install");
-    if (miniRestoreEligible) {
-        const miniT0 = Date.now();
-        const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
-            exactKey: miniKey,
-            installDir: miniInstallDir,
-            archivePath: miniArchive,
-            longWindow: 27,
-            debug: debugMode,
-            log: (msg) => logger.log(msg),
-            warn: (msg) => logger.warning(msg),
-            binaryPath: result.soldrPath,
-            expectedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
-        });
-        miniHit = restore.hit;
-        statsCollector.record({
-            label: "soldr-mini-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: miniKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - miniT0,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    else if (miniSkipReason) {
-        logger.log(`soldr-mini-cache: skipped — ${miniSkipReason}`);
-    }
-    else if (!miniEnabled) {
-        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
-    }
-    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
-    core.saveState("soldrMiniExactKey", miniKey);
-    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
-    core.saveState("soldrMiniInstallDir", miniInstallDir);
-    core.saveState("soldrMiniArchive", miniArchive);
-    if (result.enabled) {
-        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
-        // restored binary at the expected path with the expected version and
-        // short-circuits — no GH fetch.
-        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
-    }
-    else {
-        (0, install_passthrough_js_1.installPassthrough)({
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
-            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
-            "verbatim, and soldr-aware caching/observability is disabled.");
-    }
-    await (0, phase_timing_js_1.finishPhase)("install");
-    // ---- zccache-seed ----
-    // Pin setup-soldr's zccache before user workflow steps. The pinned
-    // install is home-anchored inside soldr, so later self-tests can isolate
-    // SOLDR_CACHE_DIR without repeating release lookup or cargo-install fallback.
-    await (0, phase_timing_js_1.markPhase)("zccache-seed");
-    await (0, zccache_seed_js_1.seedZccache)({
-        soldrPath: result.soldrPath,
-        actionRoot: actionRoot(),
-        enabled: result.enabled,
-        strict: isTruthy(inputs.zccacheSeedStrict),
-        log: (msg) => logger.log(msg),
-        warn: (msg) => logger.warning(msg),
-    });
-    await (0, phase_timing_js_1.finishPhase)("zccache-seed");
-    // Export SOLDR_BINARY so shims can exec it directly
-    core.exportVariable("SOLDR_BINARY", result.soldrPath);
-    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
-    // ---- shims ----
-    if (result.shimsEnabled) {
-        await (0, ensure_shims_js_1.ensureShims)({
-            shimsDir: result.shimsDir,
-            soldrPath: result.soldrPath,
-            isWindows: process.platform === "win32",
-            log: (msg) => logger.log(msg),
-        });
-    }
-    // ---- verify ----
-    await (0, phase_timing_js_1.markPhase)("verify");
-    let soldrRuntimeVersion = "passthrough";
-    if (result.enabled) {
-        const verify = await (0, verify_soldr_js_1.verifySoldr)({
-            soldrPath: result.soldrPath,
-            buildCacheMode: result.buildCache.mode,
-            requireRustPlan: result.targetCache.enabled,
-            minimumVersion: result.blessedPrepareCache.target ? "0.8.43" : undefined,
-        });
-        core.setOutput("soldr-version", verify.soldrVersion);
-        core.setOutput("soldr_version", verify.soldrVersion);
-        soldrRuntimeVersion = verify.soldrVersion;
-        core.saveState("soldrRuntimeVersion", verify.soldrVersion);
-    }
-    else {
-        core.setOutput("soldr-version", "passthrough");
-        core.setOutput("soldr_version", "passthrough");
-    }
-    await (0, phase_timing_js_1.finishPhase)("verify");
-    // ---- Dylint foundation ----
-    // Dylint mode is a complete setup contract: Soldr fetches and verifies its
-    // pinned command binaries, dated nightly/components, and matching driver.
-    // Direct Dylint UI tests also need the managed linker directory on PATH.
-    await (0, phase_timing_js_1.markPhase)("dylint-prepare");
-    await (0, prepare_dylint_js_1.prepareDylint)({
-        // cacheIdentity exists for Dylint mode even when every cache layer is
-        // disabled; preparation is functionality, not a cache side effect.
-        enabled: result.dylintCache.cacheIdentity !== "",
-        soldrPath: result.soldrPath,
-        soldrRoot: result.soldrRoot,
-        workspace: result.workspace,
-        cargoDylintVersion: result.dylintCache.cargoDylintVersion,
-        dylintLinkVersion: result.dylintCache.dylintLinkVersion,
-        addPath: (directory) => core.addPath(directory),
-    });
-    await (0, phase_timing_js_1.finishPhase)("dylint-prepare");
-    // ---- cargo-registry extraction ----
-    // Network download overlapped other layers in parallel-restore. Extraction
-    // starts only after the Soldr binary has been installed and runtime-verified.
-    await (0, phase_timing_js_1.markPhase)("cargo-registry-extract");
-    const registryDownload = cargoRegistryDownload;
-    if (registryDownload) {
-        let archiveBytes = null;
-        let restoredBytes = null;
-        let restoredFiles = null;
-        let restoredHit = registryDownload.hit;
-        let matched = registryDownload.matchedKey;
-        const markRegistryMiss = () => {
-            restoredHit = false;
-            matched = "";
-            core.setOutput("cargo-registry-cache-hit", "false");
-            core.setOutput("cargo_registry_cache_hit", "false");
-            core.saveState("cargoRegistryCacheExactHit", "false");
-            core.saveState("cargoRegistryCacheMatchedKey", "");
-        };
-        if (matched) {
-            try {
-                const archiveResult = await (0, cargo_registry_archive_js_1.restoreCargoRegistryArchive)({
-                    plan: result.cargoRegistryCache.archive,
-                    cargoHome: result.cargoHome,
-                    soldrPath: result.soldrPath,
-                    soldrVersion: soldrRuntimeVersion,
-                    cacheKey: matched,
-                    autoDefenderExclude: process.platform === "win32",
-                    debug: debugMode,
-                    log: debugLog,
-                });
-                if (!archiveResult.used) {
-                    logger.log(`cargo-registry: ${archiveResult.codecPath} unavailable for runtime Soldr ${soldrRuntimeVersion}; treating restored entry as a miss`);
-                    markRegistryMiss();
-                }
-                else {
-                    archiveBytes = archiveResult.archiveBytes;
-                    restoredBytes = archiveResult.restoredBytes;
-                    restoredFiles = archiveResult.restoredFiles;
-                    if (archiveBytes === 0 || restoredFiles === 0) {
-                        logger.warning(`cargo-registry: matched key ${matched} produced an unusable payload: ` +
-                            `archive=${archiveBytes}B extracted_files=${restoredFiles} ` +
-                            `extracted_bytes=${restoredBytes}; treating as miss`);
-                        markRegistryMiss();
-                    }
-                    else {
-                        logger.log(`cargo-registry: extracted format=${archiveResult.codecPath} archive_bytes=${archiveBytes} restored_bytes=${restoredBytes} files=${restoredFiles} duration_ms=${archiveResult.durationMs}`);
-                    }
-                }
-            }
-            catch (err) {
-                const errorCode = err?.code;
-                const encryptionFailure = errorCode === "EAUTHFAIL" || errorCode === "EENCNOKEY";
-                const skipEncryptionFailure = shouldSkipCargoRegistryExtractionError(err, result.cargoRegistryCache.archive.format, process.env["SETUP_SOLDR_CACHE_ENCRYPT_ON_FAILURE"]);
-                if (skipEncryptionFailure) {
-                    core.warning(`cargo-registry encrypted archive could not be restored; cache-encrypt-on-failure=skip treats it as a cold miss: ${err instanceof Error ? err.message : String(err)}`);
-                    markRegistryMiss();
-                }
-                else if (encryptionFailure) {
-                    throw new Error(`cargo-registry archive extraction failed for ${registryDownload.hit ? "exact-hit" : "fallback-hit"} ${matched}: ${err instanceof Error ? err.message : String(err)}`);
-                }
-                else {
-                    logger.warning(`cargo-registry: matched key ${matched} produced an unusable payload: ` +
-                        `${err instanceof Error ? err.message : String(err)}; treating as miss`);
-                    markRegistryMiss();
-                }
-            }
-        }
-        statsCollector.record({
-            label: `cargo-registry-${result.cargoRegistryCache.archive.format}`,
-            operation: "restore",
-            hit: restoredHit,
-            key: result.cargoRegistryCache.key,
-            matchedKey: matched,
-            restoreKeys: [result.cargoRegistryCache.restorePrefix],
-            archiveBytes,
-            inflatedBytes: restoredBytes,
-            fileCount: restoredFiles,
-            durationMs: Date.now() - registryDownload.startedMs,
-            timestamp: new Date().toISOString(),
-        });
-    }
-    await (0, phase_timing_js_1.finishPhase)("cargo-registry-extract");
-    // ---- cross-prepare ----
-    await (0, phase_timing_js_1.markPhase)("cross-prepare");
-    const preparePlan = result.blessedPrepareCache;
-    if (preparePlan.target) {
-        if (!result.enabled)
-            throw new Error("cross-targets requires enable: true");
-        const installedVersion = result.soldrVersionResolved || result.soldrVersionRequested;
-        (0, blessed_cross_prepare_js_1.assertMinimumSoldrVersion)(installedVersion);
-        const exactHit = core.getState("blessedPrepareCacheExactHit") === "true";
-        const matchedKey = core.getState("blessedPrepareCacheMatchedKey");
-        const prepareTargets = (0, blessed_cross_prepare_js_1.prepareTargetsFor)(preparePlan.target);
-        const archivesExist = preparePlan.archivePaths.length === prepareTargets.length
-            && preparePlan.archivePaths.every((archivePath) => fs.existsSync(archivePath) && fs.statSync(archivePath).size > 0);
-        const cacheUse = (0, blessed_cross_prepare_js_1.decideBlessedPrepareCacheUse)({
-            enabled: preparePlan.enabled,
-            exactHit,
-            matchedKey,
-            archivesExist,
-        });
-        const { effectiveExactHit, fallbackHit } = cacheUse;
-        if (exactHit && !archivesExist) {
-            logger.log("cross-prepare: exact cache key restored without every prepared archive; reseeding");
-            core.saveState("blessedPrepareCacheExactHit", "false");
-            core.setOutput("blessed-prepare-cache-hit", "false");
-        }
-        logger.log(`cross-prepare: target=${preparePlan.target} cache=${preparePlan.enabled ? (effectiveExactHit ? "hit" : fallbackHit ? "fallback-hit" : "miss") : "disabled"}`);
-        const contracts = [];
-        for (const [index, target] of prepareTargets.entries()) {
-            await (0, blessed_cross_prepare_js_1.executeBlessedPrepare)({
-                soldrPath: result.soldrPath,
-                target,
-                githubEnv: process.env["GITHUB_ENV"],
-                archivePath: preparePlan.archivePaths[index],
-                // Fallback archives are intentionally replayed across Soldr releases.
-                // Soldr always validates expected versioned paths after restore and
-                // downloads only missing/current assets before saving the exact key.
-                restore: cacheUse.restore,
-                save: cacheUse.save,
-            });
-            const targetPlan = await queryTargetPlan(result.soldrPath, target, (message) => logger.log(message));
-            if (!targetPlan) {
-                throw new Error(`Soldr did not report a machine-readable target plan for ${target}; target capability is unavailable`);
-            }
-            contracts.push((0, target_lifecycle_js_1.normalizeTargetPlan)(target, targetPlan));
-        }
-        const contract = preparePlan.target === "universal2-apple-darwin"
-            ? (0, target_lifecycle_js_1.buildUniversal2TargetContract)(contracts)
-            : contracts[0];
-        publishTargetContract(result, contract, logger);
-        core.saveState("blessedPrepareComplete", "true");
-    }
-    await (0, phase_timing_js_1.finishPhase)("cross-prepare");
-    // ---- cook (prebuild-deps via soldr-cook) ----
-    // The RESTORE was kicked off as a background promise right after the
-    // parallel-restore block above — we just await its result here. The
-    // RUN (`soldr cook`) still happens in this phase if
-    // the restore missed.
-    // Failures here are logged but never fail the action — the user's
-    // own cargo build will still work without the cooked deps.
-    await (0, phase_timing_js_1.markPhase)("cook");
-    if (cookActive && cookLayeredRestorePromise) {
-        const restore = await cookLayeredRestorePromise;
-        const loaded = await (0, cook_cache_js_1.loadLayeredCookCache)({
-            soldrBinary: result.soldrPath,
-            projectRoot: cookProjectRoot,
-            targetDir: cookTargetDir,
-            baseArchivePath: cookBaseArchive,
-            deltaArchivePath: cookDeltaArchive,
-            baseManifestPath: cookBaseManifest,
-            restore,
-            log: (msg) => logger.log(msg),
-            warn: (msg) => logger.warning(msg),
-        });
-        const baseReady = (0, cook_cache_js_1.layeredCookBaseReady)(restore, loaded);
-        const deltaReady = (0, cook_cache_js_1.layeredCookDeltaReady)(restore, loaded);
-        core.setOutput("cook-cache-base-hit", baseReady ? "true" : "false");
-        core.setOutput("cook-cache-delta-hit", deltaReady ? "true" : "false");
-        core.setOutput("cook-cache-hit", baseReady ? "true" : "false");
-        core.setOutput("cook-cache-status", deltaReady ? "hit" : baseReady ? "base-hit" : "miss");
-        core.setOutput("cook-cache-load-report-json", JSON.stringify({
-            base: loaded.baseReport,
-            delta: loaded.deltaReport,
-        }));
-        statsCollector.record({
-            label: "cook-cache-base",
-            operation: "restore",
-            hit: baseReady,
-            key: cookBaseKey,
-            matchedKey: restore.base.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.base.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: loaded.baseReport?.cacheFilesRestored ?? null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        statsCollector.record({
-            label: "cook-cache-delta",
-            operation: "restore",
-            hit: deltaReady,
-            key: cookDeltaKey,
-            matchedKey: restore.delta.matchedKey,
-            restoreKeys: cookDeltaRestoreKeys,
-            archiveBytes: restore.delta.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: loaded.deltaReport?.cacheFilesRestored ?? null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        let cookRan = false;
-        if (!deltaReady) {
-            const runRes = await (0, cook_cache_js_1.runCook)({
-                soldrBinary: result.soldrPath,
-                projectRoot: cookProjectRoot,
-                flags: cookFlags,
-                log: (msg) => logger.log(msg),
-            });
-            cookRan = runRes.exitCode === 0;
-        }
-        else {
-            logger.log("cook: base+delta cache hit - skipping cook run, target/deps already warm");
-        }
-        const cookSaveLayer = cookRan ? (baseReady ? "delta" : "base") : "none";
-        core.saveState("cookEnabled", "true");
-        core.saveState("cookLayered", "true");
-        core.saveState("cookBaseExactKey", cookBaseKey);
-        core.saveState("cookDeltaExactKey", cookDeltaKey);
-        core.saveState("cookBaseMatchedKey", restore.base.matchedKey);
-        core.saveState("cookDeltaMatchedKey", restore.delta.matchedKey);
-        core.saveState("cookBaseHit", baseReady ? "true" : "false");
-        core.saveState("cookDeltaHit", deltaReady ? "true" : "false");
-        core.saveState("cookHit", deltaReady ? "true" : "false");
-        core.saveState("cookRan", cookRan ? "true" : "false");
-        core.saveState("cookSaveLayer", cookSaveLayer);
-        core.saveState("cookProjectRoot", cookProjectRoot);
-        core.saveState("cookTargetDir", cookTargetDir);
-        core.saveState("cookBaseArchive", cookBaseArchive);
-        core.saveState("cookDeltaArchive", cookDeltaArchive);
-        core.saveState("cookBaseManifest", cookBaseManifest);
-        core.saveState("cookSoldrBinary", result.soldrPath);
-        // #268/#358: cook-cache-base previously used zstd-level 19, but
-        // production observation showed 165s of compress wall-clock per
-        // matrix job for ~224 MB output. In a 5-way matrix where 1 job
-        // wins the cache reservation and 4 lose the race, that's 660s
-        // of post-step CPU wasted per CI cycle. Lowering to -9 cuts the
-        // compress wall-clock ~4× (target ~40s) at the cost of ~25%
-        // larger archive (~280 MB) and ~1s extra upload wall-clock per
-        // save. zstd decompression speed is level-independent, so warm
-        // restores are unaffected. Net: ~125s win per save-attempt, big
-        // multiplier on race-loss scenarios.
-        core.saveState("cookCompressLevel", "9");
-        core.saveState("cookDeltaCompressLevel", "3");
-    }
-    else if (cookActive && cookRestorePromise) {
-        const restore = await cookRestorePromise;
-        core.setOutput("cook-cache-hit", restore.hit ? "true" : "false");
-        core.setOutput("cook-cache-status", restore.hit ? "hit" : "miss");
-        statsCollector.record({
-            label: "cook-cache",
-            operation: "restore",
-            hit: restore.hit,
-            key: cookKey,
-            matchedKey: restore.matchedKey,
-            restoreKeys: [],
-            archiveBytes: restore.archiveBytes || null,
-            inflatedBytes: null,
-            fileCount: null,
-            durationMs: Date.now() - cookRestoreT0,
-            timestamp: new Date().toISOString(),
-        });
-        let cookRan = false;
-        if (!restore.hit) {
-            const runRes = await (0, cook_cache_js_1.runCook)({
-                soldrBinary: result.soldrPath,
-                projectRoot: cookProjectRoot,
-                flags: cookFlags,
-                log: (msg) => logger.log(msg),
-            });
-            cookRan = runRes.exitCode === 0;
-        }
-        else {
-            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
-        }
-        core.saveState("cookEnabled", "true");
-        core.saveState("cookLayered", "false");
-        core.saveState("cookExactKey", cookKey);
-        core.saveState("cookMatchedKey", restore.matchedKey);
-        core.saveState("cookHit", restore.hit ? "true" : "false");
-        core.saveState("cookRan", cookRan ? "true" : "false");
-        core.saveState("cookTargetDir", cookTargetDir);
-        core.saveState("cookLongWindow", "27");
-        // #268/#358: see saveState("cookCompressLevel", "9") above for
-        // rationale on lowering from -19. Same logic applies to the
-        // non-layered path.
-        core.saveState("cookCompressLevel", "9");
-    }
-    else if (cookSkippedDueToTargetHit) {
-        core.setOutput("cook-cache-status", "covered-by-target-cache");
-        logger.log(`cook: skipped - target-cache matched at lockfile/shape level (matched=${targetCacheMatchedKey}); cook output would be redundant`);
-        core.saveState("cookEnabled", "false");
-        core.saveState("cookLayered", "false");
-    }
-    else {
-        logger.log(`cook: skipped - ${cookGate.reason}`);
-        core.saveState("cookEnabled", "false");
-        core.saveState("cookLayered", "false");
-    }
-    await (0, phase_timing_js_1.finishPhase)("cook");
-    // ---- shared-target warning ----
-    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
-        buildCacheEnabled,
-        effectiveTargetCacheEnabled: result.targetCache.enabled,
-        buildCacheMode: result.buildCache.mode,
-        targetDir: result.targetCache.targetPath,
-        soldrPath: result.soldrPath,
-    });
-    // ---- shim-bypass diagnostic ----
-    // Issue #160: when shims: true is requested but the effective environment
-    // (PATH ordering, CARGO/RUSTC/RUSTC_WRAPPER overrides) would bypass them,
-    // caching looks configured but compile work runs through plain cargo.
-    // Emit advisory warnings naming each offender. Runs at the very end so it
-    // sees the final state of process.env after every prior phase.
-    if (result.shimsEnabled) {
-        const bypassWarnings = (0, shim_bypass_check_js_1.diagnoseShimBypass)({
-            shimsEnabled: true,
-            shimDir: result.shimsDir,
-            path: process.env["PATH"] ?? "",
-            cargoEnv: process.env["CARGO"],
-            rustcEnv: process.env["RUSTC"],
-            rustcWrapperEnv: process.env["RUSTC_WRAPPER"],
-            soldrBinary: result.soldrPath,
-        });
-        for (const msg of bypassWarnings) {
-            core.warning(msg);
-        }
-        if (bypassWarnings.length === 0) {
-            logger.log(`shim-bypass check clean: shim dir ${result.shimsDir} at PATH front, no competing CARGO/RUSTC/RUSTC_WRAPPER overrides`);
-        }
-    }
-    // ---- stats report ----
-    statsCollector.report(statsMode, (msg) => logger.log(msg));
-    if (statsMode === "detailed") {
-        try {
-            await statsCollector.writeFiles(ctx.runnerTemp);
-            statsCollector.setGithubOutputs();
-        }
-        catch (err) {
-            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-    core.saveState("statsCollector", statsCollector.serialize());
-    core.saveState("statsMode", statsMode);
-    core.saveState("compileCacheStats", result.compileCacheStats);
-    core.saveState("runnerTemp", ctx.runnerTemp);
-    if (logging) {
-        (0, diagnostics_js_1.dumpDiagnostics)({
-            phase: "main",
-            env: process.env,
-            rawInputs: inputs,
-            result,
-            cacheOutcomes: statsCollector.snapshot(),
-            logger,
-        });
-    }
-    // #269-companion (setup side): one-line aggregate of where each
-    // setup phase's wall-clock went, before we finish the `action`
-    // phase. Mirrors the post-step `cache save totals:` line that
-    // ships from `StatsCollector.saveSummaryOneLine()`. Operators see
-    // the pre-build budget at a glance without scrolling raw
-    // SETUP_SOLDR_PHASE_*_START_MS env vars or hunting through the
-    // timeline. Phases in declared serial order:
-    const setupPhaseSummary = (0, phase_timing_js_1.setupPhaseSummaryOneLine)([
-        "resolve",
-        "parallel-restore",
-        "target-tree",
-        "toolchain",
-        "install",
-        "zccache-seed",
-        "verify",
-        "cargo-registry-extract",
-        "cross-prepare",
-        "cook",
-    ]);
-    if (setupPhaseSummary)
-        core.info(setupPhaseSummary);
-    await (0, phase_timing_js_1.finishPhase)("action");
-    // dirHasContent is exported for tests; suppress unused warning here.
-    void dirHasContent;
-}
-// Auto-invoke only when this module is run as the main entry point. This lets
-// tests import `run` (and helpers) without triggering the side-effectful
-// orchestration. The dist/main.js produced by ncc is invoked directly by the
-// Actions runtime so the check trips and the action executes normally.
-if (typeof process !== "undefined" &&
-    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
-    // import.meta.url is the file URL of this module; argv[1] is the runner
-    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
-    // the dev path — we rely on the env-var opt-out for tests instead.
-    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
-    run().catch((err) => {
-        const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        core.setFailed(`setup-soldr failed: ${message}`);
-    });
 }
 
 
@@ -83890,8 +82549,8 @@ __export(userAgentPlatform_exports, {
   setPlatformSpecificData: () => setPlatformSpecificData
 });
 module.exports = __toCommonJS(userAgentPlatform_exports);
-var import_node_os = __toESM(__nccwpck_require__(405));
-var import_node_process = __toESM(__nccwpck_require__(249));
+var import_node_os = __toESM(__nccwpck_require__(406));
+var import_node_process = __toESM(__nccwpck_require__(250));
 function getHeaderName() {
   return "User-Agent";
 }
@@ -83985,11 +82644,11 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DefaultGlobber = void 0;
 const core = __importStar(__nccwpck_require__(490));
-const fs = __importStar(__nccwpck_require__(567));
-const globOptionsHelper = __importStar(__nccwpck_require__(439));
-const path = __importStar(__nccwpck_require__(264));
+const fs = __importStar(__nccwpck_require__(568));
+const globOptionsHelper = __importStar(__nccwpck_require__(440));
+const path = __importStar(__nccwpck_require__(265));
 const patternHelper = __importStar(__nccwpck_require__(48));
-const internal_match_kind_1 = __nccwpck_require__(565);
+const internal_match_kind_1 = __nccwpck_require__(566);
 const internal_pattern_1 = __nccwpck_require__(536);
 const internal_search_state_1 = __nccwpck_require__(5);
 const IS_WINDOWS = process.platform === 'win32';
@@ -84182,7 +82841,7 @@ exports.DefaultGlobber = DefaultGlobber;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOperationArgumentValueFromParameter = getOperationArgumentValueFromParameter;
 exports.getOperationRequestInfo = getOperationRequestInfo;
-const state_js_1 = __nccwpck_require__(354);
+const state_js_1 = __nccwpck_require__(355);
 /**
  * @internal
  * Retrieves the value to use for a given operation argument
@@ -84287,7 +82946,7 @@ const { InvalidArgumentError, RequestAbortedError, SocketError } = __nccwpck_req
 const { AsyncResource } = __nccwpck_require__(456)
 const util = __nccwpck_require__(77)
 const { addSignal, removeSignal } = __nccwpck_require__(113)
-const assert = __nccwpck_require__(562)
+const assert = __nccwpck_require__(563)
 
 class UpgradeHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -84396,8 +83055,8 @@ module.exports = upgrade
 "use strict";
 
 const os = __nccwpck_require__(102);
-const tty = __nccwpck_require__(189);
-const hasFlag = __nccwpck_require__(390);
+const tty = __nccwpck_require__(190);
+const hasFlag = __nccwpck_require__(391);
 
 const {env} = process;
 
@@ -84558,7 +83217,7 @@ __export(checkInsecureConnection_exports, {
   ensureSecureConnection: () => ensureSecureConnection
 });
 module.exports = __toCommonJS(checkInsecureConnection_exports);
-var import_log = __nccwpck_require__(160);
+var import_log = __nccwpck_require__(161);
 let insecureConnectionWarningEmmitted = false;
 function allowInsecureConnection(request, options) {
   if (options.allowInsecureConnection && request.allowInsecureConnection) {
@@ -84602,7 +83261,7 @@ function ensureSecureConnection(request, options) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CacheServiceClientProtobuf = exports.CacheServiceClientJSON = void 0;
-const cache_1 = __nccwpck_require__(448);
+const cache_1 = __nccwpck_require__(449);
 class CacheServiceClientJSON {
     constructor(rpc) {
         this.rpc = rpc;
@@ -84710,7 +83369,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StatsCollector = void 0;
-const fs = __importStar(__nccwpck_require__(118));
+const fs = __importStar(__nccwpck_require__(119));
 const path = __importStar(__nccwpck_require__(542));
 const core = __importStar(__nccwpck_require__(490));
 function fmtBytes(n) {
@@ -85084,9 +83743,9 @@ exports.authorizeRequestOnTenantChallenge = exports.authorizeRequestOnClaimChall
 var serializer_js_1 = __nccwpck_require__(513);
 Object.defineProperty(exports, "createSerializer", ({ enumerable: true, get: function () { return serializer_js_1.createSerializer; } }));
 Object.defineProperty(exports, "MapperTypeNames", ({ enumerable: true, get: function () { return serializer_js_1.MapperTypeNames; } }));
-var serviceClient_js_1 = __nccwpck_require__(337);
+var serviceClient_js_1 = __nccwpck_require__(338);
 Object.defineProperty(exports, "ServiceClient", ({ enumerable: true, get: function () { return serviceClient_js_1.ServiceClient; } }));
-var pipeline_js_1 = __nccwpck_require__(302);
+var pipeline_js_1 = __nccwpck_require__(303);
 Object.defineProperty(exports, "createClientPipeline", ({ enumerable: true, get: function () { return pipeline_js_1.createClientPipeline; } }));
 var interfaces_js_1 = __nccwpck_require__(109);
 Object.defineProperty(exports, "XML_ATTRKEY", ({ enumerable: true, get: function () { return interfaces_js_1.XML_ATTRKEY; } }));
@@ -85097,9 +83756,9 @@ Object.defineProperty(exports, "deserializationPolicyName", ({ enumerable: true,
 var serializationPolicy_js_1 = __nccwpck_require__(523);
 Object.defineProperty(exports, "serializationPolicy", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicy; } }));
 Object.defineProperty(exports, "serializationPolicyName", ({ enumerable: true, get: function () { return serializationPolicy_js_1.serializationPolicyName; } }));
-var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(121);
+var authorizeRequestOnClaimChallenge_js_1 = __nccwpck_require__(122);
 Object.defineProperty(exports, "authorizeRequestOnClaimChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnClaimChallenge_js_1.authorizeRequestOnClaimChallenge; } }));
-var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(179);
+var authorizeRequestOnTenantChallenge_js_1 = __nccwpck_require__(180);
 Object.defineProperty(exports, "authorizeRequestOnTenantChallenge", ({ enumerable: true, get: function () { return authorizeRequestOnTenantChallenge_js_1.authorizeRequestOnTenantChallenge; } }));
 //# sourceMappingURL=index.js.map
 
@@ -85145,9 +83804,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createTar = exports.extractTar = exports.listTar = void 0;
 const exec_1 = __nccwpck_require__(21);
-const io = __importStar(__nccwpck_require__(315));
-const fs_1 = __nccwpck_require__(567);
-const path = __importStar(__nccwpck_require__(264));
+const io = __importStar(__nccwpck_require__(316));
+const fs_1 = __nccwpck_require__(568);
+const path = __importStar(__nccwpck_require__(265));
 const utils = __importStar(__nccwpck_require__(83));
 const constants_1 = __nccwpck_require__(51);
 const IS_WINDOWS = process.platform === 'win32';
@@ -85420,15 +84079,15 @@ __export(nodeHttpClient_exports, {
   getBodyLength: () => getBodyLength
 });
 module.exports = __toCommonJS(nodeHttpClient_exports);
-var import_node_http = __toESM(__nccwpck_require__(280));
-var import_node_https = __toESM(__nccwpck_require__(411));
+var import_node_http = __toESM(__nccwpck_require__(281));
+var import_node_https = __toESM(__nccwpck_require__(412));
 var import_node_zlib = __toESM(__nccwpck_require__(554));
 var import_node_stream = __nccwpck_require__(457);
 var import_AbortError = __nccwpck_require__(12);
 var import_httpHeaders = __nccwpck_require__(519);
 var import_restError = __nccwpck_require__(472);
-var import_log = __nccwpck_require__(160);
-var import_sanitizer = __nccwpck_require__(130);
+var import_log = __nccwpck_require__(161);
+var import_sanitizer = __nccwpck_require__(131);
 const DEFAULT_TLS_SETTINGS = {};
 function isReadableStream(body) {
   return body && typeof body.pipe === "function";
@@ -85852,8 +84511,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const crypto = __importStar(__nccwpck_require__(312));
-const fs = __importStar(__nccwpck_require__(567));
+const crypto = __importStar(__nccwpck_require__(313));
+const fs = __importStar(__nccwpck_require__(568));
 const os = __importStar(__nccwpck_require__(102));
 const utils_1 = __nccwpck_require__(538);
 function issueFileCommand(command, message) {
@@ -85914,9 +84573,9 @@ __export(restError_exports, {
   isRestError: () => isRestError
 });
 module.exports = __toCommonJS(restError_exports);
-var import_error = __nccwpck_require__(162);
+var import_error = __nccwpck_require__(163);
 var import_inspect = __nccwpck_require__(1);
-var import_sanitizer = __nccwpck_require__(130);
+var import_sanitizer = __nccwpck_require__(131);
 const errorSanitizer = new import_sanitizer.Sanitizer();
 class RestError extends Error {
   /**
@@ -86057,9 +84716,9 @@ function wrapAbortSignalLike(abortSignalLike) {
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const tslib_1 = __nccwpck_require__(225);
+const tslib_1 = __nccwpck_require__(226);
 const coreHttpCompat = tslib_1.__importStar(__nccwpck_require__(80));
-const index_js_1 = __nccwpck_require__(295);
+const index_js_1 = __nccwpck_require__(296);
 class StorageClient extends coreHttpCompat.ExtendedServiceClient {
     url;
     version;
@@ -86125,36 +84784,36 @@ exports.StorageClient = StorageClient;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logger = exports.RestError = exports.StorageBrowserPolicyFactory = exports.StorageBrowserPolicy = exports.StorageSharedKeyCredentialPolicy = exports.StorageSharedKeyCredential = exports.StorageRetryPolicyFactory = exports.StorageRetryPolicy = exports.StorageRetryPolicyType = exports.Credential = exports.CredentialPolicy = exports.BaseRequestPolicy = exports.AnonymousCredentialPolicy = exports.AnonymousCredential = exports.StorageOAuthScopes = exports.newPipeline = exports.isPipelineLike = exports.Pipeline = exports.getBlobServiceAccountAudience = exports.StorageBlobAudience = exports.PremiumPageBlobTier = exports.BlockBlobTier = exports.generateBlobSASQueryParameters = exports.generateAccountSASQueryParameters = void 0;
-const tslib_1 = __nccwpck_require__(225);
+const tslib_1 = __nccwpck_require__(226);
 const core_rest_pipeline_1 = __nccwpck_require__(111);
 Object.defineProperty(exports, "RestError", ({ enumerable: true, get: function () { return core_rest_pipeline_1.RestError; } }));
-tslib_1.__exportStar(__nccwpck_require__(427), exports);
-tslib_1.__exportStar(__nccwpck_require__(192), exports);
+tslib_1.__exportStar(__nccwpck_require__(428), exports);
+tslib_1.__exportStar(__nccwpck_require__(193), exports);
 tslib_1.__exportStar(__nccwpck_require__(71), exports);
-tslib_1.__exportStar(__nccwpck_require__(213), exports);
+tslib_1.__exportStar(__nccwpck_require__(214), exports);
 tslib_1.__exportStar(__nccwpck_require__(64), exports);
 tslib_1.__exportStar(__nccwpck_require__(2), exports);
-tslib_1.__exportStar(__nccwpck_require__(402), exports);
-var AccountSASSignatureValues_js_1 = __nccwpck_require__(310);
+tslib_1.__exportStar(__nccwpck_require__(403), exports);
+var AccountSASSignatureValues_js_1 = __nccwpck_require__(311);
 Object.defineProperty(exports, "generateAccountSASQueryParameters", ({ enumerable: true, get: function () { return AccountSASSignatureValues_js_1.generateAccountSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(358), exports);
-tslib_1.__exportStar(__nccwpck_require__(428), exports);
-tslib_1.__exportStar(__nccwpck_require__(180), exports);
+tslib_1.__exportStar(__nccwpck_require__(359), exports);
+tslib_1.__exportStar(__nccwpck_require__(429), exports);
+tslib_1.__exportStar(__nccwpck_require__(181), exports);
 tslib_1.__exportStar(__nccwpck_require__(537), exports);
 var BlobSASSignatureValues_js_1 = __nccwpck_require__(76);
 Object.defineProperty(exports, "generateBlobSASQueryParameters", ({ enumerable: true, get: function () { return BlobSASSignatureValues_js_1.generateBlobSASQueryParameters; } }));
-tslib_1.__exportStar(__nccwpck_require__(298), exports);
-var models_js_1 = __nccwpck_require__(441);
+tslib_1.__exportStar(__nccwpck_require__(299), exports);
+var models_js_1 = __nccwpck_require__(442);
 Object.defineProperty(exports, "BlockBlobTier", ({ enumerable: true, get: function () { return models_js_1.BlockBlobTier; } }));
 Object.defineProperty(exports, "PremiumPageBlobTier", ({ enumerable: true, get: function () { return models_js_1.PremiumPageBlobTier; } }));
 Object.defineProperty(exports, "StorageBlobAudience", ({ enumerable: true, get: function () { return models_js_1.StorageBlobAudience; } }));
 Object.defineProperty(exports, "getBlobServiceAccountAudience", ({ enumerable: true, get: function () { return models_js_1.getBlobServiceAccountAudience; } }));
-var Pipeline_js_1 = __nccwpck_require__(190);
+var Pipeline_js_1 = __nccwpck_require__(191);
 Object.defineProperty(exports, "Pipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.Pipeline; } }));
 Object.defineProperty(exports, "isPipelineLike", ({ enumerable: true, get: function () { return Pipeline_js_1.isPipelineLike; } }));
 Object.defineProperty(exports, "newPipeline", ({ enumerable: true, get: function () { return Pipeline_js_1.newPipeline; } }));
 Object.defineProperty(exports, "StorageOAuthScopes", ({ enumerable: true, get: function () { return Pipeline_js_1.StorageOAuthScopes; } }));
-var storage_common_1 = __nccwpck_require__(294);
+var storage_common_1 = __nccwpck_require__(295);
 Object.defineProperty(exports, "AnonymousCredential", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredential; } }));
 Object.defineProperty(exports, "AnonymousCredentialPolicy", ({ enumerable: true, get: function () { return storage_common_1.AnonymousCredentialPolicy; } }));
 Object.defineProperty(exports, "BaseRequestPolicy", ({ enumerable: true, get: function () { return storage_common_1.BaseRequestPolicy; } }));
@@ -86167,9 +84826,9 @@ Object.defineProperty(exports, "StorageSharedKeyCredential", ({ enumerable: true
 Object.defineProperty(exports, "StorageSharedKeyCredentialPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageSharedKeyCredentialPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicy", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicy; } }));
 Object.defineProperty(exports, "StorageBrowserPolicyFactory", ({ enumerable: true, get: function () { return storage_common_1.StorageBrowserPolicyFactory; } }));
-tslib_1.__exportStar(__nccwpck_require__(561), exports);
-tslib_1.__exportStar(__nccwpck_require__(345), exports);
-var log_js_1 = __nccwpck_require__(116);
+tslib_1.__exportStar(__nccwpck_require__(562), exports);
+tslib_1.__exportStar(__nccwpck_require__(346), exports);
+var log_js_1 = __nccwpck_require__(117);
 Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () { return log_js_1.logger; } }));
 //# sourceMappingURL=index.js.map
 
@@ -86182,7 +84841,7 @@ Object.defineProperty(exports, "logger", ({ enumerable: true, get: function () {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SPECIAL_HEADERS = exports.HEADER_STATE = exports.MINOR = exports.MAJOR = exports.CONNECTION_TOKEN_CHARS = exports.HEADER_CHARS = exports.TOKEN = exports.STRICT_TOKEN = exports.HEX = exports.URL_CHAR = exports.STRICT_URL_CHAR = exports.USERINFO_CHARS = exports.MARK = exports.ALPHANUM = exports.NUM = exports.HEX_MAP = exports.NUM_MAP = exports.ALPHA = exports.FINISH = exports.H_METHOD_MAP = exports.METHOD_MAP = exports.METHODS_RTSP = exports.METHODS_ICE = exports.METHODS_HTTP = exports.METHODS = exports.LENIENT_FLAGS = exports.FLAGS = exports.TYPE = exports.ERROR = void 0;
-const utils_1 = __nccwpck_require__(329);
+const utils_1 = __nccwpck_require__(330);
 // C headers
 var ERROR;
 (function (ERROR) {
@@ -86488,10 +85147,10 @@ __export(sendRequest_exports, {
 module.exports = __toCommonJS(sendRequest_exports);
 var import_restError = __nccwpck_require__(472);
 var import_httpHeaders = __nccwpck_require__(519);
-var import_pipelineRequest = __nccwpck_require__(124);
+var import_pipelineRequest = __nccwpck_require__(125);
 var import_clientHelpers = __nccwpck_require__(525);
 var import_typeGuards = __nccwpck_require__(531);
-var import_multipart = __nccwpck_require__(287);
+var import_multipart = __nccwpck_require__(288);
 async function sendRequest(method, url, pipeline, options = {}, customHttpClient) {
   const httpClient = customHttpClient ?? (0, import_clientHelpers.getCachedDefaultHttpsClient)();
   const request = buildPipelineRequest(method, url, options);
@@ -86661,7 +85320,7 @@ const {
 } = __nccwpck_require__(46)
 const { Headers } = __nccwpck_require__(550)
 const { Request, makeRequest } = __nccwpck_require__(90)
-const zlib = __nccwpck_require__(436)
+const zlib = __nccwpck_require__(437)
 const {
   bytesMatch,
   makePolicyContainer,
@@ -86693,7 +85352,7 @@ const {
   urlHasHttpsScheme
 } = __nccwpck_require__(552)
 const { kState, kHeaders, kGuard, kRealm } = __nccwpck_require__(18)
-const assert = __nccwpck_require__(562)
+const assert = __nccwpck_require__(563)
 const { safelyExtractBody } = __nccwpck_require__(27)
 const {
   redirectStatusSet,
@@ -86703,15 +85362,15 @@ const {
   subresourceSet,
   DOMException
 } = __nccwpck_require__(34)
-const { kHeadersList } = __nccwpck_require__(204)
+const { kHeadersList } = __nccwpck_require__(205)
 const EE = __nccwpck_require__(503)
-const { Readable, pipeline } = __nccwpck_require__(139)
+const { Readable, pipeline } = __nccwpck_require__(140)
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = __nccwpck_require__(77)
 const { dataURLProcessor, serializeAMimeType } = __nccwpck_require__(29)
-const { TransformStream } = __nccwpck_require__(274)
-const { getGlobalDispatcher } = __nccwpck_require__(399)
+const { TransformStream } = __nccwpck_require__(275)
+const { getGlobalDispatcher } = __nccwpck_require__(400)
 const { webidl } = __nccwpck_require__(485)
-const { STATUS_CODES } = __nccwpck_require__(353)
+const { STATUS_CODES } = __nccwpck_require__(354)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
 /** @type {import('buffer').resolveObjectURL} */
@@ -87453,7 +86112,7 @@ function schemeFetch (fetchParams) {
     }
     case 'blob:': {
       if (!resolveObjectURL) {
-        resolveObjectURL = (__nccwpck_require__(128).resolveObjectURL)
+        resolveObjectURL = (__nccwpck_require__(129).resolveObjectURL)
       }
 
       // 1. Let blobURLEntry be request’s current URL’s blob URL entry.
@@ -88452,7 +87111,7 @@ async function httpNetworkFetch (
   // cancelAlgorithm set to cancelAlgorithm, highWaterMark set to
   // highWaterMark, and sizeAlgorithm set to sizeAlgorithm.
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(274).ReadableStream)
+    ReadableStream = (__nccwpck_require__(275).ReadableStream)
   }
 
   const stream = new ReadableStream(
@@ -88847,17 +87506,17 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._internal = void 0;
 exports.installedSoldrReleaseIsUsable = installedSoldrReleaseIsUsable;
 exports.ensureSoldr = ensureSoldr;
-const fs = __importStar(__nccwpck_require__(265));
-const node_crypto_1 = __nccwpck_require__(292);
-const os = __importStar(__nccwpck_require__(405));
+const fs = __importStar(__nccwpck_require__(266));
+const node_crypto_1 = __nccwpck_require__(293);
+const os = __importStar(__nccwpck_require__(406));
 const path = __importStar(__nccwpck_require__(542));
 const core = __importStar(__nccwpck_require__(490));
 const exec = __importStar(__nccwpck_require__(21));
-const tc = __importStar(__nccwpck_require__(557));
-const fzstd = __importStar(__nccwpck_require__(376));
-const log_utils_js_1 = __nccwpck_require__(200);
-const release_readiness_js_1 = __nccwpck_require__(563);
-const verify_soldr_js_1 = __nccwpck_require__(379);
+const tc = __importStar(__nccwpck_require__(558));
+const fzstd = __importStar(__nccwpck_require__(377));
+const log_utils_js_1 = __nccwpck_require__(201);
+const release_readiness_js_1 = __nccwpck_require__(564);
+const verify_soldr_js_1 = __nccwpck_require__(380);
 const CARGO_CHEF_VERSION_BY_SOLDR = {
     "0.9.0": "0.1.73",
     "0.9.1": "0.1.73",
@@ -90095,9 +88754,9 @@ exports.lowerCamelCase = lowerCamelCase;
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.StorageClient = void 0;
-const StorageContextClient_js_1 = __nccwpck_require__(284);
-const Pipeline_js_1 = __nccwpck_require__(190);
-const utils_common_js_1 = __nccwpck_require__(163);
+const StorageContextClient_js_1 = __nccwpck_require__(285);
+const Pipeline_js_1 = __nccwpck_require__(191);
+const utils_common_js_1 = __nccwpck_require__(164);
 /**
  * A StorageClient represents a based URL class for {@link BlobServiceClient}, {@link ContainerClient}
  * and etc.
@@ -90230,7 +88889,7 @@ function parseHeaderValueAsNumber(response, headerName) {
 "use strict";
 
 
-const { types } = __nccwpck_require__(132)
+const { types } = __nccwpck_require__(133)
 const { hasOwn, toUSVString } = __nccwpck_require__(552)
 
 /** @type {import('../../types/webidl').Webidl} */
@@ -90885,8 +89544,8 @@ module.exports = {
  * Module dependencies.
  */
 
-const tty = __nccwpck_require__(189);
-const util = __nccwpck_require__(132);
+const tty = __nccwpck_require__(190);
+const util = __nccwpck_require__(133);
 
 /**
  * This is the Node.js implementation of `debug()`.
@@ -91120,7 +89779,7 @@ function init(debug) {
 	}
 }
 
-module.exports = __nccwpck_require__(151)(exports);
+module.exports = __nccwpck_require__(152)(exports);
 
 const {formatters} = module.exports;
 
@@ -91213,10 +89872,10 @@ exports.snapshotSourceMtimes = snapshotSourceMtimes;
 exports.replaySourceMtimes = replaySourceMtimes;
 exports.writeSnapshotFile = writeSnapshotFile;
 exports.readSnapshotFile = readSnapshotFile;
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
-const node_crypto_1 = __nccwpck_require__(292);
-const normalize_source_mtime_js_1 = __nccwpck_require__(260);
+const node_crypto_1 = __nccwpck_require__(293);
+const normalize_source_mtime_js_1 = __nccwpck_require__(261);
 exports.SNAPSHOT_FILENAME = "setup-soldr-source-mtimes.json";
 async function hashFile(absolute) {
     // sha256 prefix (first 32 hex = 128 bits). Streaming so we don't load
@@ -91840,7 +90499,7 @@ exports.walkSnapshot = walkSnapshot;
 exports.diffSnapshots = diffSnapshots;
 exports.diffStats = diffStats;
 exports.serializeManifest = serializeManifest;
-const fs = __importStar(__nccwpck_require__(118));
+const fs = __importStar(__nccwpck_require__(119));
 const path = __importStar(__nccwpck_require__(542));
 function entryKey(root, relpath) {
     return `${root}#${relpath}`;
@@ -91991,12 +90650,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.platform = exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = exports.markdownSummary = exports.summary = exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(569);
+const command_1 = __nccwpck_require__(570);
 const file_command_1 = __nccwpck_require__(471);
 const utils_1 = __nccwpck_require__(538);
 const os = __importStar(__nccwpck_require__(102));
-const path = __importStar(__nccwpck_require__(264));
-const oidc_utils_1 = __nccwpck_require__(142);
+const path = __importStar(__nccwpck_require__(265));
+const oidc_utils_1 = __nccwpck_require__(143);
 /**
  * The code to exit an action
  */
@@ -92281,24 +90940,24 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(369);
+var summary_1 = __nccwpck_require__(370);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(369);
+var summary_2 = __nccwpck_require__(370);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(356);
+var path_utils_1 = __nccwpck_require__(357);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
 /**
  * Platform utilities exports
  */
-exports.platform = __importStar(__nccwpck_require__(444));
+exports.platform = __importStar(__nccwpck_require__(445));
 //# sourceMappingURL=core.js.map
 
 /***/ }),
@@ -92460,9 +91119,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.tripleToCcRsSuffix = tripleToCcRsSuffix;
 exports.detectMuslCcEnv = detectMuslCcEnv;
 exports.tryDelegateToSoldrDoctorMuslCc = tryDelegateToSoldrDoctorMuslCc;
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
-const soldr_toolchain_client_js_1 = __nccwpck_require__(364);
+const soldr_toolchain_client_js_1 = __nccwpck_require__(365);
 const MUSL_TRIPLE_RE = /^[a-z0-9_]+-unknown-linux-musl$/;
 function tripleToCcRsSuffix(triple) {
     return triple.replace(/-/g, "_");
@@ -92648,8 +91307,8 @@ async function tryDelegateToSoldrDoctorMuslCc(opts) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.reflectionScalarDefault = void 0;
 const reflection_info_1 = __nccwpck_require__(481);
-const reflection_long_convert_1 = __nccwpck_require__(166);
-const pb_long_1 = __nccwpck_require__(126);
+const reflection_long_convert_1 = __nccwpck_require__(167);
+const pb_long_1 = __nccwpck_require__(127);
 /**
  * Creates the default value for a scalar type.
  */
@@ -94994,9 +93653,9 @@ exports.redactValue = redactValue;
 exports.captureProcessSnapshot = captureProcessSnapshot;
 exports.dumpDiagnostics = dumpDiagnostics;
 exports.loggingEnabled = loggingEnabled;
-const fs = __importStar(__nccwpck_require__(265));
-const node_child_process_1 = __nccwpck_require__(206);
-const compile_journal_js_1 = __nccwpck_require__(351);
+const fs = __importStar(__nccwpck_require__(266));
+const node_child_process_1 = __nccwpck_require__(207);
+const compile_journal_js_1 = __nccwpck_require__(352);
 const ENV_KEY_PREFIXES = [
     "INPUT_",
     "SOLDR_",
@@ -95842,7 +94501,7 @@ function localstorage() {
 	}
 }
 
-module.exports = __nccwpck_require__(151)(exports);
+module.exports = __nccwpck_require__(152)(exports);
 
 const {formatters} = module.exports;
 
@@ -96209,7 +94868,7 @@ __export(proxyPolicy_exports, {
   proxyPolicyName: () => proxyPolicyName
 });
 module.exports = __toCommonJS(proxyPolicy_exports);
-var import_policies = __nccwpck_require__(307);
+var import_policies = __nccwpck_require__(308);
 const proxyPolicyName = import_policies.proxyPolicyName;
 function getDefaultProxySettings(proxyUrl) {
   return (0, import_policies.getDefaultProxySettings)(proxyUrl);
@@ -96941,7 +95600,7 @@ module.exports = Dispatcher
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ServiceType = void 0;
-const reflection_info_1 = __nccwpck_require__(564);
+const reflection_info_1 = __nccwpck_require__(565);
 class ServiceType {
     constructor(typeName, methods, options) {
         this.typeName = typeName;
@@ -96964,10 +95623,10 @@ exports.ServiceType = ServiceType;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MapperTypeNames = void 0;
 exports.createSerializer = createSerializer;
-const tslib_1 = __nccwpck_require__(225);
+const tslib_1 = __nccwpck_require__(226);
 const base64 = tslib_1.__importStar(__nccwpck_require__(465));
 const interfaces_js_1 = __nccwpck_require__(109);
-const utils_js_1 = __nccwpck_require__(335);
+const utils_js_1 = __nccwpck_require__(336);
 class SerializerImpl {
     modelMappers;
     isXML;
@@ -97908,12 +96567,12 @@ exports.logger = (0, logger_1.createClientLogger)("core-client");
 "use strict";
 
 
-const { Writable } = __nccwpck_require__(139)
-const diagnosticsChannel = __nccwpck_require__(150)
+const { Writable } = __nccwpck_require__(140)
+const diagnosticsChannel = __nccwpck_require__(151)
 const { parserStates, opcodes, states, emptyBuffer } = __nccwpck_require__(499)
 const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(108)
 const { isValidStatusCode, failWebsocketConnection, websocketMessageReceived } = __nccwpck_require__(63)
-const { WebsocketFrameSend } = __nccwpck_require__(194)
+const { WebsocketFrameSend } = __nccwpck_require__(195)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -98498,8 +97157,8 @@ function createHttpHeaders(rawHeaders) {
 /***/ 520:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __nccwpck_require__(377);
-var balanced = __nccwpck_require__(140);
+var concatMap = __nccwpck_require__(378);
+var balanced = __nccwpck_require__(141);
 
 module.exports = expandTop;
 
@@ -98740,9 +97399,9 @@ __export(log_exports, {
   log: () => log
 });
 module.exports = __toCommonJS(log_exports);
-var import_node_os = __nccwpck_require__(405);
-var import_node_util = __toESM(__nccwpck_require__(398));
-var import_node_process = __toESM(__nccwpck_require__(249));
+var import_node_os = __nccwpck_require__(406);
+var import_node_util = __toESM(__nccwpck_require__(399));
+var import_node_process = __toESM(__nccwpck_require__(250));
 function log(message, ...args) {
   import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
 }
@@ -99006,7 +97665,7 @@ exports.serializeRequestBody = serializeRequestBody;
 const interfaces_js_1 = __nccwpck_require__(109);
 const operationHelpers_js_1 = __nccwpck_require__(459);
 const serializer_js_1 = __nccwpck_require__(513);
-const interfaceHelpers_js_1 = __nccwpck_require__(425);
+const interfaceHelpers_js_1 = __nccwpck_require__(426);
 /**
  * The programmatic identifier of the serializationPolicy.
  */
@@ -99163,11 +97822,11 @@ function prepareXMLRootList(obj, elementName, xmlNamespaceKey, xmlNamespace) {
 
 var net = __nccwpck_require__(543);
 var tls = __nccwpck_require__(539);
-var http = __nccwpck_require__(353);
+var http = __nccwpck_require__(354);
 var https = __nccwpck_require__(78);
 var events = __nccwpck_require__(503);
-var assert = __nccwpck_require__(562);
-var util = __nccwpck_require__(132);
+var assert = __nccwpck_require__(563);
+var util = __nccwpck_require__(133);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -99453,14 +98112,14 @@ __export(clientHelpers_exports, {
   getCachedDefaultHttpsClient: () => getCachedDefaultHttpsClient
 });
 module.exports = __toCommonJS(clientHelpers_exports);
-var import_defaultHttpClient = __nccwpck_require__(395);
-var import_createPipelineFromOptions = __nccwpck_require__(338);
-var import_apiVersionPolicy = __nccwpck_require__(238);
-var import_credentials = __nccwpck_require__(196);
+var import_defaultHttpClient = __nccwpck_require__(396);
+var import_createPipelineFromOptions = __nccwpck_require__(339);
+var import_apiVersionPolicy = __nccwpck_require__(239);
+var import_credentials = __nccwpck_require__(197);
 var import_apiKeyAuthenticationPolicy = __nccwpck_require__(97);
-var import_basicAuthenticationPolicy = __nccwpck_require__(161);
-var import_bearerAuthenticationPolicy = __nccwpck_require__(403);
-var import_oauth2AuthenticationPolicy = __nccwpck_require__(362);
+var import_basicAuthenticationPolicy = __nccwpck_require__(162);
+var import_bearerAuthenticationPolicy = __nccwpck_require__(404);
+var import_oauth2AuthenticationPolicy = __nccwpck_require__(363);
 let cachedHttpClient;
 function createDefaultPipeline(options = {}) {
   const pipeline = (0, import_createPipelineFromOptions.createPipelineFromOptions)(options);
@@ -99562,7 +98221,7 @@ exports.parseSoldrLoadReport = parseSoldrLoadReport;
 exports.tryLoadViaSoldr = tryLoadViaSoldr;
 exports.saveViaSoldr = saveViaSoldr;
 exports.trySaveViaSoldr = trySaveViaSoldr;
-const fs = __importStar(__nccwpck_require__(118));
+const fs = __importStar(__nccwpck_require__(119));
 const exec = __importStar(__nccwpck_require__(21));
 /** Min soldr version with parallel-extract `soldr load`. Released in 0.7.46 alongside zackees/soldr#575. */
 exports.MIN_SOLDR_VERSION_FOR_LOAD = "0.7.46";
@@ -99618,7 +98277,7 @@ function semverGte(value, minimum) {
  * returns (avoiding test-runner timeout from leaked descriptors).
  */
 async function detectSoldrManifest(archivePath) {
-    const { spawnSync } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 206, 23));
+    const { spawnSync } = await Promise.resolve(/* import() */).then(__nccwpck_require__.t.bind(__nccwpck_require__, 207, 23));
     // We invoke tar with `-tf <archive>` directly — bsdtar (Windows) and
     // GNU tar (Linux/macOS) both auto-detect zstd by magic byte on modern
     // versions. Bounded by `timeout: 5000ms`; if tar takes longer than
@@ -100150,7 +98809,7 @@ exports.AbortError = AbortError;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobQuickQueryStream = void 0;
 const node_stream_1 = __nccwpck_require__(457);
-const index_js_1 = __nccwpck_require__(359);
+const index_js_1 = __nccwpck_require__(360);
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
@@ -100297,12 +98956,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Pattern = void 0;
 const os = __importStar(__nccwpck_require__(102));
-const path = __importStar(__nccwpck_require__(264));
-const pathHelper = __importStar(__nccwpck_require__(231));
-const assert_1 = __importDefault(__nccwpck_require__(562));
-const minimatch_1 = __nccwpck_require__(133);
-const internal_match_kind_1 = __nccwpck_require__(565);
-const internal_path_1 = __nccwpck_require__(129);
+const path = __importStar(__nccwpck_require__(265));
+const pathHelper = __importStar(__nccwpck_require__(232));
+const assert_1 = __importDefault(__nccwpck_require__(563));
+const minimatch_1 = __nccwpck_require__(134);
+const internal_match_kind_1 = __nccwpck_require__(566);
+const internal_path_1 = __nccwpck_require__(130);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, isImplicitPattern = false, segments, homedir) {
@@ -100829,7 +99488,7 @@ function getRandomIntegerInclusive(min, max) {
 /***/ 541:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var wrappy = __nccwpck_require__(182)
+var wrappy = __nccwpck_require__(183)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -100905,13 +99564,13 @@ module.exports = require("timers");
 "use strict";
 
 
-const Readable = __nccwpck_require__(137)
+const Readable = __nccwpck_require__(138)
 const {
   InvalidArgumentError,
   RequestAbortedError
 } = __nccwpck_require__(522)
 const util = __nccwpck_require__(77)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(197)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(198)
 const { AsyncResource } = __nccwpck_require__(456)
 const { addSignal, removeSignal } = __nccwpck_require__(113)
 
@@ -101103,14 +99762,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TestTransport = void 0;
-const rpc_error_1 = __nccwpck_require__(183);
+const rpc_error_1 = __nccwpck_require__(184);
 const runtime_1 = __nccwpck_require__(22);
-const rpc_output_stream_1 = __nccwpck_require__(328);
-const rpc_options_1 = __nccwpck_require__(314);
+const rpc_output_stream_1 = __nccwpck_require__(329);
+const rpc_options_1 = __nccwpck_require__(315);
 const unary_call_1 = __nccwpck_require__(62);
 const server_streaming_call_1 = __nccwpck_require__(480);
-const client_streaming_call_1 = __nccwpck_require__(375);
-const duplex_streaming_call_1 = __nccwpck_require__(327);
+const client_streaming_call_1 = __nccwpck_require__(376);
+const duplex_streaming_call_1 = __nccwpck_require__(328);
 /**
  * Transport for testing.
  */
@@ -101464,7 +100123,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._internal = void 0;
 exports.installPassthrough = installPassthrough;
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
 const STUB_VERSION = "passthrough";
 function bashStub() {
@@ -101581,7 +100240,7 @@ exports._internal = { bashStub, cmdStub, STUB_VERSION };
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isTokenCredential = exports.isSASCredential = exports.AzureSASCredential = exports.isNamedKeyCredential = exports.AzureNamedKeyCredential = exports.isKeyCredential = exports.AzureKeyCredential = void 0;
-var azureKeyCredential_js_1 = __nccwpck_require__(318);
+var azureKeyCredential_js_1 = __nccwpck_require__(319);
 Object.defineProperty(exports, "AzureKeyCredential", ({ enumerable: true, get: function () { return azureKeyCredential_js_1.AzureKeyCredential; } }));
 var keyCredential_js_1 = __nccwpck_require__(43);
 Object.defineProperty(exports, "isKeyCredential", ({ enumerable: true, get: function () { return keyCredential_js_1.isKeyCredential; } }));
@@ -101591,7 +100250,7 @@ Object.defineProperty(exports, "isNamedKeyCredential", ({ enumerable: true, get:
 var azureSASCredential_js_1 = __nccwpck_require__(37);
 Object.defineProperty(exports, "AzureSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.AzureSASCredential; } }));
 Object.defineProperty(exports, "isSASCredential", ({ enumerable: true, get: function () { return azureSASCredential_js_1.isSASCredential; } }));
-var tokenCredential_js_1 = __nccwpck_require__(263);
+var tokenCredential_js_1 = __nccwpck_require__(264);
 Object.defineProperty(exports, "isTokenCredential", ({ enumerable: true, get: function () { return tokenCredential_js_1.isTokenCredential; } }));
 //# sourceMappingURL=index.js.map
 
@@ -101622,7 +100281,7 @@ if (typeof process === 'undefined' || process.type === 'renderer' || process.bro
 
 
 
-const { kHeadersList, kConstruct } = __nccwpck_require__(204)
+const { kHeadersList, kConstruct } = __nccwpck_require__(205)
 const { kGuard } = __nccwpck_require__(18)
 const { kEnumerableProperty } = __nccwpck_require__(77)
 const {
@@ -101630,9 +100289,9 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(552)
-const util = __nccwpck_require__(132)
+const util = __nccwpck_require__(133)
 const { webidl } = __nccwpck_require__(485)
-const assert = __nccwpck_require__(562)
+const assert = __nccwpck_require__(563)
 
 const kHeadersMap = Symbol('headers map')
 const kHeadersSortedMap = Symbol('headers map sorted')
@@ -102408,11 +101067,11 @@ function readSubPhaseDurations(parent) {
 
 
 const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(34)
-const { getGlobalOrigin } = __nccwpck_require__(148)
-const { performance } = __nccwpck_require__(343)
+const { getGlobalOrigin } = __nccwpck_require__(149)
+const { performance } = __nccwpck_require__(344)
 const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(77)
-const assert = __nccwpck_require__(562)
-const { isUint8Array } = __nccwpck_require__(207)
+const assert = __nccwpck_require__(563)
+const { isUint8Array } = __nccwpck_require__(208)
 
 let supportedHashes = []
 
@@ -102421,7 +101080,7 @@ let supportedHashes = []
 let crypto
 
 try {
-  crypto = __nccwpck_require__(312)
+  crypto = __nccwpck_require__(313)
   const possibleRelevantHashes = ['sha256', 'sha384', 'sha512']
   supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
 /* c8 ignore next 3 */
@@ -103374,7 +102033,7 @@ let ReadableStream = globalThis.ReadableStream
 
 function isReadableStreamLike (stream) {
   if (!ReadableStream) {
-    ReadableStream = (__nccwpck_require__(274).ReadableStream)
+    ReadableStream = (__nccwpck_require__(275).ReadableStream)
   }
 
   return stream instanceof ReadableStream || (
@@ -103646,6 +102305,1689 @@ module.exports = __nccwpck_require__(524);
 /***/ }),
 
 /***/ 556:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// setup-soldr entry point. Owned by Agent 2.
+//
+// Replaces the composite action's main-phase steps with a single JS
+// orchestrator. Calls the helpers in src/lib/* in the same order the
+// composite's steps fire.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.shouldSkipCargoRegistryExtractionError = shouldSkipCargoRegistryExtractionError;
+exports.run = run;
+const fs = __importStar(__nccwpck_require__(266));
+const os = __importStar(__nccwpck_require__(406));
+const path = __importStar(__nccwpck_require__(542));
+const node_child_process_1 = __nccwpck_require__(207);
+const core = __importStar(__nccwpck_require__(490));
+const cache = __importStar(__nccwpck_require__(223));
+const exec = __importStar(__nccwpck_require__(21));
+const log_utils_js_1 = __nccwpck_require__(201);
+const resolve_setup_js_1 = __nccwpck_require__(305);
+const phase_timing_js_1 = __nccwpck_require__(551);
+const ensure_rust_toolchain_js_1 = __nccwpck_require__(263);
+const ensure_soldr_js_1 = __nccwpck_require__(479);
+const verify_soldr_js_1 = __nccwpck_require__(380);
+const prepare_dylint_js_1 = __nccwpck_require__(349);
+const install_passthrough_js_1 = __nccwpck_require__(547);
+const normalize_source_mtime_js_1 = __nccwpck_require__(261);
+const detect_shared_target_warning_js_1 = __nccwpck_require__(234);
+const ensure_shims_js_1 = __nccwpck_require__(561);
+const zccache_seed_js_1 = __nccwpck_require__(94);
+const cache_compress_js_1 = __nccwpck_require__(28);
+const cargo_registry_archive_js_1 = __nccwpck_require__(260);
+const seed_isolated_cache_js_1 = __nccwpck_require__(307);
+const stats_collector_js_1 = __nccwpck_require__(464);
+const toolchain_snapshot_js_1 = __nccwpck_require__(489);
+const solo_toolchain_cache_js_1 = __nccwpck_require__(196);
+const cook_cache_js_1 = __nccwpck_require__(8);
+const soldr_mini_cache_js_1 = __nccwpck_require__(3);
+const diagnostics_js_1 = __nccwpck_require__(498);
+const shim_bypass_check_js_1 = __nccwpck_require__(335);
+const blessed_cross_prepare_js_1 = __nccwpck_require__(13);
+const target_lifecycle_js_1 = __nccwpck_require__(257);
+const source_mtime_snapshot_js_1 = __nccwpck_require__(487);
+const yank_audit_js_1 = __nccwpck_require__(114);
+/**
+ * Map (hit, matchedKey) → workflow-visible restore-status string.
+ * Mirrors post.ts's `RestoreStatus` so both phases emit the same vocabulary
+ * for the `<layer>-cache-restore-status` outputs declared in action.yml.
+ */
+function deriveRestoreStatus(hit, matchedKey) {
+    if (hit)
+        return "exact-hit";
+    if (matchedKey.trim())
+        return "restore-key-hit";
+    return "miss";
+}
+function shouldSkipCargoRegistryExtractionError(err, format, onFailure) {
+    if (format !== "legacy-v1" || onFailure?.trim().toLowerCase() !== "skip")
+        return false;
+    const code = err?.code;
+    return code === "EAUTHFAIL" || code === "EENCNOKEY";
+}
+function writeCacheKeysManifest(result, runnerTemp, log) {
+    if (!runnerTemp)
+        return;
+    const keys = [
+        result.setupCache.key,
+        result.buildCache.key,
+        result.targetCache.key,
+        result.cargoRegistryCache.key,
+    ].filter((k) => Boolean(k));
+    if (keys.length === 0)
+        return;
+    const outPath = path.join(runnerTemp, "setup-soldr-cache-keys.txt");
+    try {
+        fs.writeFileSync(outPath, keys.join("\n") + "\n", "utf8");
+        log(`cache-keys manifest written to ${outPath} (${keys.length} keys)`);
+    }
+    catch (err) {
+        log(`cache-keys manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+function isTruthy(value) {
+    return TRUTHY.has(((value ?? "").trim().toLowerCase()));
+}
+function isFalsy(value) {
+    return FALSY.has(((value ?? "").trim().toLowerCase()));
+}
+function fileExists(p) {
+    try {
+        return fs.statSync(p).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+async function queryTargetPlan(soldrPath, target, log) {
+    const output = await exec.getExecOutput(soldrPath, ["env", "--target", target, "--json"], {
+        silent: true,
+        ignoreReturnCode: true,
+    });
+    if (output.exitCode !== 0) {
+        log(`target-plan: soldr env failed with exit ${output.exitCode}`);
+        return null;
+    }
+    const line = output.stdout.split(/\r?\n/).map((value) => value.trim()).filter(Boolean).at(-1);
+    if (!line)
+        return null;
+    try {
+        return JSON.parse(line);
+    }
+    catch {
+        log("target-plan: soldr env returned non-JSON output");
+        return null;
+    }
+}
+function publishTargetContract(result, contract, logger) {
+    const target = result.blessedPrepareCache.target;
+    if (!target)
+        return;
+    if (!contract.cacheIdentity)
+        throw new Error(`Soldr target plan for ${target} has no cache identity`);
+    (0, target_lifecycle_js_1.assertTargetOperationSupported)(contract, "prepare");
+    result.targetContract = contract;
+    const mergedEnvironment = (0, target_lifecycle_js_1.mergeTargetEnvironment)(process.env, contract.environment);
+    for (const key of Object.keys(contract.environment)) {
+        core.exportVariable(key, mergedEnvironment[key] ?? contract.environment[key]);
+    }
+    const outputs = (0, target_lifecycle_js_1.buildTargetOperationOutputs)(result.workspace, contract);
+    core.setOutput("target-plan-json", JSON.stringify(contract));
+    core.setOutput("target-capabilities-json", JSON.stringify({
+        schemaVersion: contract.schemaVersion,
+        canonicalTarget: contract.canonicalTarget,
+        cacheIdentity: contract.cacheIdentity,
+        supportedOperations: contract.supportedOperations,
+        toolchain: contract.toolchain,
+        platform: contract.platform,
+    }));
+    core.setOutput("target-env-json", JSON.stringify(contract.environment));
+    core.setOutput("target-cache-identity", contract.cacheIdentity);
+    core.setOutput("target-artifact-dir", outputs.artifactDirectory);
+    core.setOutput("target-build-hook", outputs.build);
+    core.setOutput("target-clippy-hook", outputs.clippy);
+    core.setOutput("target-test-hook", outputs.testNoRun);
+    core.setOutput("target-wheel-hook", outputs.pep517Wheel);
+    core.setOutput("target-sdist-hook", outputs.pep517Sdist);
+    core.saveState("targetPlanJson", JSON.stringify(contract));
+    logger.log(`target-plan: canonical=${contract.canonicalTarget} cache=${contract.cacheIdentity} operations=${contract.supportedOperations.join(",")}`);
+}
+function dirHasContent(p) {
+    try {
+        return fs.readdirSync(p).length > 0;
+    }
+    catch {
+        return false;
+    }
+}
+async function runGitCapture(workspace, args) {
+    let stdout = "";
+    let stderr = "";
+    const code = await exec.exec("git", ["-C", workspace, ...args], {
+        silent: true,
+        ignoreReturnCode: true,
+        listeners: {
+            stdout: (data) => { stdout += data.toString("utf8"); },
+            stderr: (data) => { stderr += data.toString("utf8"); },
+        },
+    });
+    return { code, stdout, stderr };
+}
+async function deriveParentSha(workspace, githubSha, logger) {
+    // #365: derive parent SHA so cook-cache-delta + target-cache +
+    // cargo-registry can fall back to the prior commit's saved
+    // entry. Returns "" on any error (no regression from prior
+    // behavior — caller treats "" as "no fallback").
+    //
+    // Strategy: try `git log -1 --format=%P HEAD` first. On a
+    // shallow clone (actions/checkout default fetch-depth=1) this
+    // returns empty for grafted root commits — fall back to
+    // `git cat-file -p HEAD` and parse the `parent` header lines
+    // from the raw commit object, which are preserved even when
+    // the parent commit object isn't present in the local repo.
+    // Pass 1: git log %P (works on full-depth checkouts).
+    try {
+        const { code, stdout, stderr } = await runGitCapture(workspace, [
+            "log", "-1", "--format=%P", "HEAD",
+        ]);
+        if (code === 0) {
+            const first = stdout.trim().split(/\s+/)[0] ?? "";
+            if (/^[0-9a-f]{7,40}$/i.test(first)) {
+                if (first === githubSha)
+                    return "";
+                logger.log(`parent-sha: derived ${first.slice(0, 12)} from git log (#365)`);
+                return first;
+            }
+            // empty / unparseable → fall through to cat-file
+        }
+        else {
+            logger.log(`parent-sha: git log exit=${code} stderr=${stderr.trim().slice(0, 120)}; trying cat-file`);
+        }
+    }
+    catch (err) {
+        logger.log(`parent-sha: git log threw (${err instanceof Error ? err.message : String(err)}); trying cat-file`);
+    }
+    // Pass 2: git cat-file -p HEAD (works on shallow clones — the
+    // commit object's `parent` header is preserved even when the
+    // parent commit isn't fetched).
+    try {
+        const { code, stdout, stderr } = await runGitCapture(workspace, [
+            "cat-file", "-p", "HEAD",
+        ]);
+        if (code !== 0) {
+            logger.log(`parent-sha: cat-file exit=${code} stderr=${stderr.trim().slice(0, 120)}; leaving empty`);
+            return "";
+        }
+        // Raw commit object format:
+        //   tree <sha>
+        //   parent <sha>      ← first parent (mainline)
+        //   parent <sha>      ← second parent (only for merges)
+        //   author ...
+        //   committer ...
+        //
+        //   <message>
+        for (const line of stdout.split("\n")) {
+            if (line.startsWith("parent ")) {
+                const sha = line.slice("parent ".length).trim();
+                if (/^[0-9a-f]{7,40}$/i.test(sha) && sha !== githubSha) {
+                    logger.log(`parent-sha: derived ${sha.slice(0, 12)} from cat-file (#365, shallow-safe)`);
+                    return sha;
+                }
+            }
+            if (line === "")
+                break; // header section ended
+        }
+        logger.log(`parent-sha: cat-file produced no usable parent (root commit?); leaving empty`);
+        return "";
+    }
+    catch (err) {
+        logger.log(`parent-sha: cat-file threw (${err instanceof Error ? err.message : String(err)}); leaving empty`);
+        return "";
+    }
+}
+async function buildActionContext() {
+    const env = process.env;
+    const logger = (0, log_utils_js_1.createLogger)(env);
+    const workspace = env["ACTION_WORKSPACE"]?.trim() || env["GITHUB_WORKSPACE"]?.trim() || process.cwd();
+    const runnerTemp = env["RUNNER_TEMP"]?.trim() || path.join(os.tmpdir(), "setup-soldr-runner");
+    const runnerOs = env["ACTION_OS"]?.trim() || env["RUNNER_OS"]?.trim() || process.platform;
+    const runnerArch = env["ACTION_ARCH"]?.trim() || env["RUNNER_ARCH"]?.trim() || process.arch;
+    const githubSha = env["GITHUB_SHA"]?.trim() || "";
+    const githubToken = env["GITHUB_TOKEN"]?.trim() || env["INPUT_TOKEN"]?.trim() || "";
+    // #365: parentSha enables cook-cache-delta + target-cache + cargo-
+    // registry to share entries across consecutive commits. The env
+    // override (ACTION_PARENT_SHA) lets a workflow set it explicitly;
+    // otherwise we derive it from `git log -1 --format=%P HEAD` so the
+    // fallback works out of the box for any repo with non-shallow
+    // checkout. Without this, every push-event run had the delta key
+    // mismatch the prior save (0% hit rate observed on zccache).
+    let parentSha = env["ACTION_PARENT_SHA"]?.trim() || "";
+    if (!parentSha && githubSha) {
+        parentSha = await deriveParentSha(workspace, githubSha, logger);
+    }
+    return {
+        env: { ...env },
+        workspace,
+        runnerTemp,
+        runnerOs,
+        runnerArch,
+        githubSha,
+        githubToken,
+        parentSha,
+        logger,
+    };
+}
+function actionRoot() {
+    const explicit = process.env["GITHUB_ACTION_PATH"]?.trim() || process.env["SETUP_SOLDR_ACTION_ROOT"]?.trim();
+    if (explicit)
+        return path.resolve(explicit);
+    const moduleDir = typeof __dirname === "string" ? __dirname : process.cwd();
+    return path.resolve(moduleDir, "..");
+}
+async function restoreCacheSafe(paths, key, restoreKeys, logger) {
+    if (paths.length === 0 || !key) {
+        return { hit: false, matchedKey: "" };
+    }
+    try {
+        const matched = await cache.restoreCache(paths, key, restoreKeys);
+        return { hit: matched === key, matchedKey: matched ?? "" };
+    }
+    catch (err) {
+        logger.log(`cache restore failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`);
+        return { hit: false, matchedKey: "" };
+    }
+}
+async function run() {
+    const ctx = await buildActionContext();
+    const logger = ctx.logger;
+    await (0, phase_timing_js_1.markPhase)("action");
+    // ---- resolve ----
+    await (0, phase_timing_js_1.markPhase)("resolve");
+    const inputs = (0, resolve_setup_js_1.readRawInputs)(process.env);
+    const result = await (0, resolve_setup_js_1.resolveSetup)(ctx, inputs);
+    await (0, resolve_setup_js_1.applyResolveResult)(result);
+    await (0, phase_timing_js_1.finishPhase)("resolve");
+    // Always emit the cache-keys manifest right after resolve so workflow
+    // steps that run between main and post (e.g. actions/upload-artifact)
+    // can read it. The four keys are fully determined by resolveSetup and
+    // never change later in the run.
+    writeCacheKeysManifest(result, ctx.runnerTemp, (msg) => logger.log(msg));
+    const logging = (0, diagnostics_js_1.loggingEnabled)(inputs.logging);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            logger,
+            stepSummaryPath: process.env["GITHUB_STEP_SUMMARY"]?.trim() || undefined,
+        });
+    }
+    const dryRun = TRUTHY.has((process.env["SETUP_SOLDR_DRY_RUN"] ?? "").trim().toLowerCase());
+    if (dryRun) {
+        logger.log("DRY RUN: setup-soldr dry run — skipping cache, install, and verify");
+        await (0, phase_timing_js_1.finishPhase)("action");
+        return;
+    }
+    // Persist resolve state for the post-job step.
+    core.saveState("resolveResult", JSON.stringify(result));
+    core.saveState("buildCacheMode", result.buildCache.mode);
+    core.saveState("logging", logging ? "true" : "false");
+    core.saveState("preserveSourceMtimes", isTruthy(inputs.preserveSourceMtimes) ? "true" : "false");
+    const statsMode = result.stats;
+    const debugMode = result.debugMode;
+    const debugLog = debugMode ? (msg) => logger.log(msg) : () => undefined;
+    const statsCollector = new stats_collector_js_1.StatsCollector();
+    const dependencyCacheMatchedKeys = [];
+    // ---- source-mtime-normalize ----
+    if (isTruthy(inputs.sourceMtimeNormalize)) {
+        await (0, normalize_source_mtime_js_1.normalizeSourceMtime)({ workspace: ctx.workspace, enabled: true });
+    }
+    const cacheEnabled = !isFalsy(inputs.cache.trim() || "true");
+    const buildCacheEnabled = !isFalsy(inputs.buildCache.trim() || "true");
+    core.saveState("setupCacheEnabled", cacheEnabled && result.setupCache.paths.length > 0 ? "true" : "false");
+    core.saveState("setupCacheExactHit", "false");
+    core.saveState("setupCacheMatchedKey", "");
+    core.saveState("targetCacheEnabled", result.targetCache.enabled ? "true" : "false");
+    core.saveState("targetCacheExactHit", "false");
+    core.saveState("targetCacheMatchedKey", "");
+    core.saveState("buildCacheEnabled", buildCacheEnabled ? "true" : "false");
+    core.saveState("buildCacheExactHit", "false");
+    core.saveState("buildCacheMatchedKey", "");
+    core.saveState("cargoRegistryCacheEnabled", result.cargoRegistryCache.enabled ? "true" : "false");
+    core.saveState("cargoRegistryCacheExactHit", "false");
+    core.saveState("cargoRegistryCacheMatchedKey", "");
+    core.saveState("dylintCacheEnabled", result.dylintCache.enabled ? "true" : "false");
+    core.saveState("dylintCacheExactHit", "false");
+    core.saveState("dylintCacheMatchedKey", "");
+    core.saveState("dylintOutputCacheEnabled", result.dylintCache.outputCacheEnabled ? "true" : "false");
+    core.saveState("dylintOutputCacheExactHit", "false");
+    core.saveState("dylintOutputCacheMatchedKey", "");
+    core.saveState("blessedPrepareCacheEnabled", result.blessedPrepareCache.enabled ? "true" : "false");
+    core.saveState("blessedPrepareCacheExactHit", "false");
+    core.saveState("blessedPrepareCacheMatchedKey", "");
+    core.saveState("blessedPrepareComplete", "false");
+    // ---- parallel restores ----
+    // setup-cache, target-cache, build-cache, and cargo-registry write to
+    // disjoint paths and have no inter-dependencies, so they run concurrently.
+    // Sequential previously: ~18s on warm runs (setup 0.2s + target 7.7s +
+    // build 5s + cargo-registry 5s). Parallel: ~max(those) ≈ 8s. Saves ~10s.
+    //
+    // Layers that must stay sequential (wired below): solo-toolchain (writes
+    // RUSTUP_HOME, must precede ensureRustToolchain), soldr-mini (writes
+    // install dir, must precede ensureSoldr), cook (writes target/ and needs
+    // the soldr binary). Cargo-registry was previously after-cook — it's been
+    // moved into this parallel block because nothing the soldr install path
+    // touches depends on its hydrated cargo registry state.
+    await (0, phase_timing_js_1.markPhase)("parallel-restore");
+    let setupCacheExactHit = false;
+    // Capture target-cache match status so we can skip the redundant cook restore.
+    // target-cache (full prior build, ~1.5 GB) contains compiled deps; cook-cache
+    // (~2.5 GB inflated) also contains compiled deps. When target-cache matched
+    // at the lockfile/shape/toolchain level (exact OR parent-SHA OR lock-prefix
+    // fallback), we have target/deps/ already populated with identical content —
+    // cook restore would just overwrite. Skipping saves ~5–10 s per warm run.
+    // A looser restoreKeyLockfile-only match (different shape) is NOT enough to
+    // skip cook, since cook output may differ across shapes.
+    let targetCacheMatchedKey = "";
+    const setupRestorePromise = (async () => {
+        if (!(cacheEnabled && result.setupCache.paths.length > 0))
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.setupCache.paths, result.setupCache.key, [result.setupCache.restorePrefix], logger);
+        setupCacheExactHit = restore.hit;
+        core.setOutput("cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("setup_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("setup_cache_matched_key", restore.matchedKey);
+        core.saveState("setupCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("setupCacheMatchedKey", restore.matchedKey);
+        // Expose for ensure_rust_toolchain to read via env. Must be visible by
+        // the time toolchain phase runs — guaranteed by the Promise.all below.
+        process.env["SETUP_SOLDR_SETUP_CACHE_EXACT_HIT"] = restore.hit ? "true" : "false";
+        statsCollector.record({
+            label: "setup-cache", operation: "restore", hit: restore.hit,
+            key: result.setupCache.key, matchedKey: restore.matchedKey,
+            restoreKeys: [result.setupCache.restorePrefix],
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] setup-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const targetRestorePromise = (async () => {
+        if (!result.targetCache.enabled)
+            return;
+        const targetPaths = result.targetCache.paths
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (targetPaths.length === 0)
+            return;
+        const restoreKeys = [];
+        if (result.targetCache.restoreKeyParent)
+            restoreKeys.push(result.targetCache.restoreKeyParent);
+        if (result.targetCache.restoreKeyLock)
+            restoreKeys.push(result.targetCache.restoreKeyLock);
+        if (result.targetCache.restoreKeyLockfile)
+            restoreKeys.push(result.targetCache.restoreKeyLockfile);
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(targetPaths, result.targetCache.key, restoreKeys, logger);
+        core.setOutput("target-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("target-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("target_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("target_cache_matched_key", restore.matchedKey);
+        core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("targetCacheMatchedKey", restore.matchedKey);
+        targetCacheMatchedKey = restore.matchedKey;
+        if (restore.matchedKey)
+            dependencyCacheMatchedKeys.push(restore.matchedKey);
+        statsCollector.record({
+            label: "target-cache", operation: "restore", hit: restore.hit,
+            key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: null, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        if (debugMode)
+            debugLog(`[debug] target-cache: hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const buildRestorePromise = (async () => {
+        if (!buildCacheEnabled)
+            return;
+        const buildCachePath = result.buildCache.path;
+        const archivePath = `${buildCachePath}.tar.zst`;
+        const restoreKeys = [];
+        if (result.buildCache.restoreKeyParent)
+            restoreKeys.push(result.buildCache.restoreKeyParent);
+        if (result.buildCache.restoreKeyToolchain)
+            restoreKeys.push(result.buildCache.restoreKeyToolchain);
+        if (result.buildCache.restoreKeyOsArch)
+            restoreKeys.push(result.buildCache.restoreKeyOsArch);
+        const t0 = Date.now();
+        // @actions/cache hashes the `paths` array into a "version" key — save and
+        // restore MUST pass the same array or the lookup misses even when the
+        // entry exists. post.ts saves `[archivePath]` (just the .tar.zst), so
+        // restore must use the same single-path array. The decompression below
+        // unpacks archivePath → buildCachePath afterwards.
+        let restore = await restoreCacheSafe([archivePath], result.buildCache.key, restoreKeys, logger);
+        let buildArchiveBytes = null;
+        let buildInflatedBytes = null;
+        let buildFileCount = null;
+        if (restore.matchedKey) {
+            try {
+                buildArchiveBytes = fs.statSync(archivePath).size;
+            }
+            catch {
+                buildArchiveBytes = 0;
+            }
+            if (buildArchiveBytes === 0) {
+                logger.warning(`build-cache: matched key ${restore.matchedKey} produced an unusable payload: ` +
+                    `archive=0B; treating as miss`);
+                restore = { hit: false, matchedKey: "" };
+            }
+        }
+        if (restore.matchedKey && fileExists(archivePath)) {
+            const magic = await (0, cache_compress_js_1.detectCompressMagic)(archivePath);
+            const haveEncryptKey = (process.env["SETUP_SOLDR_CACHE_ENCRYPT_KEY"] ?? "").trim().length > 0;
+            if (magic === "zstd" || magic === "gzip" || haveEncryptKey) {
+                try {
+                    const dr = await (0, cache_compress_js_1.decompressCache)({
+                        archivePath,
+                        targetDir: buildCachePath,
+                        debug: debugMode,
+                        log: debugLog,
+                        cacheKey: restore.matchedKey || result.buildCache.key,
+                    });
+                    buildArchiveBytes = dr.archiveBytes;
+                    buildInflatedBytes = dr.inflatedBytes;
+                    buildFileCount = dr.fileCount;
+                    if (dr.fileCount === 0) {
+                        logger.warning(`build-cache: matched key ${restore.matchedKey} produced an unusable payload: ` +
+                            `archive=${dr.archiveBytes}B extracted_files=0 extracted_bytes=${dr.inflatedBytes}; treating as miss`);
+                        restore = { hit: false, matchedKey: "" };
+                    }
+                }
+                catch (err) {
+                    logger.warning(`build-cache: matched key ${restore.matchedKey} produced an unusable payload: ` +
+                        `archive=${buildArchiveBytes ?? 0}B decompress failed: ${err instanceof Error ? err.message : String(err)}; treating as miss`);
+                    restore = { hit: false, matchedKey: "" };
+                }
+            }
+            else {
+                logger.warning(`build-cache: matched key ${restore.matchedKey} produced an unusable payload: ` +
+                    `archive=${buildArchiveBytes ?? 0}B codec=unknown; treating as miss`);
+                restore = { hit: false, matchedKey: "" };
+            }
+        }
+        core.setOutput("build-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("build-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("build_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("build_cache_matched_key", restore.matchedKey);
+        core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("buildCacheMatchedKey", restore.matchedKey);
+        if (restore.matchedKey)
+            dependencyCacheMatchedKeys.push(restore.matchedKey);
+        // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
+        // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
+        // dir on the cold side; if it's present after decompress, walk it and
+        // set each matching source file's mtime to what cold saw. The replay
+        // is gated by (size, content-hash) match so we never overwrite a
+        // genuinely modified file's mtime — that would underbuild.
+        if (isTruthy(inputs.preserveSourceMtimes) && restore.hit) {
+            const snapshotPath = path.join(buildCachePath, source_mtime_snapshot_js_1.SNAPSHOT_FILENAME);
+            const snapshot = (0, source_mtime_snapshot_js_1.readSnapshotFile)(snapshotPath);
+            if (snapshot) {
+                const rt0 = Date.now();
+                try {
+                    // Match the project-root selection that post.ts uses when
+                    // writing the snapshot — the parent of the resolved target-dir,
+                    // not the (outer) GITHUB_WORKSPACE.
+                    const projectRoot = path.dirname(result.targetCache.targetPath);
+                    const rr = await (0, source_mtime_snapshot_js_1.replaySourceMtimes)({
+                        workspace: projectRoot,
+                        snapshot,
+                        log: (msg) => logger.log(msg),
+                    });
+                    logger.log(`source-mtime-replay: applied=${rr.applied} skipped_missing=${rr.skipped_missing} ` +
+                        `skipped_modified=${rr.skipped_modified} skipped_size_mismatch=${rr.skipped_size_mismatch} ` +
+                        `total=${rr.total} elapsed_ms=${Date.now() - rt0}`);
+                }
+                catch (err) {
+                    logger.log(`source-mtime-replay: failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+            else {
+                logger.log(`source-mtime-replay: snapshot file not found at ${snapshotPath}, skipping`);
+            }
+        }
+        statsCollector.record({
+            label: "build-cache", operation: "restore", hit: restore.hit,
+            key: result.buildCache.key, matchedKey: restore.matchedKey, restoreKeys,
+            archiveBytes: buildArchiveBytes, inflatedBytes: buildInflatedBytes, fileCount: buildFileCount,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+        // Seed an isolated SOLDR_CACHE_DIR from the just-restored build-cache
+        // artifact store (issue #240). Opt-in: only fires when the consumer
+        // declares the isolated root(s) it switches its self-test phase to, so a
+        // daemon-isolated coverage/integration phase starts warm instead of cold.
+        const seedTargets = (0, seed_isolated_cache_js_1.parseIsolatedSeedTargets)(inputs.seedIsolatedBuildCache);
+        if (seedTargets.length > 0) {
+            try {
+                (0, seed_isolated_cache_js_1.seedIsolatedBuildCache)({
+                    sourceZccacheDir: buildCachePath,
+                    targetSoldrRoots: seedTargets,
+                    log: (msg) => logger.log(msg),
+                });
+            }
+            catch (err) {
+                logger.log(`seed-isolated-build-cache: failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    })();
+    let cargoRegistryDownload = null;
+    // Download only. Archive extraction is deliberately deferred until after
+    // ensureSoldr() + runtime verification because soldr-v2 needs the installed
+    // binary and must never race its setup-cache/mini-cache restore.
+    const cargoRegistryRestorePromise = (async () => {
+        if (!result.cargoRegistryCache.enabled)
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.cargoRegistryCache.archive.restorePaths, result.cargoRegistryCache.key, [result.cargoRegistryCache.restorePrefix], logger);
+        core.setOutput("cargo-registry-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cargo_registry_cache_hit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("cargoRegistryCacheMatchedKey", restore.matchedKey);
+        cargoRegistryDownload = { hit: restore.hit, matchedKey: restore.matchedKey, startedMs: t0 };
+    })();
+    const blessedPrepareRestorePromise = (async () => {
+        const plan = result.blessedPrepareCache;
+        if (!plan.enabled)
+            return;
+        const t0 = Date.now();
+        const restored = await restoreCacheSafe(plan.archivePaths, plan.key, plan.restoreKeys, logger);
+        const restore = (0, blessed_cross_prepare_js_1.validateBlessedPrepareRestore)({
+            ...restored,
+            archivePaths: plan.archivePaths,
+            warn: (message) => logger.warning(message),
+        });
+        core.saveState("blessedPrepareCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("blessedPrepareCacheMatchedKey", restore.matchedKey);
+        core.setOutput("blessed-prepare-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("blessed-prepare-cache-key", plan.key);
+        statsCollector.record({
+            label: "blessed-prepare-cache", operation: "restore", hit: restore.hit,
+            key: plan.key, matchedKey: restore.matchedKey, restoreKeys: plan.restoreKeys,
+            archiveBytes: restore.archiveBytes, inflatedBytes: null, fileCount: null,
+            durationMs: Date.now() - t0, timestamp: new Date().toISOString(),
+        });
+    })();
+    const dylintRestorePromise = (async () => {
+        if (!result.dylintCache.enabled)
+            return;
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.dylintCache.paths, result.dylintCache.key, [], logger);
+        core.setOutput("dylint-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("dylint-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.setOutput("dylint_cache_hit", restore.hit ? "true" : "false");
+        core.setOutput("dylint_cache_matched_key", restore.matchedKey);
+        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_HIT", restore.hit ? "true" : "false");
+        core.exportVariable("SETUP_SOLDR_DYLINT_CACHE_MATCHED_KEY", restore.matchedKey);
+        core.saveState("dylintCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("dylintCacheMatchedKey", restore.matchedKey);
+        statsCollector.record({
+            label: "dylint-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: result.dylintCache.key,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - t0,
+            timestamp: new Date().toISOString(),
+        });
+        logger.log(`dylint-cache: key=${result.dylintCache.key} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    const dylintOutputRestorePromise = (async () => {
+        if (!result.dylintCache.outputCacheEnabled || result.dylintCache.outputPaths.length === 0) {
+            return;
+        }
+        const t0 = Date.now();
+        const restore = await restoreCacheSafe(result.dylintCache.outputPaths, result.dylintCache.outputKey, [], logger);
+        core.setOutput("dylint-output-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("dylint-output-cache-restore-status", deriveRestoreStatus(restore.hit, restore.matchedKey));
+        core.saveState("dylintOutputCacheExactHit", restore.hit ? "true" : "false");
+        core.saveState("dylintOutputCacheMatchedKey", restore.matchedKey);
+        statsCollector.record({
+            label: "dylint-output-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: result.dylintCache.outputKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - t0,
+            timestamp: new Date().toISOString(),
+        });
+        logger.log(`dylint-output-cache: key=${result.dylintCache.outputKey} hit=${restore.hit} matched=${restore.matchedKey || "(none)"}`);
+    })();
+    // Promise.all — each IIFE wraps its own errors via restoreCacheSafe and
+    // try/catches, so this should only see rejections for genuine programming
+    // bugs.
+    await Promise.all([
+        setupRestorePromise,
+        targetRestorePromise,
+        buildRestorePromise,
+        cargoRegistryRestorePromise,
+        blessedPrepareRestorePromise,
+        dylintRestorePromise,
+        dylintOutputRestorePromise,
+    ]);
+    await (0, phase_timing_js_1.finishPhase)("parallel-restore");
+    // ---- target-tree-cache (full mode) ----
+    // The bundle path is included in target-cache restore paths above when full
+    // mode is requested, so there's no separate restore here. We keep the phase
+    // marker for parity with the composite step ordering.
+    await (0, phase_timing_js_1.markPhase)("target-tree");
+    await (0, phase_timing_js_1.finishPhase)("target-tree");
+    // Plan soldr-mini-cache restore now, but perform the extract inside the
+    // install phase. Restoring this layer in the background can rewrite the
+    // install dir while later phases spawn PATH tools, which surfaced as Linux
+    // ETXTBSY on the warm demo after soldr-cook started invoking soldr earlier.
+    const miniEnabled = !isFalsy(inputs.soldrMiniCache.trim() || "true");
+    const miniInstallDir = path.dirname(result.soldrPath);
+    const miniArchive = `${miniInstallDir}.tar.zst`;
+    let miniHit = false;
+    let miniKey = "";
+    let miniSkipReason = "";
+    let miniRestoreEligible = false;
+    if (miniEnabled) {
+        const eligibility = (0, soldr_mini_cache_js_1.isEligibleForMiniCache)({
+            hasRef: Boolean(result.soldrRef.trim()),
+            enable: result.enabled,
+            resolvedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
+        });
+        if (eligibility.eligible) {
+            const version = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
+            miniKey = (0, soldr_mini_cache_js_1.buildMiniCacheKey)({
+                runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+                runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+                libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+                soldrVersion: version,
+            });
+            miniRestoreEligible = true;
+            logger.log(`soldr-mini-cache: key=${miniKey} installDir=${miniInstallDir}`);
+        }
+        else {
+            miniSkipReason = eligibility.reason;
+        }
+    }
+    // Kick off cook restore in the background. It overlaps with the
+    // sequential toolchain + soldr install + shims + verify steps that
+    // follow. By the time the cook phase runs, the restore is done — we
+    // just await the promise. Saves ~5–7 s of warm-build wall clock.
+    //
+    // Why this is safe (vs the disastrous PR #145 which added cook to the
+    // BIG parallel block): cook now races with SMALL ops (rust install
+    // ~1–2 s, soldr install ~2–3 s, shims/verify ~1–2 s). Those don't
+    // contend on disk write bandwidth the way target/build/cargo-registry
+    // restores did. Cook's 2.5 GB tar write becomes the long pole and
+    // hides behind the small ops.
+    //
+    // SAFETY: when target-cache writes to target/ (build-cache-mode: full),
+    // cook restore would race with target-cache restore on the same dir.
+    // The parallel-restore block above already finished target-cache, but
+    // we still want a runtime gate just in case the mode changes.
+    const cookGate = (0, cook_cache_js_1.decideCookGate)({
+        prebuildDeps: inputs.prebuildDeps,
+        cacheUmbrella: cacheEnabled,
+        lockfilePath: result.targetCache.lockfilePath,
+    });
+    const cookActive = cookGate.enabled && result.enabled;
+    let cookFlags = [];
+    let cookKey = "";
+    let cookBaseKey = "";
+    let cookDeltaKey = "";
+    let cookDeltaParentKey = "";
+    let cookDeltaRestoreKeys = [];
+    let cookProjectRoot = "";
+    let cookTargetDir = "";
+    let cookArchive = "";
+    let cookBaseArchive = "";
+    let cookDeltaArchive = "";
+    let cookBaseManifest = "";
+    let cookLayered = false;
+    core.setOutput("cook-cache-hit", "false");
+    core.setOutput("cook-cache-base-hit", "false");
+    core.setOutput("cook-cache-delta-hit", "false");
+    core.setOutput("cook-cache-status", cookActive ? "miss" : "disabled");
+    core.setOutput("cook-cache-load-report-json", "{}");
+    let cookRestoreT0 = Date.now();
+    let cookRestorePromise = null;
+    let cookLayeredRestorePromise = null;
+    // Skip cook restore when target-cache matched at the lockfile/shape level.
+    // restoreKeyLock = `${prefix}-${targetInputsHash}-${suffix}-` where
+    // targetInputsHash = sha256(toolchain, lockfile, manifest, shape). A
+    // matchedKey starting with restoreKeyLock means the cached entry was built
+    // with the same toolchain + lockfile + shape — its target/deps/ matches
+    // what cook would restore. Covers:
+    //   - exact hit  (matchedKey === current key, also startsWith restoreKeyLock)
+    //   - parent-SHA hit (matchedKey === restoreKeyParent, also startsWith)
+    //   - lock-prefix fallback (any saved entry with same lockfile+shape)
+    // Does NOT cover restoreKeyLockfile fallback (shorter prefix that drops
+    // shape) — different shape may mean different cook output, so cook still
+    // runs there as the safety net.
+    const targetCacheLockMatch = !!targetCacheMatchedKey &&
+        !!result.targetCache.restoreKeyLock &&
+        targetCacheMatchedKey.startsWith(result.targetCache.restoreKeyLock);
+    const cookSkippedDueToTargetHit = cookActive && targetCacheLockMatch;
+    if (cookActive && !cookSkippedDueToTargetHit) {
+        cookFlags = (0, cook_cache_js_1.canonicalizeCookFlags)((0, cook_cache_js_1.parseCookFlags)(inputs.prebuildDepsFlags));
+        const flagsHash = (0, cook_cache_js_1.hashCookFlags)(cookFlags);
+        const lockHash = result.targetCache.lockfileHash || "no-lock";
+        const cookKeyParts = {
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            flagsHash,
+            lockHash,
+            soldrVersion: result.soldrSourceIdentity.trim() ||
+                result.soldrVersionResolved.trim() ||
+                result.soldrVersionRequested.trim() ||
+                "unset",
+            keySuffix: inputs.cacheKeySuffix.trim(),
+        };
+        cookProjectRoot = path.dirname(result.targetCache.targetPath);
+        cookTargetDir = result.targetCache.targetPath;
+        cookRestoreT0 = Date.now();
+        const deltaInput = inputs.prebuildDepsDeltaCache.trim() || "true";
+        const deltaRequested = !isFalsy(deltaInput);
+        const soldrVersionForCook = result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim();
+        cookLayered = deltaRequested && (0, cook_cache_js_1.supportsLayeredCookCache)(soldrVersionForCook);
+        if (cookLayered) {
+            const shapeHash = (0, cook_cache_js_1.hashCookBuildShape)(result.targetCache.restoreKeyLock || result.targetCache.key);
+            cookBaseKey = (0, cook_cache_js_1.buildCookBaseCacheKey)(cookKeyParts);
+            cookDeltaKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
+                ...cookKeyParts,
+                buildShapeHash: shapeHash,
+                githubSha: ctx.githubSha || "nosha",
+            });
+            if (ctx.parentSha && ctx.parentSha !== ctx.githubSha) {
+                cookDeltaParentKey = (0, cook_cache_js_1.buildCookDeltaCacheKey)({
+                    ...cookKeyParts,
+                    buildShapeHash: shapeHash,
+                    githubSha: ctx.parentSha,
+                });
+            }
+            cookDeltaRestoreKeys = cookDeltaParentKey ? [cookDeltaParentKey] : [];
+            cookDeltaRestoreKeys.push((0, cook_cache_js_1.buildCookDeltaCacheRestorePrefix)({
+                ...cookKeyParts,
+                buildShapeHash: shapeHash,
+            }));
+            cookBaseArchive = `${cookTargetDir}.soldr-base.tar.zst`;
+            cookDeltaArchive = `${cookTargetDir}.soldr-delta.tar.zst`;
+            cookBaseManifest = `${cookTargetDir}.soldr-base-manifest.pb`;
+            logger.log(`cook: layered keys base=${cookBaseKey} delta=${cookDeltaKey}` +
+                (cookDeltaParentKey ? ` delta-fallback=${cookDeltaParentKey}` : ` (no parent-fallback — parentSha unavailable, #365)`) +
+                ` delta-prefix=${cookDeltaRestoreKeys.at(-1)}` +
+                ` starting archive restore concurrent with install`);
+            cookLayeredRestorePromise = (0, cook_cache_js_1.restoreLayeredCookCacheArchives)({
+                baseKey: cookBaseKey,
+                deltaKey: cookDeltaKey,
+                deltaRestoreKeys: cookDeltaRestoreKeys,
+                baseArchivePath: cookBaseArchive,
+                deltaArchivePath: cookDeltaArchive,
+                log: (msg) => logger.log(msg),
+                warn: (msg) => logger.warning(msg),
+            });
+        }
+        else {
+            if (deltaRequested) {
+                logger.log(`cook: layered cache requires soldr >=0.7.38; ` +
+                    `version=${soldrVersionForCook || "unknown"} falling back to legacy cook cache`);
+            }
+            else {
+                logger.log("cook: layered cache disabled via prebuild-deps-delta-cache=false");
+            }
+            cookKey = (0, cook_cache_js_1.buildCookCacheKey)(cookKeyParts);
+            cookArchive = `${cookTargetDir}.tar.zst`;
+            logger.log(`cook: key=${cookKey} starting background restore concurrent with install`);
+            cookRestorePromise = (0, cook_cache_js_1.restoreCookCache)({
+                exactKey: cookKey,
+                archivePath: cookArchive,
+                targetDir: cookTargetDir,
+                longWindow: 27,
+                debug: debugMode,
+                log: (msg) => logger.log(msg),
+                warn: (msg) => logger.warning(msg),
+            });
+        }
+    }
+    // ---- toolchain ----
+    // Snapshot $RUSTUP_HOME/toolchains/ + $CARGO_HOME/bin/ around the
+    // toolchain install so we can see which inodes setup-soldr added on
+    // top of the runner image. When solo-toolchain-cache is opted in, a
+    // third snapshot is taken *before* the cache restore so the saved
+    // tarball captures the full above-runner state — not just the
+    // post-restore delta. See CLAUDE.md "Detect-then-cache" + "Cache-
+    // lifetime axis".
+    await (0, phase_timing_js_1.markPhase)("toolchain");
+    const snapshotRoots = [
+        path.join(result.rustupHome, "toolchains"),
+        path.join(result.cargoHome, "bin"),
+    ];
+    const soloRootMap = {
+        "rustup-toolchains": snapshotRoots[0],
+        "cargo-bin": snapshotRoots[1],
+    };
+    const soloEnabled = isTruthy(inputs.soloToolchainCache);
+    // #310: default-changed from "19" → "9". Measured first-save cost
+    // dropped from ~104s → ~12s on 140 MB toolchain delta; restore stays
+    // bandwidth-bound either way.
+    const soloLevel = (inputs.soloToolchainCacheLevel.trim() || "9");
+    let soloKeys = null;
+    let soloMatchedKey = "";
+    let soloExactHit = false;
+    let forceToolchainRepair = false;
+    let soloRestoreInvalid = false;
+    let soloRestoredBytes = 0;
+    // Pre-restore snapshot — only needed when solo cache is enabled, so
+    // we can compute the full save-diff (post-install vs runner-image,
+    // not vs post-restore baseline). (#302: timed as sub-phase.)
+    const preRestoreSnapshot = soloEnabled
+        ? await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-pre", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots))
+        : null;
+    if (soloEnabled) {
+        soloKeys = (0, solo_toolchain_cache_js_1.buildSoloCacheKeys)({
+            runnerOs: ctx.runnerOs.toLowerCase() || process.platform,
+            runnerArch: ctx.runnerArch.toLowerCase() || process.arch,
+            libc: (0, solo_toolchain_cache_js_1.detectLibc)(),
+            rustcRelease: result.toolchain.cacheChannel.trim() || result.toolchain.channel.trim(),
+            componentsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.components),
+            targetsHash: (0, solo_toolchain_cache_js_1.hashStringArray)(result.toolchain.targets),
+            soldrVersion: result.soldrVersionResolved.trim() || result.soldrVersionRequested.trim() || "unset",
+        });
+        logger.log(`solo-toolchain-cache: key=${soloKeys.exact}`);
+        const restoreT0 = Date.now();
+        const stagingDir = path.join(ctx.runnerTemp, "setup-soldr-solo-cache");
+        const restored = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "solo-restore", () => (0, solo_toolchain_cache_js_1.restoreSoloCache)({
+            keys: soloKeys,
+            rootMap: soloRootMap,
+            stagingDir,
+            log: (msg) => logger.log(msg),
+            // #316 follow-up: pass canonical archive path explicitly so
+            // save and restore agree regardless of stagingDir layout.
+            cacheArchivePath: (0, solo_toolchain_cache_js_1.soloCacheArchivePath)(ctx.runnerTemp),
+        }));
+        soloMatchedKey = restored.matchedKey;
+        soloRestoredBytes = restored.restoredBytes;
+        let verifiedMatch = true;
+        if (restored.verified && restored.matchedKey) {
+            const expected = result.toolchain.cacheChannel.trim();
+            // The rustup home is set up so `rustc` will resolve through the
+            // restored toolchain dir. Use `rustc` from PATH (rustup shim) or
+            // the cargo bin one.
+            const rustcCmd = process.platform === "win32" ? "rustc.exe" : "rustc";
+            const verify = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
+                expectedRelease: expected,
+                expectedTargets: result.toolchain.targets,
+                expectedComponents: result.toolchain.components,
+                channel: result.toolchain.channel,
+                rustupCommand: process.platform === "win32" ? "rustup.exe" : "rustup",
+                log: (msg) => logger.log(msg),
+            });
+            verifiedMatch = verify.match;
+        }
+        soloRestoreInvalid = Boolean(restored.matchedKey) && (!restored.verified || !verifiedMatch);
+        forceToolchainRepair = soloRestoreInvalid;
+        if (soloRestoreInvalid) {
+            core.warning(`solo-toolchain-cache: restored entry failed validation; key=${restored.matchedKey} ` +
+                `archive=${restored.restoredBytes}B. The requested toolchain and targets will be repaired, ` +
+                `then the poisoned cache entry will be deleted and replaced (#473).`);
+        }
+        soloExactHit = restored.hit && restored.verified && verifiedMatch;
+        core.saveState("soloToolchainEnabled", "true");
+        core.saveState("soloToolchainExactKey", soloKeys.exact);
+        core.saveState("soloToolchainMatchedKey", soloMatchedKey);
+        core.saveState("soloToolchainExactHit", soloExactHit ? "true" : "false");
+        core.saveState("soloToolchainRestoreInvalid", soloRestoreInvalid ? "true" : "false");
+        core.saveState("soloToolchainInvalidMatchedKey", soloRestoreInvalid ? soloMatchedKey : "");
+        core.saveState("soloToolchainRestoredBytes", String(soloRestoredBytes));
+        core.saveState("soloToolchainLevel", soloLevel);
+        statsCollector.record({
+            label: "solo-toolchain-cache",
+            operation: "restore",
+            hit: soloExactHit,
+            key: soloKeys.exact,
+            matchedKey: soloMatchedKey,
+            restoreKeys: soloKeys.fallbacks,
+            archiveBytes: restored.restoredBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - restoreT0,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    else {
+        core.saveState("soloToolchainEnabled", "false");
+        core.saveState("soloToolchainRestoreInvalid", "false");
+    }
+    const baselineSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-base", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
+    // #323: when solo-cache exact-hit AND verifyRestoredToolchain
+    // passed, the requested toolchain is already on disk from the
+    // restore. `rustup toolchain install` would be a no-op but still
+    // costs ~8s on hosted runners (self-update check, metadata fetch,
+    // profile diff). Skip the install entirely on the verified
+    // exact-hit path. The snapshot still runs so cache-save logic
+    // downstream sees an unchanged tree (install-delta empty).
+    if (soloExactHit) {
+        logger.log("toolchain: solo-cache exact-hit + verified — skipping rustup install (#323)");
+        // The restored tree is already valid, but the skipped installer is also
+        // where ensureRustToolchain normally exports the selected channel. Keep
+        // cache-hit jobs explicit so rustup proxies used by later probes never
+        // depend on a runner-global default toolchain.
+        core.exportVariable("RUSTUP_TOOLCHAIN", result.toolchain.channel);
+        process.env["RUSTUP_TOOLCHAIN"] = result.toolchain.channel;
+    }
+    else {
+        await (0, phase_timing_js_1.timeSubPhase)("toolchain", "rustup-install", () => (0, ensure_rust_toolchain_js_1.ensureRustToolchain)({
+            resolveResult: result,
+            setupCacheExactHit,
+            forceRepair: forceToolchainRepair,
+        }));
+        if (forceToolchainRepair) {
+            const repaired = await (0, solo_toolchain_cache_js_1.verifyRestoredToolchain)({
+                expectedRelease: result.toolchain.cacheChannel.trim(),
+                expectedTargets: result.toolchain.targets,
+                expectedComponents: result.toolchain.components,
+                channel: result.toolchain.channel,
+                rustupCommand: process.platform === "win32" ? "rustup.exe" : "rustup",
+                log: (msg) => logger.log(msg),
+            });
+            if (!repaired.match) {
+                throw new Error(`solo-toolchain-cache: repair did not restore the requested toolchain and targets for key=${soloMatchedKey}`);
+            }
+            logger.log(`solo-toolchain-cache: repaired toolchain and requested targets verified for key=${soloMatchedKey}`);
+        }
+    }
+    const postInstallSnapshot = await (0, phase_timing_js_1.timeSubPhase)("toolchain", "snapshot-post", () => (0, toolchain_snapshot_js_1.walkSnapshot)(snapshotRoots));
+    const toolchainDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(baselineSnapshot, postInstallSnapshot);
+    const toolchainDiffStats = (0, toolchain_snapshot_js_1.diffStats)(toolchainDiff);
+    // When solo cache is enabled, also compute the save-diff (post-install
+    // vs pre-restore) so post.ts has the full above-runner manifest to tar.
+    if (soloEnabled && preRestoreSnapshot && ctx.runnerTemp) {
+        const saveDiff = (0, toolchain_snapshot_js_1.diffSnapshots)(preRestoreSnapshot, postInstallSnapshot);
+        const saveDiffStats = (0, toolchain_snapshot_js_1.diffStats)(saveDiff);
+        const saveDiffPath = path.join(ctx.runnerTemp, "setup-soldr-solo-save-diff.json");
+        try {
+            await fs.promises.writeFile(saveDiffPath, (0, toolchain_snapshot_js_1.serializeManifest)(saveDiff, saveDiffStats), "utf8");
+            core.saveState("soloToolchainSaveDiffPath", saveDiffPath);
+            core.saveState("soloToolchainIncrementalEmpty", toolchainDiff.added.length === 0 ? "true" : "false");
+            logger.log(`solo-toolchain-cache: save-diff added=${saveDiffStats.addedFiles} files (${saveDiffStats.addedBytes < 1024 * 1024
+                ? `${(saveDiffStats.addedBytes / 1024).toFixed(1)}KB`
+                : `${(saveDiffStats.addedBytes / 1024 / 1024).toFixed(1)}MB`}) ` +
+                `incremental-empty=${toolchainDiff.added.length === 0}`);
+        }
+        catch (err) {
+            logger.log(`solo-toolchain-cache: save-diff write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    const fmtMB = (bytes) => bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+    logger.log(`toolchain-snapshot: added=${toolchainDiffStats.addedFiles} files (${fmtMB(toolchainDiffStats.addedBytes)}) ` +
+        `changed=${toolchainDiffStats.changedFiles} removed=${toolchainDiffStats.removedFiles}`);
+    if (ctx.runnerTemp) {
+        const manifestPath = path.join(ctx.runnerTemp, "setup-soldr-toolchain-diff.json");
+        try {
+            await fs.promises.writeFile(manifestPath, (0, toolchain_snapshot_js_1.serializeManifest)(toolchainDiff, toolchainDiffStats), "utf8");
+            logger.log(`toolchain-snapshot: manifest at ${manifestPath}`);
+        }
+        catch (err) {
+            logger.log(`toolchain-snapshot: manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    await (0, phase_timing_js_1.finishPhase)("toolchain");
+    // ---- install soldr ----
+    // Restore soldr-mini-cache synchronously so the install dir is quiescent
+    // before ensureSoldr's installedVersion() check or any later soldr spawn.
+    await (0, phase_timing_js_1.markPhase)("install");
+    if (miniRestoreEligible) {
+        const miniT0 = Date.now();
+        const restore = await (0, soldr_mini_cache_js_1.restoreMiniCache)({
+            exactKey: miniKey,
+            installDir: miniInstallDir,
+            archivePath: miniArchive,
+            longWindow: 27,
+            debug: debugMode,
+            log: (msg) => logger.log(msg),
+            warn: (msg) => logger.warning(msg),
+            binaryPath: result.soldrPath,
+            expectedVersion: result.soldrVersionResolved || result.soldrVersionRequested,
+        });
+        miniHit = restore.hit;
+        statsCollector.record({
+            label: "soldr-mini-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: miniKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - miniT0,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    else if (miniSkipReason) {
+        logger.log(`soldr-mini-cache: skipped — ${miniSkipReason}`);
+    }
+    else if (!miniEnabled) {
+        logger.log("soldr-mini-cache: disabled via soldr-mini-cache=false");
+    }
+    core.saveState("soldrMiniEnabled", miniEnabled ? "true" : "false");
+    core.saveState("soldrMiniExactKey", miniKey);
+    core.saveState("soldrMiniHit", miniHit ? "true" : "false");
+    core.saveState("soldrMiniInstallDir", miniInstallDir);
+    core.saveState("soldrMiniArchive", miniArchive);
+    if (result.enabled) {
+        // On mini-cache hit, ensureSoldr's installedVersion() check sees the
+        // restored binary at the expected path with the expected version and
+        // short-circuits — no GH fetch.
+        await (0, ensure_soldr_js_1.ensureSoldr)({ resolveResult: result, githubToken: ctx.githubToken });
+    }
+    else {
+        (0, install_passthrough_js_1.installPassthrough)({
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+        logger.warning("setup-soldr: enable=false — installed a passthrough stub at " +
+            `${result.soldrPath}. \`soldr <tool> <args>\` will run \`<tool> <args>\` ` +
+            "verbatim, and soldr-aware caching/observability is disabled.");
+    }
+    await (0, phase_timing_js_1.finishPhase)("install");
+    // ---- zccache-seed ----
+    // Pin setup-soldr's zccache before user workflow steps. The pinned
+    // install is home-anchored inside soldr, so later self-tests can isolate
+    // SOLDR_CACHE_DIR without repeating release lookup or cargo-install fallback.
+    await (0, phase_timing_js_1.markPhase)("zccache-seed");
+    await (0, zccache_seed_js_1.seedZccache)({
+        soldrPath: result.soldrPath,
+        actionRoot: actionRoot(),
+        enabled: result.enabled,
+        strict: isTruthy(inputs.zccacheSeedStrict),
+        log: (msg) => logger.log(msg),
+        warn: (msg) => logger.warning(msg),
+    });
+    await (0, phase_timing_js_1.finishPhase)("zccache-seed");
+    // Export SOLDR_BINARY so shims can exec it directly
+    core.exportVariable("SOLDR_BINARY", result.soldrPath);
+    core.saveState("setupSoldrPassthrough", result.enabled ? "false" : "true");
+    // ---- shims ----
+    if (result.shimsEnabled) {
+        await (0, ensure_shims_js_1.ensureShims)({
+            shimsDir: result.shimsDir,
+            soldrPath: result.soldrPath,
+            isWindows: process.platform === "win32",
+            log: (msg) => logger.log(msg),
+        });
+    }
+    // ---- verify ----
+    await (0, phase_timing_js_1.markPhase)("verify");
+    let soldrRuntimeVersion = "passthrough";
+    if (result.enabled) {
+        const verify = await (0, verify_soldr_js_1.verifySoldr)({
+            soldrPath: result.soldrPath,
+            buildCacheMode: result.buildCache.mode,
+            requireRustPlan: result.targetCache.enabled,
+            minimumVersion: result.blessedPrepareCache.target ? "0.8.43" : undefined,
+        });
+        core.setOutput("soldr-version", verify.soldrVersion);
+        core.setOutput("soldr_version", verify.soldrVersion);
+        soldrRuntimeVersion = verify.soldrVersion;
+        core.saveState("soldrRuntimeVersion", verify.soldrVersion);
+    }
+    else {
+        core.setOutput("soldr-version", "passthrough");
+        core.setOutput("soldr_version", "passthrough");
+    }
+    await (0, phase_timing_js_1.finishPhase)("verify");
+    // ---- Dylint foundation ----
+    // Dylint mode is a complete setup contract: Soldr fetches and verifies its
+    // pinned command binaries, dated nightly/components, and matching driver.
+    // Direct Dylint UI tests also need the managed linker directory on PATH.
+    await (0, phase_timing_js_1.markPhase)("dylint-prepare");
+    await (0, prepare_dylint_js_1.prepareDylint)({
+        // cacheIdentity exists for Dylint mode even when every cache layer is
+        // disabled; preparation is functionality, not a cache side effect.
+        enabled: result.dylintCache.cacheIdentity !== "",
+        soldrPath: result.soldrPath,
+        soldrRoot: result.soldrRoot,
+        workspace: result.workspace,
+        cargoDylintVersion: result.dylintCache.cargoDylintVersion,
+        dylintLinkVersion: result.dylintCache.dylintLinkVersion,
+        addPath: (directory) => core.addPath(directory),
+    });
+    await (0, phase_timing_js_1.finishPhase)("dylint-prepare");
+    // ---- cargo-registry extraction ----
+    // Network download overlapped other layers in parallel-restore. Extraction
+    // starts only after the Soldr binary has been installed and runtime-verified.
+    await (0, phase_timing_js_1.markPhase)("cargo-registry-extract");
+    const registryDownload = cargoRegistryDownload;
+    if (registryDownload) {
+        let archiveBytes = null;
+        let restoredBytes = null;
+        let restoredFiles = null;
+        let restoredHit = registryDownload.hit;
+        let matched = registryDownload.matchedKey;
+        const markRegistryMiss = () => {
+            restoredHit = false;
+            matched = "";
+            core.setOutput("cargo-registry-cache-hit", "false");
+            core.setOutput("cargo_registry_cache_hit", "false");
+            core.saveState("cargoRegistryCacheExactHit", "false");
+            core.saveState("cargoRegistryCacheMatchedKey", "");
+        };
+        if (matched) {
+            try {
+                const archiveResult = await (0, cargo_registry_archive_js_1.restoreCargoRegistryArchive)({
+                    plan: result.cargoRegistryCache.archive,
+                    cargoHome: result.cargoHome,
+                    soldrPath: result.soldrPath,
+                    soldrVersion: soldrRuntimeVersion,
+                    cacheKey: matched,
+                    autoDefenderExclude: process.platform === "win32",
+                    debug: debugMode,
+                    log: debugLog,
+                });
+                if (!archiveResult.used) {
+                    logger.log(`cargo-registry: ${archiveResult.codecPath} unavailable for runtime Soldr ${soldrRuntimeVersion}; treating restored entry as a miss`);
+                    markRegistryMiss();
+                }
+                else {
+                    archiveBytes = archiveResult.archiveBytes;
+                    restoredBytes = archiveResult.restoredBytes;
+                    restoredFiles = archiveResult.restoredFiles;
+                    if (archiveBytes === 0 || restoredFiles === 0) {
+                        logger.warning(`cargo-registry: matched key ${matched} produced an unusable payload: ` +
+                            `archive=${archiveBytes}B extracted_files=${restoredFiles} ` +
+                            `extracted_bytes=${restoredBytes}; treating as miss`);
+                        markRegistryMiss();
+                    }
+                    else {
+                        dependencyCacheMatchedKeys.push(matched);
+                        logger.log(`cargo-registry: extracted format=${archiveResult.codecPath} archive_bytes=${archiveBytes} restored_bytes=${restoredBytes} files=${restoredFiles} duration_ms=${archiveResult.durationMs}`);
+                    }
+                }
+            }
+            catch (err) {
+                const errorCode = err?.code;
+                const encryptionFailure = errorCode === "EAUTHFAIL" || errorCode === "EENCNOKEY";
+                const skipEncryptionFailure = shouldSkipCargoRegistryExtractionError(err, result.cargoRegistryCache.archive.format, process.env["SETUP_SOLDR_CACHE_ENCRYPT_ON_FAILURE"]);
+                if (skipEncryptionFailure) {
+                    core.warning(`cargo-registry encrypted archive could not be restored; cache-encrypt-on-failure=skip treats it as a cold miss: ${err instanceof Error ? err.message : String(err)}`);
+                    markRegistryMiss();
+                }
+                else if (encryptionFailure) {
+                    throw new Error(`cargo-registry archive extraction failed for ${registryDownload.hit ? "exact-hit" : "fallback-hit"} ${matched}: ${err instanceof Error ? err.message : String(err)}`);
+                }
+                else {
+                    logger.warning(`cargo-registry: matched key ${matched} produced an unusable payload: ` +
+                        `${err instanceof Error ? err.message : String(err)}; treating as miss`);
+                    markRegistryMiss();
+                }
+            }
+        }
+        statsCollector.record({
+            label: `cargo-registry-${result.cargoRegistryCache.archive.format}`,
+            operation: "restore",
+            hit: restoredHit,
+            key: result.cargoRegistryCache.key,
+            matchedKey: matched,
+            restoreKeys: [result.cargoRegistryCache.restorePrefix],
+            archiveBytes,
+            inflatedBytes: restoredBytes,
+            fileCount: restoredFiles,
+            durationMs: Date.now() - registryDownload.startedMs,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    await (0, phase_timing_js_1.finishPhase)("cargo-registry-extract");
+    // ---- cross-prepare ----
+    await (0, phase_timing_js_1.markPhase)("cross-prepare");
+    const preparePlan = result.blessedPrepareCache;
+    if (preparePlan.target) {
+        if (!result.enabled)
+            throw new Error("cross-targets requires enable: true");
+        const installedVersion = result.soldrVersionResolved || result.soldrVersionRequested;
+        (0, blessed_cross_prepare_js_1.assertMinimumSoldrVersion)(installedVersion);
+        const exactHit = core.getState("blessedPrepareCacheExactHit") === "true";
+        const matchedKey = core.getState("blessedPrepareCacheMatchedKey");
+        const prepareTargets = (0, blessed_cross_prepare_js_1.prepareTargetsFor)(preparePlan.target);
+        const archivesExist = preparePlan.archivePaths.length === prepareTargets.length
+            && preparePlan.archivePaths.every((archivePath) => fs.existsSync(archivePath) && fs.statSync(archivePath).size > 0);
+        const cacheUse = (0, blessed_cross_prepare_js_1.decideBlessedPrepareCacheUse)({
+            enabled: preparePlan.enabled,
+            exactHit,
+            matchedKey,
+            archivesExist,
+        });
+        const { effectiveExactHit, fallbackHit } = cacheUse;
+        if (exactHit && !archivesExist) {
+            logger.log("cross-prepare: exact cache key restored without every prepared archive; reseeding");
+            core.saveState("blessedPrepareCacheExactHit", "false");
+            core.setOutput("blessed-prepare-cache-hit", "false");
+        }
+        logger.log(`cross-prepare: target=${preparePlan.target} cache=${preparePlan.enabled ? (effectiveExactHit ? "hit" : fallbackHit ? "fallback-hit" : "miss") : "disabled"}`);
+        const contracts = [];
+        for (const [index, target] of prepareTargets.entries()) {
+            await (0, blessed_cross_prepare_js_1.executeBlessedPrepare)({
+                soldrPath: result.soldrPath,
+                target,
+                githubEnv: process.env["GITHUB_ENV"],
+                archivePath: preparePlan.archivePaths[index],
+                // Fallback archives are intentionally replayed across Soldr releases.
+                // Soldr always validates expected versioned paths after restore and
+                // downloads only missing/current assets before saving the exact key.
+                restore: cacheUse.restore,
+                save: cacheUse.save,
+            });
+            const targetPlan = await queryTargetPlan(result.soldrPath, target, (message) => logger.log(message));
+            if (!targetPlan) {
+                throw new Error(`Soldr did not report a machine-readable target plan for ${target}; target capability is unavailable`);
+            }
+            contracts.push((0, target_lifecycle_js_1.normalizeTargetPlan)(target, targetPlan));
+        }
+        const contract = preparePlan.target === "universal2-apple-darwin"
+            ? (0, target_lifecycle_js_1.buildUniversal2TargetContract)(contracts)
+            : contracts[0];
+        publishTargetContract(result, contract, logger);
+        core.saveState("blessedPrepareComplete", "true");
+    }
+    await (0, phase_timing_js_1.finishPhase)("cross-prepare");
+    // ---- cook (prebuild-deps via soldr-cook) ----
+    // The RESTORE was kicked off as a background promise right after the
+    // parallel-restore block above — we just await its result here. The
+    // RUN (`soldr cook`) still happens in this phase if
+    // the restore missed.
+    // Failures here are logged but never fail the action — the user's
+    // own cargo build will still work without the cooked deps.
+    await (0, phase_timing_js_1.markPhase)("cook");
+    if (cookActive && cookLayeredRestorePromise) {
+        const restore = await cookLayeredRestorePromise;
+        const loaded = await (0, cook_cache_js_1.loadLayeredCookCache)({
+            soldrBinary: result.soldrPath,
+            projectRoot: cookProjectRoot,
+            targetDir: cookTargetDir,
+            baseArchivePath: cookBaseArchive,
+            deltaArchivePath: cookDeltaArchive,
+            baseManifestPath: cookBaseManifest,
+            restore,
+            log: (msg) => logger.log(msg),
+            warn: (msg) => logger.warning(msg),
+        });
+        const baseReady = (0, cook_cache_js_1.layeredCookBaseReady)(restore, loaded);
+        const deltaReady = (0, cook_cache_js_1.layeredCookDeltaReady)(restore, loaded);
+        if (baseReady && restore.base.matchedKey) {
+            dependencyCacheMatchedKeys.push(restore.base.matchedKey);
+        }
+        if (deltaReady && restore.delta.matchedKey) {
+            dependencyCacheMatchedKeys.push(restore.delta.matchedKey);
+        }
+        core.setOutput("cook-cache-base-hit", baseReady ? "true" : "false");
+        core.setOutput("cook-cache-delta-hit", deltaReady ? "true" : "false");
+        core.setOutput("cook-cache-hit", baseReady ? "true" : "false");
+        core.setOutput("cook-cache-status", deltaReady ? "hit" : baseReady ? "base-hit" : "miss");
+        core.setOutput("cook-cache-load-report-json", JSON.stringify({
+            base: loaded.baseReport,
+            delta: loaded.deltaReport,
+        }));
+        statsCollector.record({
+            label: "cook-cache-base",
+            operation: "restore",
+            hit: baseReady,
+            key: cookBaseKey,
+            matchedKey: restore.base.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.base.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: loaded.baseReport?.cacheFilesRestored ?? null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        statsCollector.record({
+            label: "cook-cache-delta",
+            operation: "restore",
+            hit: deltaReady,
+            key: cookDeltaKey,
+            matchedKey: restore.delta.matchedKey,
+            restoreKeys: cookDeltaRestoreKeys,
+            archiveBytes: restore.delta.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: loaded.deltaReport?.cacheFilesRestored ?? null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        let cookRan = false;
+        if (!deltaReady) {
+            const runRes = await (0, cook_cache_js_1.runCook)({
+                soldrBinary: result.soldrPath,
+                projectRoot: cookProjectRoot,
+                flags: cookFlags,
+                log: (msg) => logger.log(msg),
+            });
+            cookRan = runRes.exitCode === 0;
+        }
+        else {
+            logger.log("cook: base+delta cache hit - skipping cook run, target/deps already warm");
+        }
+        const cookSaveLayer = cookRan ? (baseReady ? "delta" : "base") : "none";
+        core.saveState("cookEnabled", "true");
+        core.saveState("cookLayered", "true");
+        core.saveState("cookBaseExactKey", cookBaseKey);
+        core.saveState("cookDeltaExactKey", cookDeltaKey);
+        core.saveState("cookBaseMatchedKey", restore.base.matchedKey);
+        core.saveState("cookDeltaMatchedKey", restore.delta.matchedKey);
+        core.saveState("cookBaseHit", baseReady ? "true" : "false");
+        core.saveState("cookDeltaHit", deltaReady ? "true" : "false");
+        core.saveState("cookHit", deltaReady ? "true" : "false");
+        core.saveState("cookRan", cookRan ? "true" : "false");
+        core.saveState("cookSaveLayer", cookSaveLayer);
+        core.saveState("cookProjectRoot", cookProjectRoot);
+        core.saveState("cookTargetDir", cookTargetDir);
+        core.saveState("cookBaseArchive", cookBaseArchive);
+        core.saveState("cookDeltaArchive", cookDeltaArchive);
+        core.saveState("cookBaseManifest", cookBaseManifest);
+        core.saveState("cookSoldrBinary", result.soldrPath);
+        // #268/#358: cook-cache-base previously used zstd-level 19, but
+        // production observation showed 165s of compress wall-clock per
+        // matrix job for ~224 MB output. In a 5-way matrix where 1 job
+        // wins the cache reservation and 4 lose the race, that's 660s
+        // of post-step CPU wasted per CI cycle. Lowering to -9 cuts the
+        // compress wall-clock ~4× (target ~40s) at the cost of ~25%
+        // larger archive (~280 MB) and ~1s extra upload wall-clock per
+        // save. zstd decompression speed is level-independent, so warm
+        // restores are unaffected. Net: ~125s win per save-attempt, big
+        // multiplier on race-loss scenarios.
+        core.saveState("cookCompressLevel", "9");
+        core.saveState("cookDeltaCompressLevel", "3");
+    }
+    else if (cookActive && cookRestorePromise) {
+        const restore = await cookRestorePromise;
+        core.setOutput("cook-cache-hit", restore.hit ? "true" : "false");
+        core.setOutput("cook-cache-status", restore.hit ? "hit" : "miss");
+        statsCollector.record({
+            label: "cook-cache",
+            operation: "restore",
+            hit: restore.hit,
+            key: cookKey,
+            matchedKey: restore.matchedKey,
+            restoreKeys: [],
+            archiveBytes: restore.archiveBytes || null,
+            inflatedBytes: null,
+            fileCount: null,
+            durationMs: Date.now() - cookRestoreT0,
+            timestamp: new Date().toISOString(),
+        });
+        let cookRan = false;
+        if (!restore.hit) {
+            const runRes = await (0, cook_cache_js_1.runCook)({
+                soldrBinary: result.soldrPath,
+                projectRoot: cookProjectRoot,
+                flags: cookFlags,
+                log: (msg) => logger.log(msg),
+            });
+            cookRan = runRes.exitCode === 0;
+        }
+        else {
+            logger.log("cook: cache hit - skipping cook run, target/deps already warm");
+        }
+        core.saveState("cookEnabled", "true");
+        core.saveState("cookLayered", "false");
+        core.saveState("cookExactKey", cookKey);
+        core.saveState("cookMatchedKey", restore.matchedKey);
+        if (restore.hit && restore.matchedKey)
+            dependencyCacheMatchedKeys.push(restore.matchedKey);
+        core.saveState("cookHit", restore.hit ? "true" : "false");
+        core.saveState("cookRan", cookRan ? "true" : "false");
+        core.saveState("cookTargetDir", cookTargetDir);
+        core.saveState("cookLongWindow", "27");
+        // #268/#358: see saveState("cookCompressLevel", "9") above for
+        // rationale on lowering from -19. Same logic applies to the
+        // non-layered path.
+        core.saveState("cookCompressLevel", "9");
+    }
+    else if (cookSkippedDueToTargetHit) {
+        core.setOutput("cook-cache-status", "covered-by-target-cache");
+        logger.log(`cook: skipped - target-cache matched at lockfile/shape level (matched=${targetCacheMatchedKey}); cook output would be redundant`);
+        core.saveState("cookEnabled", "false");
+        core.saveState("cookLayered", "false");
+    }
+    else {
+        logger.log(`cook: skipped - ${cookGate.reason}`);
+        core.saveState("cookEnabled", "false");
+        core.saveState("cookLayered", "false");
+    }
+    await (0, phase_timing_js_1.finishPhase)("cook");
+    // #476: content-addressed keys cannot observe a later registry yank. Start
+    // the network check only after every dependency-bearing restore has been
+    // validated, then let it run concurrently with the consumer's build. The
+    // post action joins this result before any cache save can report success.
+    const poisonedCandidates = [...new Set(dependencyCacheMatchedKeys.filter(Boolean))];
+    core.saveState("yankAuditStarted", "false");
+    if (poisonedCandidates.length > 0) {
+        const resultPath = path.join(ctx.runnerTemp, "setup-soldr-yank-audit", "result.json");
+        const configPath = path.join(ctx.runnerTemp, "setup-soldr-yank-audit", "config.json");
+        try {
+            if (!result.targetCache.lockfilePath) {
+                throw new Error("restored dependency cache has no Cargo.lock path");
+            }
+            const lockfilePath = path.isAbsolute(result.targetCache.lockfilePath)
+                ? result.targetCache.lockfilePath
+                : path.resolve(ctx.workspace, result.targetCache.lockfilePath);
+            const dependencies = (0, yank_audit_js_1.readRegistryDependencies)(lockfilePath);
+            const config = {
+                dependencies,
+                requestTimeoutMs: 30_000,
+                // Finish before post's 60s join ceiling even if every registry
+                // request stalls. The worker aborts all in-flight requests together.
+                overallTimeoutMs: 45_000,
+            };
+            fs.mkdirSync(path.dirname(configPath), { recursive: true });
+            fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`, "utf8");
+            (0, yank_audit_js_1.writeYankAuditResult)(resultPath, { status: "pending" });
+            core.saveState("yankAuditStarted", "true");
+            core.saveState("yankAuditResultPath", resultPath);
+            core.saveState("yankAuditCacheKeys", JSON.stringify(poisonedCandidates));
+            if (dependencies.length === 0) {
+                (0, yank_audit_js_1.writeYankAuditResult)(resultPath, {
+                    status: "clean",
+                    checkedAt: new Date().toISOString(),
+                    dependencyCount: 0,
+                    checkedCount: 0,
+                    yanked: [],
+                    errors: [],
+                });
+            }
+            else {
+                const entrypoint = process.argv[1];
+                if (!entrypoint)
+                    throw new Error("Node action entrypoint is unavailable");
+                const child = (0, node_child_process_1.spawn)(process.execPath, [entrypoint, yank_audit_js_1.YANK_AUDIT_WORKER_ARG, configPath, resultPath], { detached: true, stdio: "ignore", windowsHide: true });
+                child.unref();
+                logger.log(`yank-audit: started pid=${child.pid ?? "unknown"} dependencies=${dependencies.length} ` +
+                    `cache_keys=${poisonedCandidates.length}`);
+            }
+        }
+        catch (err) {
+            (0, yank_audit_js_1.writeYankAuditResult)(resultPath, {
+                status: "not-checked",
+                checkedAt: new Date().toISOString(),
+                errors: [err instanceof Error ? err.message : String(err)],
+            });
+            core.saveState("yankAuditStarted", "true");
+            core.saveState("yankAuditResultPath", resultPath);
+            core.saveState("yankAuditCacheKeys", JSON.stringify(poisonedCandidates));
+            logger.warning(`yank-audit: not checked: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    // ---- shared-target warning ----
+    await (0, detect_shared_target_warning_js_1.detectSharedTargetWarning)({
+        buildCacheEnabled,
+        effectiveTargetCacheEnabled: result.targetCache.enabled,
+        buildCacheMode: result.buildCache.mode,
+        targetDir: result.targetCache.targetPath,
+        soldrPath: result.soldrPath,
+    });
+    // ---- shim-bypass diagnostic ----
+    // Issue #160: when shims: true is requested but the effective environment
+    // (PATH ordering, CARGO/RUSTC/RUSTC_WRAPPER overrides) would bypass them,
+    // caching looks configured but compile work runs through plain cargo.
+    // Emit advisory warnings naming each offender. Runs at the very end so it
+    // sees the final state of process.env after every prior phase.
+    if (result.shimsEnabled) {
+        const bypassWarnings = (0, shim_bypass_check_js_1.diagnoseShimBypass)({
+            shimsEnabled: true,
+            shimDir: result.shimsDir,
+            path: process.env["PATH"] ?? "",
+            cargoEnv: process.env["CARGO"],
+            rustcEnv: process.env["RUSTC"],
+            rustcWrapperEnv: process.env["RUSTC_WRAPPER"],
+            soldrBinary: result.soldrPath,
+        });
+        for (const msg of bypassWarnings) {
+            core.warning(msg);
+        }
+        if (bypassWarnings.length === 0) {
+            logger.log(`shim-bypass check clean: shim dir ${result.shimsDir} at PATH front, no competing CARGO/RUSTC/RUSTC_WRAPPER overrides`);
+        }
+    }
+    // ---- stats report ----
+    statsCollector.report(statsMode, (msg) => logger.log(msg));
+    if (statsMode === "detailed") {
+        try {
+            await statsCollector.writeFiles(ctx.runnerTemp);
+            statsCollector.setGithubOutputs();
+        }
+        catch (err) {
+            logger.log(`stats: failed to write files: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    core.saveState("statsCollector", statsCollector.serialize());
+    core.saveState("statsMode", statsMode);
+    core.saveState("compileCacheStats", result.compileCacheStats);
+    core.saveState("runnerTemp", ctx.runnerTemp);
+    if (logging) {
+        (0, diagnostics_js_1.dumpDiagnostics)({
+            phase: "main",
+            env: process.env,
+            rawInputs: inputs,
+            result,
+            cacheOutcomes: statsCollector.snapshot(),
+            logger,
+        });
+    }
+    // #269-companion (setup side): one-line aggregate of where each
+    // setup phase's wall-clock went, before we finish the `action`
+    // phase. Mirrors the post-step `cache save totals:` line that
+    // ships from `StatsCollector.saveSummaryOneLine()`. Operators see
+    // the pre-build budget at a glance without scrolling raw
+    // SETUP_SOLDR_PHASE_*_START_MS env vars or hunting through the
+    // timeline. Phases in declared serial order:
+    const setupPhaseSummary = (0, phase_timing_js_1.setupPhaseSummaryOneLine)([
+        "resolve",
+        "parallel-restore",
+        "target-tree",
+        "toolchain",
+        "install",
+        "zccache-seed",
+        "verify",
+        "cargo-registry-extract",
+        "cross-prepare",
+        "cook",
+    ]);
+    if (setupPhaseSummary)
+        core.info(setupPhaseSummary);
+    await (0, phase_timing_js_1.finishPhase)("action");
+    // dirHasContent is exported for tests; suppress unused warning here.
+    void dirHasContent;
+}
+// Auto-invoke only when this module is run as the main entry point. This lets
+// tests import `run` (and helpers) without triggering the side-effectful
+// orchestration. The dist/main.js produced by ncc is invoked directly by the
+// Actions runtime so the check trips and the action executes normally.
+if (typeof process !== "undefined" &&
+    process.env["SETUP_SOLDR_SKIP_AUTOSTART"] !== "1" &&
+    // import.meta.url is the file URL of this module; argv[1] is the runner
+    // entrypoint. ncc bundles into dist/main.js so the bundled path won't equal
+    // the dev path — we rely on the env-var opt-out for tests instead.
+    !process.env["SETUP_SOLDR_TEST_IMPORT"]) {
+    if (process.argv[2] === yank_audit_js_1.YANK_AUDIT_WORKER_ARG) {
+        const configPath = process.argv[3];
+        const resultPath = process.argv[4];
+        if (!configPath || !resultPath) {
+            process.exitCode = 2;
+        }
+        else {
+            (0, yank_audit_js_1.runYankAuditWorker)(configPath, resultPath).catch(() => {
+                process.exitCode = 1;
+            });
+        }
+    }
+    else {
+        run().catch((err) => {
+            const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+            core.setFailed(`setup-soldr failed: ${message}`);
+        });
+    }
+}
+
+
+/***/ }),
+
+/***/ 557:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -103690,7 +104032,7 @@ function throttlingRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 557:
+/***/ 558:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -103730,17 +104072,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.evaluateVersions = exports.isExplicitVersion = exports.findFromManifest = exports.getManifestFromRepo = exports.findAllVersions = exports.find = exports.cacheFile = exports.cacheDir = exports.extractZip = exports.extractXar = exports.extractTar = exports.extract7z = exports.downloadTool = exports.HTTPError = void 0;
 const core = __importStar(__nccwpck_require__(490));
-const io = __importStar(__nccwpck_require__(315));
-const crypto = __importStar(__nccwpck_require__(312));
-const fs = __importStar(__nccwpck_require__(567));
-const mm = __importStar(__nccwpck_require__(355));
+const io = __importStar(__nccwpck_require__(316));
+const crypto = __importStar(__nccwpck_require__(313));
+const fs = __importStar(__nccwpck_require__(568));
+const mm = __importStar(__nccwpck_require__(356));
 const os = __importStar(__nccwpck_require__(102));
-const path = __importStar(__nccwpck_require__(264));
-const httpm = __importStar(__nccwpck_require__(303));
-const semver = __importStar(__nccwpck_require__(186));
-const stream = __importStar(__nccwpck_require__(139));
-const util = __importStar(__nccwpck_require__(132));
-const assert_1 = __nccwpck_require__(562);
+const path = __importStar(__nccwpck_require__(265));
+const httpm = __importStar(__nccwpck_require__(304));
+const semver = __importStar(__nccwpck_require__(187));
+const stream = __importStar(__nccwpck_require__(140));
+const util = __importStar(__nccwpck_require__(133));
+const assert_1 = __nccwpck_require__(563);
 const exec_1 = __nccwpck_require__(21);
 const retry_helper_1 = __nccwpck_require__(11);
 class HTTPError extends Error {
@@ -104363,7 +104705,7 @@ function _unique(values) {
 
 /***/ }),
 
-/***/ 558:
+/***/ 559:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var __defProp = Object.defineProperty;
@@ -104389,7 +104731,7 @@ __export(exponentialRetryPolicy_exports, {
   exponentialRetryPolicyName: () => exponentialRetryPolicyName
 });
 module.exports = __toCommonJS(exponentialRetryPolicy_exports);
-var import_exponentialRetryStrategy = __nccwpck_require__(420);
+var import_exponentialRetryStrategy = __nccwpck_require__(421);
 var import_retryPolicy = __nccwpck_require__(19);
 var import_constants = __nccwpck_require__(54);
 const exponentialRetryPolicyName = "exponentialRetryPolicy";
@@ -104413,7 +104755,7 @@ function exponentialRetryPolicy(options = {}) {
 
 /***/ }),
 
-/***/ 559:
+/***/ 560:
 /***/ ((module) => {
 
 var __defProp = Object.defineProperty;
@@ -104627,7 +104969,7 @@ function createEmptyPipeline() {
 
 /***/ }),
 
-/***/ 560:
+/***/ 561:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -104680,10 +105022,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ensureShimsLegacy = ensureShimsLegacy;
 exports.tryDelegateToSoldrToolchainLink = tryDelegateToSoldrToolchainLink;
 exports.ensureShims = ensureShims;
-const fs = __importStar(__nccwpck_require__(265));
+const fs = __importStar(__nccwpck_require__(266));
 const path = __importStar(__nccwpck_require__(542));
 const core = __importStar(__nccwpck_require__(490));
-const soldr_toolchain_client_js_1 = __nccwpck_require__(364);
+const soldr_toolchain_client_js_1 = __nccwpck_require__(365);
 // Tools that route through `soldr <tool>`:
 const ROUTED_TOOLS = ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"];
 // Unix bash shim template (per tool):
@@ -104787,7 +105129,7 @@ async function ensureShims(opts) {
 
 /***/ }),
 
-/***/ 561:
+/***/ 562:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -104796,8 +105138,8 @@ async function ensureShims(opts) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SASQueryParameters = exports.SASProtocol = void 0;
-const SasIPRange_js_1 = __nccwpck_require__(384);
-const utils_common_js_1 = __nccwpck_require__(163);
+const SasIPRange_js_1 = __nccwpck_require__(385);
+const utils_common_js_1 = __nccwpck_require__(164);
 /**
  * Protocols for generated SAS.
  */
@@ -105161,7 +105503,7 @@ exports.SASQueryParameters = SASQueryParameters;
 
 /***/ }),
 
-/***/ 562:
+/***/ 563:
 /***/ ((module) => {
 
 "use strict";
@@ -105169,7 +105511,7 @@ module.exports = require("assert");
 
 /***/ }),
 
-/***/ 563:
+/***/ 564:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -105279,7 +105621,7 @@ async function retryReleaseRequest(request, options = {}) {
 
 /***/ }),
 
-/***/ 564:
+/***/ 565:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -105344,7 +105686,7 @@ exports.readServiceOption = readServiceOption;
 
 /***/ }),
 
-/***/ 565:
+/***/ 566:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -105369,27 +105711,27 @@ var MatchKind;
 
 /***/ }),
 
-/***/ 566:
+/***/ 567:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MessageType = void 0;
-const message_type_contract_1 = __nccwpck_require__(432);
+const message_type_contract_1 = __nccwpck_require__(433);
 const reflection_info_1 = __nccwpck_require__(481);
-const reflection_type_check_1 = __nccwpck_require__(311);
-const reflection_json_reader_1 = __nccwpck_require__(367);
+const reflection_type_check_1 = __nccwpck_require__(312);
+const reflection_json_reader_1 = __nccwpck_require__(368);
 const reflection_json_writer_1 = __nccwpck_require__(100);
-const reflection_binary_reader_1 = __nccwpck_require__(434);
-const reflection_binary_writer_1 = __nccwpck_require__(193);
-const reflection_create_1 = __nccwpck_require__(214);
-const reflection_merge_partial_1 = __nccwpck_require__(145);
-const json_typings_1 = __nccwpck_require__(419);
-const json_format_contract_1 = __nccwpck_require__(254);
+const reflection_binary_reader_1 = __nccwpck_require__(435);
+const reflection_binary_writer_1 = __nccwpck_require__(194);
+const reflection_create_1 = __nccwpck_require__(215);
+const reflection_merge_partial_1 = __nccwpck_require__(146);
+const json_typings_1 = __nccwpck_require__(420);
+const json_format_contract_1 = __nccwpck_require__(255);
 const reflection_equals_1 = __nccwpck_require__(492);
-const binary_writer_1 = __nccwpck_require__(267);
-const binary_reader_1 = __nccwpck_require__(143);
+const binary_writer_1 = __nccwpck_require__(268);
+const binary_reader_1 = __nccwpck_require__(144);
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
 const messageTypeDescriptor = baseDescriptors[message_type_contract_1.MESSAGE_TYPE] = {};
 /**
@@ -105554,7 +105896,7 @@ exports.MessageType = MessageType;
 
 /***/ }),
 
-/***/ 567:
+/***/ 568:
 /***/ ((module) => {
 
 "use strict";
@@ -105562,7 +105904,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 568:
+/***/ 569:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -105644,7 +105986,7 @@ exports.stackDuplexStreamingInterceptors = stackDuplexStreamingInterceptors;
 
 /***/ }),
 
-/***/ 569:
+/***/ 570:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -105747,7 +106089,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 570:
+/***/ 571:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -105757,7 +106099,7 @@ function escapeProperty(s) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BlobBeginCopyFromUrlPoller = void 0;
 const core_util_1 = __nccwpck_require__(17);
-const core_lro_1 = __nccwpck_require__(237);
+const core_lro_1 = __nccwpck_require__(238);
 /**
  * This is the poller returned by {@link BlobClient.beginCopyFromURL}.
  * This can not be instantiated directly outside of this package.
@@ -105892,7 +106234,7 @@ function makeBlobBeginCopyFromURLPollOperation(state) {
 
 /***/ }),
 
-/***/ 571:
+/***/ 572:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -106149,7 +106491,7 @@ function withCustomRequest(customRequest) {
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(450);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(556);
 /******/ 	module.exports = __webpack_exports__;
 /******/
 /******/ })()

--- a/dist/post.js
+++ b/dist/post.js
@@ -12443,6 +12443,2174 @@ exports.AbortSignal = AbortSignal;
 
 /***/ }),
 
+/***/ 38557:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+const f = __nccwpck_require__(9470)
+const DateTime = global.Date
+
+class Date extends DateTime {
+  constructor (value) {
+    super(value)
+    this.isDate = true
+  }
+  toISOString () {
+    return `${this.getUTCFullYear()}-${f(2, this.getUTCMonth() + 1)}-${f(2, this.getUTCDate())}`
+  }
+}
+
+module.exports = value => {
+  const date = new Date(value)
+  /* istanbul ignore if */
+  if (isNaN(date)) {
+    throw new TypeError('Invalid Datetime')
+  } else {
+    return date
+  }
+}
+
+
+/***/ }),
+
+/***/ 9487:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+const f = __nccwpck_require__(9470)
+
+class FloatingDateTime extends Date {
+  constructor (value) {
+    super(value + 'Z')
+    this.isFloating = true
+  }
+  toISOString () {
+    const date = `${this.getUTCFullYear()}-${f(2, this.getUTCMonth() + 1)}-${f(2, this.getUTCDate())}`
+    const time = `${f(2, this.getUTCHours())}:${f(2, this.getUTCMinutes())}:${f(2, this.getUTCSeconds())}.${f(3, this.getUTCMilliseconds())}`
+    return `${date}T${time}`
+  }
+}
+
+module.exports = value => {
+  const date = new FloatingDateTime(value)
+  /* istanbul ignore if */
+  if (isNaN(date)) {
+    throw new TypeError('Invalid Datetime')
+  } else {
+    return date
+  }
+}
+
+
+/***/ }),
+
+/***/ 26376:
+/***/ ((module) => {
+
+"use strict";
+
+module.exports = value => {
+  const date = new Date(value)
+  /* istanbul ignore if */
+  if (isNaN(date)) {
+    throw new TypeError('Invalid Datetime')
+  } else {
+    return date
+  }
+}
+
+
+/***/ }),
+
+/***/ 40420:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+const f = __nccwpck_require__(9470)
+
+class Time extends Date {
+  constructor (value) {
+    super(`0000-01-01T${value}Z`)
+    this.isTime = true
+  }
+  toISOString () {
+    return `${f(2, this.getUTCHours())}:${f(2, this.getUTCMinutes())}:${f(2, this.getUTCSeconds())}.${f(3, this.getUTCMilliseconds())}`
+  }
+}
+
+module.exports = value => {
+  const date = new Time(value)
+  /* istanbul ignore if */
+  if (isNaN(date)) {
+    throw new TypeError('Invalid Datetime')
+  } else {
+    return date
+  }
+}
+
+
+/***/ }),
+
+/***/ 9470:
+/***/ ((module) => {
+
+"use strict";
+
+module.exports = (d, num) => {
+  num = String(num)
+  while (num.length < d) num = '0' + num
+  return num
+}
+
+
+/***/ }),
+
+/***/ 25991:
+/***/ ((module) => {
+
+"use strict";
+
+const ParserEND = 0x110000
+class ParserError extends Error {
+  /* istanbul ignore next */
+  constructor (msg, filename, linenumber) {
+    super('[ParserError] ' + msg, filename, linenumber)
+    this.name = 'ParserError'
+    this.code = 'ParserError'
+    if (Error.captureStackTrace) Error.captureStackTrace(this, ParserError)
+  }
+}
+class State {
+  constructor (parser) {
+    this.parser = parser
+    this.buf = ''
+    this.returned = null
+    this.result = null
+    this.resultTable = null
+    this.resultArr = null
+  }
+}
+class Parser {
+  constructor () {
+    this.pos = 0
+    this.col = 0
+    this.line = 0
+    this.obj = {}
+    this.ctx = this.obj
+    this.stack = []
+    this._buf = ''
+    this.char = null
+    this.ii = 0
+    this.state = new State(this.parseStart)
+  }
+
+  parse (str) {
+    /* istanbul ignore next */
+    if (str.length === 0 || str.length == null) return
+
+    this._buf = String(str)
+    this.ii = -1
+    this.char = -1
+    let getNext
+    while (getNext === false || this.nextChar()) {
+      getNext = this.runOne()
+    }
+    this._buf = null
+  }
+  nextChar () {
+    if (this.char === 0x0A) {
+      ++this.line
+      this.col = -1
+    }
+    ++this.ii
+    this.char = this._buf.codePointAt(this.ii)
+    ++this.pos
+    ++this.col
+    return this.haveBuffer()
+  }
+  haveBuffer () {
+    return this.ii < this._buf.length
+  }
+  runOne () {
+    return this.state.parser.call(this, this.state.returned)
+  }
+  finish () {
+    this.char = ParserEND
+    let last
+    do {
+      last = this.state.parser
+      this.runOne()
+    } while (this.state.parser !== last)
+
+    this.ctx = null
+    this.state = null
+    this._buf = null
+
+    return this.obj
+  }
+  next (fn) {
+    /* istanbul ignore next */
+    if (typeof fn !== 'function') throw new ParserError('Tried to set state to non-existent state: ' + JSON.stringify(fn))
+    this.state.parser = fn
+  }
+  goto (fn) {
+    this.next(fn)
+    return this.runOne()
+  }
+  call (fn, returnWith) {
+    if (returnWith) this.next(returnWith)
+    this.stack.push(this.state)
+    this.state = new State(fn)
+  }
+  callNow (fn, returnWith) {
+    this.call(fn, returnWith)
+    return this.runOne()
+  }
+  return (value) {
+    /* istanbul ignore next */
+    if (this.stack.length === 0) throw this.error(new ParserError('Stack underflow'))
+    if (value === undefined) value = this.state.buf
+    this.state = this.stack.pop()
+    this.state.returned = value
+  }
+  returnNow (value) {
+    this.return(value)
+    return this.runOne()
+  }
+  consume () {
+    /* istanbul ignore next */
+    if (this.char === ParserEND) throw this.error(new ParserError('Unexpected end-of-buffer'))
+    this.state.buf += this._buf[this.ii]
+  }
+  error (err) {
+    err.line = this.line
+    err.col = this.col
+    err.pos = this.pos
+    return err
+  }
+  /* istanbul ignore next */
+  parseStart () {
+    throw new ParserError('Must declare a parseStart method')
+  }
+}
+Parser.END = ParserEND
+Parser.Error = ParserError
+module.exports = Parser
+
+
+/***/ }),
+
+/***/ 82862:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+/* eslint-disable no-new-wrappers, no-eval, camelcase, operator-linebreak */
+module.exports = makeParserClass(__nccwpck_require__(25991))
+module.exports.makeParserClass = makeParserClass
+
+class TomlError extends Error {
+  constructor (msg) {
+    super(msg)
+    this.name = 'TomlError'
+    /* istanbul ignore next */
+    if (Error.captureStackTrace) Error.captureStackTrace(this, TomlError)
+    this.fromTOML = true
+    this.wrapped = null
+  }
+}
+TomlError.wrap = err => {
+  const terr = new TomlError(err.message)
+  terr.code = err.code
+  terr.wrapped = err
+  return terr
+}
+module.exports.TomlError = TomlError
+
+const createDateTime = __nccwpck_require__(26376)
+const createDateTimeFloat = __nccwpck_require__(9487)
+const createDate = __nccwpck_require__(38557)
+const createTime = __nccwpck_require__(40420)
+
+const CTRL_I = 0x09
+const CTRL_J = 0x0A
+const CTRL_M = 0x0D
+const CTRL_CHAR_BOUNDARY = 0x1F // the last non-character in the latin1 region of unicode, except DEL
+const CHAR_SP = 0x20
+const CHAR_QUOT = 0x22
+const CHAR_NUM = 0x23
+const CHAR_APOS = 0x27
+const CHAR_PLUS = 0x2B
+const CHAR_COMMA = 0x2C
+const CHAR_HYPHEN = 0x2D
+const CHAR_PERIOD = 0x2E
+const CHAR_0 = 0x30
+const CHAR_1 = 0x31
+const CHAR_7 = 0x37
+const CHAR_9 = 0x39
+const CHAR_COLON = 0x3A
+const CHAR_EQUALS = 0x3D
+const CHAR_A = 0x41
+const CHAR_E = 0x45
+const CHAR_F = 0x46
+const CHAR_T = 0x54
+const CHAR_U = 0x55
+const CHAR_Z = 0x5A
+const CHAR_LOWBAR = 0x5F
+const CHAR_a = 0x61
+const CHAR_b = 0x62
+const CHAR_e = 0x65
+const CHAR_f = 0x66
+const CHAR_i = 0x69
+const CHAR_l = 0x6C
+const CHAR_n = 0x6E
+const CHAR_o = 0x6F
+const CHAR_r = 0x72
+const CHAR_s = 0x73
+const CHAR_t = 0x74
+const CHAR_u = 0x75
+const CHAR_x = 0x78
+const CHAR_z = 0x7A
+const CHAR_LCUB = 0x7B
+const CHAR_RCUB = 0x7D
+const CHAR_LSQB = 0x5B
+const CHAR_BSOL = 0x5C
+const CHAR_RSQB = 0x5D
+const CHAR_DEL = 0x7F
+const SURROGATE_FIRST = 0xD800
+const SURROGATE_LAST = 0xDFFF
+
+const escapes = {
+  [CHAR_b]: '\u0008',
+  [CHAR_t]: '\u0009',
+  [CHAR_n]: '\u000A',
+  [CHAR_f]: '\u000C',
+  [CHAR_r]: '\u000D',
+  [CHAR_QUOT]: '\u0022',
+  [CHAR_BSOL]: '\u005C'
+}
+
+function isDigit (cp) {
+  return cp >= CHAR_0 && cp <= CHAR_9
+}
+function isHexit (cp) {
+  return (cp >= CHAR_A && cp <= CHAR_F) || (cp >= CHAR_a && cp <= CHAR_f) || (cp >= CHAR_0 && cp <= CHAR_9)
+}
+function isBit (cp) {
+  return cp === CHAR_1 || cp === CHAR_0
+}
+function isOctit (cp) {
+  return (cp >= CHAR_0 && cp <= CHAR_7)
+}
+function isAlphaNumQuoteHyphen (cp) {
+  return (cp >= CHAR_A && cp <= CHAR_Z)
+      || (cp >= CHAR_a && cp <= CHAR_z)
+      || (cp >= CHAR_0 && cp <= CHAR_9)
+      || cp === CHAR_APOS
+      || cp === CHAR_QUOT
+      || cp === CHAR_LOWBAR
+      || cp === CHAR_HYPHEN
+}
+function isAlphaNumHyphen (cp) {
+  return (cp >= CHAR_A && cp <= CHAR_Z)
+      || (cp >= CHAR_a && cp <= CHAR_z)
+      || (cp >= CHAR_0 && cp <= CHAR_9)
+      || cp === CHAR_LOWBAR
+      || cp === CHAR_HYPHEN
+}
+const _type = Symbol('type')
+const _declared = Symbol('declared')
+
+const hasOwnProperty = Object.prototype.hasOwnProperty
+const defineProperty = Object.defineProperty
+const descriptor = {configurable: true, enumerable: true, writable: true, value: undefined}
+
+function hasKey (obj, key) {
+  if (hasOwnProperty.call(obj, key)) return true
+  if (key === '__proto__') defineProperty(obj, '__proto__', descriptor)
+  return false
+}
+
+const INLINE_TABLE = Symbol('inline-table')
+function InlineTable () {
+  return Object.defineProperties({}, {
+    [_type]: {value: INLINE_TABLE}
+  })
+}
+function isInlineTable (obj) {
+  if (obj === null || typeof (obj) !== 'object') return false
+  return obj[_type] === INLINE_TABLE
+}
+
+const TABLE = Symbol('table')
+function Table () {
+  return Object.defineProperties({}, {
+    [_type]: {value: TABLE},
+    [_declared]: {value: false, writable: true}
+  })
+}
+function isTable (obj) {
+  if (obj === null || typeof (obj) !== 'object') return false
+  return obj[_type] === TABLE
+}
+
+const _contentType = Symbol('content-type')
+const INLINE_LIST = Symbol('inline-list')
+function InlineList (type) {
+  return Object.defineProperties([], {
+    [_type]: {value: INLINE_LIST},
+    [_contentType]: {value: type}
+  })
+}
+function isInlineList (obj) {
+  if (obj === null || typeof (obj) !== 'object') return false
+  return obj[_type] === INLINE_LIST
+}
+
+const LIST = Symbol('list')
+function List () {
+  return Object.defineProperties([], {
+    [_type]: {value: LIST}
+  })
+}
+function isList (obj) {
+  if (obj === null || typeof (obj) !== 'object') return false
+  return obj[_type] === LIST
+}
+
+// in an eval, to let bundlers not slurp in a util proxy
+let _custom
+try {
+  const utilInspect = eval("require('util').inspect")
+  _custom = utilInspect.custom
+} catch (_) {
+  /* eval require not available in transpiled bundle */
+}
+/* istanbul ignore next */
+const _inspect = _custom || 'inspect'
+
+class BoxedBigInt {
+  constructor (value) {
+    try {
+      this.value = global.BigInt.asIntN(64, value)
+    } catch (_) {
+      /* istanbul ignore next */
+      this.value = null
+    }
+    Object.defineProperty(this, _type, {value: INTEGER})
+  }
+  isNaN () {
+    return this.value === null
+  }
+  /* istanbul ignore next */
+  toString () {
+    return String(this.value)
+  }
+  /* istanbul ignore next */
+  [_inspect] () {
+    return `[BigInt: ${this.toString()}]}`
+  }
+  valueOf () {
+    return this.value
+  }
+}
+
+const INTEGER = Symbol('integer')
+function Integer (value) {
+  let num = Number(value)
+  // -0 is a float thing, not an int thing
+  if (Object.is(num, -0)) num = 0
+  /* istanbul ignore else */
+  if (global.BigInt && !Number.isSafeInteger(num)) {
+    return new BoxedBigInt(value)
+  } else {
+    /* istanbul ignore next */
+    return Object.defineProperties(new Number(num), {
+      isNaN: {value: function () { return isNaN(this) }},
+      [_type]: {value: INTEGER},
+      [_inspect]: {value: () => `[Integer: ${value}]`}
+    })
+  }
+}
+function isInteger (obj) {
+  if (obj === null || typeof (obj) !== 'object') return false
+  return obj[_type] === INTEGER
+}
+
+const FLOAT = Symbol('float')
+function Float (value) {
+  /* istanbul ignore next */
+  return Object.defineProperties(new Number(value), {
+    [_type]: {value: FLOAT},
+    [_inspect]: {value: () => `[Float: ${value}]`}
+  })
+}
+function isFloat (obj) {
+  if (obj === null || typeof (obj) !== 'object') return false
+  return obj[_type] === FLOAT
+}
+
+function tomlType (value) {
+  const type = typeof value
+  if (type === 'object') {
+    /* istanbul ignore if */
+    if (value === null) return 'null'
+    if (value instanceof Date) return 'datetime'
+    /* istanbul ignore else */
+    if (_type in value) {
+      switch (value[_type]) {
+        case INLINE_TABLE: return 'inline-table'
+        case INLINE_LIST: return 'inline-list'
+        /* istanbul ignore next */
+        case TABLE: return 'table'
+        /* istanbul ignore next */
+        case LIST: return 'list'
+        case FLOAT: return 'float'
+        case INTEGER: return 'integer'
+      }
+    }
+  }
+  return type
+}
+
+function makeParserClass (Parser) {
+  class TOMLParser extends Parser {
+    constructor () {
+      super()
+      this.ctx = this.obj = Table()
+    }
+
+    /* MATCH HELPER */
+    atEndOfWord () {
+      return this.char === CHAR_NUM || this.char === CTRL_I || this.char === CHAR_SP || this.atEndOfLine()
+    }
+    atEndOfLine () {
+      return this.char === Parser.END || this.char === CTRL_J || this.char === CTRL_M
+    }
+
+    parseStart () {
+      if (this.char === Parser.END) {
+        return null
+      } else if (this.char === CHAR_LSQB) {
+        return this.call(this.parseTableOrList)
+      } else if (this.char === CHAR_NUM) {
+        return this.call(this.parseComment)
+      } else if (this.char === CTRL_J || this.char === CHAR_SP || this.char === CTRL_I || this.char === CTRL_M) {
+        return null
+      } else if (isAlphaNumQuoteHyphen(this.char)) {
+        return this.callNow(this.parseAssignStatement)
+      } else {
+        throw this.error(new TomlError(`Unknown character "${this.char}"`))
+      }
+    }
+
+    // HELPER, this strips any whitespace and comments to the end of the line
+    // then RETURNS. Last state in a production.
+    parseWhitespaceToEOL () {
+      if (this.char === CHAR_SP || this.char === CTRL_I || this.char === CTRL_M) {
+        return null
+      } else if (this.char === CHAR_NUM) {
+        return this.goto(this.parseComment)
+      } else if (this.char === Parser.END || this.char === CTRL_J) {
+        return this.return()
+      } else {
+        throw this.error(new TomlError('Unexpected character, expected only whitespace or comments till end of line'))
+      }
+    }
+
+    /* ASSIGNMENT: key = value */
+    parseAssignStatement () {
+      return this.callNow(this.parseAssign, this.recordAssignStatement)
+    }
+    recordAssignStatement (kv) {
+      let target = this.ctx
+      let finalKey = kv.key.pop()
+      for (let kw of kv.key) {
+        if (hasKey(target, kw) && (!isTable(target[kw]) || target[kw][_declared])) {
+          throw this.error(new TomlError("Can't redefine existing key"))
+        }
+        target = target[kw] = target[kw] || Table()
+      }
+      if (hasKey(target, finalKey)) {
+        throw this.error(new TomlError("Can't redefine existing key"))
+      }
+      // unbox our numbers
+      if (isInteger(kv.value) || isFloat(kv.value)) {
+        target[finalKey] = kv.value.valueOf()
+      } else {
+        target[finalKey] = kv.value
+      }
+      return this.goto(this.parseWhitespaceToEOL)
+    }
+
+    /* ASSSIGNMENT expression, key = value possibly inside an inline table */
+    parseAssign () {
+      return this.callNow(this.parseKeyword, this.recordAssignKeyword)
+    }
+    recordAssignKeyword (key) {
+      if (this.state.resultTable) {
+        this.state.resultTable.push(key)
+      } else {
+        this.state.resultTable = [key]
+      }
+      return this.goto(this.parseAssignKeywordPreDot)
+    }
+    parseAssignKeywordPreDot () {
+      if (this.char === CHAR_PERIOD) {
+        return this.next(this.parseAssignKeywordPostDot)
+      } else if (this.char !== CHAR_SP && this.char !== CTRL_I) {
+        return this.goto(this.parseAssignEqual)
+      }
+    }
+    parseAssignKeywordPostDot () {
+      if (this.char !== CHAR_SP && this.char !== CTRL_I) {
+        return this.callNow(this.parseKeyword, this.recordAssignKeyword)
+      }
+    }
+
+    parseAssignEqual () {
+      if (this.char === CHAR_EQUALS) {
+        return this.next(this.parseAssignPreValue)
+      } else {
+        throw this.error(new TomlError('Invalid character, expected "="'))
+      }
+    }
+    parseAssignPreValue () {
+      if (this.char === CHAR_SP || this.char === CTRL_I) {
+        return null
+      } else {
+        return this.callNow(this.parseValue, this.recordAssignValue)
+      }
+    }
+    recordAssignValue (value) {
+      return this.returnNow({key: this.state.resultTable, value: value})
+    }
+
+    /* COMMENTS: #...eol */
+    parseComment () {
+      do {
+        if (this.char === Parser.END || this.char === CTRL_J) {
+          return this.return()
+        }
+      } while (this.nextChar())
+    }
+
+    /* TABLES AND LISTS, [foo] and [[foo]] */
+    parseTableOrList () {
+      if (this.char === CHAR_LSQB) {
+        this.next(this.parseList)
+      } else {
+        return this.goto(this.parseTable)
+      }
+    }
+
+    /* TABLE [foo.bar.baz] */
+    parseTable () {
+      this.ctx = this.obj
+      return this.goto(this.parseTableNext)
+    }
+    parseTableNext () {
+      if (this.char === CHAR_SP || this.char === CTRL_I) {
+        return null
+      } else {
+        return this.callNow(this.parseKeyword, this.parseTableMore)
+      }
+    }
+    parseTableMore (keyword) {
+      if (this.char === CHAR_SP || this.char === CTRL_I) {
+        return null
+      } else if (this.char === CHAR_RSQB) {
+        if (hasKey(this.ctx, keyword) && (!isTable(this.ctx[keyword]) || this.ctx[keyword][_declared])) {
+          throw this.error(new TomlError("Can't redefine existing key"))
+        } else {
+          this.ctx = this.ctx[keyword] = this.ctx[keyword] || Table()
+          this.ctx[_declared] = true
+        }
+        return this.next(this.parseWhitespaceToEOL)
+      } else if (this.char === CHAR_PERIOD) {
+        if (!hasKey(this.ctx, keyword)) {
+          this.ctx = this.ctx[keyword] = Table()
+        } else if (isTable(this.ctx[keyword])) {
+          this.ctx = this.ctx[keyword]
+        } else if (isList(this.ctx[keyword])) {
+          this.ctx = this.ctx[keyword][this.ctx[keyword].length - 1]
+        } else {
+          throw this.error(new TomlError("Can't redefine existing key"))
+        }
+        return this.next(this.parseTableNext)
+      } else {
+        throw this.error(new TomlError('Unexpected character, expected whitespace, . or ]'))
+      }
+    }
+
+    /* LIST [[a.b.c]] */
+    parseList () {
+      this.ctx = this.obj
+      return this.goto(this.parseListNext)
+    }
+    parseListNext () {
+      if (this.char === CHAR_SP || this.char === CTRL_I) {
+        return null
+      } else {
+        return this.callNow(this.parseKeyword, this.parseListMore)
+      }
+    }
+    parseListMore (keyword) {
+      if (this.char === CHAR_SP || this.char === CTRL_I) {
+        return null
+      } else if (this.char === CHAR_RSQB) {
+        if (!hasKey(this.ctx, keyword)) {
+          this.ctx[keyword] = List()
+        }
+        if (isInlineList(this.ctx[keyword])) {
+          throw this.error(new TomlError("Can't extend an inline array"))
+        } else if (isList(this.ctx[keyword])) {
+          const next = Table()
+          this.ctx[keyword].push(next)
+          this.ctx = next
+        } else {
+          throw this.error(new TomlError("Can't redefine an existing key"))
+        }
+        return this.next(this.parseListEnd)
+      } else if (this.char === CHAR_PERIOD) {
+        if (!hasKey(this.ctx, keyword)) {
+          this.ctx = this.ctx[keyword] = Table()
+        } else if (isInlineList(this.ctx[keyword])) {
+          throw this.error(new TomlError("Can't extend an inline array"))
+        } else if (isInlineTable(this.ctx[keyword])) {
+          throw this.error(new TomlError("Can't extend an inline table"))
+        } else if (isList(this.ctx[keyword])) {
+          this.ctx = this.ctx[keyword][this.ctx[keyword].length - 1]
+        } else if (isTable(this.ctx[keyword])) {
+          this.ctx = this.ctx[keyword]
+        } else {
+          throw this.error(new TomlError("Can't redefine an existing key"))
+        }
+        return this.next(this.parseListNext)
+      } else {
+        throw this.error(new TomlError('Unexpected character, expected whitespace, . or ]'))
+      }
+    }
+    parseListEnd (keyword) {
+      if (this.char === CHAR_RSQB) {
+        return this.next(this.parseWhitespaceToEOL)
+      } else {
+        throw this.error(new TomlError('Unexpected character, expected whitespace, . or ]'))
+      }
+    }
+
+    /* VALUE string, number, boolean, inline list, inline object */
+    parseValue () {
+      if (this.char === Parser.END) {
+        throw this.error(new TomlError('Key without value'))
+      } else if (this.char === CHAR_QUOT) {
+        return this.next(this.parseDoubleString)
+      } if (this.char === CHAR_APOS) {
+        return this.next(this.parseSingleString)
+      } else if (this.char === CHAR_HYPHEN || this.char === CHAR_PLUS) {
+        return this.goto(this.parseNumberSign)
+      } else if (this.char === CHAR_i) {
+        return this.next(this.parseInf)
+      } else if (this.char === CHAR_n) {
+        return this.next(this.parseNan)
+      } else if (isDigit(this.char)) {
+        return this.goto(this.parseNumberOrDateTime)
+      } else if (this.char === CHAR_t || this.char === CHAR_f) {
+        return this.goto(this.parseBoolean)
+      } else if (this.char === CHAR_LSQB) {
+        return this.call(this.parseInlineList, this.recordValue)
+      } else if (this.char === CHAR_LCUB) {
+        return this.call(this.parseInlineTable, this.recordValue)
+      } else {
+        throw this.error(new TomlError('Unexpected character, expecting string, number, datetime, boolean, inline array or inline table'))
+      }
+    }
+    recordValue (value) {
+      return this.returnNow(value)
+    }
+
+    parseInf () {
+      if (this.char === CHAR_n) {
+        return this.next(this.parseInf2)
+      } else {
+        throw this.error(new TomlError('Unexpected character, expected "inf", "+inf" or "-inf"'))
+      }
+    }
+    parseInf2 () {
+      if (this.char === CHAR_f) {
+        if (this.state.buf === '-') {
+          return this.return(-Infinity)
+        } else {
+          return this.return(Infinity)
+        }
+      } else {
+        throw this.error(new TomlError('Unexpected character, expected "inf", "+inf" or "-inf"'))
+      }
+    }
+
+    parseNan () {
+      if (this.char === CHAR_a) {
+        return this.next(this.parseNan2)
+      } else {
+        throw this.error(new TomlError('Unexpected character, expected "nan"'))
+      }
+    }
+    parseNan2 () {
+      if (this.char === CHAR_n) {
+        return this.return(NaN)
+      } else {
+        throw this.error(new TomlError('Unexpected character, expected "nan"'))
+      }
+    }
+
+    /* KEYS, barewords or basic, literal, or dotted */
+    parseKeyword () {
+      if (this.char === CHAR_QUOT) {
+        return this.next(this.parseBasicString)
+      } else if (this.char === CHAR_APOS) {
+        return this.next(this.parseLiteralString)
+      } else {
+        return this.goto(this.parseBareKey)
+      }
+    }
+
+    /* KEYS: barewords */
+    parseBareKey () {
+      do {
+        if (this.char === Parser.END) {
+          throw this.error(new TomlError('Key ended without value'))
+        } else if (isAlphaNumHyphen(this.char)) {
+          this.consume()
+        } else if (this.state.buf.length === 0) {
+          throw this.error(new TomlError('Empty bare keys are not allowed'))
+        } else {
+          return this.returnNow()
+        }
+      } while (this.nextChar())
+    }
+
+    /* STRINGS, single quoted (literal) */
+    parseSingleString () {
+      if (this.char === CHAR_APOS) {
+        return this.next(this.parseLiteralMultiStringMaybe)
+      } else {
+        return this.goto(this.parseLiteralString)
+      }
+    }
+    parseLiteralString () {
+      do {
+        if (this.char === CHAR_APOS) {
+          return this.return()
+        } else if (this.atEndOfLine()) {
+          throw this.error(new TomlError('Unterminated string'))
+        } else if (this.char === CHAR_DEL || (this.char <= CTRL_CHAR_BOUNDARY && this.char !== CTRL_I)) {
+          throw this.errorControlCharInString()
+        } else {
+          this.consume()
+        }
+      } while (this.nextChar())
+    }
+    parseLiteralMultiStringMaybe () {
+      if (this.char === CHAR_APOS) {
+        return this.next(this.parseLiteralMultiString)
+      } else {
+        return this.returnNow()
+      }
+    }
+    parseLiteralMultiString () {
+      if (this.char === CTRL_M) {
+        return null
+      } else if (this.char === CTRL_J) {
+        return this.next(this.parseLiteralMultiStringContent)
+      } else {
+        return this.goto(this.parseLiteralMultiStringContent)
+      }
+    }
+    parseLiteralMultiStringContent () {
+      do {
+        if (this.char === CHAR_APOS) {
+          return this.next(this.parseLiteralMultiEnd)
+        } else if (this.char === Parser.END) {
+          throw this.error(new TomlError('Unterminated multi-line string'))
+        } else if (this.char === CHAR_DEL || (this.char <= CTRL_CHAR_BOUNDARY && this.char !== CTRL_I && this.char !== CTRL_J && this.char !== CTRL_M)) {
+          throw this.errorControlCharInString()
+        } else {
+          this.consume()
+        }
+      } while (this.nextChar())
+    }
+    parseLiteralMultiEnd () {
+      if (this.char === CHAR_APOS) {
+        return this.next(this.parseLiteralMultiEnd2)
+      } else {
+        this.state.buf += "'"
+        return this.goto(this.parseLiteralMultiStringContent)
+      }
+    }
+    parseLiteralMultiEnd2 () {
+      if (this.char === CHAR_APOS) {
+        return this.return()
+      } else {
+        this.state.buf += "''"
+        return this.goto(this.parseLiteralMultiStringContent)
+      }
+    }
+
+    /* STRINGS double quoted */
+    parseDoubleString () {
+      if (this.char === CHAR_QUOT) {
+        return this.next(this.parseMultiStringMaybe)
+      } else {
+        return this.goto(this.parseBasicString)
+      }
+    }
+    parseBasicString () {
+      do {
+        if (this.char === CHAR_BSOL) {
+          return this.call(this.parseEscape, this.recordEscapeReplacement)
+        } else if (this.char === CHAR_QUOT) {
+          return this.return()
+        } else if (this.atEndOfLine()) {
+          throw this.error(new TomlError('Unterminated string'))
+        } else if (this.char === CHAR_DEL || (this.char <= CTRL_CHAR_BOUNDARY && this.char !== CTRL_I)) {
+          throw this.errorControlCharInString()
+        } else {
+          this.consume()
+        }
+      } while (this.nextChar())
+    }
+    recordEscapeReplacement (replacement) {
+      this.state.buf += replacement
+      return this.goto(this.parseBasicString)
+    }
+    parseMultiStringMaybe () {
+      if (this.char === CHAR_QUOT) {
+        return this.next(this.parseMultiString)
+      } else {
+        return this.returnNow()
+      }
+    }
+    parseMultiString () {
+      if (this.char === CTRL_M) {
+        return null
+      } else if (this.char === CTRL_J) {
+        return this.next(this.parseMultiStringContent)
+      } else {
+        return this.goto(this.parseMultiStringContent)
+      }
+    }
+    parseMultiStringContent () {
+      do {
+        if (this.char === CHAR_BSOL) {
+          return this.call(this.parseMultiEscape, this.recordMultiEscapeReplacement)
+        } else if (this.char === CHAR_QUOT) {
+          return this.next(this.parseMultiEnd)
+        } else if (this.char === Parser.END) {
+          throw this.error(new TomlError('Unterminated multi-line string'))
+        } else if (this.char === CHAR_DEL || (this.char <= CTRL_CHAR_BOUNDARY && this.char !== CTRL_I && this.char !== CTRL_J && this.char !== CTRL_M)) {
+          throw this.errorControlCharInString()
+        } else {
+          this.consume()
+        }
+      } while (this.nextChar())
+    }
+    errorControlCharInString () {
+      let displayCode = '\\u00'
+      if (this.char < 16) {
+        displayCode += '0'
+      }
+      displayCode += this.char.toString(16)
+
+      return this.error(new TomlError(`Control characters (codes < 0x1f and 0x7f) are not allowed in strings, use ${displayCode} instead`))
+    }
+    recordMultiEscapeReplacement (replacement) {
+      this.state.buf += replacement
+      return this.goto(this.parseMultiStringContent)
+    }
+    parseMultiEnd () {
+      if (this.char === CHAR_QUOT) {
+        return this.next(this.parseMultiEnd2)
+      } else {
+        this.state.buf += '"'
+        return this.goto(this.parseMultiStringContent)
+      }
+    }
+    parseMultiEnd2 () {
+      if (this.char === CHAR_QUOT) {
+        return this.return()
+      } else {
+        this.state.buf += '""'
+        return this.goto(this.parseMultiStringContent)
+      }
+    }
+    parseMultiEscape () {
+      if (this.char === CTRL_M || this.char === CTRL_J) {
+        return this.next(this.parseMultiTrim)
+      } else if (this.char === CHAR_SP || this.char === CTRL_I) {
+        return this.next(this.parsePreMultiTrim)
+      } else {
+        return this.goto(this.parseEscape)
+      }
+    }
+    parsePreMultiTrim () {
+      if (this.char === CHAR_SP || this.char === CTRL_I) {
+        return null
+      } else if (this.char === CTRL_M || this.char === CTRL_J) {
+        return this.next(this.parseMultiTrim)
+      } else {
+        throw this.error(new TomlError("Can't escape whitespace"))
+      }
+    }
+    parseMultiTrim () {
+      // explicitly whitespace here, END should follow the same path as chars
+      if (this.char === CTRL_J || this.char === CHAR_SP || this.char === CTRL_I || this.char === CTRL_M) {
+        return null
+      } else {
+        return this.returnNow()
+      }
+    }
+    parseEscape () {
+      if (this.char in escapes) {
+        return this.return(escapes[this.char])
+      } else if (this.char === CHAR_u) {
+        return this.call(this.parseSmallUnicode, this.parseUnicodeReturn)
+      } else if (this.char === CHAR_U) {
+        return this.call(this.parseLargeUnicode, this.parseUnicodeReturn)
+      } else {
+        throw this.error(new TomlError('Unknown escape character: ' + this.char))
+      }
+    }
+    parseUnicodeReturn (char) {
+      try {
+        const codePoint = parseInt(char, 16)
+        if (codePoint >= SURROGATE_FIRST && codePoint <= SURROGATE_LAST) {
+          throw this.error(new TomlError('Invalid unicode, character in range 0xD800 - 0xDFFF is reserved'))
+        }
+        return this.returnNow(String.fromCodePoint(codePoint))
+      } catch (err) {
+        throw this.error(TomlError.wrap(err))
+      }
+    }
+    parseSmallUnicode () {
+      if (!isHexit(this.char)) {
+        throw this.error(new TomlError('Invalid character in unicode sequence, expected hex'))
+      } else {
+        this.consume()
+        if (this.state.buf.length >= 4) return this.return()
+      }
+    }
+    parseLargeUnicode () {
+      if (!isHexit(this.char)) {
+        throw this.error(new TomlError('Invalid character in unicode sequence, expected hex'))
+      } else {
+        this.consume()
+        if (this.state.buf.length >= 8) return this.return()
+      }
+    }
+
+    /* NUMBERS */
+    parseNumberSign () {
+      this.consume()
+      return this.next(this.parseMaybeSignedInfOrNan)
+    }
+    parseMaybeSignedInfOrNan () {
+      if (this.char === CHAR_i) {
+        return this.next(this.parseInf)
+      } else if (this.char === CHAR_n) {
+        return this.next(this.parseNan)
+      } else {
+        return this.callNow(this.parseNoUnder, this.parseNumberIntegerStart)
+      }
+    }
+    parseNumberIntegerStart () {
+      if (this.char === CHAR_0) {
+        this.consume()
+        return this.next(this.parseNumberIntegerExponentOrDecimal)
+      } else {
+        return this.goto(this.parseNumberInteger)
+      }
+    }
+    parseNumberIntegerExponentOrDecimal () {
+      if (this.char === CHAR_PERIOD) {
+        this.consume()
+        return this.call(this.parseNoUnder, this.parseNumberFloat)
+      } else if (this.char === CHAR_E || this.char === CHAR_e) {
+        this.consume()
+        return this.next(this.parseNumberExponentSign)
+      } else {
+        return this.returnNow(Integer(this.state.buf))
+      }
+    }
+    parseNumberInteger () {
+      if (isDigit(this.char)) {
+        this.consume()
+      } else if (this.char === CHAR_LOWBAR) {
+        return this.call(this.parseNoUnder)
+      } else if (this.char === CHAR_E || this.char === CHAR_e) {
+        this.consume()
+        return this.next(this.parseNumberExponentSign)
+      } else if (this.char === CHAR_PERIOD) {
+        this.consume()
+        return this.call(this.parseNoUnder, this.parseNumberFloat)
+      } else {
+        const result = Integer(this.state.buf)
+        /* istanbul ignore if */
+        if (result.isNaN()) {
+          throw this.error(new TomlError('Invalid number'))
+        } else {
+          return this.returnNow(result)
+        }
+      }
+    }
+    parseNoUnder () {
+      if (this.char === CHAR_LOWBAR || this.char === CHAR_PERIOD || this.char === CHAR_E || this.char === CHAR_e) {
+        throw this.error(new TomlError('Unexpected character, expected digit'))
+      } else if (this.atEndOfWord()) {
+        throw this.error(new TomlError('Incomplete number'))
+      }
+      return this.returnNow()
+    }
+    parseNoUnderHexOctBinLiteral () {
+      if (this.char === CHAR_LOWBAR || this.char === CHAR_PERIOD) {
+        throw this.error(new TomlError('Unexpected character, expected digit'))
+      } else if (this.atEndOfWord()) {
+        throw this.error(new TomlError('Incomplete number'))
+      }
+      return this.returnNow()
+    }
+    parseNumberFloat () {
+      if (this.char === CHAR_LOWBAR) {
+        return this.call(this.parseNoUnder, this.parseNumberFloat)
+      } else if (isDigit(this.char)) {
+        this.consume()
+      } else if (this.char === CHAR_E || this.char === CHAR_e) {
+        this.consume()
+        return this.next(this.parseNumberExponentSign)
+      } else {
+        return this.returnNow(Float(this.state.buf))
+      }
+    }
+    parseNumberExponentSign () {
+      if (isDigit(this.char)) {
+        return this.goto(this.parseNumberExponent)
+      } else if (this.char === CHAR_HYPHEN || this.char === CHAR_PLUS) {
+        this.consume()
+        this.call(this.parseNoUnder, this.parseNumberExponent)
+      } else {
+        throw this.error(new TomlError('Unexpected character, expected -, + or digit'))
+      }
+    }
+    parseNumberExponent () {
+      if (isDigit(this.char)) {
+        this.consume()
+      } else if (this.char === CHAR_LOWBAR) {
+        return this.call(this.parseNoUnder)
+      } else {
+        return this.returnNow(Float(this.state.buf))
+      }
+    }
+
+    /* NUMBERS or DATETIMES  */
+    parseNumberOrDateTime () {
+      if (this.char === CHAR_0) {
+        this.consume()
+        return this.next(this.parseNumberBaseOrDateTime)
+      } else {
+        return this.goto(this.parseNumberOrDateTimeOnly)
+      }
+    }
+    parseNumberOrDateTimeOnly () {
+      // note, if two zeros are in a row then it MUST be a date
+      if (this.char === CHAR_LOWBAR) {
+        return this.call(this.parseNoUnder, this.parseNumberInteger)
+      } else if (isDigit(this.char)) {
+        this.consume()
+        if (this.state.buf.length > 4) this.next(this.parseNumberInteger)
+      } else if (this.char === CHAR_E || this.char === CHAR_e) {
+        this.consume()
+        return this.next(this.parseNumberExponentSign)
+      } else if (this.char === CHAR_PERIOD) {
+        this.consume()
+        return this.call(this.parseNoUnder, this.parseNumberFloat)
+      } else if (this.char === CHAR_HYPHEN) {
+        return this.goto(this.parseDateTime)
+      } else if (this.char === CHAR_COLON) {
+        return this.goto(this.parseOnlyTimeHour)
+      } else {
+        return this.returnNow(Integer(this.state.buf))
+      }
+    }
+    parseDateTimeOnly () {
+      if (this.state.buf.length < 4) {
+        if (isDigit(this.char)) {
+          return this.consume()
+        } else if (this.char === CHAR_COLON) {
+          return this.goto(this.parseOnlyTimeHour)
+        } else {
+          throw this.error(new TomlError('Expected digit while parsing year part of a date'))
+        }
+      } else {
+        if (this.char === CHAR_HYPHEN) {
+          return this.goto(this.parseDateTime)
+        } else {
+          throw this.error(new TomlError('Expected hyphen (-) while parsing year part of date'))
+        }
+      }
+    }
+    parseNumberBaseOrDateTime () {
+      if (this.char === CHAR_b) {
+        this.consume()
+        return this.call(this.parseNoUnderHexOctBinLiteral, this.parseIntegerBin)
+      } else if (this.char === CHAR_o) {
+        this.consume()
+        return this.call(this.parseNoUnderHexOctBinLiteral, this.parseIntegerOct)
+      } else if (this.char === CHAR_x) {
+        this.consume()
+        return this.call(this.parseNoUnderHexOctBinLiteral, this.parseIntegerHex)
+      } else if (this.char === CHAR_PERIOD) {
+        return this.goto(this.parseNumberInteger)
+      } else if (isDigit(this.char)) {
+        return this.goto(this.parseDateTimeOnly)
+      } else {
+        return this.returnNow(Integer(this.state.buf))
+      }
+    }
+    parseIntegerHex () {
+      if (isHexit(this.char)) {
+        this.consume()
+      } else if (this.char === CHAR_LOWBAR) {
+        return this.call(this.parseNoUnderHexOctBinLiteral)
+      } else {
+        const result = Integer(this.state.buf)
+        /* istanbul ignore if */
+        if (result.isNaN()) {
+          throw this.error(new TomlError('Invalid number'))
+        } else {
+          return this.returnNow(result)
+        }
+      }
+    }
+    parseIntegerOct () {
+      if (isOctit(this.char)) {
+        this.consume()
+      } else if (this.char === CHAR_LOWBAR) {
+        return this.call(this.parseNoUnderHexOctBinLiteral)
+      } else {
+        const result = Integer(this.state.buf)
+        /* istanbul ignore if */
+        if (result.isNaN()) {
+          throw this.error(new TomlError('Invalid number'))
+        } else {
+          return this.returnNow(result)
+        }
+      }
+    }
+    parseIntegerBin () {
+      if (isBit(this.char)) {
+        this.consume()
+      } else if (this.char === CHAR_LOWBAR) {
+        return this.call(this.parseNoUnderHexOctBinLiteral)
+      } else {
+        const result = Integer(this.state.buf)
+        /* istanbul ignore if */
+        if (result.isNaN()) {
+          throw this.error(new TomlError('Invalid number'))
+        } else {
+          return this.returnNow(result)
+        }
+      }
+    }
+
+    /* DATETIME */
+    parseDateTime () {
+      // we enter here having just consumed the year and about to consume the hyphen
+      if (this.state.buf.length < 4) {
+        throw this.error(new TomlError('Years less than 1000 must be zero padded to four characters'))
+      }
+      this.state.result = this.state.buf
+      this.state.buf = ''
+      return this.next(this.parseDateMonth)
+    }
+    parseDateMonth () {
+      if (this.char === CHAR_HYPHEN) {
+        if (this.state.buf.length < 2) {
+          throw this.error(new TomlError('Months less than 10 must be zero padded to two characters'))
+        }
+        this.state.result += '-' + this.state.buf
+        this.state.buf = ''
+        return this.next(this.parseDateDay)
+      } else if (isDigit(this.char)) {
+        this.consume()
+      } else {
+        throw this.error(new TomlError('Incomplete datetime'))
+      }
+    }
+    parseDateDay () {
+      if (this.char === CHAR_T || this.char === CHAR_SP) {
+        if (this.state.buf.length < 2) {
+          throw this.error(new TomlError('Days less than 10 must be zero padded to two characters'))
+        }
+        this.state.result += '-' + this.state.buf
+        this.state.buf = ''
+        return this.next(this.parseStartTimeHour)
+      } else if (this.atEndOfWord()) {
+        return this.returnNow(createDate(this.state.result + '-' + this.state.buf))
+      } else if (isDigit(this.char)) {
+        this.consume()
+      } else {
+        throw this.error(new TomlError('Incomplete datetime'))
+      }
+    }
+    parseStartTimeHour () {
+      if (this.atEndOfWord()) {
+        return this.returnNow(createDate(this.state.result))
+      } else {
+        return this.goto(this.parseTimeHour)
+      }
+    }
+    parseTimeHour () {
+      if (this.char === CHAR_COLON) {
+        if (this.state.buf.length < 2) {
+          throw this.error(new TomlError('Hours less than 10 must be zero padded to two characters'))
+        }
+        this.state.result += 'T' + this.state.buf
+        this.state.buf = ''
+        return this.next(this.parseTimeMin)
+      } else if (isDigit(this.char)) {
+        this.consume()
+      } else {
+        throw this.error(new TomlError('Incomplete datetime'))
+      }
+    }
+    parseTimeMin () {
+      if (this.state.buf.length < 2 && isDigit(this.char)) {
+        this.consume()
+      } else if (this.state.buf.length === 2 && this.char === CHAR_COLON) {
+        this.state.result += ':' + this.state.buf
+        this.state.buf = ''
+        return this.next(this.parseTimeSec)
+      } else {
+        throw this.error(new TomlError('Incomplete datetime'))
+      }
+    }
+    parseTimeSec () {
+      if (isDigit(this.char)) {
+        this.consume()
+        if (this.state.buf.length === 2) {
+          this.state.result += ':' + this.state.buf
+          this.state.buf = ''
+          return this.next(this.parseTimeZoneOrFraction)
+        }
+      } else {
+        throw this.error(new TomlError('Incomplete datetime'))
+      }
+    }
+
+    parseOnlyTimeHour () {
+      /* istanbul ignore else */
+      if (this.char === CHAR_COLON) {
+        if (this.state.buf.length < 2) {
+          throw this.error(new TomlError('Hours less than 10 must be zero padded to two characters'))
+        }
+        this.state.result = this.state.buf
+        this.state.buf = ''
+        return this.next(this.parseOnlyTimeMin)
+      } else {
+        throw this.error(new TomlError('Incomplete time'))
+      }
+    }
+    parseOnlyTimeMin () {
+      if (this.state.buf.length < 2 && isDigit(this.char)) {
+        this.consume()
+      } else if (this.state.buf.length === 2 && this.char === CHAR_COLON) {
+        this.state.result += ':' + this.state.buf
+        this.state.buf = ''
+        return this.next(this.parseOnlyTimeSec)
+      } else {
+        throw this.error(new TomlError('Incomplete time'))
+      }
+    }
+    parseOnlyTimeSec () {
+      if (isDigit(this.char)) {
+        this.consume()
+        if (this.state.buf.length === 2) {
+          return this.next(this.parseOnlyTimeFractionMaybe)
+        }
+      } else {
+        throw this.error(new TomlError('Incomplete time'))
+      }
+    }
+    parseOnlyTimeFractionMaybe () {
+      this.state.result += ':' + this.state.buf
+      if (this.char === CHAR_PERIOD) {
+        this.state.buf = ''
+        this.next(this.parseOnlyTimeFraction)
+      } else {
+        return this.return(createTime(this.state.result))
+      }
+    }
+    parseOnlyTimeFraction () {
+      if (isDigit(this.char)) {
+        this.consume()
+      } else if (this.atEndOfWord()) {
+        if (this.state.buf.length === 0) throw this.error(new TomlError('Expected digit in milliseconds'))
+        return this.returnNow(createTime(this.state.result + '.' + this.state.buf))
+      } else {
+        throw this.error(new TomlError('Unexpected character in datetime, expected period (.), minus (-), plus (+) or Z'))
+      }
+    }
+
+    parseTimeZoneOrFraction () {
+      if (this.char === CHAR_PERIOD) {
+        this.consume()
+        this.next(this.parseDateTimeFraction)
+      } else if (this.char === CHAR_HYPHEN || this.char === CHAR_PLUS) {
+        this.consume()
+        this.next(this.parseTimeZoneHour)
+      } else if (this.char === CHAR_Z) {
+        this.consume()
+        return this.return(createDateTime(this.state.result + this.state.buf))
+      } else if (this.atEndOfWord()) {
+        return this.returnNow(createDateTimeFloat(this.state.result + this.state.buf))
+      } else {
+        throw this.error(new TomlError('Unexpected character in datetime, expected period (.), minus (-), plus (+) or Z'))
+      }
+    }
+    parseDateTimeFraction () {
+      if (isDigit(this.char)) {
+        this.consume()
+      } else if (this.state.buf.length === 1) {
+        throw this.error(new TomlError('Expected digit in milliseconds'))
+      } else if (this.char === CHAR_HYPHEN || this.char === CHAR_PLUS) {
+        this.consume()
+        this.next(this.parseTimeZoneHour)
+      } else if (this.char === CHAR_Z) {
+        this.consume()
+        return this.return(createDateTime(this.state.result + this.state.buf))
+      } else if (this.atEndOfWord()) {
+        return this.returnNow(createDateTimeFloat(this.state.result + this.state.buf))
+      } else {
+        throw this.error(new TomlError('Unexpected character in datetime, expected period (.), minus (-), plus (+) or Z'))
+      }
+    }
+    parseTimeZoneHour () {
+      if (isDigit(this.char)) {
+        this.consume()
+        // FIXME: No more regexps
+        if (/\d\d$/.test(this.state.buf)) return this.next(this.parseTimeZoneSep)
+      } else {
+        throw this.error(new TomlError('Unexpected character in datetime, expected digit'))
+      }
+    }
+    parseTimeZoneSep () {
+      if (this.char === CHAR_COLON) {
+        this.consume()
+        this.next(this.parseTimeZoneMin)
+      } else {
+        throw this.error(new TomlError('Unexpected character in datetime, expected colon'))
+      }
+    }
+    parseTimeZoneMin () {
+      if (isDigit(this.char)) {
+        this.consume()
+        if (/\d\d$/.test(this.state.buf)) return this.return(createDateTime(this.state.result + this.state.buf))
+      } else {
+        throw this.error(new TomlError('Unexpected character in datetime, expected digit'))
+      }
+    }
+
+    /* BOOLEAN */
+    parseBoolean () {
+      /* istanbul ignore else */
+      if (this.char === CHAR_t) {
+        this.consume()
+        return this.next(this.parseTrue_r)
+      } else if (this.char === CHAR_f) {
+        this.consume()
+        return this.next(this.parseFalse_a)
+      }
+    }
+    parseTrue_r () {
+      if (this.char === CHAR_r) {
+        this.consume()
+        return this.next(this.parseTrue_u)
+      } else {
+        throw this.error(new TomlError('Invalid boolean, expected true or false'))
+      }
+    }
+    parseTrue_u () {
+      if (this.char === CHAR_u) {
+        this.consume()
+        return this.next(this.parseTrue_e)
+      } else {
+        throw this.error(new TomlError('Invalid boolean, expected true or false'))
+      }
+    }
+    parseTrue_e () {
+      if (this.char === CHAR_e) {
+        return this.return(true)
+      } else {
+        throw this.error(new TomlError('Invalid boolean, expected true or false'))
+      }
+    }
+
+    parseFalse_a () {
+      if (this.char === CHAR_a) {
+        this.consume()
+        return this.next(this.parseFalse_l)
+      } else {
+        throw this.error(new TomlError('Invalid boolean, expected true or false'))
+      }
+    }
+
+    parseFalse_l () {
+      if (this.char === CHAR_l) {
+        this.consume()
+        return this.next(this.parseFalse_s)
+      } else {
+        throw this.error(new TomlError('Invalid boolean, expected true or false'))
+      }
+    }
+
+    parseFalse_s () {
+      if (this.char === CHAR_s) {
+        this.consume()
+        return this.next(this.parseFalse_e)
+      } else {
+        throw this.error(new TomlError('Invalid boolean, expected true or false'))
+      }
+    }
+
+    parseFalse_e () {
+      if (this.char === CHAR_e) {
+        return this.return(false)
+      } else {
+        throw this.error(new TomlError('Invalid boolean, expected true or false'))
+      }
+    }
+
+    /* INLINE LISTS */
+    parseInlineList () {
+      if (this.char === CHAR_SP || this.char === CTRL_I || this.char === CTRL_M || this.char === CTRL_J) {
+        return null
+      } else if (this.char === Parser.END) {
+        throw this.error(new TomlError('Unterminated inline array'))
+      } else if (this.char === CHAR_NUM) {
+        return this.call(this.parseComment)
+      } else if (this.char === CHAR_RSQB) {
+        return this.return(this.state.resultArr || InlineList())
+      } else {
+        return this.callNow(this.parseValue, this.recordInlineListValue)
+      }
+    }
+    recordInlineListValue (value) {
+      if (this.state.resultArr) {
+        const listType = this.state.resultArr[_contentType]
+        const valueType = tomlType(value)
+        if (listType !== valueType) {
+          throw this.error(new TomlError(`Inline lists must be a single type, not a mix of ${listType} and ${valueType}`))
+        }
+      } else {
+        this.state.resultArr = InlineList(tomlType(value))
+      }
+      if (isFloat(value) || isInteger(value)) {
+        // unbox now that we've verified they're ok
+        this.state.resultArr.push(value.valueOf())
+      } else {
+        this.state.resultArr.push(value)
+      }
+      return this.goto(this.parseInlineListNext)
+    }
+    parseInlineListNext () {
+      if (this.char === CHAR_SP || this.char === CTRL_I || this.char === CTRL_M || this.char === CTRL_J) {
+        return null
+      } else if (this.char === CHAR_NUM) {
+        return this.call(this.parseComment)
+      } else if (this.char === CHAR_COMMA) {
+        return this.next(this.parseInlineList)
+      } else if (this.char === CHAR_RSQB) {
+        return this.goto(this.parseInlineList)
+      } else {
+        throw this.error(new TomlError('Invalid character, expected whitespace, comma (,) or close bracket (])'))
+      }
+    }
+
+    /* INLINE TABLE */
+    parseInlineTable () {
+      if (this.char === CHAR_SP || this.char === CTRL_I) {
+        return null
+      } else if (this.char === Parser.END || this.char === CHAR_NUM || this.char === CTRL_J || this.char === CTRL_M) {
+        throw this.error(new TomlError('Unterminated inline array'))
+      } else if (this.char === CHAR_RCUB) {
+        return this.return(this.state.resultTable || InlineTable())
+      } else {
+        if (!this.state.resultTable) this.state.resultTable = InlineTable()
+        return this.callNow(this.parseAssign, this.recordInlineTableValue)
+      }
+    }
+    recordInlineTableValue (kv) {
+      let target = this.state.resultTable
+      let finalKey = kv.key.pop()
+      for (let kw of kv.key) {
+        if (hasKey(target, kw) && (!isTable(target[kw]) || target[kw][_declared])) {
+          throw this.error(new TomlError("Can't redefine existing key"))
+        }
+        target = target[kw] = target[kw] || Table()
+      }
+      if (hasKey(target, finalKey)) {
+        throw this.error(new TomlError("Can't redefine existing key"))
+      }
+      if (isInteger(kv.value) || isFloat(kv.value)) {
+        target[finalKey] = kv.value.valueOf()
+      } else {
+        target[finalKey] = kv.value
+      }
+      return this.goto(this.parseInlineTableNext)
+    }
+    parseInlineTableNext () {
+      if (this.char === CHAR_SP || this.char === CTRL_I) {
+        return null
+      } else if (this.char === Parser.END || this.char === CHAR_NUM || this.char === CTRL_J || this.char === CTRL_M) {
+        throw this.error(new TomlError('Unterminated inline array'))
+      } else if (this.char === CHAR_COMMA) {
+        return this.next(this.parseInlineTable)
+      } else if (this.char === CHAR_RCUB) {
+        return this.goto(this.parseInlineTable)
+      } else {
+        throw this.error(new TomlError('Invalid character, expected whitespace, comma (,) or close bracket (])'))
+      }
+    }
+  }
+  return TOMLParser
+}
+
+
+/***/ }),
+
+/***/ 27072:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+module.exports = parseAsync
+
+const TOMLParser = __nccwpck_require__(82862)
+const prettyError = __nccwpck_require__(97349)
+
+function parseAsync (str, opts) {
+  if (!opts) opts = {}
+  const index = 0
+  const blocksize = opts.blocksize || 40960
+  const parser = new TOMLParser()
+  return new Promise((resolve, reject) => {
+    setImmediate(parseAsyncNext, index, blocksize, resolve, reject)
+  })
+  function parseAsyncNext (index, blocksize, resolve, reject) {
+    if (index >= str.length) {
+      try {
+        return resolve(parser.finish())
+      } catch (err) {
+        return reject(prettyError(err, str))
+      }
+    }
+    try {
+      parser.parse(str.slice(index, index + blocksize))
+      setImmediate(parseAsyncNext, index + blocksize, blocksize, resolve, reject)
+    } catch (err) {
+      reject(prettyError(err, str))
+    }
+  }
+}
+
+
+/***/ }),
+
+/***/ 97349:
+/***/ ((module) => {
+
+"use strict";
+
+module.exports = prettyError
+
+function prettyError (err, buf) {
+  /* istanbul ignore if */
+  if (err.pos == null || err.line == null) return err
+  let msg = err.message
+  msg += ` at row ${err.line + 1}, col ${err.col + 1}, pos ${err.pos}:\n`
+
+  /* istanbul ignore else */
+  if (buf && buf.split) {
+    const lines = buf.split(/\n/)
+    const lineNumWidth = String(Math.min(lines.length, err.line + 3)).length
+    let linePadding = ' '
+    while (linePadding.length < lineNumWidth) linePadding += ' '
+    for (let ii = Math.max(0, err.line - 1); ii < Math.min(lines.length, err.line + 2); ++ii) {
+      let lineNum = String(ii + 1)
+      if (lineNum.length < lineNumWidth) lineNum = ' ' + lineNum
+      if (err.line === ii) {
+        msg += lineNum + '> ' + lines[ii] + '\n'
+        msg += linePadding + '  '
+        for (let hh = 0; hh < err.col; ++hh) {
+          msg += ' '
+        }
+        msg += '^\n'
+      } else {
+        msg += lineNum + ': ' + lines[ii] + '\n'
+      }
+    }
+  }
+  err.message = msg + '\n'
+  return err
+}
+
+
+/***/ }),
+
+/***/ 86874:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+module.exports = parseStream
+
+const stream = __nccwpck_require__(2203)
+const TOMLParser = __nccwpck_require__(82862)
+
+function parseStream (stm) {
+  if (stm) {
+    return parseReadable(stm)
+  } else {
+    return parseTransform(stm)
+  }
+}
+
+function parseReadable (stm) {
+  const parser = new TOMLParser()
+  stm.setEncoding('utf8')
+  return new Promise((resolve, reject) => {
+    let readable
+    let ended = false
+    let errored = false
+    function finish () {
+      ended = true
+      if (readable) return
+      try {
+        resolve(parser.finish())
+      } catch (err) {
+        reject(err)
+      }
+    }
+    function error (err) {
+      errored = true
+      reject(err)
+    }
+    stm.once('end', finish)
+    stm.once('error', error)
+    readNext()
+
+    function readNext () {
+      readable = true
+      let data
+      while ((data = stm.read()) !== null) {
+        try {
+          parser.parse(data)
+        } catch (err) {
+          return error(err)
+        }
+      }
+      readable = false
+      /* istanbul ignore if */
+      if (ended) return finish()
+      /* istanbul ignore if */
+      if (errored) return
+      stm.once('readable', readNext)
+    }
+  })
+}
+
+function parseTransform () {
+  const parser = new TOMLParser()
+  return new stream.Transform({
+    objectMode: true,
+    transform (chunk, encoding, cb) {
+      try {
+        parser.parse(chunk.toString(encoding))
+      } catch (err) {
+        this.emit('error', err)
+      }
+      cb()
+    },
+    flush (cb) {
+      try {
+        this.push(parser.finish())
+      } catch (err) {
+        this.emit('error', err)
+      }
+      cb()
+    }
+  })
+}
+
+
+/***/ }),
+
+/***/ 24171:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+module.exports = parseString
+
+const TOMLParser = __nccwpck_require__(82862)
+const prettyError = __nccwpck_require__(97349)
+
+function parseString (str) {
+  if (global.Buffer && global.Buffer.isBuffer(str)) {
+    str = str.toString('utf8')
+  }
+  const parser = new TOMLParser()
+  try {
+    parser.parse(str)
+    return parser.finish()
+  } catch (err) {
+    throw prettyError(err, str)
+  }
+}
+
+
+/***/ }),
+
+/***/ 79185:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+module.exports = __nccwpck_require__(24171)
+module.exports.async = __nccwpck_require__(27072)
+module.exports.stream = __nccwpck_require__(86874)
+module.exports.prettyError = __nccwpck_require__(97349)
+
+
+/***/ }),
+
+/***/ 43887:
+/***/ ((module) => {
+
+"use strict";
+
+module.exports = stringify
+module.exports.value = stringifyInline
+
+function stringify (obj) {
+  if (obj === null) throw typeError('null')
+  if (obj === void (0)) throw typeError('undefined')
+  if (typeof obj !== 'object') throw typeError(typeof obj)
+
+  if (typeof obj.toJSON === 'function') obj = obj.toJSON()
+  if (obj == null) return null
+  const type = tomlType(obj)
+  if (type !== 'table') throw typeError(type)
+  return stringifyObject('', '', obj)
+}
+
+function typeError (type) {
+  return new Error('Can only stringify objects, not ' + type)
+}
+
+function arrayOneTypeError () {
+  return new Error("Array values can't have mixed types")
+}
+
+function getInlineKeys (obj) {
+  return Object.keys(obj).filter(key => isInline(obj[key]))
+}
+function getComplexKeys (obj) {
+  return Object.keys(obj).filter(key => !isInline(obj[key]))
+}
+
+function toJSON (obj) {
+  let nobj = Array.isArray(obj) ? [] : Object.prototype.hasOwnProperty.call(obj, '__proto__') ? {['__proto__']: undefined} : {}
+  for (let prop of Object.keys(obj)) {
+    if (obj[prop] && typeof obj[prop].toJSON === 'function' && !('toISOString' in obj[prop])) {
+      nobj[prop] = obj[prop].toJSON()
+    } else {
+      nobj[prop] = obj[prop]
+    }
+  }
+  return nobj
+}
+
+function stringifyObject (prefix, indent, obj) {
+  obj = toJSON(obj)
+  var inlineKeys
+  var complexKeys
+  inlineKeys = getInlineKeys(obj)
+  complexKeys = getComplexKeys(obj)
+  var result = []
+  var inlineIndent = indent || ''
+  inlineKeys.forEach(key => {
+    var type = tomlType(obj[key])
+    if (type !== 'undefined' && type !== 'null') {
+      result.push(inlineIndent + stringifyKey(key) + ' = ' + stringifyAnyInline(obj[key], true))
+    }
+  })
+  if (result.length > 0) result.push('')
+  var complexIndent = prefix && inlineKeys.length > 0 ? indent + '  ' : ''
+  complexKeys.forEach(key => {
+    result.push(stringifyComplex(prefix, complexIndent, key, obj[key]))
+  })
+  return result.join('\n')
+}
+
+function isInline (value) {
+  switch (tomlType(value)) {
+    case 'undefined':
+    case 'null':
+    case 'integer':
+    case 'nan':
+    case 'float':
+    case 'boolean':
+    case 'string':
+    case 'datetime':
+      return true
+    case 'array':
+      return value.length === 0 || tomlType(value[0]) !== 'table'
+    case 'table':
+      return Object.keys(value).length === 0
+    /* istanbul ignore next */
+    default:
+      return false
+  }
+}
+
+function tomlType (value) {
+  if (value === undefined) {
+    return 'undefined'
+  } else if (value === null) {
+    return 'null'
+  /* eslint-disable valid-typeof */
+  } else if (typeof value === 'bigint' || (Number.isInteger(value) && !Object.is(value, -0))) {
+    return 'integer'
+  } else if (typeof value === 'number') {
+    return 'float'
+  } else if (typeof value === 'boolean') {
+    return 'boolean'
+  } else if (typeof value === 'string') {
+    return 'string'
+  } else if ('toISOString' in value) {
+    return isNaN(value) ? 'undefined' : 'datetime'
+  } else if (Array.isArray(value)) {
+    return 'array'
+  } else {
+    return 'table'
+  }
+}
+
+function stringifyKey (key) {
+  var keyStr = String(key)
+  if (/^[-A-Za-z0-9_]+$/.test(keyStr)) {
+    return keyStr
+  } else {
+    return stringifyBasicString(keyStr)
+  }
+}
+
+function stringifyBasicString (str) {
+  return '"' + escapeString(str).replace(/"/g, '\\"') + '"'
+}
+
+function stringifyLiteralString (str) {
+  return "'" + str + "'"
+}
+
+function numpad (num, str) {
+  while (str.length < num) str = '0' + str
+  return str
+}
+
+function escapeString (str) {
+  return str.replace(/\\/g, '\\\\')
+    .replace(/[\b]/g, '\\b')
+    .replace(/\t/g, '\\t')
+    .replace(/\n/g, '\\n')
+    .replace(/\f/g, '\\f')
+    .replace(/\r/g, '\\r')
+    /* eslint-disable no-control-regex */
+    .replace(/([\u0000-\u001f\u007f])/, c => '\\u' + numpad(4, c.codePointAt(0).toString(16)))
+    /* eslint-enable no-control-regex */
+}
+
+function stringifyMultilineString (str) {
+  let escaped = str.split(/\n/).map(str => {
+    return escapeString(str).replace(/"(?="")/g, '\\"')
+  }).join('\n')
+  if (escaped.slice(-1) === '"') escaped += '\\\n'
+  return '"""\n' + escaped + '"""'
+}
+
+function stringifyAnyInline (value, multilineOk) {
+  let type = tomlType(value)
+  if (type === 'string') {
+    if (multilineOk && /\n/.test(value)) {
+      type = 'string-multiline'
+    } else if (!/[\b\t\n\f\r']/.test(value) && /"/.test(value)) {
+      type = 'string-literal'
+    }
+  }
+  return stringifyInline(value, type)
+}
+
+function stringifyInline (value, type) {
+  /* istanbul ignore if */
+  if (!type) type = tomlType(value)
+  switch (type) {
+    case 'string-multiline':
+      return stringifyMultilineString(value)
+    case 'string':
+      return stringifyBasicString(value)
+    case 'string-literal':
+      return stringifyLiteralString(value)
+    case 'integer':
+      return stringifyInteger(value)
+    case 'float':
+      return stringifyFloat(value)
+    case 'boolean':
+      return stringifyBoolean(value)
+    case 'datetime':
+      return stringifyDatetime(value)
+    case 'array':
+      return stringifyInlineArray(value.filter(_ => tomlType(_) !== 'null' && tomlType(_) !== 'undefined' && tomlType(_) !== 'nan'))
+    case 'table':
+      return stringifyInlineTable(value)
+    /* istanbul ignore next */
+    default:
+      throw typeError(type)
+  }
+}
+
+function stringifyInteger (value) {
+  /* eslint-disable security/detect-unsafe-regex */
+  return String(value).replace(/\B(?=(\d{3})+(?!\d))/g, '_')
+}
+
+function stringifyFloat (value) {
+  if (value === Infinity) {
+    return 'inf'
+  } else if (value === -Infinity) {
+    return '-inf'
+  } else if (Object.is(value, NaN)) {
+    return 'nan'
+  } else if (Object.is(value, -0)) {
+    return '-0.0'
+  }
+  var chunks = String(value).split('.')
+  var int = chunks[0]
+  var dec = chunks[1] || 0
+  return stringifyInteger(int) + '.' + dec
+}
+
+function stringifyBoolean (value) {
+  return String(value)
+}
+
+function stringifyDatetime (value) {
+  return value.toISOString()
+}
+
+function isNumber (type) {
+  return type === 'float' || type === 'integer'
+}
+function arrayType (values) {
+  var contentType = tomlType(values[0])
+  if (values.every(_ => tomlType(_) === contentType)) return contentType
+  // mixed integer/float, emit as floats
+  if (values.every(_ => isNumber(tomlType(_)))) return 'float'
+  return 'mixed'
+}
+function validateArray (values) {
+  const type = arrayType(values)
+  if (type === 'mixed') {
+    throw arrayOneTypeError()
+  }
+  return type
+}
+
+function stringifyInlineArray (values) {
+  values = toJSON(values)
+  const type = validateArray(values)
+  var result = '['
+  var stringified = values.map(_ => stringifyInline(_, type))
+  if (stringified.join(', ').length > 60 || /\n/.test(stringified)) {
+    result += '\n  ' + stringified.join(',\n  ') + '\n'
+  } else {
+    result += ' ' + stringified.join(', ') + (stringified.length > 0 ? ' ' : '')
+  }
+  return result + ']'
+}
+
+function stringifyInlineTable (value) {
+  value = toJSON(value)
+  var result = []
+  Object.keys(value).forEach(key => {
+    result.push(stringifyKey(key) + ' = ' + stringifyAnyInline(value[key], false))
+  })
+  return '{ ' + result.join(', ') + (result.length > 0 ? ' ' : '') + '}'
+}
+
+function stringifyComplex (prefix, indent, key, value) {
+  var valueType = tomlType(value)
+  /* istanbul ignore else */
+  if (valueType === 'array') {
+    return stringifyArrayOfTables(prefix, indent, key, value)
+  } else if (valueType === 'table') {
+    return stringifyComplexTable(prefix, indent, key, value)
+  } else {
+    throw typeError(valueType)
+  }
+}
+
+function stringifyArrayOfTables (prefix, indent, key, values) {
+  values = toJSON(values)
+  validateArray(values)
+  var firstValueType = tomlType(values[0])
+  /* istanbul ignore if */
+  if (firstValueType !== 'table') throw typeError(firstValueType)
+  var fullKey = prefix + stringifyKey(key)
+  var result = ''
+  values.forEach(table => {
+    if (result.length > 0) result += '\n'
+    result += indent + '[[' + fullKey + ']]\n'
+    result += stringifyObject(fullKey + '.', indent, table)
+  })
+  return result
+}
+
+function stringifyComplexTable (prefix, indent, key, value) {
+  var fullKey = prefix + stringifyKey(key)
+  var result = ''
+  if (getInlineKeys(value).length > 0) {
+    result += indent + '[' + fullKey + ']\n'
+  }
+  return result + stringifyObject(fullKey + '.', indent, value)
+}
+
+
+/***/ }),
+
+/***/ 64572:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+exports.parse = __nccwpck_require__(79185)
+exports.stringify = __nccwpck_require__(43887)
+
+
+/***/ }),
+
 /***/ 93708:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -47588,6 +49756,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.FOUNDATION_PREFIXES = void 0;
 exports.ageFloorForOvershoot = ageFloorForOvershoot;
 exports.thresholdsForPolicy = thresholdsForPolicy;
+exports.deleteCacheEntriesByKeys = deleteCacheEntriesByKeys;
 exports.evictIfOverBudget = evictIfOverBudget;
 const github = __importStar(__nccwpck_require__(93228));
 /**
@@ -47663,6 +49832,90 @@ function thresholdsForPolicy(policy) {
             // can't tolerate overshoot or want tighter management.
             return { triggerGb: 7, targetGb: 6, minAgeHoursBeforeDelete: 2 };
     }
+}
+/**
+ * Delete every Actions-cache entry whose key exactly matches one of `keys`.
+ *
+ * This is the targeted repair path used when a restored dependency closure is
+ * later found to contain a yanked crate. It deliberately lives beside the LRU
+ * eviction implementation so both paths share the same list-by-key and
+ * delete-by-id Actions API plumbing.
+ */
+async function deleteCacheEntriesByKeys(opts) {
+    const keys = [...new Set(opts.keys.map((key) => key.trim()).filter(Boolean))];
+    if (!opts.owner || !opts.repo || !opts.token || keys.length === 0) {
+        opts.log("cache-eviction: cannot delete targeted keys: repository, token, or keys are missing");
+        return { found: 0, deleted: 0, failed: keys.length || 1 };
+    }
+    const octokit = github.getOctokit(opts.token);
+    const listCachesForKey = opts.listCachesForKey ?? (async (key) => {
+        const entries = [];
+        let page = 1;
+        while (true) {
+            const response = await octokit.rest.actions.getActionsCacheList({
+                owner: opts.owner,
+                repo: opts.repo,
+                key,
+                per_page: 100,
+                page,
+            });
+            const items = response.data.actions_caches ?? [];
+            for (const item of items) {
+                if (item.id != null && item.key != null && item.size_in_bytes != null && item.created_at != null) {
+                    entries.push({
+                        id: item.id,
+                        key: item.key,
+                        size_in_bytes: item.size_in_bytes,
+                        created_at: item.created_at,
+                    });
+                }
+            }
+            if (items.length < 100)
+                break;
+            page += 1;
+        }
+        return entries;
+    });
+    const deleteCacheById = opts.deleteCacheById ?? (async (cacheId) => {
+        await octokit.rest.actions.deleteActionsCacheById({
+            owner: opts.owner,
+            repo: opts.repo,
+            cache_id: cacheId,
+        });
+    });
+    const entriesById = new Map();
+    let failed = 0;
+    for (const key of keys) {
+        try {
+            for (const entry of await listCachesForKey(key)) {
+                if (entry.key === key)
+                    entriesById.set(entry.id, entry);
+            }
+        }
+        catch (err) {
+            failed += 1;
+            opts.log(`cache-eviction: failed to list poisoned key=${key}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    let deleted = 0;
+    for (const entry of entriesById.values()) {
+        try {
+            await deleteCacheById(entry.id);
+            deleted += 1;
+            opts.log(`cache-eviction: deleted poisoned entry id=${entry.id} key=${entry.key}`);
+        }
+        catch (err) {
+            const status = err.status;
+            if (status === 404) {
+                deleted += 1;
+                continue;
+            }
+            failed += 1;
+            opts.log(`cache-eviction: failed to delete poisoned entry id=${entry.id} key=${entry.key} ` +
+                `(status=${status ?? "?"}): ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    return { found: entriesById.size, deleted, failed };
 }
 /**
  * Run an eviction pass. Returns a summary suitable for logging.
@@ -54818,6 +57071,256 @@ async function verifySoldr(opts) {
 
 /***/ }),
 
+/***/ 23140:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.YANK_AUDIT_WORKER_ARG = void 0;
+exports.readRegistryDependencies = readRegistryDependencies;
+exports.cratesIoSparsePath = cratesIoSparsePath;
+exports.auditDependencyYanks = auditDependencyYanks;
+exports.writeYankAuditResult = writeYankAuditResult;
+exports.readYankAuditResult = readYankAuditResult;
+exports.waitForYankAuditResult = waitForYankAuditResult;
+exports.runYankAuditWorker = runYankAuditWorker;
+const fs = __importStar(__nccwpck_require__(73024));
+const path = __importStar(__nccwpck_require__(76760));
+const toml = __importStar(__nccwpck_require__(64572));
+exports.YANK_AUDIT_WORKER_ARG = "--setup-soldr-yank-audit-worker";
+const CRATES_IO_GIT_INDEX = "registry+https://github.com/rust-lang/crates.io-index";
+const CRATES_IO_SPARSE_INDEX = "sparse+https://index.crates.io/";
+function isCratesIoSource(source) {
+    return source === CRATES_IO_GIT_INDEX || source === CRATES_IO_SPARSE_INDEX;
+}
+function readRegistryDependencies(lockfilePath) {
+    const parsed = toml.parse(fs.readFileSync(lockfilePath, "utf8"));
+    const seen = new Set();
+    const dependencies = [];
+    for (const pkg of Array.isArray(parsed.package) ? parsed.package : []) {
+        if (typeof pkg.name !== "string" || typeof pkg.version !== "string")
+            continue;
+        if (typeof pkg.source !== "string" ||
+            (!pkg.source.startsWith("registry+") && !pkg.source.startsWith("sparse+")))
+            continue;
+        const key = `${pkg.source}\0${pkg.name}\0${pkg.version}`;
+        if (seen.has(key))
+            continue;
+        seen.add(key);
+        dependencies.push({ name: pkg.name, version: pkg.version, source: pkg.source });
+    }
+    return dependencies;
+}
+function cratesIoSparsePath(crateName) {
+    const name = crateName.toLowerCase();
+    if (name.length === 1)
+        return `1/${name}`;
+    if (name.length === 2)
+        return `2/${name}`;
+    if (name.length === 3)
+        return `3/${name[0]}/${name}`;
+    return `${name.slice(0, 2)}/${name.slice(2, 4)}/${name}`;
+}
+async function fetchCrateYanks(crateName, versions, fetchImpl, timeoutMs, overallSignal) {
+    const controller = new AbortController();
+    const abortForOverallDeadline = () => controller.abort();
+    overallSignal.addEventListener("abort", abortForOverallDeadline, { once: true });
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const response = await fetchImpl(`https://index.crates.io/${cratesIoSparsePath(crateName)}`, {
+            headers: {
+                "Accept": "text/plain",
+                "User-Agent": "setup-soldr-yank-audit/1",
+            },
+            signal: controller.signal,
+        });
+        if (!response.ok)
+            throw new Error(`HTTP ${response.status}`);
+        const records = new Map();
+        for (const line of (await response.text()).split(/\r?\n/)) {
+            if (!line.trim())
+                continue;
+            const record = JSON.parse(line);
+            if (typeof record.vers === "string" && typeof record.yanked === "boolean") {
+                records.set(record.vers, record.yanked);
+            }
+        }
+        const checked = [];
+        const yanked = [];
+        for (const version of versions) {
+            if (!records.has(version)) {
+                throw new Error(`version ${crateName} ${version} absent from sparse index`);
+            }
+            const dependency = { name: crateName, version };
+            checked.push(dependency);
+            if (records.get(version))
+                yanked.push(dependency);
+        }
+        return { checked, yanked };
+    }
+    finally {
+        clearTimeout(timeout);
+        overallSignal.removeEventListener("abort", abortForOverallDeadline);
+    }
+}
+async function auditDependencyYanks(dependencies, options = {}) {
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const timeoutMs = options.requestTimeoutMs ?? 30_000;
+    const concurrency = Math.max(1, options.concurrency ?? 12);
+    const overallTimeoutMs = Math.max(1, options.overallTimeoutMs ?? 45_000);
+    const overallController = new AbortController();
+    const overallTimeout = setTimeout(() => overallController.abort(), overallTimeoutMs);
+    const errors = [];
+    const yanked = [];
+    let checkedCount = 0;
+    const byCrate = new Map();
+    for (const dependency of dependencies) {
+        if (!isCratesIoSource(dependency.source)) {
+            errors.push(`${dependency.name} ${dependency.version}: registry ${dependency.source} is not supported`);
+            continue;
+        }
+        const versions = byCrate.get(dependency.name) ?? new Set();
+        versions.add(dependency.version);
+        byCrate.set(dependency.name, versions);
+    }
+    const work = [...byCrate.entries()];
+    let index = 0;
+    let omittedErrors = 0;
+    const recordError = (message) => {
+        if (errors.length < 20)
+            errors.push(message);
+        else
+            omittedErrors += 1;
+    };
+    const worker = async () => {
+        while (true) {
+            const item = work[index++];
+            if (!item)
+                return;
+            const [crateName, versions] = item;
+            try {
+                if (overallController.signal.aborted) {
+                    throw new Error(`audit deadline exceeded after ${overallTimeoutMs}ms`);
+                }
+                const result = await fetchCrateYanks(crateName, [...versions], fetchImpl, timeoutMs, overallController.signal);
+                checkedCount += result.checked.length;
+                yanked.push(...result.yanked);
+            }
+            catch (err) {
+                recordError(`${crateName}: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    };
+    try {
+        await Promise.all(Array.from({ length: Math.min(concurrency, work.length) }, () => worker()));
+    }
+    finally {
+        clearTimeout(overallTimeout);
+    }
+    if (omittedErrors > 0)
+        errors.push(`${omittedErrors} additional registry errors omitted`);
+    const base = {
+        checkedAt: new Date().toISOString(),
+        dependencyCount: dependencies.length,
+        checkedCount,
+    };
+    if (yanked.length > 0) {
+        return { ...base, status: "yanked", yanked, errors };
+    }
+    if (errors.length > 0) {
+        return { ...base, status: "not-checked", yanked: [], errors };
+    }
+    return { ...base, status: "clean", yanked: [], errors: [] };
+}
+function writeYankAuditResult(resultPath, result) {
+    fs.mkdirSync(path.dirname(resultPath), { recursive: true });
+    const temporaryPath = `${resultPath}.${process.pid}.tmp`;
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(result)}\n`, "utf8");
+    fs.renameSync(temporaryPath, resultPath);
+}
+function readYankAuditResult(resultPath) {
+    try {
+        const result = JSON.parse(fs.readFileSync(resultPath, "utf8"));
+        if (!["pending", "clean", "yanked", "not-checked"].includes(result.status))
+            return null;
+        return result;
+    }
+    catch {
+        return null;
+    }
+}
+async function waitForYankAuditResult(resultPath, options = {}) {
+    const timeoutMs = options.timeoutMs ?? 60_000;
+    const pollMs = options.pollMs ?? 250;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const result = readYankAuditResult(resultPath);
+        if (result && result.status !== "pending")
+            return result;
+        await new Promise((resolve) => setTimeout(resolve, pollMs));
+    }
+    return {
+        status: "not-checked",
+        checkedAt: new Date().toISOString(),
+        errors: [`audit did not finish within ${timeoutMs}ms`],
+        joinTimedOut: true,
+    };
+}
+async function runYankAuditWorker(configPath, resultPath) {
+    try {
+        const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+        const result = await auditDependencyYanks(config.dependencies, {
+            requestTimeoutMs: config.requestTimeoutMs,
+            overallTimeoutMs: config.overallTimeoutMs,
+        });
+        writeYankAuditResult(resultPath, result);
+    }
+    catch (err) {
+        writeYankAuditResult(resultPath, {
+            status: "not-checked",
+            checkedAt: new Date().toISOString(),
+            errors: [err instanceof Error ? err.message : String(err)],
+        });
+    }
+}
+
+
+/***/ }),
+
 /***/ 86661:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -54897,6 +57400,7 @@ const compile_cache_stats_js_1 = __nccwpck_require__(63355);
 const diagnostics_js_1 = __nccwpck_require__(92587);
 const raw_inputs_js_1 = __nccwpck_require__(52183);
 const cache_eviction_js_1 = __nccwpck_require__(15795);
+const yank_audit_js_1 = __nccwpck_require__(23140);
 const source_mtime_snapshot_js_1 = __nccwpck_require__(38502);
 function dirExists(p) {
     try {
@@ -55904,6 +58408,64 @@ async function run() {
         logsArchiveDir,
         log,
     });
+    // #476: main launched this audit after the final dependency-bearing
+    // restore, so it ran concurrently with the consumer's build. Join before
+    // any save: a poisoned restored closure must never be republished under a
+    // new exact key or allowed to produce a successful job.
+    if (core.getState("yankAuditStarted") === "true") {
+        const auditPath = core.getState("yankAuditResultPath");
+        let cacheKeys = [];
+        try {
+            const parsed = JSON.parse(core.getState("yankAuditCacheKeys"));
+            if (Array.isArray(parsed)) {
+                cacheKeys = [...new Set(parsed.filter((key) => typeof key === "string" && key.length > 0))];
+            }
+        }
+        catch {
+            // The result below will still be surfaced as not checked if state was
+            // damaged; never convert malformed state into a clean verdict.
+        }
+        const audit = auditPath
+            ? await (0, yank_audit_js_1.waitForYankAuditResult)(auditPath, { timeoutMs: 60_000 })
+            : { status: "not-checked", errors: ["audit result path is missing"] };
+        if (audit.status === "not-checked" && audit.joinTimedOut) {
+            core.setFailed(`yank-audit: not checked because the background audit did not reach a terminal result: ` +
+                `${(audit.errors ?? ["join timed out"]).join("; ")}. ` +
+                `Refusing to save caches or report success while the audit may still be in flight.`);
+            return;
+        }
+        else if (audit.status === "not-checked") {
+            core.warning(`yank-audit: not checked: ${(audit.errors ?? ["unknown registry error"]).join("; ")}`);
+        }
+        else if (audit.status === "clean") {
+            log(`yank-audit: clean checked=${audit.checkedCount ?? 0}/${audit.dependencyCount ?? 0} ` +
+                `cache_keys=${cacheKeys.length}`);
+        }
+        else if (audit.status === "yanked") {
+            const yanked = audit.yanked ?? [];
+            const crates = yanked.map((dependency) => `${dependency.name} ${dependency.version}`).join(", ");
+            const githubRepository = (process.env["GITHUB_REPOSITORY"] ?? "").trim();
+            const [owner, repo] = githubRepository.split("/");
+            const token = (process.env["GITHUB_TOKEN"] ?? "").trim() ||
+                (process.env["INPUT_TOKEN"] ?? "").trim();
+            const deletion = await (0, cache_eviction_js_1.deleteCacheEntriesByKeys)({
+                owner: owner ?? "",
+                repo: repo ?? "",
+                token,
+                keys: cacheKeys,
+                log,
+            });
+            const deletionComplete = deletion.failed === 0 && deletion.deleted === deletion.found;
+            const repair = deletionComplete
+                ? `poisoned entries deleted=${deletion.deleted}/${deletion.found}; rerun to rebuild from a clean cache miss`
+                : `automatic deletion incomplete (deleted=${deletion.deleted}/${deletion.found}, failures=${deletion.failed}); ` +
+                    `grant the workflow actions: write permission or manually delete these exact cache keys before retrying`;
+            core.setFailed(`yank-audit: restored dependency closure contains yanked crate(s): ${crates}; ` +
+                `cache key(s): ${cacheKeys.join(", ") || "unknown"}; ` +
+                `${repair}. This run is aborted.`);
+            return;
+        }
+    }
     // Source-mtime snapshot (preserve-source-mtimes opt-in). Walk tracked
     // sources, capture each (mtime, size, content-hash), and drop the JSON
     // INSIDE the build-cache directory so it gets bundled into the same

--- a/src/lib/cache-eviction.ts
+++ b/src/lib/cache-eviction.ts
@@ -160,6 +160,107 @@ export interface EvictResult {
   deletedBytes?: number;
 }
 
+export interface DeleteCacheKeysResult {
+  found: number;
+  deleted: number;
+  failed: number;
+}
+
+/**
+ * Delete every Actions-cache entry whose key exactly matches one of `keys`.
+ *
+ * This is the targeted repair path used when a restored dependency closure is
+ * later found to contain a yanked crate. It deliberately lives beside the LRU
+ * eviction implementation so both paths share the same list-by-key and
+ * delete-by-id Actions API plumbing.
+ */
+export async function deleteCacheEntriesByKeys(opts: {
+  owner: string;
+  repo: string;
+  token: string;
+  keys: readonly string[];
+  log: (msg: string) => void;
+  listCachesForKey?: (key: string) => Promise<CacheEntry[]>;
+  deleteCacheById?: (cacheId: number) => Promise<void>;
+}): Promise<DeleteCacheKeysResult> {
+  const keys = [...new Set(opts.keys.map((key) => key.trim()).filter(Boolean))];
+  if (!opts.owner || !opts.repo || !opts.token || keys.length === 0) {
+    opts.log("cache-eviction: cannot delete targeted keys: repository, token, or keys are missing");
+    return { found: 0, deleted: 0, failed: keys.length || 1 };
+  }
+  const octokit = github.getOctokit(opts.token);
+  const listCachesForKey = opts.listCachesForKey ?? (async (key: string): Promise<CacheEntry[]> => {
+    const entries: CacheEntry[] = [];
+    let page = 1;
+    while (true) {
+      const response = await octokit.rest.actions.getActionsCacheList({
+        owner: opts.owner,
+        repo: opts.repo,
+        key,
+        per_page: 100,
+        page,
+      });
+      const items = response.data.actions_caches ?? [];
+      for (const item of items) {
+        if (item.id != null && item.key != null && item.size_in_bytes != null && item.created_at != null) {
+          entries.push({
+            id: item.id,
+            key: item.key,
+            size_in_bytes: item.size_in_bytes,
+            created_at: item.created_at,
+          });
+        }
+      }
+      if (items.length < 100) break;
+      page += 1;
+    }
+    return entries;
+  });
+  const deleteCacheById = opts.deleteCacheById ?? (async (cacheId: number): Promise<void> => {
+    await octokit.rest.actions.deleteActionsCacheById({
+      owner: opts.owner,
+      repo: opts.repo,
+      cache_id: cacheId,
+    });
+  });
+
+  const entriesById = new Map<number, CacheEntry>();
+  let failed = 0;
+  for (const key of keys) {
+    try {
+      for (const entry of await listCachesForKey(key)) {
+        if (entry.key === key) entriesById.set(entry.id, entry);
+      }
+    } catch (err) {
+      failed += 1;
+      opts.log(
+        `cache-eviction: failed to list poisoned key=${key}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  let deleted = 0;
+  for (const entry of entriesById.values()) {
+    try {
+      await deleteCacheById(entry.id);
+      deleted += 1;
+      opts.log(`cache-eviction: deleted poisoned entry id=${entry.id} key=${entry.key}`);
+    } catch (err) {
+      const status = (err as { status?: number }).status;
+      if (status === 404) {
+        deleted += 1;
+        continue;
+      }
+      failed += 1;
+      opts.log(
+        `cache-eviction: failed to delete poisoned entry id=${entry.id} key=${entry.key} ` +
+          `(status=${status ?? "?"}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  return { found: entriesById.size, deleted, failed };
+}
+
 /**
  * Run an eviction pass. Returns a summary suitable for logging.
  * Never throws on permission/network errors — best-effort.

--- a/src/lib/yank-audit.ts
+++ b/src/lib/yank-audit.ts
@@ -1,0 +1,257 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as toml from "@iarna/toml";
+
+export const YANK_AUDIT_WORKER_ARG = "--setup-soldr-yank-audit-worker";
+
+export interface YankAuditDependency {
+  name: string;
+  version: string;
+  source: string;
+}
+
+export interface YankedDependency {
+  name: string;
+  version: string;
+}
+
+export interface YankAuditResult {
+  status: "pending" | "clean" | "yanked" | "not-checked";
+  checkedAt?: string;
+  dependencyCount?: number;
+  checkedCount?: number;
+  yanked?: YankedDependency[];
+  errors?: string[];
+  joinTimedOut?: boolean;
+}
+
+export interface YankAuditWorkerConfig {
+  dependencies: YankAuditDependency[];
+  requestTimeoutMs: number;
+  overallTimeoutMs: number;
+}
+
+type FetchLike = typeof fetch;
+
+interface CargoLockPackage {
+  name?: unknown;
+  version?: unknown;
+  source?: unknown;
+}
+
+const CRATES_IO_GIT_INDEX = "registry+https://github.com/rust-lang/crates.io-index";
+const CRATES_IO_SPARSE_INDEX = "sparse+https://index.crates.io/";
+
+function isCratesIoSource(source: string): boolean {
+  return source === CRATES_IO_GIT_INDEX || source === CRATES_IO_SPARSE_INDEX;
+}
+
+export function readRegistryDependencies(lockfilePath: string): YankAuditDependency[] {
+  const parsed = toml.parse(fs.readFileSync(lockfilePath, "utf8")) as {
+    package?: CargoLockPackage[];
+  };
+  const seen = new Set<string>();
+  const dependencies: YankAuditDependency[] = [];
+  for (const pkg of Array.isArray(parsed.package) ? parsed.package : []) {
+    if (typeof pkg.name !== "string" || typeof pkg.version !== "string") continue;
+    if (
+      typeof pkg.source !== "string" ||
+      (!pkg.source.startsWith("registry+") && !pkg.source.startsWith("sparse+"))
+    ) continue;
+    const key = `${pkg.source}\0${pkg.name}\0${pkg.version}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    dependencies.push({ name: pkg.name, version: pkg.version, source: pkg.source });
+  }
+  return dependencies;
+}
+
+export function cratesIoSparsePath(crateName: string): string {
+  const name = crateName.toLowerCase();
+  if (name.length === 1) return `1/${name}`;
+  if (name.length === 2) return `2/${name}`;
+  if (name.length === 3) return `3/${name[0]}/${name}`;
+  return `${name.slice(0, 2)}/${name.slice(2, 4)}/${name}`;
+}
+
+async function fetchCrateYanks(
+  crateName: string,
+  versions: readonly string[],
+  fetchImpl: FetchLike,
+  timeoutMs: number,
+  overallSignal: AbortSignal,
+): Promise<{ checked: YankedDependency[]; yanked: YankedDependency[] }> {
+  const controller = new AbortController();
+  const abortForOverallDeadline = (): void => controller.abort();
+  overallSignal.addEventListener("abort", abortForOverallDeadline, { once: true });
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(`https://index.crates.io/${cratesIoSparsePath(crateName)}`, {
+      headers: {
+        "Accept": "text/plain",
+        "User-Agent": "setup-soldr-yank-audit/1",
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const records = new Map<string, boolean>();
+    for (const line of (await response.text()).split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      const record = JSON.parse(line) as { vers?: unknown; yanked?: unknown };
+      if (typeof record.vers === "string" && typeof record.yanked === "boolean") {
+        records.set(record.vers, record.yanked);
+      }
+    }
+    const checked: YankedDependency[] = [];
+    const yanked: YankedDependency[] = [];
+    for (const version of versions) {
+      if (!records.has(version)) {
+        throw new Error(`version ${crateName} ${version} absent from sparse index`);
+      }
+      const dependency = { name: crateName, version };
+      checked.push(dependency);
+      if (records.get(version)) yanked.push(dependency);
+    }
+    return { checked, yanked };
+  } finally {
+    clearTimeout(timeout);
+    overallSignal.removeEventListener("abort", abortForOverallDeadline);
+  }
+}
+
+export async function auditDependencyYanks(
+  dependencies: readonly YankAuditDependency[],
+  options: {
+    fetchImpl?: FetchLike;
+    requestTimeoutMs?: number;
+    overallTimeoutMs?: number;
+    concurrency?: number;
+  } = {},
+): Promise<YankAuditResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.requestTimeoutMs ?? 30_000;
+  const concurrency = Math.max(1, options.concurrency ?? 12);
+  const overallTimeoutMs = Math.max(1, options.overallTimeoutMs ?? 45_000);
+  const overallController = new AbortController();
+  const overallTimeout = setTimeout(() => overallController.abort(), overallTimeoutMs);
+  const errors: string[] = [];
+  const yanked: YankedDependency[] = [];
+  let checkedCount = 0;
+
+  const byCrate = new Map<string, Set<string>>();
+  for (const dependency of dependencies) {
+    if (!isCratesIoSource(dependency.source)) {
+      errors.push(
+        `${dependency.name} ${dependency.version}: registry ${dependency.source} is not supported`,
+      );
+      continue;
+    }
+    const versions = byCrate.get(dependency.name) ?? new Set<string>();
+    versions.add(dependency.version);
+    byCrate.set(dependency.name, versions);
+  }
+
+  const work = [...byCrate.entries()];
+  let index = 0;
+  let omittedErrors = 0;
+  const recordError = (message: string): void => {
+    if (errors.length < 20) errors.push(message);
+    else omittedErrors += 1;
+  };
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const item = work[index++];
+      if (!item) return;
+      const [crateName, versions] = item;
+      try {
+        if (overallController.signal.aborted) {
+          throw new Error(`audit deadline exceeded after ${overallTimeoutMs}ms`);
+        }
+        const result = await fetchCrateYanks(
+          crateName,
+          [...versions],
+          fetchImpl,
+          timeoutMs,
+          overallController.signal,
+        );
+        checkedCount += result.checked.length;
+        yanked.push(...result.yanked);
+      } catch (err) {
+        recordError(`${crateName}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  };
+  try {
+    await Promise.all(Array.from({ length: Math.min(concurrency, work.length) }, () => worker()));
+  } finally {
+    clearTimeout(overallTimeout);
+  }
+  if (omittedErrors > 0) errors.push(`${omittedErrors} additional registry errors omitted`);
+
+  const base = {
+    checkedAt: new Date().toISOString(),
+    dependencyCount: dependencies.length,
+    checkedCount,
+  };
+  if (yanked.length > 0) {
+    return { ...base, status: "yanked", yanked, errors };
+  }
+  if (errors.length > 0) {
+    return { ...base, status: "not-checked", yanked: [], errors };
+  }
+  return { ...base, status: "clean", yanked: [], errors: [] };
+}
+
+export function writeYankAuditResult(resultPath: string, result: YankAuditResult): void {
+  fs.mkdirSync(path.dirname(resultPath), { recursive: true });
+  const temporaryPath = `${resultPath}.${process.pid}.tmp`;
+  fs.writeFileSync(temporaryPath, `${JSON.stringify(result)}\n`, "utf8");
+  fs.renameSync(temporaryPath, resultPath);
+}
+
+export function readYankAuditResult(resultPath: string): YankAuditResult | null {
+  try {
+    const result = JSON.parse(fs.readFileSync(resultPath, "utf8")) as YankAuditResult;
+    if (!["pending", "clean", "yanked", "not-checked"].includes(result.status)) return null;
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+export async function waitForYankAuditResult(
+  resultPath: string,
+  options: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<YankAuditResult> {
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const pollMs = options.pollMs ?? 250;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = readYankAuditResult(resultPath);
+    if (result && result.status !== "pending") return result;
+    await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
+  }
+  return {
+    status: "not-checked",
+    checkedAt: new Date().toISOString(),
+    errors: [`audit did not finish within ${timeoutMs}ms`],
+    joinTimedOut: true,
+  };
+}
+
+export async function runYankAuditWorker(configPath: string, resultPath: string): Promise<void> {
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as YankAuditWorkerConfig;
+    const result = await auditDependencyYanks(config.dependencies, {
+      requestTimeoutMs: config.requestTimeoutMs,
+      overallTimeoutMs: config.overallTimeoutMs,
+    });
+    writeYankAuditResult(resultPath, result);
+  } catch (err) {
+    writeYankAuditResult(resultPath, {
+      status: "not-checked",
+      checkedAt: new Date().toISOString(),
+      errors: [err instanceof Error ? err.message : String(err)],
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { spawn } from "node:child_process";
 import * as core from "@actions/core";
 import * as cache from "@actions/cache";
 import * as exec from "@actions/exec";
@@ -96,6 +97,13 @@ import type {
   CargoRegistryArchiveFormat,
   ResolveResult,
 } from "./lib/types.js";
+import {
+  YANK_AUDIT_WORKER_ARG,
+  readRegistryDependencies,
+  runYankAuditWorker,
+  writeYankAuditResult,
+  type YankAuditWorkerConfig,
+} from "./lib/yank-audit.js";
 
 /**
  * Map (hit, matchedKey) → workflow-visible restore-status string.
@@ -422,6 +430,7 @@ export async function run(): Promise<void> {
   const debugMode = result.debugMode;
   const debugLog = debugMode ? (msg: string): void => logger.log(msg) : (): void => undefined;
   const statsCollector = new StatsCollector();
+  const dependencyCacheMatchedKeys: string[] = [];
 
   // ---- source-mtime-normalize ----
   if (isTruthy(inputs.sourceMtimeNormalize)) {
@@ -526,6 +535,7 @@ export async function run(): Promise<void> {
     core.saveState("targetCacheExactHit", restore.hit ? "true" : "false");
     core.saveState("targetCacheMatchedKey", restore.matchedKey);
     targetCacheMatchedKey = restore.matchedKey;
+    if (restore.matchedKey) dependencyCacheMatchedKeys.push(restore.matchedKey);
     statsCollector.record({
       label: "target-cache", operation: "restore", hit: restore.hit,
       key: result.targetCache.key, matchedKey: restore.matchedKey, restoreKeys,
@@ -615,6 +625,7 @@ export async function run(): Promise<void> {
     core.setOutput("build_cache_matched_key", restore.matchedKey);
     core.saveState("buildCacheExactHit", restore.hit ? "true" : "false");
     core.saveState("buildCacheMatchedKey", restore.matchedKey);
+    if (restore.matchedKey) dependencyCacheMatchedKeys.push(restore.matchedKey);
     // Source-mtime replay (preserve-source-mtimes opt-in). post.ts dropped
     // a `setup-soldr-source-mtimes.json` sidecar inside the build-cache
     // dir on the cold side; if it's present after decompress, walk it and
@@ -1391,6 +1402,7 @@ export async function run(): Promise<void> {
             );
             markRegistryMiss();
           } else {
+            dependencyCacheMatchedKeys.push(matched);
             logger.log(
               `cargo-registry: extracted format=${archiveResult.codecPath} archive_bytes=${archiveBytes} restored_bytes=${restoredBytes} files=${restoredFiles} duration_ms=${archiveResult.durationMs}`,
             );
@@ -1515,6 +1527,12 @@ export async function run(): Promise<void> {
     });
     const baseReady = layeredCookBaseReady(restore, loaded);
     const deltaReady = layeredCookDeltaReady(restore, loaded);
+    if (baseReady && restore.base.matchedKey) {
+      dependencyCacheMatchedKeys.push(restore.base.matchedKey);
+    }
+    if (deltaReady && restore.delta.matchedKey) {
+      dependencyCacheMatchedKeys.push(restore.delta.matchedKey);
+    }
     core.setOutput("cook-cache-base-hit", baseReady ? "true" : "false");
     core.setOutput("cook-cache-delta-hit", deltaReady ? "true" : "false");
     core.setOutput("cook-cache-hit", baseReady ? "true" : "false");
@@ -1624,6 +1642,7 @@ export async function run(): Promise<void> {
     core.saveState("cookLayered", "false");
     core.saveState("cookExactKey", cookKey);
     core.saveState("cookMatchedKey", restore.matchedKey);
+    if (restore.hit && restore.matchedKey) dependencyCacheMatchedKeys.push(restore.matchedKey);
     core.saveState("cookHit", restore.hit ? "true" : "false");
     core.saveState("cookRan", cookRan ? "true" : "false");
     core.saveState("cookTargetDir", cookTargetDir);
@@ -1645,6 +1664,74 @@ export async function run(): Promise<void> {
     core.saveState("cookLayered", "false");
   }
   await finishPhase("cook");
+
+  // #476: content-addressed keys cannot observe a later registry yank. Start
+  // the network check only after every dependency-bearing restore has been
+  // validated, then let it run concurrently with the consumer's build. The
+  // post action joins this result before any cache save can report success.
+  const poisonedCandidates = [...new Set(dependencyCacheMatchedKeys.filter(Boolean))];
+  core.saveState("yankAuditStarted", "false");
+  if (poisonedCandidates.length > 0) {
+    const resultPath = path.join(ctx.runnerTemp, "setup-soldr-yank-audit", "result.json");
+    const configPath = path.join(ctx.runnerTemp, "setup-soldr-yank-audit", "config.json");
+    try {
+      if (!result.targetCache.lockfilePath) {
+        throw new Error("restored dependency cache has no Cargo.lock path");
+      }
+      const lockfilePath = path.isAbsolute(result.targetCache.lockfilePath)
+        ? result.targetCache.lockfilePath
+        : path.resolve(ctx.workspace, result.targetCache.lockfilePath);
+      const dependencies = readRegistryDependencies(lockfilePath);
+      const config: YankAuditWorkerConfig = {
+        dependencies,
+        requestTimeoutMs: 30_000,
+        // Finish before post's 60s join ceiling even if every registry
+        // request stalls. The worker aborts all in-flight requests together.
+        overallTimeoutMs: 45_000,
+      };
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`, "utf8");
+      writeYankAuditResult(resultPath, { status: "pending" });
+      core.saveState("yankAuditStarted", "true");
+      core.saveState("yankAuditResultPath", resultPath);
+      core.saveState("yankAuditCacheKeys", JSON.stringify(poisonedCandidates));
+      if (dependencies.length === 0) {
+        writeYankAuditResult(resultPath, {
+          status: "clean",
+          checkedAt: new Date().toISOString(),
+          dependencyCount: 0,
+          checkedCount: 0,
+          yanked: [],
+          errors: [],
+        });
+      } else {
+        const entrypoint = process.argv[1];
+        if (!entrypoint) throw new Error("Node action entrypoint is unavailable");
+        const child = spawn(
+          process.execPath,
+          [entrypoint, YANK_AUDIT_WORKER_ARG, configPath, resultPath],
+          { detached: true, stdio: "ignore", windowsHide: true },
+        );
+        child.unref();
+        logger.log(
+          `yank-audit: started pid=${child.pid ?? "unknown"} dependencies=${dependencies.length} ` +
+            `cache_keys=${poisonedCandidates.length}`,
+        );
+      }
+    } catch (err) {
+      writeYankAuditResult(resultPath, {
+        status: "not-checked",
+        checkedAt: new Date().toISOString(),
+        errors: [err instanceof Error ? err.message : String(err)],
+      });
+      core.saveState("yankAuditStarted", "true");
+      core.saveState("yankAuditResultPath", resultPath);
+      core.saveState("yankAuditCacheKeys", JSON.stringify(poisonedCandidates));
+      logger.warning(
+        `yank-audit: not checked: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
 
   // ---- shared-target warning ----
   await detectSharedTargetWarning({
@@ -1746,8 +1833,20 @@ if (
   // the dev path — we rely on the env-var opt-out for tests instead.
   !process.env["SETUP_SOLDR_TEST_IMPORT"]
 ) {
-  run().catch((err: unknown) => {
-    const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-    core.setFailed(`setup-soldr failed: ${message}`);
-  });
+  if (process.argv[2] === YANK_AUDIT_WORKER_ARG) {
+    const configPath = process.argv[3];
+    const resultPath = process.argv[4];
+    if (!configPath || !resultPath) {
+      process.exitCode = 2;
+    } else {
+      runYankAuditWorker(configPath, resultPath).catch(() => {
+        process.exitCode = 1;
+      });
+    }
+  } else {
+    run().catch((err: unknown) => {
+      const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+      core.setFailed(`setup-soldr failed: ${message}`);
+    });
+  }
 }

--- a/src/post.ts
+++ b/src/post.ts
@@ -53,7 +53,12 @@ import {
 } from "./lib/compile-cache-stats.js";
 import { captureProcessSnapshot, dumpDiagnostics, loggingEnabled } from "./lib/diagnostics.js";
 import { readRawInputs } from "./lib/raw-inputs.js";
-import { evictIfOverBudget, type CacheEvictionPolicy } from "./lib/cache-eviction.js";
+import {
+  deleteCacheEntriesByKeys,
+  evictIfOverBudget,
+  type CacheEvictionPolicy,
+} from "./lib/cache-eviction.js";
+import { waitForYankAuditResult } from "./lib/yank-audit.js";
 import {
   snapshotSourceMtimes,
   writeSnapshotFile,
@@ -1289,6 +1294,69 @@ export async function run(): Promise<void> {
     logsArchiveDir,
     log,
   });
+
+  // #476: main launched this audit after the final dependency-bearing
+  // restore, so it ran concurrently with the consumer's build. Join before
+  // any save: a poisoned restored closure must never be republished under a
+  // new exact key or allowed to produce a successful job.
+  if (core.getState("yankAuditStarted") === "true") {
+    const auditPath = core.getState("yankAuditResultPath");
+    let cacheKeys: string[] = [];
+    try {
+      const parsed = JSON.parse(core.getState("yankAuditCacheKeys")) as unknown;
+      if (Array.isArray(parsed)) {
+        cacheKeys = [...new Set(parsed.filter((key): key is string => typeof key === "string" && key.length > 0))];
+      }
+    } catch {
+      // The result below will still be surfaced as not checked if state was
+      // damaged; never convert malformed state into a clean verdict.
+    }
+    const audit = auditPath
+      ? await waitForYankAuditResult(auditPath, { timeoutMs: 60_000 })
+      : { status: "not-checked" as const, errors: ["audit result path is missing"] };
+    if (audit.status === "not-checked" && audit.joinTimedOut) {
+      core.setFailed(
+        `yank-audit: not checked because the background audit did not reach a terminal result: ` +
+          `${(audit.errors ?? ["join timed out"]).join("; ")}. ` +
+          `Refusing to save caches or report success while the audit may still be in flight.`,
+      );
+      return;
+    } else if (audit.status === "not-checked") {
+      core.warning(
+        `yank-audit: not checked: ${(audit.errors ?? ["unknown registry error"]).join("; ")}`,
+      );
+    } else if (audit.status === "clean") {
+      log(
+        `yank-audit: clean checked=${audit.checkedCount ?? 0}/${audit.dependencyCount ?? 0} ` +
+          `cache_keys=${cacheKeys.length}`,
+      );
+    } else if (audit.status === "yanked") {
+      const yanked = audit.yanked ?? [];
+      const crates = yanked.map((dependency) => `${dependency.name} ${dependency.version}`).join(", ");
+      const githubRepository = (process.env["GITHUB_REPOSITORY"] ?? "").trim();
+      const [owner, repo] = githubRepository.split("/");
+      const token = (process.env["GITHUB_TOKEN"] ?? "").trim() ||
+        (process.env["INPUT_TOKEN"] ?? "").trim();
+      const deletion = await deleteCacheEntriesByKeys({
+        owner: owner ?? "",
+        repo: repo ?? "",
+        token,
+        keys: cacheKeys,
+        log,
+      });
+      const deletionComplete = deletion.failed === 0 && deletion.deleted === deletion.found;
+      const repair = deletionComplete
+        ? `poisoned entries deleted=${deletion.deleted}/${deletion.found}; rerun to rebuild from a clean cache miss`
+        : `automatic deletion incomplete (deleted=${deletion.deleted}/${deletion.found}, failures=${deletion.failed}); ` +
+          `grant the workflow actions: write permission or manually delete these exact cache keys before retrying`;
+      core.setFailed(
+        `yank-audit: restored dependency closure contains yanked crate(s): ${crates}; ` +
+          `cache key(s): ${cacheKeys.join(", ") || "unknown"}; ` +
+          `${repair}. This run is aborted.`,
+      );
+      return;
+    }
+  }
 
   // Source-mtime snapshot (preserve-source-mtimes opt-in). Walk tracked
   // sources, capture each (mtime, size, content-hash), and drop the JSON


### PR DESCRIPTION
## Summary

- launch a detached crates.io sparse-index yank audit after validated dependency-bearing cache restores, so it overlaps the consumer build
- join the audit in post before any save or successful completion, with a 45-second global worker deadline and a fail-closed 60-second join ceiling
- delete every exact matched poisoned cache key through the existing cache-eviction Actions API path, then fail with crate, version, key, and repair status
- report registry failures and unsupported private registries explicitly as not checked; never convert them to a clean verdict
- prevent republishing poisoned content, and give actionable actions: write/manual-removal guidance if deletion is incomplete

## Validation

- npm test: 731 tests, 719 passed, 12 intentional skips
- npm run typecheck
- npm run lint:vendor-prose
- targeted yank/deletion tests: 24 passed
- live crates.io sparse-index probes: serde 1.0.228 clean; rand 0.4.4 yanked
- bundled dist/main.js worker detects live yanked rand 0.4.4
- Linux action bundles regenerated with Bosn
- adversarial clud-review: clean

Fixes #476