### PR TITLE
docs(action): mark the target-cache inputs deprecated and inert

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -225,21 +225,35 @@ inputs:
     default: "false"
   target-cache:
     description: >
-      Deprecated compatibility input. Empty (default) resolves to "false"
-      unless `cache-preset: full` overrides it. Set to "true" to enable
-      Rust target artifact caching; prefer `build-cache-mode` for selecting
-      once/thin/full. (#251 cache-preset)
+      DEPRECATED AND INERT with soldr >= the release containing zackees/soldr#3001.
+      Soldr removed its target cache entirely: the `rust_plan` machinery that
+      consumed SOLDR_TARGET_CACHE_* was deleted, so this layer has nothing left
+      to drive and setting it has no effect. It remains declared so existing
+      workflows do not fail on an unexpected input, and it still functions for
+      a pinned older soldr.
+
+      Use `soldr cook` instead -- it is the durable dependency cache, and
+      zackees/soldr#2996 measured it both smaller and faster than the target
+      cache it replaces (497.4 MiB vs 635.0 MiB on one lane, 378.4 s saved per
+      warm run).
+
+      Empty (default) resolves to "false" unless `cache-preset: full` overrides
+      it. (#251 cache-preset)
     required: false
     default: ""
   target-cache-mode:
     description: >
-      Deprecated compatibility input translated into build-cache-mode.
-      "hot" maps to "thin", "full" maps to "full", and "off" disables Rust
-      target artifact caching.
+      DEPRECATED AND INERT -- see `target-cache`. Translated into
+      build-cache-mode; "hot" maps to "thin", "full" maps to "full", and "off"
+      disables Rust target artifact caching. With a soldr that has dropped the
+      target cache, every value behaves the same: nothing happens.
     required: false
     default: ""
   target-dir:
-    description: Cargo target directory used by soldr when constructing the Rust artifact cache plan.
+    description: >
+      Cargo target directory. Its only remaining consumers are cache-key
+      shaping and the cook layer; the Rust artifact cache plan it was named
+      for no longer exists (see `target-cache`).
     required: false
     default: target
   target-cache-profile:


### PR DESCRIPTION
Completes the action-side half of zackees/soldr#2996 Phase 2.

## Why

zackees/soldr#3001 removed soldr's target cache outright — the whole `rust_plan` module family that consumed `SOLDR_TARGET_CACHE_*` is gone, ~6,250 lines. With a soldr at or past that release, `target-cache` and `target-cache-mode` have **nothing left to drive**: the action still exports the environment and nothing reads it.

## Scope: descriptions only

The inputs stay declared. Removing them would fail every workflow that passes them, and they still work for a consumer pinning an older soldr — so this is a metadata edit. **No behaviour, no TypeScript, no `dist` rebuild.**

A runtime deprecation warning is the stronger form, but it needs a src change plus a bundle rebuild and release. Left as a follow-up rather than smuggled into a docs commit.

## What the replacement is worth

The descriptions point at `soldr cook`, with the numbers soldr#2996 measured on one lane:

- cook entry **497.4 MiB** vs Swatinem/rust-cache **635.0 MiB**
- **378.4 s saved per warm run** (387.7 s cold cook to 9.3 s warm, for a 10.4 s restore)

Cook is both smaller and faster than the layer these inputs drove.

## Verification

`action.yml` parses; `raw-inputs.test.ts`, which reads it, passes 18/18.

`npm test` has **pre-existing** failures on a clean tree here — `two-phase-actions-cache`, `cook-cache`, `resolve-setup` — which reproduce without this change and look environment-dependent. Flagging rather than claiming a green suite I did not get.

Refs zackees/soldr#2996 Phase 2, zackees/soldr#3001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJVhqURDjmFKceXREagUph