### PR TITLE
fix(action): default Soldr to rolling latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Soldr Action](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml/badge.svg)](https://github.com/zackees/setup-soldr/actions/workflows/setup-soldr-action.yml)
 
-Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or toolchain homes by default. The default Soldr version is `0.9.9`.
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain, and restoring cacheable Soldr/zccache state without rehydrating large Cargo or toolchain homes by default. The default Soldr version is `latest`.
 
 This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
 
@@ -435,7 +435,7 @@ preferred for new workflows.
 
 | Input | Meaning |
 |---|---|
-| `version` | Soldr release tag or version to install. Defaults to `0.9.9`. |
+| `version` | Soldr release tag or version to install. Defaults to the latest release. |
 | `source-path` | Internal development override that builds Soldr from a pinned local Git checkout such as `_vender/soldr`; the checkout must include required submodules. Release assets remain the production default. |
 | `cross-targets` | One canonical target per job for Soldr blessed preparation; use a matrix for multiple targets. |
 | `token` | GitHub token used for authenticated release metadata and asset download requests. Defaults to `${{ github.token }}`. |
@@ -546,7 +546,7 @@ preferred for new workflows.
 
 - Development branches may pin the tracked `_vender/soldr` checkout and pass `source-path: _vender/soldr`; setup-soldr keys the build on the checkout's exact `HEAD`; commit local edits before expecting a new source identity. Production installs remain release-asset based.
 - `soldr-cook` rematerialization is a two-part dependency closure: the cooked `target/` base (fingerprints, dep-info, rlibs/proc macros, build-script executables and outputs) plus Cargo registry/git sources. The action restores both by default and reports transport/load status through the `cook-cache-*` outputs.
-- The action installs exactly one released `soldr` binary for the active runner target, defaulting to Soldr `0.9.9`. Combined GitHub release archives remain preferred; for explicitly supported wheel-compatible releases (currently `0.9.0` through `0.9.6`), a missing exact target archive falls back to the matching hash-verified wheel from the same version on PyPI.
+- The action installs exactly one released `soldr` binary for the active runner target, defaulting to the latest release. Combined GitHub release archives remain preferred; for explicitly supported wheel-compatible releases (currently `0.9.0` through `0.9.6`), a missing exact target archive falls back to the matching hash-verified wheel from the same version on PyPI.
 - For soldr `0.7.43+`, the action installs the release-pinned `cargo-chef`
   binary and exports `SOLDR_CARGO_CHEF_LOCAL_DIR`, so `soldr cook` does not
   need a live upstream GitHub lookup. Combined archives bundle the helper;

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   version:
-    description: Soldr version or tag to install. Defaults to 0.9.9.
+    description: Soldr version or tag to install. Defaults to the latest release.
     required: false
-    default: "0.9.9"
+    default: "latest"
   repo:
     description: Internal override for the Soldr source repository used by integration branches.
     required: false

--- a/scripts/check-default-release-readiness.mjs
+++ b/scripts/check-default-release-readiness.mjs
@@ -36,16 +36,21 @@ const cargoChefPlatforms = {
 };
 
 const action = readFileSync("action.yml", "utf8");
-const version = action.match(/^  version:\r?\n[\s\S]*?^    default:\s*["']?([^"'\r\n]+)["']?\s*$/m)?.[1]?.trim();
-if (!version) throw new Error("could not read inputs.version default from action.yml");
+const requestedVersion = action.match(/^  version:\r?\n[\s\S]*?^    default:\s*["']?([^"'\r\n]+)["']?\s*$/m)?.[1]?.trim();
+if (!requestedVersion) throw new Error("could not read inputs.version default from action.yml");
 
-const tag = version.startsWith("v") ? version : `v${version}`;
 const headers = { Accept: "application/vnd.github+json", "User-Agent": "setup-soldr-release-readiness" };
 const token = process.env.GITHUB_TOKEN?.trim();
 if (token) headers.Authorization = `Bearer ${token}`;
-const response = await fetch(`https://api.github.com/repos/zackees/soldr/releases/tags/${tag}`, { headers });
-if (!response.ok) throw new Error(`default release ${tag} returned HTTP ${response.status}`);
+const releaseEndpoint = requestedVersion.toLowerCase() === "latest"
+  ? "https://api.github.com/repos/zackees/soldr/releases/latest"
+  : `https://api.github.com/repos/zackees/soldr/releases/tags/${requestedVersion.startsWith("v") ? requestedVersion : `v${requestedVersion}`}`;
+const response = await fetch(releaseEndpoint, { headers });
+if (!response.ok) throw new Error(`default release ${requestedVersion} returned HTTP ${response.status}`);
 const release = await response.json();
+const tag = typeof release.tag_name === "string" ? release.tag_name.trim() : "";
+if (!/^v?\d+\.\d+\.\d+$/.test(tag)) throw new Error("default release has no semantic tag_name");
+const version = tag.replace(/^v/, "");
 if (release.draft) throw new Error(`default release ${tag} is a draft`);
 if (!Array.isArray(release.assets)) throw new Error(`default release ${tag} has no assets array`);
 

--- a/tests/test_action_target_cache_wiring.py
+++ b/tests/test_action_target_cache_wiring.py
@@ -176,7 +176,7 @@ EXPECTED_OUTPUTS = {
     "compile-cache-verification",
 }
 
-EXPECTED_SOLDR_DEFAULT_VERSION = "0.9.9"
+EXPECTED_SOLDR_DEFAULT_VERSION = "latest"
 
 
 def _load_action() -> dict:
@@ -199,7 +199,7 @@ def test_action_preserves_all_original_inputs() -> None:
     assert "release-cache" not in manifest["inputs"]
 
 
-def test_action_default_soldr_version_is_current_release() -> None:
+def test_action_default_soldr_version_is_rolling_latest() -> None:
     manifest = _load_action()
     version_input = manifest["inputs"]["version"]
     assert version_input["default"] == EXPECTED_SOLDR_DEFAULT_VERSION

--- a/tests/test_cross_target_public_contract.py
+++ b/tests/test_cross_target_public_contract.py
@@ -35,7 +35,7 @@ def test_cross_target_action_description_has_only_blessed_contract() -> None:
 def test_readme_recommends_only_target_driven_cross_compilation() -> None:
     readme = README_PATH.read_text(encoding="utf-8")
 
-    assert "The default Soldr version is `0.9.9`." in readme
+    assert "The default Soldr version is `latest`." in readme
     assert "### Legacy cross-compile auto-bootstrap" not in readme
     assert "soldr cargo zigbuild" not in readme
     assert "cross-tool:" not in readme
@@ -50,7 +50,7 @@ def test_default_soldr_version_is_one_public_constant() -> None:
     readme = README_PATH.read_text(encoding="utf-8")
     contract = CONTRACT_PATH.read_text(encoding="utf-8")
 
-    assert version == "0.9.9"
+    assert version == "latest"
     assert f"The default Soldr version is `{version}`." in readme
     assert f'EXPECTED_SOLDR_DEFAULT_VERSION = "{version}"' in contract
 


### PR DESCRIPTION
Closes #490

## Summary
- make omitted ersion resolve the same rolling release as explicit latest
- teach the readiness gate to resolve the latest release tag before validating assets
- update the public contract and documentation

## Validation
- default-release readiness: v0.9.9, all 6 supported targets
- Python contract tests: 9 passed
- npm run typecheck
- npm test: 725 tests, 713 passed, 12 skipped
- git diff --check

Unblocks zackees/clud#1026.