### PR TITLE
ci(contract): authenticate the default-release readiness lookup

### DIFF
--- a/.github/workflows/setup-soldr-contract.yml
+++ b/.github/workflows/setup-soldr-contract.yml
@@ -164,6 +164,12 @@ jobs:
           node-version: 24
 
       - name: Verify the action default is published and complete
+        # The script sends `Authorization: Bearer $GITHUB_TOKEN` when the
+        # variable is set. Without it the releases lookup is an anonymous
+        # call against the shared per-IP rate limit and fails with HTTP 403
+        # on busy runners (2026-09-04, run 33914038321, green on rerun).
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/check-default-release-readiness.mjs
 
   wheel-fallback-smoke:


### PR DESCRIPTION
`scripts/check-default-release-readiness.mjs` sends `Authorization: Bearer $GITHUB_TOKEN` when the variable is set, but the "Verify the action default is published and complete" step never set it. The releases lookup therefore ran anonymously against the shared per-IP rate limit and failed with `default release latest returned HTTP 403` on the first contract run after #502 (run 33914038321); the rerun passed. That flake blocks the v0 promotion, since Update v0 tag only fires on a green contract run.

This passes the job token to the step. One-line change, no script change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRsrtGd9JGqmFR8XSzGVAE